### PR TITLE
chore: ignore .claude/ harness directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 build/
 uv.lock
 traces/
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` so the Claude Code harness's local worktree state isn't picked up as untracked changes when running multi-agent sessions in this repo.

This is purely a housekeeping change — no code or behavior is touched.

## Test plan
- [x] `git status` is clean after the change.

https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW)_

## Summary by Sourcery

Build:
- Add the .claude/ harness directory to .gitignore to prevent local Claude Code worktree files from being tracked.