### PR TITLE
[Hackathon] stanford-ml-phd: EigenTrust plugin for the trust layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ resolved by name via entry points or a built-in default.
 |  3 | Identity      | `Identity`      | `did_key` (deterministic public-key signatures for simulation; not Ed25519) |
 |  4 | Registry      | `Registry`      | `in_memory` (dict lookup, no persistence) |
 |  5 | Auth          | `Auth`          | `jwt` (HMAC-SHA256 token; not RFC JWT) |
-|  6 | Trust         | `Trust`         | `score_average` (running mean reputation; no Sybil resistance) |
+|  6 | Trust         | `Trust`         | `score_average` (running mean reputation; no Sybil resistance). Also bundled: `eigentrust` (transitive, Sybil-resistant). |
 |  7 | Payments      | `Payments`      | `prepaid_credits` (in-memory ledger) |
 |  8 | Coordination  | `Coordination`  | `contract_net` (FIPA: propose · bid · resolve · commit) |
 |  9 | Negotiation   | `Negotiation`   | `alternating_offers` (Rubinstein, with patience discount) |

--- a/docs/layers/trust.md
+++ b/docs/layers/trust.md
@@ -15,20 +15,26 @@ class Trust(Protocol):
 
 Full definition: [`nest_core/layers/trust.py`](../../packages/nest-core/nest_core/layers/trust.py).
 
-## Default plugin
+## Built-in plugins
 
-`score_average` — running mean of feedback scores. No Sybil resistance,
-no decay, no stake economics.
+| name | summary | Sybil-resistant? |
+|---|---|---|
+| `score_average` (default) | Running mean of feedback scores. | No |
+| `eigentrust` | Transitive reputation via the EigenTrust eigenvector (Kamvar et al., WWW '03). Weighs each report by the reporter's current trust, with a teleport to a configurable pre-trusted seed set. | Yes |
 
-Source: [`nest_plugins_reference/trust/score_average.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/score_average.py).
+Sources:
+- [`nest_plugins_reference/trust/score_average.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/score_average.py)
+- [`nest_plugins_reference/trust/eigentrust.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/eigentrust.py)
 
 The `reputation` scenario exercises this layer — 16 honest + 4
 malicious + 1 observer that samples cheat reports probabilistically.
+Swap `trust: score_average` for `trust: eigentrust` in the scenario
+YAML to compare adversarial behaviour under the two ranking rules.
 
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under
 entry point group `nest.plugins.trust`.
 
-Good fits to test here: EigenTrust-style transitive reputation,
-proof-of-stake reputation, decaying scores, attestation graphs.
+Good fits to test here: proof-of-stake reputation, decaying / time-
+weighted scores, attestation graphs, learned reputation models.

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -23,6 +23,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
+    ("trust", "eigentrust"): f"{_REF}.trust.eigentrust:EigenTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("coordination", "contract_net"): f"{_REF}.coordination.contract_net:ContractNet",
     ("negotiation", "alternating_offers"): (

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/eigentrust.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/eigentrust.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+"""EigenTrust plugin — transitive, Sybil-resistant reputation.
+
+Implements the EigenTrust algorithm of Kamvar, Schlosser, and Garcia-Molina
+(WWW '03, "The EigenTrust Algorithm for Reputation Management in P2P
+Networks"). Global trust is computed as the principal left eigenvector of
+the row-stochastic local-trust matrix, with a teleport to a "pre-trusted"
+distribution that protects against Sybil attacks.
+
+Why this matters
+----------------
+The default ``score_average`` trust plugin treats every report as equally
+credible and ignores who reported it. A malicious clique can therefore
+inflate (or trash) any agent's score by spamming reports. EigenTrust fixes
+this in two ways:
+
+1. Reports are weighted by the *reporter's* current trust — an agent you
+   already distrust cannot lower someone else's score.
+2. A small teleport probability ``a`` to a fixed set of pre-trusted seeds
+   bounds the influence of any Sybil cluster regardless of size.
+
+The implementation is deterministic given the same evidence sequence
+(stable agent ordering, fixed power-iteration tolerance and cap), so it
+preserves NEST's "same seed -> same trace" guarantee.
+
+Example::
+
+    trust = EigenTrust(pre_trusted={AgentId("observer-0")})
+    await trust.report(agent_id, Evidence(reporter=..., subject=..., kind="positive"))
+    score = await trust.score(AgentId("a1"))
+
+References
+----------
+- Kamvar, Schlosser, Garcia-Molina. "The EigenTrust Algorithm for
+  Reputation Management in P2P Networks." WWW 2003.
+- Page, Brin, Motwani, Winograd. "The PageRank Citation Ranking" (1998).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from nest_core.types import (
+    AgentId,
+    Attestation,
+    Claim,
+    Evidence,
+    ReputationScore,
+    Signature,
+)
+
+# Reasonable defaults from the EigenTrust paper. ``alpha`` (teleport
+# probability) of 0.1-0.2 is standard; we pick 0.15 (the PageRank default)
+# so the seed mass is small but non-negligible. Power iteration converges
+# geometrically with rate ``1 - alpha`` so 64 iterations is plenty for any
+# practical agent count and the tolerance below is the real stopping rule.
+_DEFAULT_ALPHA = 0.15
+_DEFAULT_MAX_ITERATIONS = 64
+_DEFAULT_TOLERANCE = 1e-8
+
+
+class EigenTrust:
+    """Transitive, Sybil-resistant trust via the EigenTrust algorithm.
+
+    The class maintains a sparse local-trust matrix ``C[i][j]`` =
+    normalized positive feedback that reporter ``i`` has provided about
+    subject ``j``. Calling :meth:`score` runs power iteration on a
+    teleport-smoothed version of ``C`` and returns the global trust
+    value for ``agent``.
+
+    The matrix is recomputed lazily: ``report`` invalidates the cached
+    eigenvector, ``score`` recomputes it on the next call. For workloads
+    with many ``score`` queries between ``report`` calls this gives a
+    flat amortized cost.
+
+    Parameters
+    ----------
+    identity:
+        Optional NEST identity plugin used to sign attestations. The
+        reference :class:`ScoreAverageTrust` accepts it; we mirror the
+        signature for drop-in compatibility.
+    pre_trusted:
+        Iterable of agent ids that form the seed set ``p``. If empty
+        (the default), ``p`` is the uniform distribution over agents
+        that have ever appeared as a reporter or a subject.
+    alpha:
+        Teleport probability (the weight of ``p``). Higher values give
+        stronger Sybil resistance at the cost of less responsiveness to
+        peer evidence. Defaults to 0.15.
+    max_iterations / tolerance:
+        Power-iteration stopping rule. The defaults are tight enough
+        that scores agree to ~7 significant figures across runs.
+
+    Example::
+
+        trust = EigenTrust(pre_trusted={AgentId("observer-0")}, alpha=0.15)
+        await trust.report(target, Evidence(reporter=r, subject=target, kind="positive"))
+        rep = await trust.score(target)
+    """
+
+    def __init__(
+        self,
+        identity: Any = None,
+        *,
+        pre_trusted: Iterable[AgentId] | None = None,
+        alpha: float = _DEFAULT_ALPHA,
+        max_iterations: int = _DEFAULT_MAX_ITERATIONS,
+        tolerance: float = _DEFAULT_TOLERANCE,
+    ) -> None:
+        if not 0.0 < alpha < 1.0:
+            msg = f"alpha must be in (0, 1), got {alpha}"
+            raise ValueError(msg)
+        if max_iterations < 1:
+            msg = f"max_iterations must be >= 1, got {max_iterations}"
+            raise ValueError(msg)
+        if tolerance <= 0:
+            msg = f"tolerance must be > 0, got {tolerance}"
+            raise ValueError(msg)
+
+        self._identity = identity
+        self._alpha = alpha
+        self._max_iterations = max_iterations
+        self._tolerance = tolerance
+        self._pre_trusted: set[AgentId] = set(pre_trusted or [])
+
+        # Sparse local trust: positive[reporter][subject], negative[r][s].
+        # We keep them separate so an agent with mixed feedback gets a
+        # net-positive credit rather than being silently averaged out.
+        self._positive: dict[AgentId, dict[AgentId, int]] = {}
+        self._negative: dict[AgentId, dict[AgentId, int]] = {}
+        self._stakes: dict[AgentId, int] = {}
+        self._sample_count: dict[AgentId, int] = {}
+        self._agents: set[AgentId] = set()
+        self._dirty = True
+        self._global_trust: dict[AgentId, float] = {}
+        self._iterations_last_run = 0  # exposed for tests / metrics
+
+    # ---------------------------------------------------------------- API
+
+    async def score(self, agent: AgentId) -> ReputationScore:
+        """Return the global EigenTrust score for ``agent`` in [0, 1].
+
+        Recomputes the eigenvector if any reports have arrived since the
+        last call. Returns the neutral prior (0.5) for unknown agents,
+        matching :class:`ScoreAverageTrust`'s behaviour so swapping
+        plugins doesn't change baseline numbers.
+
+        Example::
+
+            rep = await trust.score(AgentId("a1"))
+        """
+        if not self._agents:
+            return ReputationScore(agent_id=agent, score=0.5, confidence=0.0, sample_count=0)
+
+        if self._dirty:
+            self._recompute()
+
+        raw = self._global_trust.get(agent)
+        if raw is None:
+            # Agent we've never heard of: same neutral prior as the
+            # reference plugin so validators that compare baselines
+            # don't see a free win.
+            return ReputationScore(agent_id=agent, score=0.5, confidence=0.0, sample_count=0)
+
+        # Normalise so the most-trusted agent gets ~1.0 (raw eigenvector
+        # entries sum to 1, which makes them hard to compare to the
+        # reference plugin's [0, 1] scale).
+        max_val = max(self._global_trust.values()) or 1.0
+        score = raw / max_val
+
+        samples = self._sample_count.get(agent, 0)
+        confidence = min(1.0, samples / 100.0)
+        return ReputationScore(
+            agent_id=agent,
+            score=score,
+            confidence=confidence,
+            sample_count=samples,
+        )
+
+    async def attest(self, agent: AgentId, claim: Claim) -> Attestation:
+        """Create a (possibly signed) attestation about ``agent``.
+
+        Mirrors :class:`ScoreAverageTrust.attest`: if an identity plugin
+        is configured we use it to sign, otherwise we return a stub
+        signature so callers can still inspect the structure.
+
+        Example::
+
+            att = await trust.attest(AgentId("a1"), claim)
+        """
+        sig = Signature(signer=AgentId("system"), value=b"attestation", algorithm="none")
+        if self._identity is not None:
+            sig = self._identity.sign(claim.model_dump_json().encode())
+        return Attestation(issuer=AgentId("system"), claim=claim, signature=sig)
+
+    async def report(self, agent: AgentId, evidence: Evidence) -> None:
+        """Record ``evidence`` against ``agent``'s reputation.
+
+        ``evidence.reporter`` is the source of the report. Unlike
+        :class:`ScoreAverageTrust`, EigenTrust *does* care who reported:
+        a report from an agent with no incoming trust contributes
+        approximately nothing to the global score.
+
+        Recognised evidence kinds:
+
+        - ``"positive"``: +1 to the (reporter, subject) edge.
+        - ``"negative"`` / ``"byzantine"``: +1 to the negative-edge count.
+        - Anything else: counted as a sample but does not move the edges
+          (useful for "I observed but make no claim" telemetry).
+
+        Example::
+
+            ev = Evidence(reporter=AgentId("a2"), subject=AgentId("a1"), kind="positive")
+            await trust.report(AgentId("a1"), ev)
+        """
+        # The reference plugin keys by the ``agent`` argument and ignores
+        # ``evidence.subject``. We prefer ``evidence.subject`` when set so
+        # callers can pass either, but fall back to ``agent`` for parity.
+        subject = evidence.subject or agent
+        reporter = evidence.reporter
+
+        self._agents.add(subject)
+        self._agents.add(reporter)
+        self._sample_count[subject] = self._sample_count.get(subject, 0) + 1
+
+        if evidence.kind == "positive":
+            self._positive.setdefault(reporter, {})
+            self._positive[reporter][subject] = self._positive[reporter].get(subject, 0) + 1
+        elif evidence.kind in ("negative", "byzantine"):
+            self._negative.setdefault(reporter, {})
+            self._negative[reporter][subject] = self._negative[reporter].get(subject, 0) + 1
+        # ``unknown`` kinds: counted but neutral.
+        self._dirty = True
+
+    async def stake(self, agent: AgentId, amount: int) -> None:
+        """Stake reputation on ``agent``'s good behaviour.
+
+        Kept for interface compatibility; staking does not influence
+        the EigenTrust eigenvector in this implementation, but the
+        amount is tracked so callers / validators can inspect it.
+
+        Example::
+
+            await trust.stake(AgentId("a1"), 100)
+        """
+        self._stakes[agent] = self._stakes.get(agent, 0) + amount
+
+    # ------------------------------------------------------- introspection
+
+    def global_trust(self) -> dict[AgentId, float]:
+        """Return the raw (sums-to-1) global trust vector. For tests / metrics.
+
+        Example::
+
+            t = trust.global_trust()  # dict[AgentId, float]
+        """
+        if self._dirty:
+            self._recompute()
+        return dict(self._global_trust)
+
+    @property
+    def iterations_last_run(self) -> int:
+        """Number of power-iteration steps in the most recent recompute."""
+        return self._iterations_last_run
+
+    # --------------------------------------------------------- internals
+
+    def _local_trust_row(self, reporter: AgentId) -> dict[AgentId, float]:
+        """Compute the row-stochastic local trust ``s_ij = max(p_ij - n_ij, 0)``.
+
+        Following the paper (eq. 1 / 2): normalise the non-negative
+        residual by its row sum. Reporters with no net-positive feedback
+        return an empty dict; the matrix builder then re-distributes
+        their mass to the pre-trusted set (the paper's "well-defined C"
+        construction).
+        """
+        pos = self._positive.get(reporter, {})
+        neg = self._negative.get(reporter, {})
+        residuals: dict[AgentId, float] = {}
+        total = 0.0
+        for subject, p in pos.items():
+            n = neg.get(subject, 0)
+            r = max(p - n, 0)
+            if r > 0:
+                residuals[subject] = float(r)
+                total += float(r)
+        if total <= 0:
+            return {}
+        return {s: v / total for s, v in residuals.items()}
+
+    def _seed_vector(self, ordered_agents: list[AgentId]) -> dict[AgentId, float]:
+        """Build the teleport / seed distribution ``p``.
+
+        Defaults to uniform over all known agents when no explicit seed
+        set was provided — that matches the simplest variant in the
+        paper. With an explicit seed set, mass is split uniformly across
+        seeds that we've actually observed; unknown seeds are ignored so
+        a stale config can't shift trust onto absent agents.
+        """
+        if not ordered_agents:
+            return {}
+        if not self._pre_trusted:
+            w = 1.0 / len(ordered_agents)
+            return {a: w for a in ordered_agents}
+        active_seeds = [a for a in ordered_agents if a in self._pre_trusted]
+        if not active_seeds:
+            # Configured seeds haven't shown up yet -> uniform fallback.
+            w = 1.0 / len(ordered_agents)
+            return {a: w for a in ordered_agents}
+        w = 1.0 / len(active_seeds)
+        return {a: w for a in active_seeds}
+
+    def _recompute(self) -> None:
+        """Power-iterate the EigenTrust update until convergence.
+
+        We use a dict-of-dicts representation rather than a dense matrix
+        so the cost scales with the number of *edges* (reports), not
+        n^2. Convergence is geometric with rate ``1 - alpha``; in
+        practice 5-15 iterations are plenty for ``alpha = 0.15``.
+        """
+        ordered = sorted(self._agents)  # stable order -> deterministic
+        if not ordered:
+            self._global_trust = {}
+            self._dirty = False
+            self._iterations_last_run = 0
+            return
+
+        seed = self._seed_vector(ordered)
+
+        # Precompute the (sparse) C^T rows: for each subject ``j``, the
+        # list of (reporter ``i``, weight ``c_ij``) pairs.
+        transposed: dict[AgentId, list[tuple[AgentId, float]]] = {a: [] for a in ordered}
+        sinks: list[AgentId] = []  # reporters with no usable local trust
+        for reporter in ordered:
+            row = self._local_trust_row(reporter)
+            if not row:
+                sinks.append(reporter)
+                continue
+            for subject, w in row.items():
+                transposed.setdefault(subject, []).append((reporter, w))
+
+        # Initialise with the seed distribution (the paper's choice;
+        # any positive vector summing to 1 works, but starting at the
+        # seed shaves a couple of iterations off convergence).
+        t = dict(seed)
+
+        alpha = self._alpha
+        last_delta = float("inf")
+        iterations = 0
+        for step in range(1, self._max_iterations + 1):
+            iterations = step
+            # Dangling mass: reporters with no outgoing local trust
+            # redistribute according to the seed vector (standard
+            # PageRank treatment of sinks).
+            dangling = sum(t.get(a, 0.0) for a in sinks)
+            t_next: dict[AgentId, float] = {}
+            for subject in ordered:
+                propagated = 0.0
+                for reporter, w in transposed.get(subject, ()):
+                    propagated += w * t.get(reporter, 0.0)
+                # Spread sink mass uniformly through ``seed`` (this is
+                # the standard reformulation that keeps C row-stochastic).
+                propagated += dangling * seed.get(subject, 0.0)
+                t_next[subject] = (1.0 - alpha) * propagated + alpha * seed.get(subject, 0.0)
+
+            # L1 normalisation guards against floating-point drift; in
+            # exact arithmetic the vector already sums to 1.
+            total = sum(t_next.values())
+            if total > 0:
+                t_next = {k: v / total for k, v in t_next.items()}
+
+            last_delta = sum(abs(t_next.get(a, 0.0) - t.get(a, 0.0)) for a in ordered)
+            t = t_next
+            if last_delta < self._tolerance:
+                break
+
+        self._global_trust = t
+        self._dirty = False
+        self._iterations_last_run = iterations

--- a/packages/nest-plugins-reference/tests/test_eigentrust.py
+++ b/packages/nest-plugins-reference/tests/test_eigentrust.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the EigenTrust plugin.
+
+The reference :class:`ScoreAverageTrust` is naive: it weighs every
+reporter equally, so a Sybil clique can promote itself to the top of
+the ranking. EigenTrust is supposed to fix exactly that. These tests
+exercise both the basic ``Trust`` protocol contract and the
+adversarial properties EigenTrust is *meant* to deliver.
+
+Run with::
+
+    uv run pytest packages/nest-plugins-reference/tests/test_eigentrust.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.types import AgentId, Claim, Evidence
+from nest_plugins_reference.trust.eigentrust import EigenTrust
+
+# ---------------------------------------------------------------------------
+# 1. Protocol contract
+# ---------------------------------------------------------------------------
+
+
+class TestEigenTrustContract:
+    """Behaviours the ``Trust`` protocol implementations must share."""
+
+    @pytest.mark.asyncio
+    async def test_default_score_for_unknown_agent_is_neutral(self) -> None:
+        trust = EigenTrust()
+        score = await trust.score(AgentId("ghost"))
+        # Matches the reference plugin so swapping doesn't shift baselines.
+        assert score.score == 0.5
+        assert score.confidence == 0.0
+        assert score.sample_count == 0
+
+    @pytest.mark.asyncio
+    async def test_score_returns_normalised_value_in_unit_interval(self) -> None:
+        trust = EigenTrust()
+        # Build a tiny network so EigenTrust has something to chew on.
+        for _ in range(3):
+            await trust.report(
+                AgentId("a"),
+                Evidence(reporter=AgentId("b"), subject=AgentId("a"), kind="positive"),
+            )
+        score = await trust.score(AgentId("a"))
+        assert 0.0 <= score.score <= 1.0
+        assert score.sample_count == 3
+
+    @pytest.mark.asyncio
+    async def test_attest_returns_attestation(self) -> None:
+        trust = EigenTrust()
+        claim = Claim(subject=AgentId("a"), predicate="ok", value="yes")
+        att = await trust.attest(AgentId("a"), claim)
+        assert att.issuer == AgentId("system")
+        assert att.claim == claim
+
+    @pytest.mark.asyncio
+    async def test_stake_does_not_raise(self) -> None:
+        # ``stake`` is interface scaffolding; we only assert it runs.
+        trust = EigenTrust()
+        await trust.stake(AgentId("a"), 42)
+        await trust.stake(AgentId("a"), 8)
+
+    @pytest.mark.asyncio
+    async def test_negative_evidence_lowers_score(self) -> None:
+        trust = EigenTrust()
+        good, bad = AgentId("good"), AgentId("bad")
+        reporter = AgentId("rep")
+        await trust.report(good, Evidence(reporter=reporter, subject=good, kind="positive"))
+        await trust.report(bad, Evidence(reporter=reporter, subject=bad, kind="negative"))
+        s_good = (await trust.score(good)).score
+        s_bad = (await trust.score(bad)).score
+        assert s_good > s_bad
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_alpha(self) -> None:
+        with pytest.raises(ValueError, match="alpha"):
+            EigenTrust(alpha=0.0)
+        with pytest.raises(ValueError, match="alpha"):
+            EigenTrust(alpha=1.0)
+
+
+# ---------------------------------------------------------------------------
+# 2. Sybil / adversarial properties
+# ---------------------------------------------------------------------------
+
+
+class TestSybilResistance:
+    """The whole reason for using EigenTrust over score_average."""
+
+    @pytest.mark.asyncio
+    async def test_sybil_clique_cannot_promote_itself(self) -> None:
+        """A self-vouching clique with no external trust should rank low.
+
+        Setup: ten Sybil identities all give each other glowing reports.
+        One honest agent has a single positive report from a pre-trusted
+        seed. Under ``score_average`` the Sybils would tie or beat the
+        honest agent; under EigenTrust the honest agent dominates.
+        """
+        seed = AgentId("seed")
+        honest = AgentId("honest")
+        sybils = [AgentId(f"sybil-{i}") for i in range(10)]
+
+        trust = EigenTrust(pre_trusted={seed})
+
+        # Seed vouches for honest agent (single, low-volume edge).
+        await trust.report(honest, Evidence(reporter=seed, subject=honest, kind="positive"))
+
+        # Sybils circle-vouch each other to the moon (high volume edges).
+        for i, src in enumerate(sybils):
+            for j, dst in enumerate(sybils):
+                if i == j:
+                    continue
+                for _ in range(5):
+                    await trust.report(dst, Evidence(reporter=src, subject=dst, kind="positive"))
+
+        s_honest = (await trust.score(honest)).score
+        sybil_scores: list[float] = []
+        for s in sybils:
+            sybil_scores.append((await trust.score(s)).score)
+        assert max(sybil_scores) < s_honest, (
+            f"Sybil clique scored max {max(sybil_scores)}, honest scored "
+            f"{s_honest} — EigenTrust failed Sybil-resistance property."
+        )
+
+    @pytest.mark.asyncio
+    async def test_self_vouching_does_not_inflate(self) -> None:
+        """An agent reporting itself ``positive`` cannot lift its score
+        above an agent reporting another peer."""
+        a, b, witness = AgentId("a"), AgentId("b"), AgentId("witness")
+        trust = EigenTrust(pre_trusted={witness})
+
+        # ``a`` self-promotes ten times.
+        for _ in range(10):
+            await trust.report(a, Evidence(reporter=a, subject=a, kind="positive"))
+        # ``witness`` (pre-trusted) vouches for ``b`` once.
+        await trust.report(b, Evidence(reporter=witness, subject=b, kind="positive"))
+
+        s_a = (await trust.score(a)).score
+        s_b = (await trust.score(b)).score
+        assert s_b > s_a
+
+    @pytest.mark.asyncio
+    async def test_distrusted_reporter_cannot_swing_against_seed(self) -> None:
+        """An attacker with no incoming trust should not be able to
+        outrank an agent that the pre-trusted seed has vouched for."""
+        target = AgentId("target")
+        rogue = AgentId("rogue")
+        seed = AgentId("seed")
+        peer = AgentId("peer")
+        trust = EigenTrust(pre_trusted={seed})
+
+        # Seed vouches for target a few times.
+        for _ in range(3):
+            await trust.report(target, Evidence(reporter=seed, subject=target, kind="positive"))
+        # Seed vouches for peer once (so peer enters the graph too).
+        await trust.report(peer, Evidence(reporter=seed, subject=peer, kind="positive"))
+
+        # Rogue blasts negative reports against target.
+        for _ in range(200):
+            await trust.report(target, Evidence(reporter=rogue, subject=target, kind="negative"))
+        # Rogue also self-promotes hard.
+        for _ in range(200):
+            await trust.report(rogue, Evidence(reporter=rogue, subject=rogue, kind="positive"))
+
+        s_target = (await trust.score(target)).score
+        s_rogue = (await trust.score(rogue)).score
+        assert s_target > s_rogue, (
+            f"Untrusted rogue ({s_rogue}) outranked seed-anchored target ({s_target})."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Pre-trusted seed behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestPreTrustedSeed:
+    @pytest.mark.asyncio
+    async def test_seed_propagates_trust_transitively(self) -> None:
+        """Seed -> A -> B should give B a non-trivial score."""
+        seed = AgentId("seed")
+        a, b = AgentId("a"), AgentId("b")
+        trust = EigenTrust(pre_trusted={seed})
+
+        for _ in range(3):
+            await trust.report(a, Evidence(reporter=seed, subject=a, kind="positive"))
+            await trust.report(b, Evidence(reporter=a, subject=b, kind="positive"))
+
+        s_b = (await trust.score(b)).score
+        assert s_b > 0.0
+        # Transitive trust should still leave the direct neighbour
+        # ahead of the second-hop neighbour.
+        s_a = (await trust.score(a)).score
+        assert s_a >= s_b
+
+    @pytest.mark.asyncio
+    async def test_seed_set_unknown_falls_back_to_uniform(self) -> None:
+        """If configured seeds never appear in evidence, the algorithm
+        should still produce sane scores (uniform fallback)."""
+        absent_seed = AgentId("absent")
+        a, b = AgentId("a"), AgentId("b")
+        trust = EigenTrust(pre_trusted={absent_seed})
+
+        await trust.report(a, Evidence(reporter=b, subject=a, kind="positive"))
+        await trust.report(b, Evidence(reporter=a, subject=b, kind="positive"))
+        s_a = (await trust.score(a)).score
+        s_b = (await trust.score(b)).score
+        assert s_a > 0.0
+        assert s_b > 0.0
+
+
+# ---------------------------------------------------------------------------
+# 4. Determinism & convergence
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    @pytest.mark.asyncio
+    async def test_same_evidence_sequence_yields_identical_vector(self) -> None:
+        """Determinism is a hard requirement for NEST's reproducibility."""
+
+        async def run() -> dict[AgentId, float]:
+            t = EigenTrust(pre_trusted={AgentId("seed")})
+            agents = [AgentId(f"a-{i}") for i in range(8)]
+            for src in agents:
+                for dst in agents:
+                    if src == dst:
+                        continue
+                    await t.report(dst, Evidence(reporter=src, subject=dst, kind="positive"))
+            return t.global_trust()
+
+        v1 = await run()
+        v2 = await run()
+        assert v1.keys() == v2.keys()
+        for k in v1:
+            # Power iteration on the same sequence -> bit-for-bit identical
+            # in CPython (no parallelism, deterministic dict ordering).
+            assert v1[k] == v2[k]
+
+    @pytest.mark.asyncio
+    async def test_global_trust_sums_to_one(self) -> None:
+        trust = EigenTrust()
+        for src in (AgentId("a"), AgentId("b"), AgentId("c")):
+            for dst in (AgentId("a"), AgentId("b"), AgentId("c")):
+                if src == dst:
+                    continue
+                await trust.report(dst, Evidence(reporter=src, subject=dst, kind="positive"))
+        total = sum(trust.global_trust().values())
+        assert abs(total - 1.0) < 1e-9
+
+    @pytest.mark.asyncio
+    async def test_converges_within_iteration_cap(self) -> None:
+        trust = EigenTrust(alpha=0.15, tolerance=1e-8, max_iterations=64)
+        agents = [AgentId(f"a-{i}") for i in range(20)]
+        for src in agents:
+            for dst in agents:
+                if src == dst:
+                    continue
+                await trust.report(dst, Evidence(reporter=src, subject=dst, kind="positive"))
+        _ = trust.global_trust()
+        # alpha = 0.15 -> contraction factor 0.85 -> log_0.85(1e-8) ~= 113
+        # but with a connected dense graph we hit floating point noise
+        # much sooner. 50 is a generous ceiling.
+        assert trust.iterations_last_run < 50
+
+    @pytest.mark.asyncio
+    async def test_recompute_is_lazy(self) -> None:
+        """Many ``score`` calls between two ``report`` calls should
+        only trigger one recompute."""
+        trust = EigenTrust()
+        await trust.report(
+            AgentId("a"),
+            Evidence(reporter=AgentId("b"), subject=AgentId("a"), kind="positive"),
+        )
+        # First read forces recompute.
+        await trust.score(AgentId("a"))
+        n1 = trust.iterations_last_run
+        # Subsequent reads with no new evidence: vector reused.
+        await trust.score(AgentId("a"))
+        await trust.score(AgentId("b"))
+        assert trust.iterations_last_run == n1
+
+
+# ---------------------------------------------------------------------------
+# 5. Beats the reference plugin on the headline adversarial property
+# ---------------------------------------------------------------------------
+
+
+class TestBeatsScoreAverage:
+    @pytest.mark.asyncio
+    async def test_eigentrust_separates_cheater_below_honest(self) -> None:
+        """Realistic miniature of the ``reputation`` scenario: with the
+        cheater being reported by every honest peer, EigenTrust should
+        rank the cheater strictly below every honest agent."""
+        seed = AgentId("seed")
+        honest = [AgentId(f"honest-{i}") for i in range(6)]
+        cheater = AgentId("malicious-0")
+        trust = EigenTrust(pre_trusted={seed})
+
+        # Seed vouches for honest agents at the start (bootstrap).
+        for h in honest:
+            await trust.report(h, Evidence(reporter=seed, subject=h, kind="positive"))
+
+        # Honest agents trade reliably among themselves -> positive reports.
+        for src in honest:
+            for dst in honest:
+                if src == dst:
+                    continue
+                await trust.report(dst, Evidence(reporter=src, subject=dst, kind="positive"))
+
+        # Cheater tries to game the system: only honest peers report it,
+        # and they report it negatively.
+        for h in honest:
+            await trust.report(cheater, Evidence(reporter=h, subject=cheater, kind="negative"))
+
+        s_cheater = (await trust.score(cheater)).score
+        honest_scores: list[float] = []
+        for h in honest:
+            honest_scores.append((await trust.score(h)).score)
+        min_honest = min(honest_scores)
+        assert s_cheater < min_honest, (
+            f"Cheater scored {s_cheater}, min honest {min_honest} — "
+            "EigenTrust failed to separate adversarial agent."
+        )


### PR DESCRIPTION
## Which piece and why

**Layer 6 (Trust)** — adds a second built-in plugin, `eigentrust`, alongside the existing `score_average`.

The default `score_average` plugin is the textbook naive baseline: every report counts equally and the reporter's identity is ignored. That's fine as scaffolding but it means the `reputation` scenario can't actually surface anything interesting about *who* is reporting *whom* — a Sybil clique can promote itself to the top in O(reports), so any protocol researcher comparing against `score_average` is fighting a strawman. As an ML/security researcher this is the layer where the bundled reference plugin most clearly limits what NEST can reveal.

## Core idea

`EigenTrust` (Kamvar, Schlosser, Garcia-Molina; WWW '03) — the canonical "trust as graph centrality" algorithm and a frequent baseline in the multi-agent / P2P-reputation literature.

- Maintain a sparse local-trust matrix `C[reporter][subject]` from `Evidence` reports (positive minus negative, then row-normalized).
- Compute the global trust vector as the principal left eigenvector of the teleport-smoothed matrix via sparse power iteration: `t ← (1 − α)·Cᵀ t + α·p`.
- `p` is a configurable pre-trusted seed distribution (defaults to uniform over observed agents); reporters with no usable local trust are treated as dangling and redistributed through `p`, mirroring the standard PageRank reformulation.
- Cached lazily: `report` marks dirty, `score` recomputes on demand — so many `score` queries between reports are essentially free.
- Deterministic under sorted agent ordering with a fixed iteration cap (64) and tolerance (1e-8). Same evidence sequence → bit-identical global-trust vector. NEST's "same seed → same trace" guarantee is preserved.

No new runtime dependencies (no NumPy); pure Python dict-of-dicts so cost scales with edges, not n².

## How to test

Unit + property tests (16, all passing):

```bash
uv run pytest packages/nest-plugins-reference/tests/test_eigentrust.py -v
```

Headline adversarial properties covered:

- `test_sybil_clique_cannot_promote_itself` — 10 Sybils circle-vouching 5× each cannot beat one honest agent with a single seed endorsement.
- `test_self_vouching_does_not_inflate` — agents reporting themselves do not climb above a seed-anchored peer.
- `test_distrusted_reporter_cannot_swing_against_seed` — 200 rogue negative reports + 200 rogue self-promotions still leave a seed-anchored target above the rogue.
- `test_eigentrust_separates_cheater_below_honest` — miniature of the bundled `reputation` scenario: cheater ends strictly below every honest agent.
- `test_same_evidence_sequence_yields_identical_vector` — determinism check (bit-equal floats across runs).

End-to-end swap against the `reputation` scenario:

```yaml
# scenarios/reputation.yaml
layers:
  trust: eigentrust   # was: score_average
```

```bash
uv run nest run scenarios/reputation.yaml
uv run python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
  [print(('PASS' if r.passed else 'FAIL'), r.name) for r in validate_trace(Path('traces/reputation.jsonl'), 'reputation')]"
```

Full workspace suite (regression check): `uv run pytest packages/ -q` → **275 passed** (up from 259 with my 16 new tests).

Lint + types both clean: `uv run ruff check ...` and `uv run pyright ...` pass on the new files.

## Key assumptions

- α (teleport probability) defaults to 0.15, the PageRank canonical value; the paper recommends 0.1–0.2. Exposed as a constructor kwarg.
- Without an explicit `pre_trusted` set, `p` is uniform over agents that have appeared as a reporter or subject. With explicit seeds that haven't appeared yet, the algorithm falls back to uniform rather than concentrating mass on absent agents.
- Score is normalized by dividing by the max raw eigenvector entry, so the most-trusted agent gets ~1.0. This matches `score_average`'s [0, 1] scale for fair side-by-side comparisons.
- Unknown agents return the same neutral prior (0.5) as `score_average`, so baseline numbers don't shift on a plugin swap.
- `Trust.stake` is kept as interface-compatible passthrough; staking does not influence the eigenvector in this implementation (could be added later via weighting `p`).
- The `reputation` scenario's `ObserverAgent` currently keeps its own counter and does not call `trust.score()`, so the plugin's effect on validator output is via the trust-layer state, not the trace. A natural follow-up is to have the observer publish the global trust vector to the blackboard so validators can assert on rank-ordering.

## Persona

Stanford ML PhD interested in adversarial multi-agent RL, benchmark design, and reproducibility — looking for plugins that turn NEST scenarios into proper protocol stress tests rather than smoke tests.

## Future work

- **Time-weighted EigenTrust** — apply an exponential decay to old reports before computing C (Kamvar 2003 §6, also explored in BetaReputation [Jøsang & Ismail]).
- **Stake-weighted seeds** — fold `stake()` amounts into the seed distribution `p` so committed-stake agents anchor the system, giving NEST a free testbed for proof-of-stake reputation.
- **Validator extension** — add a `trust_ranking` property check that compares the trust-layer global vector against ground-truth honesty labels in the `reputation` scenario (e.g., Spearman rank correlation between EigenTrust score and the actual cheat probability). That would turn the validator into a real adversarial benchmark.
- **EigenTrust on the marketplace scenario** — the bundled marketplace doesn't currently exercise the trust layer; wiring buyer-side `trust.score()` lookups before accepting a seller would let researchers benchmark trust-driven partner selection.

https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW)_

## Summary by Sourcery

Add a new EigenTrust-based trust plugin alongside the existing score_average implementation and document how to use it for Sybil-resistant reputation scoring.

New Features:
- Introduce an EigenTrust trust plugin that computes transitive, Sybil-resistant global reputation scores from evidence reports.
- Expose the EigenTrust plugin as a built-in trust-layer option that can be selected by name in scenarios.

Enhancements:
- Extend trust-layer documentation to describe all bundled trust plugins and how to switch between them in scenarios.
- Update the main README to mention EigenTrust as an additional built-in trust plugin at the Trust layer.

Tests:
- Add a comprehensive EigenTrust test suite covering protocol contract behaviour, Sybil-resistance properties, seed handling, determinism, and convergence characteristics.