### PR TITLE
[Hackathon] harvard-phd: EigenTrust plugin with checkable invariants

### DIFF
--- a/docs/layers/trust.md
+++ b/docs/layers/trust.md
@@ -25,6 +25,32 @@ Source: [`nest_plugins_reference/trust/score_average.py`](../../packages/nest-pl
 The `reputation` scenario exercises this layer — 16 honest + 4
 malicious + 1 observer that samples cheat reports probabilistically.
 
+## Bundled alternative: `eigentrust`
+
+`eigentrust` — transitive, Sybil-resistant reputation as the stationary
+distribution of a teleporting random walk over the local-trust graph
+(Kamvar, Schlosser, Garcia-Molina, WWW 2003). The fixed point is
+
+```
+t = (1 - alpha) * C^T * t + alpha * p
+```
+
+where `C` is the row-normalized local-trust matrix and `p` is a
+distribution over pre-trusted peers. Properties the test suite checks:
+simplex (`sum_i t_i == 1`), row-stochasticity of `C`, fixed-point
+residual `< tol`, and a Sybil upper bound `t_sybil <= alpha * p_sybil`
+when no honest agent endorses the Sybil.
+
+Flip a scenario to use it:
+
+```yaml
+layers:
+  trust: eigentrust
+```
+
+Source: [`nest_plugins_reference/trust/eigentrust.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/eigentrust.py).
+Tests: [`tests/test_eigentrust.py`](../../packages/nest-plugins-reference/tests/test_eigentrust.py).
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -23,6 +23,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
+    ("trust", "eigentrust"): f"{_REF}.trust.eigentrust:EigenTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("coordination", "contract_net"): f"{_REF}.coordination.contract_net:ContractNet",
     ("negotiation", "alternating_offers"): (

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/eigentrust.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/eigentrust.py
@@ -269,11 +269,14 @@ class EigenTrust:
         self._agents.add(agent)
         t = self._compute_trust_vector()
         value = t.get(agent, 0.0)
-        sample_count = sum(
-            len(self._pos[i]) + len(self._neg[i]) for i in self._agents
-        )
-        confidence = 0.0 if self._tol <= 0 else max(
-            0.0, min(1.0, 1.0 - self.last_residual / max(self._tol, 1e-12)),
+        sample_count = sum(len(self._pos[i]) + len(self._neg[i]) for i in self._agents)
+        confidence = (
+            0.0
+            if self._tol <= 0
+            else max(
+                0.0,
+                min(1.0, 1.0 - self.last_residual / max(self._tol, 1e-12)),
+            )
         )
         return ReputationScore(
             agent_id=agent,
@@ -358,7 +361,8 @@ class EigenTrust:
         return {a: mass for a in agents}
 
     def _local_trust_raw(
-        self, agents: list[AgentId],
+        self,
+        agents: list[AgentId],
     ) -> dict[AgentId, dict[AgentId, float]]:
         """Build ``s_ij = max(0, pos_ij - neg_ij)`` over the known agents."""
         raw: dict[AgentId, dict[AgentId, float]] = {}
@@ -389,7 +393,12 @@ class EigenTrust:
         raw = self._local_trust_raw(agents)
         c = _normalize_local_trust(raw, agents, p)
         t, iters, residual = _power_iterate(
-            c, p, self._alpha, agents, self._max_iter, self._tol,
+            c,
+            p,
+            self._alpha,
+            agents,
+            self._max_iter,
+            self._tol,
         )
         self.last_iters = iters
         self.last_residual = residual

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/eigentrust.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/eigentrust.py
@@ -1,0 +1,422 @@
+# SPDX-License-Identifier: Apache-2.0
+"""EigenTrust trust plugin — transitive, Sybil-resistant reputation.
+
+EigenTrust (Kamvar, Schlosser, Garcia-Molina, WWW 2003) computes a global
+trust vector ``t`` as the stationary distribution of a Markov chain whose
+transition matrix is built from each agent's *local* trust opinions.
+
+Where ``score_average`` answers "what is the average feedback for this
+agent?", EigenTrust answers "what mass of probability does a random walker,
+restarted with probability ``a`` to a pre-trusted set ``p``, spend on this
+agent in the limit?". The fixed point
+
+    t = (1 - a) * C^T * t + a * p
+
+is provably the unique stationary distribution on the probability simplex
+when ``a > 0`` (Perron-Frobenius applied to an aperiodic, irreducible chain
+formed by the teleport mixture).
+
+What this plugin actually implements
+------------------------------------
+
+* Local trust ``s_ij`` is the running sum of positive minus negative
+  evidence, clipped at zero (``max(0, pos - neg)``).
+* Row-normalized to ``c_ij = s_ij / sum_k s_ik``.  Rows that sum to zero
+  fall back to the pre-trusted distribution ``p`` (a "naive" walker
+  teleports to known-honest peers).
+* Power iteration of ``t <- (1 - a) C^T t + a p`` until ``||delta||_1 <
+  tol`` or ``max_iter`` is reached.
+* ``score(agent)`` returns the converged mass for ``agent``, in ``[0, 1]``.
+
+Properties checked by the test suite
+------------------------------------
+
+* **simplex**: ``sum_i t_i == 1`` and ``t_i >= 0`` for all agents.
+* **row-stochasticity**: every row of ``C`` sums to 1.
+* **fixed point**: ``||(1-a) C^T t + a p - t||_inf < tol``.
+* **Sybil lower bound**: a Sybil peer with no incoming local trust from
+  honest agents earns at most ``a * p_i`` mass.  This is the central
+  Sybil-resistance result.
+* **monotonicity (weak)**: holding everyone else's feedback fixed,
+  increasing positive evidence for agent ``j`` from honest reporters does
+  not decrease ``t_j``.
+
+The plugin is *deterministic* and dependency-free (pure Python, no numpy),
+matching the rest of the reference plugin pack.
+
+Example::
+
+    trust = EigenTrust(
+        identity=None,
+        pretrusted=[AgentId("a1"), AgentId("a2")],
+        alpha=0.1,
+    )
+    await trust.report(AgentId("a3"),
+        Evidence(reporter=AgentId("a1"), subject=AgentId("a3"), kind="positive"))
+    score = await trust.score(AgentId("a3"))
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from nest_core.types import (
+    AgentId,
+    Attestation,
+    Claim,
+    Evidence,
+    ReputationScore,
+    Signature,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level invariants exposed for tests and external assertion.  Keeping
+# them as constants instead of magic numbers makes the proof obligations
+# explicit.
+# ---------------------------------------------------------------------------
+
+#: Default teleport / pre-trusted mixing weight.  ``a > 0`` is required for
+#: convergence; ``a`` close to 1 ignores the local-trust graph entirely.
+DEFAULT_ALPHA: float = 0.1
+
+#: Maximum power-iteration steps before we accept the current estimate.
+#: For ``alpha = 0.1`` the convergence factor per step is ``(1 - alpha) =
+#: 0.9``, so reaching residual ``1e-6`` from a worst-case initial gap of
+#: ``2`` requires roughly ``log(2 / tol) / log(1 / (1 - alpha)) ≈ 138``
+#: iterations.  ``300`` leaves comfortable headroom and is still cheap on
+#: the agent counts NEST scenarios actually exercise.
+DEFAULT_MAX_ITER: int = 300
+
+#: L1 convergence tolerance for power iteration.
+DEFAULT_TOL: float = 1.0e-6
+
+#: How heavily a single piece of negative evidence outweighs positive
+#: evidence when forming the raw local-trust score.  EigenTrust's original
+#: paper uses ``sat - unsat`` clipped at 0; we match that.
+_NEG_WEIGHT: int = 1
+_POS_WEIGHT: int = 1
+
+
+def _normalize_local_trust(
+    raw: dict[AgentId, dict[AgentId, float]],
+    agents: list[AgentId],
+    pretrusted_dist: dict[AgentId, float],
+) -> dict[AgentId, dict[AgentId, float]]:
+    """Row-normalize the local trust matrix.
+
+    For each agent ``i``:
+
+    * if ``sum_j raw[i][j] > 0``, set ``c_ij = raw[i][j] / row_sum``;
+    * otherwise (the "naive walker"), set ``c_ij = p_j``.
+
+    The result satisfies ``sum_j c_ij == 1`` for every agent ``i`` —
+    the row-stochasticity invariant.
+    """
+    c: dict[AgentId, dict[AgentId, float]] = {}
+    for i in agents:
+        row = raw.get(i, {})
+        total = sum(max(0.0, v) for v in row.values())
+        if total <= 0.0:
+            c[i] = dict(pretrusted_dist)
+        else:
+            c[i] = {j: max(0.0, row.get(j, 0.0)) / total for j in agents}
+    return c
+
+
+def _power_iterate(
+    c: dict[AgentId, dict[AgentId, float]],
+    p: dict[AgentId, float],
+    alpha: float,
+    agents: list[AgentId],
+    max_iter: int,
+    tol: float,
+) -> tuple[dict[AgentId, float], int, float]:
+    """Compute the stationary distribution of ``(1 - alpha) C^T + alpha P``.
+
+    Returns ``(t, iters, residual)``: the trust vector, the number of
+    iterations used, and the final L1 residual ``||t_k - t_{k-1}||_1``.
+
+    Loop invariants:
+
+    * ``sum_i t_i == 1`` after every iteration (probability mass conserved
+      because each ``C`` row sums to 1 and so does ``p``);
+    * ``t_i >= 0`` for all ``i`` (non-negative combination of non-negative
+      vectors).
+    """
+    n = len(agents)
+    if n == 0:
+        return {}, 0, 0.0
+    t: dict[AgentId, float] = dict(p)
+    residual = 0.0
+    iters = 0
+    for k in range(max_iter):
+        iters = k + 1
+        next_t: dict[AgentId, float] = dict.fromkeys(agents, 0.0)
+        # Compute (C^T t)_j = sum_i c_ij * t_i.
+        for i in agents:
+            ti = t[i]
+            if ti == 0.0:
+                continue
+            row = c[i]
+            for j, c_ij in row.items():
+                if c_ij == 0.0:
+                    continue
+                next_t[j] += c_ij * ti
+        # Mix with the pre-trusted distribution.
+        for j in agents:
+            next_t[j] = (1.0 - alpha) * next_t[j] + alpha * p[j]
+        residual = sum(abs(next_t[j] - t[j]) for j in agents)
+        t = next_t
+        if residual < tol:
+            break
+    return t, iters, residual
+
+
+class EigenTrust:
+    """Transitive, Sybil-resistant reputation via stationary distribution.
+
+    Parameters
+    ----------
+    identity:
+        Optional ``Identity`` used to sign attestations.  Kept compatible
+        with ``ScoreAverageTrust``.
+    pretrusted:
+        Iterable of pre-trusted agent ids.  These agents seed the teleport
+        distribution ``p``.  If empty, ``p`` is uniform over all agents
+        seen so far (a permissive default — good for tests, less Sybil
+        resistant in practice).
+    alpha:
+        Teleport / pre-trusted mixing weight in ``(0, 1]``.  Defaults to
+        ``DEFAULT_ALPHA = 0.1`` per the EigenTrust paper.
+    max_iter, tol:
+        Power-iteration knobs.  See ``DEFAULT_MAX_ITER`` / ``DEFAULT_TOL``.
+
+    Example::
+
+        trust = EigenTrust(pretrusted=[AgentId("a1")], alpha=0.1)
+        await trust.report(AgentId("a2"),
+            Evidence(reporter=AgentId("a1"), subject=AgentId("a2"), kind="positive"))
+        score = await trust.score(AgentId("a2"))
+    """
+
+    def __init__(
+        self,
+        identity: Any = None,
+        pretrusted: list[AgentId] | None = None,
+        alpha: float = DEFAULT_ALPHA,
+        max_iter: int = DEFAULT_MAX_ITER,
+        tol: float = DEFAULT_TOL,
+    ) -> None:
+        if not 0.0 < alpha <= 1.0:
+            msg = f"alpha must be in (0, 1]; got {alpha}"
+            raise ValueError(msg)
+        if max_iter < 1:
+            msg = f"max_iter must be >= 1; got {max_iter}"
+            raise ValueError(msg)
+        if tol <= 0.0:
+            msg = f"tol must be > 0; got {tol}"
+            raise ValueError(msg)
+
+        self._identity = identity
+        self._alpha = alpha
+        self._max_iter = max_iter
+        self._tol = tol
+
+        # Pre-trusted set is stored as a *list* so the seed distribution is
+        # reproducible regardless of dict ordering.
+        self._pretrusted: list[AgentId] = list(pretrusted or [])
+
+        # Local-trust counts.  ``self._pos[i][j]`` is the count of positive
+        # evidence agent ``i`` reported about agent ``j``; same for neg.
+        # We never mutate these once they go into the convergence step --
+        # power iteration reads from a snapshot.
+        self._pos: dict[AgentId, dict[AgentId, int]] = defaultdict(
+            lambda: defaultdict(int),
+        )
+        self._neg: dict[AgentId, dict[AgentId, int]] = defaultdict(
+            lambda: defaultdict(int),
+        )
+
+        # Agents we've ever seen (as reporter, subject, or pre-trusted).
+        self._agents: set[AgentId] = set(self._pretrusted)
+
+        # Optional stakes (kept for protocol compatibility; not used in the
+        # eigenvector computation).
+        self._stakes: dict[AgentId, int] = {}
+
+        # Cached convergence diagnostics from the last ``score()`` call.
+        # Tests and validators can read these to assert convergence.
+        self.last_iters: int = 0
+        self.last_residual: float = 0.0
+
+    # ------------------------------------------------------------------ API
+
+    async def score(self, agent: AgentId) -> ReputationScore:
+        """Return the converged EigenTrust mass for ``agent``.
+
+        The score is on ``[0, 1]`` and the full trust vector sums to 1.
+        ``confidence`` is reported as ``1 - last_residual / tol`` clipped
+        to ``[0, 1]`` — a soft signal of how well power iteration
+        converged on this call.
+
+        Example::
+
+            score = await trust.score(AgentId("a1"))
+        """
+        # Ensure the agent is part of the known set so an isolated query
+        # doesn't lie by omission.  This keeps ``score()`` total.
+        self._agents.add(agent)
+        t = self._compute_trust_vector()
+        value = t.get(agent, 0.0)
+        sample_count = sum(
+            len(self._pos[i]) + len(self._neg[i]) for i in self._agents
+        )
+        confidence = 0.0 if self._tol <= 0 else max(
+            0.0, min(1.0, 1.0 - self.last_residual / max(self._tol, 1e-12)),
+        )
+        return ReputationScore(
+            agent_id=agent,
+            score=value,
+            confidence=confidence,
+            sample_count=sample_count,
+        )
+
+    async def attest(self, agent: AgentId, claim: Claim) -> Attestation:
+        """Create a signed attestation about ``agent``.
+
+        Example::
+
+            att = await trust.attest(AgentId("a1"), claim)
+        """
+        sig = Signature(signer=AgentId("system"), value=b"attestation", algorithm="none")
+        if self._identity is not None:
+            sig = self._identity.sign(claim.model_dump_json().encode())
+        return Attestation(issuer=AgentId("system"), claim=claim, signature=sig)
+
+    async def report(self, agent: AgentId, evidence: Evidence) -> None:
+        """Record a piece of evidence about ``agent``.
+
+        Evidence kinds:
+
+        * ``"positive"`` — increments ``pos[reporter][subject]``.
+        * ``"negative"`` or ``"byzantine"`` — increments ``neg[reporter][subject]``.
+        * anything else is treated as neutral and ignored (does not bias
+          the local-trust matrix in either direction).
+
+        Example::
+
+            await trust.report(
+                AgentId("a2"),
+                Evidence(reporter=AgentId("a1"), subject=AgentId("a2"), kind="positive"),
+            )
+        """
+        reporter = evidence.reporter
+        subject = evidence.subject
+        # Defensive: if the caller passed a stale ``agent`` distinct from
+        # ``evidence.subject``, trust the explicit argument so this
+        # matches the protocol's signature.
+        if subject != agent:
+            subject = agent
+        self._agents.add(reporter)
+        self._agents.add(subject)
+        kind = evidence.kind
+        if kind == "positive":
+            self._pos[reporter][subject] += _POS_WEIGHT
+        elif kind in ("negative", "byzantine"):
+            self._neg[reporter][subject] += _NEG_WEIGHT
+        # Other kinds: deliberately no-op.
+
+    async def stake(self, agent: AgentId, amount: int) -> None:
+        """Record a stake on ``agent`` (informational only).
+
+        Example::
+
+            await trust.stake(AgentId("a1"), 100)
+        """
+        self._agents.add(agent)
+        self._stakes[agent] = self._stakes.get(agent, 0) + amount
+
+    # ------------------------------------------------------------ Internals
+
+    def _pretrusted_distribution(self, agents: list[AgentId]) -> dict[AgentId, float]:
+        """Return the seed distribution ``p`` over ``agents``.
+
+        Invariant: ``sum_i p_i == 1`` and ``p_i >= 0``.
+        """
+        n = len(agents)
+        if n == 0:
+            return {}
+        pretrusted_in_known = [a for a in self._pretrusted if a in set(agents)]
+        if pretrusted_in_known:
+            mass = 1.0 / len(pretrusted_in_known)
+            return {a: (mass if a in pretrusted_in_known else 0.0) for a in agents}
+        # No pretrusted set declared — fall back to uniform.  This makes
+        # the plugin usable in the existing ``reputation`` scenario
+        # without YAML changes, at the cost of weaker Sybil resistance.
+        mass = 1.0 / n
+        return {a: mass for a in agents}
+
+    def _local_trust_raw(
+        self, agents: list[AgentId],
+    ) -> dict[AgentId, dict[AgentId, float]]:
+        """Build ``s_ij = max(0, pos_ij - neg_ij)`` over the known agents."""
+        raw: dict[AgentId, dict[AgentId, float]] = {}
+        for i in agents:
+            row: dict[AgentId, float] = {}
+            pos_row = self._pos.get(i, {})
+            neg_row = self._neg.get(i, {})
+            subjects = set(pos_row.keys()) | set(neg_row.keys())
+            for j in subjects:
+                if j == i:
+                    # No self-trust.  An agent rating itself would let it
+                    # short-circuit the random walk.
+                    continue
+                val = float(pos_row.get(j, 0) * _POS_WEIGHT - neg_row.get(j, 0) * _NEG_WEIGHT)
+                if val > 0.0:
+                    row[j] = val
+            raw[i] = row
+        return raw
+
+    def _compute_trust_vector(self) -> dict[AgentId, float]:
+        """Run power iteration and cache convergence diagnostics."""
+        agents = sorted(self._agents)
+        if not agents:
+            self.last_iters = 0
+            self.last_residual = 0.0
+            return {}
+        p = self._pretrusted_distribution(agents)
+        raw = self._local_trust_raw(agents)
+        c = _normalize_local_trust(raw, agents, p)
+        t, iters, residual = _power_iterate(
+            c, p, self._alpha, agents, self._max_iter, self._tol,
+        )
+        self.last_iters = iters
+        self.last_residual = residual
+        return t
+
+    # ----------------------------------------------------------- Introspection
+
+    def trust_vector(self) -> dict[AgentId, float]:
+        """Return the current converged trust vector ``t`` as a dict.
+
+        Useful for validators / tests that want to inspect the whole
+        simplex rather than a single agent's mass.
+
+        Example::
+
+            t = trust.trust_vector()
+            assert abs(sum(t.values()) - 1.0) < 1e-9
+        """
+        return self._compute_trust_vector()
+
+    def local_trust_matrix(self) -> dict[AgentId, dict[AgentId, float]]:
+        """Return the row-normalized local trust matrix ``C``.
+
+        Every row sums to 1, by construction.  Exposed so tests can
+        assert the row-stochasticity invariant directly.
+        """
+        agents = sorted(self._agents)
+        p = self._pretrusted_distribution(agents)
+        raw = self._local_trust_raw(agents)
+        return _normalize_local_trust(raw, agents, p)

--- a/packages/nest-plugins-reference/tests/test_eigentrust.py
+++ b/packages/nest-plugins-reference/tests/test_eigentrust.py
@@ -1,0 +1,434 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the EigenTrust plugin.
+
+We check three layers of correctness:
+
+1.  **Plugin conformance**: ``EigenTrust`` implements the ``Trust``
+    protocol the same way ``ScoreAverageTrust`` does (drop-in).
+2.  **Algorithmic invariants** (hand-rolled unit tests on small graphs):
+    row-stochasticity, simplex, fixed point, Sybil lower bound,
+    weak monotonicity.
+3.  **Property-based** (hypothesis): the above invariants survive on
+    randomly generated trust graphs.
+
+These properties are *checkable*, not commented.  That is the whole
+point of the plugin: where ``score_average`` says "trust is the mean of
+feedback" and leaves Sybils silently winning, EigenTrust gives you a
+fixed point you can assert against.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Claim, Evidence
+from nest_plugins_reference.trust.eigentrust import (
+    DEFAULT_ALPHA,
+    DEFAULT_TOL,
+    EigenTrust,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+#: Numerical slack for floating-point comparisons.  We compute in pure
+#: Python doubles, so 1e-9 is comfortable.
+_EPS = 1e-9
+
+
+def _agents(n: int) -> list[AgentId]:
+    return [AgentId(f"a{i}") for i in range(n)]
+
+
+async def _feed(
+    trust: EigenTrust,
+    reports: list[tuple[str, str, str]],
+) -> None:
+    """Feed a list of ``(reporter, subject, kind)`` tuples into the plugin."""
+    for reporter, subject, kind in reports:
+        await trust.report(
+            AgentId(subject),
+            Evidence(
+                reporter=AgentId(reporter),
+                subject=AgentId(subject),
+                kind=kind,
+            ),
+        )
+
+
+def _assert_on_simplex(t: dict[AgentId, float]) -> None:
+    """t is a probability distribution: non-negative, sums to 1."""
+    for a, v in t.items():
+        assert v >= -_EPS, f"{a} has negative mass {v}"
+    total = sum(t.values())
+    assert math.isclose(total, 1.0, abs_tol=1e-6), (
+        f"trust vector does not sum to 1: {total}"
+    )
+
+
+def _assert_row_stochastic(c: dict[AgentId, dict[AgentId, float]]) -> None:
+    for i, row in c.items():
+        total = sum(row.values())
+        # Empty rows are not valid; we always fall back to ``p``.
+        assert math.isclose(total, 1.0, abs_tol=1e-6), (
+            f"row for {i} does not sum to 1: {total} (row={row})"
+        )
+        for j, v in row.items():
+            assert v >= -_EPS, f"c[{i}][{j}] is negative: {v}"
+
+
+def _assert_fixed_point(trust: EigenTrust, tol_factor: float = 10.0) -> None:
+    """||(1-a) C^T t + a p - t||_inf < tol_factor * configured tol."""
+    agents = sorted(trust.trust_vector().keys())
+    if not agents:
+        return
+    t = trust.trust_vector()
+    c = trust.local_trust_matrix()
+    p = trust._pretrusted_distribution(agents)  # noqa: SLF001 — test wants internals
+    alpha = trust._alpha  # noqa: SLF001
+    next_t: dict[AgentId, float] = dict.fromkeys(agents, 0.0)
+    for i in agents:
+        for j, c_ij in c[i].items():
+            next_t[j] += c_ij * t[i]
+    for j in agents:
+        next_t[j] = (1.0 - alpha) * next_t[j] + alpha * p[j]
+    worst = max(abs(next_t[j] - t[j]) for j in agents)
+    assert worst < tol_factor * DEFAULT_TOL, (
+        f"fixed-point residual {worst} exceeds tolerance"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Plugin conformance — same shape as ``ScoreAverageTrust``
+# ---------------------------------------------------------------------------
+
+
+class TestEigenTrustConformance:
+    @pytest.mark.asyncio
+    async def test_default_score_is_uniform(self) -> None:
+        """With no evidence and no pre-trusted set, score should be uniform.
+
+        Because the seed distribution falls back to uniform when no
+        pretrusted set is declared, an unknown agent gets ``1 / n`` mass
+        after we register it via the ``score`` call.
+        """
+        trust = EigenTrust()
+        score = await trust.score(AgentId("a1"))
+        assert math.isclose(score.score, 1.0, abs_tol=1e-9)
+        # One agent in the world -> all mass on it.
+        assert score.sample_count == 0
+
+    @pytest.mark.asyncio
+    async def test_positive_reports_raise_score(self) -> None:
+        trust = EigenTrust(pretrusted=[AgentId("a0")])
+        # a0 is pretrusted; it endorses a1 ten times; a2 gets nothing.
+        for _ in range(10):
+            await trust.report(
+                AgentId("a1"),
+                Evidence(reporter=AgentId("a0"), subject=AgentId("a1"), kind="positive"),
+            )
+        s1 = await trust.score(AgentId("a1"))
+        s2 = await trust.score(AgentId("a2"))
+        assert s1.score > s2.score
+
+    @pytest.mark.asyncio
+    async def test_negative_reports_lower_score(self) -> None:
+        trust = EigenTrust(pretrusted=[AgentId("a0")])
+        await trust.report(
+            AgentId("a1"),
+            Evidence(reporter=AgentId("a0"), subject=AgentId("a1"), kind="positive"),
+        )
+        before = (await trust.score(AgentId("a1"))).score
+        await trust.report(
+            AgentId("a1"),
+            Evidence(reporter=AgentId("a0"), subject=AgentId("a1"), kind="negative"),
+        )
+        after = (await trust.score(AgentId("a1"))).score
+        assert after <= before + _EPS
+
+    @pytest.mark.asyncio
+    async def test_attest_returns_attestation(self) -> None:
+        trust = EigenTrust()
+        claim = Claim(subject=AgentId("a1"), predicate="completed_task", value="t1")
+        att = await trust.attest(AgentId("a1"), claim)
+        assert att.claim.subject == AgentId("a1")
+        assert att.signature is not None
+
+    @pytest.mark.asyncio
+    async def test_stake_does_not_change_trust(self) -> None:
+        trust = EigenTrust()
+        before = (await trust.score(AgentId("a1"))).score
+        await trust.stake(AgentId("a1"), 1_000)
+        after = (await trust.score(AgentId("a1"))).score
+        assert math.isclose(before, after, abs_tol=_EPS)
+
+    def test_rejects_bad_alpha(self) -> None:
+        with pytest.raises(ValueError, match="alpha"):
+            EigenTrust(alpha=0.0)
+        with pytest.raises(ValueError, match="alpha"):
+            EigenTrust(alpha=1.1)
+
+    def test_rejects_bad_iter_tol(self) -> None:
+        with pytest.raises(ValueError, match="max_iter"):
+            EigenTrust(max_iter=0)
+        with pytest.raises(ValueError, match="tol"):
+            EigenTrust(tol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# 2. Algorithmic invariants on hand-crafted graphs
+# ---------------------------------------------------------------------------
+
+
+class TestEigenTrustInvariants:
+    @pytest.mark.asyncio
+    async def test_simplex_invariant_after_arbitrary_reports(self) -> None:
+        trust = EigenTrust(pretrusted=[AgentId("a0")])
+        await _feed(
+            trust,
+            [
+                ("a0", "a1", "positive"),
+                ("a0", "a1", "positive"),
+                ("a1", "a2", "positive"),
+                ("a2", "a3", "positive"),
+                ("a3", "a4", "negative"),
+                ("a1", "a4", "negative"),
+            ],
+        )
+        # Touch a few agents so they're known.
+        for i in range(5):
+            await trust.score(AgentId(f"a{i}"))
+        t = trust.trust_vector()
+        _assert_on_simplex(t)
+
+    @pytest.mark.asyncio
+    async def test_row_stochastic_after_arbitrary_reports(self) -> None:
+        trust = EigenTrust(pretrusted=[AgentId("a0")])
+        await _feed(
+            trust,
+            [
+                ("a0", "a1", "positive"),
+                ("a1", "a2", "positive"),
+                ("a1", "a3", "positive"),
+                ("a2", "a0", "negative"),
+            ],
+        )
+        for i in range(4):
+            await trust.score(AgentId(f"a{i}"))
+        c = trust.local_trust_matrix()
+        _assert_row_stochastic(c)
+
+    @pytest.mark.asyncio
+    async def test_fixed_point_residual_within_tolerance(self) -> None:
+        trust = EigenTrust(pretrusted=[AgentId("a0")])
+        await _feed(
+            trust,
+            [
+                ("a0", "a1", "positive"),
+                ("a1", "a2", "positive"),
+                ("a2", "a3", "positive"),
+                ("a3", "a1", "positive"),
+            ],
+        )
+        for i in range(4):
+            await trust.score(AgentId(f"a{i}"))
+        _assert_fixed_point(trust)
+        assert trust.last_iters >= 1
+
+    @pytest.mark.asyncio
+    async def test_sybil_lower_bound(self) -> None:
+        """A Sybil with no incoming honest trust gets at most ``alpha * p_i`` mass.
+
+        Concretely: a0 is the only pretrusted agent; honest agents a1..a3
+        endorse each other but never the Sybil ``s1``.  The Sybil can
+        self-loop and shill its friends, but no honest mass flows toward
+        it, so its score must be bounded above by ``alpha * p[s1]``.
+        Since ``s1`` is not pretrusted, ``p[s1] == 0`` and the bound is
+        ``alpha * 0 == 0``.
+        """
+        trust = EigenTrust(pretrusted=[AgentId("a0")], alpha=0.1)
+        honest_reports = [
+            ("a0", "a1", "positive"),
+            ("a1", "a2", "positive"),
+            ("a2", "a3", "positive"),
+            ("a3", "a1", "positive"),
+        ]
+        sybil_reports = [
+            # Sybils shilling each other.
+            ("s1", "s2", "positive"),
+            ("s2", "s1", "positive"),
+            # Sybil claiming honest agents endorsed it -- *but* the
+            # plugin only records reports made by the actual reporter,
+            # which here is ``s1``, not ``a1``.  This is the threat
+            # model: a Sybil cannot forge an honest agent's report.
+            ("s1", "s1", "positive"),
+        ]
+        await _feed(trust, honest_reports + sybil_reports)
+        for a in ["a0", "a1", "a2", "a3", "s1", "s2"]:
+            await trust.score(AgentId(a))
+
+        t = trust.trust_vector()
+        p = trust._pretrusted_distribution(sorted(trust._agents))  # noqa: SLF001
+        # Sybils only get the teleport mass alpha * p_i, and p_i = 0 for
+        # non-pretrusted agents.  Allow tiny slack for numerical noise.
+        assert t[AgentId("s1")] <= 0.1 * p[AgentId("s1")] + 1e-9
+        assert t[AgentId("s2")] <= 0.1 * p[AgentId("s2")] + 1e-9
+        # And the honest agents collectively dominate the simplex.
+        honest_mass = sum(t[AgentId(a)] for a in ["a0", "a1", "a2", "a3"])
+        assert honest_mass > 0.99
+
+    @pytest.mark.asyncio
+    async def test_weak_monotonicity_of_positive_evidence(self) -> None:
+        """More positive reports from honest agents can only weakly raise score.
+
+        Holding all other evidence fixed, increasing the positive count
+        from a pretrusted reporter to a target ``t`` must not decrease
+        ``t``'s score.
+        """
+        base = EigenTrust(pretrusted=[AgentId("a0")])
+        await _feed(
+            base,
+            [
+                ("a0", "a1", "positive"),
+                ("a1", "a2", "positive"),
+                ("a2", "a3", "negative"),
+            ],
+        )
+        await base.score(AgentId("a2"))
+        s_before = (await base.score(AgentId("a2"))).score
+
+        more = EigenTrust(pretrusted=[AgentId("a0")])
+        await _feed(
+            more,
+            [
+                ("a0", "a1", "positive"),
+                ("a0", "a1", "positive"),  # honest agent gets more endorsement
+                ("a1", "a2", "positive"),
+                ("a2", "a3", "negative"),
+            ],
+        )
+        await more.score(AgentId("a2"))
+        s_after = (await more.score(AgentId("a2"))).score
+        # Bumping a1's incoming honest trust should not reduce a2's
+        # downstream score (a2 receives all its mass through a1).
+        assert s_after + _EPS >= s_before
+
+    @pytest.mark.asyncio
+    async def test_alpha_one_recovers_pretrusted_distribution(self) -> None:
+        """With ``alpha = 1`` the chain *is* the pre-trusted distribution.
+
+        This is a sanity check on the teleport mixture: at ``alpha = 1``
+        the local trust graph is ignored and ``t == p`` exactly.
+        """
+        trust = EigenTrust(
+            pretrusted=[AgentId("a0"), AgentId("a1")],
+            alpha=1.0,
+        )
+        # Throw in some misleading reports — none should matter.
+        await _feed(
+            trust,
+            [
+                ("a2", "a3", "positive"),
+                ("a3", "a4", "positive"),
+            ],
+        )
+        for i in range(5):
+            await trust.score(AgentId(f"a{i}"))
+        t = trust.trust_vector()
+        assert math.isclose(t[AgentId("a0")], 0.5, abs_tol=1e-6)
+        assert math.isclose(t[AgentId("a1")], 0.5, abs_tol=1e-6)
+        for i in [2, 3, 4]:
+            assert math.isclose(t[AgentId(f"a{i}")], 0.0, abs_tol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 3. Property-based tests (hypothesis)
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def _trust_graph(draw: st.DrawFn) -> tuple[list[AgentId], list[tuple[str, str, str]]]:
+    """Generate a small random trust graph for hypothesis."""
+    n = draw(st.integers(min_value=2, max_value=6))
+    agents = _agents(n)
+    edge_count = draw(st.integers(min_value=0, max_value=2 * n))
+    reports: list[tuple[str, str, str]] = []
+    for _ in range(edge_count):
+        i = draw(st.integers(min_value=0, max_value=n - 1))
+        j = draw(st.integers(min_value=0, max_value=n - 1))
+        kind = draw(st.sampled_from(["positive", "negative"]))
+        if i == j:
+            continue
+        reports.append((f"a{i}", f"a{j}", kind))
+    return agents, reports
+
+
+class TestEigenTrustProperties:
+    @settings(
+        max_examples=80,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(_trust_graph())
+    @pytest.mark.asyncio
+    async def test_simplex_and_row_stochastic(
+        self,
+        graph: tuple[list[AgentId], list[tuple[str, str, str]]],
+    ) -> None:
+        agents, reports = graph
+        trust = EigenTrust(pretrusted=[agents[0]])
+        await _feed(trust, reports)
+        for a in agents:
+            await trust.score(a)
+        _assert_on_simplex(trust.trust_vector())
+        _assert_row_stochastic(trust.local_trust_matrix())
+
+    @settings(
+        max_examples=40,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(_trust_graph())
+    @pytest.mark.asyncio
+    async def test_fixed_point(
+        self,
+        graph: tuple[list[AgentId], list[tuple[str, str, str]]],
+    ) -> None:
+        agents, reports = graph
+        trust = EigenTrust(pretrusted=[agents[0]])
+        await _feed(trust, reports)
+        for a in agents:
+            await trust.score(a)
+        _assert_fixed_point(trust, tol_factor=100.0)
+
+    @settings(
+        max_examples=40,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(_trust_graph())
+    @pytest.mark.asyncio
+    async def test_pretrusted_mass_lower_bound(
+        self,
+        graph: tuple[list[AgentId], list[tuple[str, str, str]]],
+    ) -> None:
+        """Pre-trusted agents receive at least ``alpha * p_i`` mass.
+
+        This is the obvious lower bound coming straight off the fixed-
+        point equation: ``t = (1-a) C^T t + a p`` implies
+        ``t_i >= a * p_i`` because the first term is non-negative.
+        """
+        agents, reports = graph
+        pretrusted = [agents[0]]
+        trust = EigenTrust(pretrusted=pretrusted, alpha=DEFAULT_ALPHA)
+        await _feed(trust, reports)
+        for a in agents:
+            await trust.score(a)
+        t = trust.trust_vector()
+        p = trust._pretrusted_distribution(sorted(trust._agents))  # noqa: SLF001
+        for a in pretrusted:
+            assert t[a] + 1e-9 >= DEFAULT_ALPHA * p[a]

--- a/packages/nest-plugins-reference/tests/test_eigentrust.py
+++ b/packages/nest-plugins-reference/tests/test_eigentrust.py
@@ -65,9 +65,7 @@ def _assert_on_simplex(t: dict[AgentId, float]) -> None:
     for a, v in t.items():
         assert v >= -_EPS, f"{a} has negative mass {v}"
     total = sum(t.values())
-    assert math.isclose(total, 1.0, abs_tol=1e-6), (
-        f"trust vector does not sum to 1: {total}"
-    )
+    assert math.isclose(total, 1.0, abs_tol=1e-6), f"trust vector does not sum to 1: {total}"
 
 
 def _assert_row_stochastic(c: dict[AgentId, dict[AgentId, float]]) -> None:
@@ -88,8 +86,8 @@ def _assert_fixed_point(trust: EigenTrust, tol_factor: float = 10.0) -> None:
         return
     t = trust.trust_vector()
     c = trust.local_trust_matrix()
-    p = trust._pretrusted_distribution(agents)  # noqa: SLF001 — test wants internals
-    alpha = trust._alpha  # noqa: SLF001
+    p = trust._pretrusted_distribution(agents)  # noqa: SLF001 — test wants internals  # pyright: ignore[reportPrivateUsage]
+    alpha = trust._alpha  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     next_t: dict[AgentId, float] = dict.fromkeys(agents, 0.0)
     for i in agents:
         for j, c_ij in c[i].items():
@@ -97,9 +95,7 @@ def _assert_fixed_point(trust: EigenTrust, tol_factor: float = 10.0) -> None:
     for j in agents:
         next_t[j] = (1.0 - alpha) * next_t[j] + alpha * p[j]
     worst = max(abs(next_t[j] - t[j]) for j in agents)
-    assert worst < tol_factor * DEFAULT_TOL, (
-        f"fixed-point residual {worst} exceeds tolerance"
-    )
+    assert worst < tol_factor * DEFAULT_TOL, f"fixed-point residual {worst} exceeds tolerance"
 
 
 # ---------------------------------------------------------------------------
@@ -272,7 +268,7 @@ class TestEigenTrustInvariants:
             await trust.score(AgentId(a))
 
         t = trust.trust_vector()
-        p = trust._pretrusted_distribution(sorted(trust._agents))  # noqa: SLF001
+        p = trust._pretrusted_distribution(sorted(trust._agents))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         # Sybils only get the teleport mass alpha * p_i, and p_i = 0 for
         # non-pretrusted agents.  Allow tiny slack for numerical noise.
         assert t[AgentId("s1")] <= 0.1 * p[AgentId("s1")] + 1e-9
@@ -429,6 +425,6 @@ class TestEigenTrustProperties:
         for a in agents:
             await trust.score(a)
         t = trust.trust_vector()
-        p = trust._pretrusted_distribution(sorted(trust._agents))  # noqa: SLF001
+        p = trust._pretrusted_distribution(sorted(trust._agents))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         for a in pretrusted:
             assert t[a] + 1e-9 >= DEFAULT_ALPHA * p[a]


### PR DESCRIPTION
## Which piece

**Trust layer.** Adds `eigentrust` as a bundled alternative to the
default `score_average` plugin, registered under
`(trust, eigentrust)` in `nest_core.plugins`.

## Why

The trust layer is the most interesting "what could go wrong"
surface in NEST: the bundled `score_average` is a running mean with
no Sybil resistance, no transitivity, no decay. The docs even point
to EigenTrust as "a good fit to test here". This PR delivers it —
not as an academic curiosity, but as a plugin whose correctness
properties are *asserted in tests*, not promised in comments.

## Core idea

EigenTrust (Kamvar, Schlosser, Garcia-Molina, WWW 2003) computes the
global trust vector as the stationary distribution of a teleporting
random walk over the local-trust graph:

```
t = (1 - alpha) * C^T * t + alpha * p
```

where

* `C` is the row-normalized local-trust matrix
  (`c_ij = max(0, pos_ij - neg_ij) / row_sum`, fallback to `p` when
  a row sums to zero — the "naive walker"), and
* `p` is the seed distribution over pre-trusted peers (uniform
  fallback when no pre-trusted set is declared).

Solved by power iteration; pure Python, no numpy dependency, in
line with the rest of the reference plugin pack.

## What's checkable, not just commented

The whole point of doing this in a verification-flavored way: every
property the algorithm claims is asserted in `test_eigentrust.py`.

| Property | Where it's enforced |
|---|---|
| Simplex (`sum_i t_i == 1`, `t_i >= 0`) | `_assert_on_simplex`, hand-rolled + hypothesis |
| Row-stochasticity of `C` | `_assert_row_stochastic`, hand-rolled + hypothesis |
| Fixed-point residual `< tol` | `_assert_fixed_point`, hand-rolled + hypothesis |
| Sybil upper bound `t_sybil <= alpha * p_sybil` | `test_sybil_lower_bound` |
| Weak monotonicity in honest positive evidence | `test_weak_monotonicity_of_positive_evidence` |
| `alpha = 1` recovers `p` exactly | `test_alpha_one_recovers_pretrusted_distribution` |
| Pre-trusted mass lower bound `t_i >= alpha * p_i` | property-based |

Hypothesis is already a dev dependency, so the property tests cost
nothing to add.

## How to test

```bash
# from the repo root, with the dev venv active
pip install -e packages/nest-core -e packages/nest-sdk -e packages/nest-plugins-reference
pip install pytest pytest-asyncio hypothesis

pytest packages/nest-plugins-reference/tests/test_eigentrust.py -v
# 16 tests, ~0.6s
```

Or wire it into a scenario:

```yaml
# scenarios/reputation.yaml
layers:
  trust: eigentrust
```

The plugin is drop-in compatible with the existing `Trust` protocol,
so no scenario YAML changes are required to test it under the
`reputation` scenario or anywhere else.

## Key assumptions

* **Threat model.** The plugin records reports under the reporter's
  identity (the `Evidence.reporter` field). A Sybil cannot forge an
  honest agent's report; if NEST's auth/identity layers fail upstream,
  no trust layer can save you.
* **Pre-trusted set is optional.** If you don't pass one, `p` is
  uniform and the Sybil-resistance bound degrades to the uniform
  case. The test for the Sybil upper bound makes this explicit by
  passing `pretrusted=[a0]`.
* **No self-trust.** Diagonal entries `c_ii` are forced to zero so
  agents can't short-circuit the random walk by endorsing
  themselves.
* **Pure Python.** Deliberately no numpy: keeps the reference pack
  free of heavy deps. Power iteration runs in `O(iters * |E|)` over
  the local-trust graph; with `DEFAULT_MAX_ITER=300` (sized for
  `(1 - alpha)^k < tol`) and the agent counts NEST actually
  simulates, this is sub-millisecond.

## Persona

Harvard CS PhD candidate in formal methods — invariants beat
comments; a property you can check beats a promise that one holds.

## Future work

* A `validate_reputation_sybil_bound` validator that reads a trace
  and asserts the Sybil upper bound directly, on top of the existing
  `reputation_scoring` / `reputation_warnings` checks.
* Time-decayed local trust (sliding window over evidence) — easy
  extension of the same fixed-point formulation.
* TLA+ spec of the teleport mixture and refinement mapping to this
  Python implementation; left for a follow-up because a 1-PR
  hackathon is the wrong place for it.

https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW


---
_Generated by [Claude Code](https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW)_

## Summary by Sourcery

Add an EigenTrust-based trust plugin as a bundled alternative to score_average, document it, and verify its core invariants with targeted and property-based tests.

New Features:
- Introduce an EigenTrust trust plugin implementing transitive, Sybil-resistant reputation compatible with the existing Trust protocol.
- Register the eigentrust plugin in the core plugin registry for use in scenarios via the trust layer configuration key.

Enhancements:
- Expose introspection helpers on the EigenTrust plugin to inspect the global trust vector and row-normalized local trust matrix for validation and analysis.

Documentation:
- Document the eigentrust trust layer, its probabilistic model, configuration, and how to enable it in scenarios.

Tests:
- Add a comprehensive EigenTrust test suite covering protocol conformance, algorithmic invariants such as simplex, row-stochasticity, fixed-point convergence, and Sybil/monotonicity properties, plus property-based tests over random trust graphs.