### PR TITLE
[Hackathon] mit-undergrad: EigenTrust plugin for the trust layer

### DIFF
--- a/docs/layers/trust.md
+++ b/docs/layers/trust.md
@@ -25,6 +25,20 @@ Source: [`nest_plugins_reference/trust/score_average.py`](../../packages/nest-pl
 The `reputation` scenario exercises this layer — 16 honest + 4
 malicious + 1 observer that samples cheat reports probabilistically.
 
+## Bundled alternative: `eigentrust`
+
+`eigentrust` — EigenTrust-style transitive reputation (Kamvar et al.,
+WWW 2003) with exponential time decay and pre-trusted seeds. Each
+report is weighted by the reporter's own global trust, so a Sybil
+swarm endorsing one of their own cannot overpower an endorsement from
+a pre-trusted seed. Configurable via constructor parameters
+(`alpha`, `decay_lambda`, `pre_trusted`); same `Trust` interface, so
+it is a drop-in replacement.
+
+Source: [`nest_plugins_reference/trust/eigentrust.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/eigentrust.py).
+
+Use it in a scenario YAML with `trust: eigentrust`.
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -23,6 +23,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
+    ("trust", "eigentrust"): f"{_REF}.trust.eigentrust:EigenTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("coordination", "contract_net"): f"{_REF}.coordination.contract_net:ContractNet",
     ("negotiation", "alternating_offers"): (

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/eigentrust.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/eigentrust.py
@@ -1,0 +1,374 @@
+# SPDX-License-Identifier: Apache-2.0
+"""EigenTrust-style reputation plugin with exponential time decay.
+
+A reference implementation of the EigenTrust algorithm
+(Kamvar, Schlosser, Garcia-Molina, *EigenTrust: Reputation Management
+in P2P Networks*, WWW 2003), adapted for NEST's single-process discrete
+event simulator and extended with:
+
+* **Exponential time decay** of evidence — recent reports outweigh stale
+  ones, so the system reacts to defectors faster than a naive running
+  mean ever can.
+* **Pre-trusted seed peers** — an optional set ``P`` of bootstrap agents
+  whose mass is mixed in via a damping coefficient ``alpha`` (PageRank-
+  style "random jump"). Prevents collusive cliques from running away
+  with the score in the absence of any seed.
+* **Stake as a confidence floor** — calls to :py:meth:`stake` raise the
+  reported ``confidence`` of an agent (skin-in-the-game is information,
+  even if NEST cannot slash it).
+* **Lazy power iteration** with epoch invalidation — :py:meth:`score`
+  recomputes the global trust vector only when new evidence has been
+  reported since the last call. Constant amortised work in steady state.
+
+The local trust matrix ``C`` is built from reported evidence:
+``c_ij`` = max(0, positives - negatives) from i to j, with each report
+exponentially decayed by ``exp(-lambda * (now - t))``. Rows are
+L1-normalised; an all-zero row falls back to ``p``. The global trust
+vector is the fixed point of ``t = (1-alpha) * C^T t + alpha * p``,
+clamped to ``[0, 1]``.
+
+Example::
+
+    from nest_plugins_reference.trust.eigentrust import EigenTrust
+    trust = EigenTrust(
+        pre_trusted=[AgentId("seed-0")],
+        decay_lambda=0.01,
+        alpha=0.15,
+    )
+    await trust.report(AgentId("a1"), evidence)
+    score = await trust.score(AgentId("a1"))
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from nest_core.types import (
+    AgentId,
+    Attestation,
+    Claim,
+    Evidence,
+    ReputationScore,
+    Signature,
+)
+
+# Public defaults. Exposed so callers can sweep them in scenarios.
+DEFAULT_ALPHA: float = 0.15  # PageRank-style damping / pre-trust weight.
+DEFAULT_DECAY_LAMBDA: float = 0.0  # No decay by default — opt-in via ctor.
+DEFAULT_MAX_ITERS: int = 100
+DEFAULT_TOLERANCE: float = 1e-6
+DEFAULT_SCORE: float = 0.5
+
+
+@dataclass(slots=True)
+class _Report:
+    """A single decayable report. Internal; not part of the public API."""
+
+    reporter: AgentId
+    subject: AgentId
+    weight: float  # +1.0 for positive, -1.0 for negative/byzantine.
+    tick: int  # Monotonic event counter — deterministic across runs.
+
+
+def _evidence_weight(kind: str) -> float:
+    """Map an Evidence kind string to a signed weight.
+
+    Positive evidence pulls trust up; negative / byzantine evidence pulls
+    it down. Unknown kinds count as a neutral observation (weight 0) so
+    that future kind extensions degrade gracefully.
+    """
+    if kind == "positive":
+        return 1.0
+    if kind in ("negative", "byzantine"):
+        return -1.0
+    return 0.0
+
+
+class EigenTrust:
+    """EigenTrust-style global reputation with time decay.
+
+    Thread-unsafe by design — NEST is single-process and the simulator
+    serialises plugin calls through an async event loop. Doing locking
+    here would only hide bugs.
+
+    Parameters
+    ----------
+    identity:
+        Optional identity plugin used to sign attestations. Mirrors the
+        ``score_average`` reference plugin so the two are drop-in
+        compatible.
+    pre_trusted:
+        Iterable of pre-trusted seed agent ids ``P``. If empty, ``p`` is
+        the uniform distribution over agents that have been observed.
+        Cold-start agents inherit ``DEFAULT_SCORE`` until they have been
+        reported on at least once.
+    alpha:
+        Damping coefficient. ``alpha`` of the mass is mixed in from
+        ``p`` each iteration; the rest follows the trust matrix. The
+        WWW 2003 paper uses ``a = 0.15`` (same as PageRank).
+    decay_lambda:
+        Exponential time-decay rate per tick. A report ``k`` ticks old
+        contributes ``exp(-decay_lambda * k)`` of its original weight.
+        ``0.0`` disables decay; ``0.01`` is a sensible "recent half-life
+        of ~70 ticks" default. The tick is a monotonic event counter so
+        the decay is deterministic across runs with the same seed.
+    max_iters / tolerance:
+        Power-iteration stopping conditions. Power iteration on a
+        stochastic matrix with damping is geometric in ``1 - alpha``, so
+        100 iterations at ``alpha = 0.15`` is wildly more than enough.
+    """
+
+    def __init__(
+        self,
+        identity: Any = None,
+        *,
+        pre_trusted: list[AgentId] | tuple[AgentId, ...] | None = None,
+        alpha: float = DEFAULT_ALPHA,
+        decay_lambda: float = DEFAULT_DECAY_LAMBDA,
+        max_iters: int = DEFAULT_MAX_ITERS,
+        tolerance: float = DEFAULT_TOLERANCE,
+    ) -> None:
+        if not 0.0 < alpha <= 1.0:
+            msg = f"alpha must be in (0, 1], got {alpha}"
+            raise ValueError(msg)
+        if decay_lambda < 0.0:
+            msg = f"decay_lambda must be >= 0, got {decay_lambda}"
+            raise ValueError(msg)
+        if max_iters < 1:
+            msg = f"max_iters must be >= 1, got {max_iters}"
+            raise ValueError(msg)
+
+        self._identity = identity
+        self._pre_trusted: set[AgentId] = set(pre_trusted or ())
+        self._alpha = alpha
+        self._decay_lambda = decay_lambda
+        self._max_iters = max_iters
+        self._tolerance = tolerance
+
+        # Event log of reports. Append-only, decayed at score() time.
+        self._reports: list[_Report] = []
+        self._stakes: dict[AgentId, int] = {}
+
+        # Every agent we've ever seen as reporter or subject, in
+        # insertion order. Using a dict for ordered-set semantics.
+        self._agents: dict[AgentId, None] = {}
+
+        # Per-agent sample count — number of reports about this agent,
+        # used as the ``sample_count`` field on ReputationScore.
+        self._sample_count: dict[AgentId, int] = {}
+
+        # Caches invalidated on every report().
+        self._tick: int = 0
+        self._dirty_epoch: int = 0
+        self._cache_epoch: int = -1
+        self._cached_trust: dict[AgentId, float] = {}
+
+    # ------------------------------------------------------------------
+    # Trust protocol
+    # ------------------------------------------------------------------
+
+    async def score(self, agent: AgentId) -> ReputationScore:
+        """Return the current global trust score for ``agent``.
+
+        The score is in ``[0, 1]``. ``confidence`` rises with both the
+        number of samples (capped at 100 like ``score_average``) and any
+        stake placed via :py:meth:`stake`. ``sample_count`` is the number
+        of reports about ``agent``.
+        """
+        self._recompute_if_dirty()
+
+        n_samples = self._sample_count.get(agent, 0)
+        if n_samples == 0 and agent not in self._pre_trusted:
+            # Cold start — give a neutral prior. Matches score_average.
+            return ReputationScore(
+                agent_id=agent,
+                score=DEFAULT_SCORE,
+                confidence=0.0,
+                sample_count=0,
+            )
+
+        raw = self._cached_trust.get(agent, DEFAULT_SCORE)
+        # Sample-based confidence (matches score_average's curve) plus a
+        # small additive boost from staked credits.
+        sample_conf = min(1.0, n_samples / 100.0)
+        stake_conf = min(1.0, self._stakes.get(agent, 0) / 1000.0)
+        confidence = min(1.0, sample_conf + 0.25 * stake_conf)
+        return ReputationScore(
+            agent_id=agent,
+            score=raw,
+            confidence=confidence,
+            sample_count=n_samples,
+        )
+
+    async def attest(self, agent: AgentId, claim: Claim) -> Attestation:
+        """Create an attestation about ``agent``. Mirrors score_average."""
+        sig = Signature(signer=AgentId("system"), value=b"attestation", algorithm="none")
+        if self._identity is not None:
+            sig = self._identity.sign(claim.model_dump_json().encode())
+        return Attestation(issuer=AgentId("system"), claim=claim, signature=sig)
+
+    async def report(self, agent: AgentId, evidence: Evidence) -> None:
+        """Record an evidence report and invalidate the trust cache.
+
+        The ``evidence.reporter`` field is required and load-bearing —
+        EigenTrust weights each report by the reporter's own current
+        global trust. A report from a previously-reported-on-as-bad
+        peer effectively counts for nothing, which is the whole point.
+        """
+        weight = _evidence_weight(evidence.kind)
+        if weight == 0.0:
+            return  # Unknown / neutral kind — silently ignore.
+
+        self._tick += 1
+        self._reports.append(
+            _Report(
+                reporter=evidence.reporter,
+                subject=agent,
+                weight=weight,
+                tick=self._tick,
+            )
+        )
+        self._sample_count[agent] = self._sample_count.get(agent, 0) + 1
+        self._agents.setdefault(agent, None)
+        self._agents.setdefault(evidence.reporter, None)
+        self._dirty_epoch += 1
+
+    async def stake(self, agent: AgentId, amount: int) -> None:
+        """Stake credits on ``agent``'s good behaviour.
+
+        Stake raises ``confidence`` but does not directly raise ``score``
+        — the literature is unanimous that stake without slashing is a
+        confidence signal, not a trust signal. Slashing is out of scope
+        for this plugin; a payments-coupled variant could wire it up.
+        """
+        if amount == 0:
+            return
+        self._stakes[agent] = self._stakes.get(agent, 0) + amount
+        self._agents.setdefault(agent, None)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _recompute_if_dirty(self) -> None:
+        """Recompute the global trust vector if any report changed it."""
+        if self._cache_epoch == self._dirty_epoch:
+            return
+        self._cached_trust = self._compute_trust()
+        self._cache_epoch = self._dirty_epoch
+
+    def _compute_trust(self) -> dict[AgentId, float]:
+        """Run power iteration on the decayed local-trust matrix.
+
+        Returns the global trust vector as a dict ``{agent: score}`` with
+        values in ``[0, 1]``. The math:
+
+            t_{k+1} = (1 - alpha) * C^T t_k + alpha * p
+
+        ``C`` is built fresh from the decayed report log; ``p`` is the
+        seed distribution; ``alpha`` is the damping coefficient. We
+        L1-normalise rows of ``C`` and the input vectors, then rescale
+        the final vector to ``[0, 1]`` by dividing by its max so the
+        score returned to callers is comparable to ``score_average``.
+        """
+        agents = list(self._agents.keys())
+        if not agents:
+            return {}
+
+        n = len(agents)
+        index = {a: i for i, a in enumerate(agents)}
+
+        # Build the decayed local trust matrix as a dense 2D list. n is
+        # bounded by simulator size (10k in the README); for the trust
+        # layer in practice ``n`` is small enough that O(n^2) is fine.
+        # If someone needs sparse for 10k+ agents, swap the storage —
+        # the algorithm is unchanged.
+        c: list[list[float]] = [[0.0] * n for _ in range(n)]
+        now = self._tick
+        decay = self._decay_lambda
+        for r in self._reports:
+            i = index.get(r.reporter)
+            j = index.get(r.subject)
+            if i is None or j is None or i == j:
+                # Drop self-reports — EigenTrust forbids them; otherwise
+                # an agent can endorse itself into the trusted set.
+                continue
+            age = now - r.tick
+            factor = math.exp(-decay * age) if decay > 0.0 else 1.0
+            c[i][j] += r.weight * factor
+
+        # Clip to non-negative (negatives become zero local trust, not
+        # "negative endorsement" — the math requires a stochastic matrix)
+        # and L1-normalise each row.
+        for i in range(n):
+            row = c[i]
+            for j in range(n):
+                if row[j] < 0.0:
+                    row[j] = 0.0
+            s = sum(row)
+            if s > 0.0:
+                inv = 1.0 / s
+                for j in range(n):
+                    row[j] *= inv
+
+        # Seed distribution p. Default: uniform over pre-trusted set;
+        # if no pre-trusted set is given, uniform over all observed
+        # agents (matches the WWW 2003 fallback).
+        p = [0.0] * n
+        seed_agents = [a for a in self._pre_trusted if a in index]
+        if seed_agents:
+            w = 1.0 / len(seed_agents)
+            for a in seed_agents:
+                p[index[a]] = w
+        else:
+            w = 1.0 / n
+            for i in range(n):
+                p[i] = w
+
+        # Rows that are all zero (no outgoing trust) fall back to p so
+        # the matrix is stochastic. Standard PageRank trick.
+        for i in range(n):
+            if sum(c[i]) == 0.0:
+                c[i] = list(p)
+
+        # Power iteration: t_{k+1} = (1 - alpha) * C^T t_k + alpha * p.
+        t = list(p)
+        alpha = self._alpha
+        one_minus_alpha = 1.0 - alpha
+        for _ in range(self._max_iters):
+            new_t = [alpha * p[j] for j in range(n)]
+            for i in range(n):
+                ti = t[i]
+                if ti == 0.0:
+                    continue
+                row = c[i]
+                contribution_factor = one_minus_alpha * ti
+                for j in range(n):
+                    new_t[j] += contribution_factor * row[j]
+            # Numerical L1-renormalise — shouldn't drift much, but a
+            # stochastic matrix can lose a bit of mass to floating point.
+            s = sum(new_t)
+            if s > 0.0:
+                inv = 1.0 / s
+                for j in range(n):
+                    new_t[j] *= inv
+            # L1 convergence check.
+            delta = sum(abs(new_t[j] - t[j]) for j in range(n))
+            t = new_t
+            if delta < self._tolerance:
+                break
+
+        # Rescale to [0, 1] by dividing by the max so a single dominant
+        # agent gets 1.0 — keeps the score numerically comparable to
+        # score_average. If everyone is equal, max == 1/n and we get a
+        # uniform 1.0; that's the "no information" case, so map it to
+        # DEFAULT_SCORE instead.
+        m = max(t)
+        if m <= 0.0:
+            return {a: DEFAULT_SCORE for a in agents}
+        spread = max(t) - min(t)
+        if spread < 1e-12:
+            return {a: DEFAULT_SCORE for a in agents}
+        return {a: t[index[a]] / m for a in agents}

--- a/packages/nest-plugins-reference/tests/test_eigentrust.py
+++ b/packages/nest-plugins-reference/tests/test_eigentrust.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the EigenTrust reputation plugin.
+
+These tests pin down the algorithm's distinguishing behaviours vs the
+naive ``score_average`` plugin:
+
+* A Sybil swarm reporting a colluding peer as "positive" cannot push
+  that peer's global trust above a peer endorsed by pre-trusted seeds.
+* Recent negative evidence decays old positive evidence under temporal
+  decay.
+* Self-reports are ignored.
+* Pre-trusted seeds bootstrap a sensible global score.
+* The implementation is deterministic — same inputs, same scores.
+* Repeated ``score`` calls without new reports are cache hits.
+
+Asyncio mode is enabled in the workspace pyproject so ``pytest-asyncio``
+picks these up automatically.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.types import AgentId, Evidence
+from nest_plugins_reference.trust.eigentrust import (
+    DEFAULT_SCORE,
+    EigenTrust,
+)
+
+
+def _pos(reporter: str, subject: str) -> Evidence:
+    return Evidence(
+        reporter=AgentId(reporter),
+        subject=AgentId(subject),
+        kind="positive",
+    )
+
+
+def _neg(reporter: str, subject: str) -> Evidence:
+    return Evidence(
+        reporter=AgentId(reporter),
+        subject=AgentId(subject),
+        kind="negative",
+    )
+
+
+class TestBasic:
+    """Sanity properties shared with score_average."""
+
+    @pytest.mark.asyncio
+    async def test_cold_start_score_is_neutral(self) -> None:
+        trust = EigenTrust()
+        s = await trust.score(AgentId("nobody"))
+        assert s.score == DEFAULT_SCORE
+        assert s.confidence == 0.0
+        assert s.sample_count == 0
+
+    @pytest.mark.asyncio
+    async def test_score_is_bounded(self) -> None:
+        trust = EigenTrust()
+        # Build a small graph: a1 endorses a2, a3 endorses a2.
+        await trust.report(AgentId("a2"), _pos("a1", "a2"))
+        await trust.report(AgentId("a2"), _pos("a3", "a2"))
+        s = await trust.score(AgentId("a2"))
+        assert 0.0 <= s.score <= 1.0
+        assert s.sample_count == 2
+
+    @pytest.mark.asyncio
+    async def test_negative_report_lowers_score(self) -> None:
+        trust = EigenTrust(pre_trusted=[AgentId("seed")])
+        # Pre-trusted seed reports good first, then bad — net should be
+        # lower than the all-positive case.
+        await trust.report(AgentId("a1"), _pos("seed", "a1"))
+        good = (await trust.score(AgentId("a1"))).score
+
+        trust2 = EigenTrust(pre_trusted=[AgentId("seed")])
+        await trust2.report(AgentId("a1"), _pos("seed", "a1"))
+        await trust2.report(AgentId("a1"), _neg("seed", "a1"))
+        mixed = (await trust2.score(AgentId("a1"))).score
+        assert mixed < good
+
+    @pytest.mark.asyncio
+    async def test_unknown_evidence_kind_is_neutral(self) -> None:
+        trust = EigenTrust()
+        await trust.report(
+            AgentId("a1"),
+            Evidence(reporter=AgentId("a2"), subject=AgentId("a1"), kind="indifferent"),
+        )
+        s = await trust.score(AgentId("a1"))
+        # Unknown kinds add no signal: agent stays cold-start.
+        assert s.sample_count == 0
+        assert s.score == DEFAULT_SCORE
+
+
+class TestEigenProperties:
+    """The properties that justify shipping a second trust plugin."""
+
+    @pytest.mark.asyncio
+    async def test_sybil_swarm_cannot_outweigh_pre_trusted_seed(self) -> None:
+        """A flood of mutual endorsements among unknown peers must not
+        beat a single endorsement from a pre-trusted seed.
+
+        Setup: ``seed`` is pre-trusted. ``honest`` gets one positive
+        report from ``seed``. ``sybil-target`` gets 100 positive reports
+        from 100 unknown ``sybil-N`` peers, who only know each other.
+        EigenTrust mixes in the seed's pre-trust mass, so the honest
+        peer should still come out ahead.
+        """
+        trust = EigenTrust(pre_trusted=[AgentId("seed")], alpha=0.2)
+
+        # The seed endorses the honest agent once.
+        await trust.report(AgentId("honest"), _pos("seed", "honest"))
+
+        # A Sybil swarm: 100 fake peers that endorse the target and each
+        # other heavily. None of them is connected to the seed.
+        for k in range(100):
+            await trust.report(
+                AgentId("sybil-target"),
+                _pos(f"sybil-{k}", "sybil-target"),
+            )
+            # Mutual back-scratching to maximally pump each other up.
+            await trust.report(
+                AgentId(f"sybil-{k}"),
+                _pos("sybil-target", f"sybil-{k}"),
+            )
+
+        honest_score = (await trust.score(AgentId("honest"))).score
+        sybil_score = (await trust.score(AgentId("sybil-target"))).score
+        assert honest_score > sybil_score, (
+            f"Sybil clique outranked honest peer: honest={honest_score}, "
+            f"sybil={sybil_score}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_time_decay_lets_recent_negatives_dominate(self) -> None:
+        """Without decay, 10 old positives outweigh 1 recent negative.
+        With strong decay, the recent negative wins.
+        """
+        # No decay: many old positives win.
+        no_decay = EigenTrust(pre_trusted=[AgentId("s")], decay_lambda=0.0)
+        for _ in range(10):
+            await no_decay.report(AgentId("a"), _pos("s", "a"))
+        await no_decay.report(AgentId("a"), _neg("s", "a"))
+        score_no_decay = (await no_decay.score(AgentId("a"))).score
+
+        # Aggressive decay: recent negative dominates the old positives.
+        decay = EigenTrust(pre_trusted=[AgentId("s")], decay_lambda=1.0)
+        for _ in range(10):
+            await decay.report(AgentId("a"), _pos("s", "a"))
+        await decay.report(AgentId("a"), _neg("s", "a"))
+        score_decay = (await decay.score(AgentId("a"))).score
+
+        assert score_decay < score_no_decay, (
+            f"decay did not lower score: no_decay={score_no_decay}, "
+            f"decay={score_decay}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_self_reports_are_ignored(self) -> None:
+        """An agent cannot endorse itself into the trusted set."""
+        trust = EigenTrust()
+        for _ in range(100):
+            await trust.report(AgentId("liar"), _pos("liar", "liar"))
+        # An honest two-party endorsement exists alongside.
+        await trust.report(AgentId("good"), _pos("seed", "good"))
+        liar_score = (await trust.score(AgentId("liar"))).score
+        good_score = (await trust.score(AgentId("good"))).score
+        assert liar_score <= good_score
+
+    @pytest.mark.asyncio
+    async def test_pre_trusted_seed_gets_positive_score(self) -> None:
+        """A seed peer with no incoming reports still gets prior mass."""
+        trust = EigenTrust(pre_trusted=[AgentId("seed")])
+        # No reports at all. seed should still be > DEFAULT_SCORE-ish
+        # once we've observed it.
+        await trust.stake(AgentId("seed"), 1)  # registers seed as observed
+        # With only one observed agent (seed itself), the global vector
+        # collapses to "everyone equal" — we map that to DEFAULT_SCORE.
+        # Add another observed agent to break the symmetry.
+        await trust.report(AgentId("other"), _pos("seed", "other"))
+        s_seed = await trust.score(AgentId("seed"))
+        s_other = await trust.score(AgentId("other"))
+        # With alpha=0.15, the seed retains the lion's share of mass
+        # because it's the only source of pre-trust.
+        assert s_seed.score >= s_other.score
+        assert s_seed.score > 0.0
+
+
+class TestDeterminismAndCaching:
+    """The plugin must be deterministic and cheap to query."""
+
+    @pytest.mark.asyncio
+    async def test_deterministic_across_two_runs(self) -> None:
+        reports = [
+            _pos("a", "b"),
+            _pos("b", "c"),
+            _neg("c", "a"),
+            _pos("seed", "a"),
+        ]
+        scores: list[dict[str, float]] = []
+        for _ in range(2):
+            trust = EigenTrust(pre_trusted=[AgentId("seed")])
+            for ev in reports:
+                await trust.report(ev.subject, ev)
+            run_scores = {
+                name: (await trust.score(AgentId(name))).score
+                for name in ("a", "b", "c", "seed")
+            }
+            scores.append(run_scores)
+        assert scores[0] == scores[1]
+
+    @pytest.mark.asyncio
+    async def test_score_cache_returns_consistent_values(self) -> None:
+        trust = EigenTrust(pre_trusted=[AgentId("seed")])
+        await trust.report(AgentId("a"), _pos("seed", "a"))
+        s1 = (await trust.score(AgentId("a"))).score
+        # Many lookups without new reports must return the same number.
+        for _ in range(10):
+            assert (await trust.score(AgentId("a"))).score == s1
+        # A new report busts the cache.
+        await trust.report(AgentId("a"), _neg("seed", "a"))
+        s2 = (await trust.score(AgentId("a"))).score
+        assert s2 != s1
+
+
+class TestConfiguration:
+    """Validation of constructor parameters."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_alpha_raises(self) -> None:
+        with pytest.raises(ValueError):
+            EigenTrust(alpha=0.0)
+        with pytest.raises(ValueError):
+            EigenTrust(alpha=1.5)
+
+    @pytest.mark.asyncio
+    async def test_invalid_decay_raises(self) -> None:
+        with pytest.raises(ValueError):
+            EigenTrust(decay_lambda=-0.01)
+
+    @pytest.mark.asyncio
+    async def test_invalid_max_iters_raises(self) -> None:
+        with pytest.raises(ValueError):
+            EigenTrust(max_iters=0)
+
+    @pytest.mark.asyncio
+    async def test_stake_raises_confidence(self) -> None:
+        trust = EigenTrust(pre_trusted=[AgentId("seed")])
+        await trust.report(AgentId("a"), _pos("seed", "a"))
+        before = (await trust.score(AgentId("a"))).confidence
+        await trust.stake(AgentId("a"), 1000)
+        after = (await trust.score(AgentId("a"))).confidence
+        assert after > before
+
+
+class TestPluginRegistry:
+    """The plugin must be reachable via the built-in registry name."""
+
+    def test_resolves_via_plugin_registry(self) -> None:
+        from nest_core.plugins import PluginRegistry
+
+        cls = PluginRegistry().resolve("trust", "eigentrust")
+        # We don't import EigenTrust here directly — that's the point of
+        # the registry. Verify by name and protocol.
+        from nest_core.layers.trust import Trust
+
+        assert cls.__name__ == "EigenTrust"
+        instance = cls()
+        assert isinstance(instance, Trust)

--- a/packages/nest-plugins-reference/tests/test_eigentrust.py
+++ b/packages/nest-plugins-reference/tests/test_eigentrust.py
@@ -126,8 +126,7 @@ class TestEigenProperties:
         honest_score = (await trust.score(AgentId("honest"))).score
         sybil_score = (await trust.score(AgentId("sybil-target"))).score
         assert honest_score > sybil_score, (
-            f"Sybil clique outranked honest peer: honest={honest_score}, "
-            f"sybil={sybil_score}"
+            f"Sybil clique outranked honest peer: honest={honest_score}, sybil={sybil_score}"
         )
 
     @pytest.mark.asyncio
@@ -150,8 +149,7 @@ class TestEigenProperties:
         score_decay = (await decay.score(AgentId("a"))).score
 
         assert score_decay < score_no_decay, (
-            f"decay did not lower score: no_decay={score_no_decay}, "
-            f"decay={score_decay}"
+            f"decay did not lower score: no_decay={score_no_decay}, decay={score_decay}"
         )
 
     @pytest.mark.asyncio
@@ -202,8 +200,7 @@ class TestDeterminismAndCaching:
             for ev in reports:
                 await trust.report(ev.subject, ev)
             run_scores = {
-                name: (await trust.score(AgentId(name))).score
-                for name in ("a", "b", "c", "seed")
+                name: (await trust.score(AgentId(name))).score for name in ("a", "b", "c", "seed")
             }
             scores.append(run_scores)
         assert scores[0] == scores[1]


### PR DESCRIPTION
## Which piece

Layer 6 — **Trust**. A second reference plugin, `eigentrust`, alongside the existing `score_average`.

## Why

The bundled `score_average` is a flat running mean. Every reporter is weighted equally, so a few colluding Sybil agents can drown out honest reports just by spamming `positive` evidence about each other. There's also no time decay — a peer that builds 100 good interactions and then defects has to be reported 100 more times before the running mean reflects the new reality. That makes it hard to use NEST to test trust-sensitive protocols (the `reputation` scenario, marketplace with adversarial sellers, etc.) under realistic adversary models.

EigenTrust (Kamvar, Schlosser, Garcia-Molina, *EigenTrust: Reputation Management in P2P Networks*, WWW 2003) is the textbook fix: weight each report by the reporter's own global trust, mix in a pre-trusted seed distribution via a PageRank-style damping coefficient, and you get a system where one trusted endorsement beats a hundred Sybil endorsements.

## The core idea

The new `EigenTrust` plugin in `nest_plugins_reference/trust/eigentrust.py` implements:

1. **Transitive weighted trust.** Builds the local trust matrix `C` from reported evidence and computes the fixed point of `t = (1 - alpha) * C^T t + alpha * p` via power iteration. `alpha` is the damping coefficient, `p` is the seed distribution.
2. **Exponential time decay** of evidence — a report `k` event-ticks old contributes `exp(-decay_lambda * k)` of its original weight. Uses a deterministic monotonic event counter so replays are byte-identical under the same seed.
3. **Pre-trusted seeds.** Optional set `P` whose distribution is mixed in via `alpha`. Without seeds, falls back to uniform-over-observed (the WWW 2003 fallback).
4. **Stake as a confidence signal.** `stake()` raises `confidence` (not `score`) — slashing is out of scope, but skin-in-the-game is still information.
5. **Lazy recomputation with epoch invalidation** — `score()` only re-runs power iteration when new evidence has been reported. Constant amortised work for read-heavy workloads.
6. **Drop-in.** Same `Trust` protocol; selectable in any scenario YAML via `trust: eigentrust`.

## How to test

```bash
# Unit tests (15 tests covering Sybil resistance, decay, determinism, cache, validation)
pytest packages/nest-plugins-reference/tests/test_eigentrust.py -v

# Full plugins + core suite (no regressions)
pytest packages/nest-plugins-reference/tests packages/nest-core/tests -q

# End-to-end against the bundled marketplace scenario
cp scenarios/marketplace.yaml /tmp/mkt.yaml
sed -i 's/trust: score_average/trust: eigentrust/' /tmp/mkt.yaml
nest run /tmp/mkt.yaml -o /tmp/mkt.jsonl
python -c "
from pathlib import Path
from nest_core.validators import validate_trace
for r in validate_trace(Path('/tmp/mkt.jsonl'), 'marketplace'):
    print(('PASS' if r.passed else 'FAIL'), r.name)
"
# All three marketplace validators pass with eigentrust.
```

The headline property test is `test_sybil_swarm_cannot_outweigh_pre_trusted_seed`: 100 Sybil peers mutually endorsing a colluding `sybil-target` against 1 endorsement of `honest` from a pre-trusted seed — `honest` still scores higher. That's the property `score_average` cannot give you.

## Key assumptions

- Single-process, single trust-plugin instance (matches how NEST wires `ctx.plugins.get("trust")` — verified in `marketplace.py`).
- `Evidence.reporter` is set by all in-tree callers (it is — checked in the marketplace scenario).
- Event-tick ordering is enough for determinism; we don't depend on the simulator's virtual clock (which is `0.0` on the default in-memory transport anyway, per the README).
- O(n^2) matrix construction is fine at the trust layer's typical agent counts. The reports are an append-only log; swapping the dense matrix for a sparse one is a localised change if someone ever wants 10k+ agents.

## Persona

3rd-year MIT EECS undergrad. Distributed-systems-pilled (Lamport, Ousterhout, 6.5840). Writes Python like Go, tests like Erlang.

## Future work

- A `stake_slashable` variant that wires negative `Evidence` to a payments-layer slash, closing the loop on stake economics.
- Sparse `scipy.sparse` storage behind the same interface for >1k-agent simulations.
- A validator for the `reputation` scenario that asserts pre-trusted-seed-mediated convergence (the bundled validator currently flags `malicious-3` as not reported regardless of trust plugin — pre-existing scenario issue, unrelated to this PR).

https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW)_

## Summary by Sourcery

Introduce an EigenTrust-based reputation plugin as an alternative trust mechanism and wire it into the core plugin registry, with documentation and tests validating its behaviour.

New Features:
- Add an EigenTrust trust plugin implementing transitive, seed-weighted reputation with optional time decay and stake-informed confidence.
- Expose the EigenTrust plugin through the core PluginRegistry so it can be selected via `trust: eigentrust` in scenarios.

Documentation:
- Document the EigenTrust trust plugin, its configuration parameters, and how to enable it in scenario YAMLs.

Tests:
- Add a dedicated EigenTrust test suite covering Sybil resistance, time decay, self-report handling, pre-trusted seeds, determinism, caching, configuration validation, and registry resolution.