### PR TITLE
[Hackathon] google-staff: netem transport + tail-latency metrics + SLO validators

### DIFF
--- a/examples/netem-transport/README.md
+++ b/examples/netem-transport/README.md
@@ -1,0 +1,95 @@
+# `netem` transport: realistic latency in NEST
+
+The bundled `in_memory` transport delivers messages at `time = now` so every
+trace shows zero latency. That is fine for correctness work — and useless
+for SLO / tail-latency / capacity work. `netem` is a sim-aware drop-in that
+injects per-message latency, jitter, bandwidth-bound serialization delay,
+reordering, and per-link drops, all driven by the seeded simulator RNG.
+
+## Use it
+
+In any scenario YAML:
+
+```yaml
+layers:
+  transport: netem
+
+transport:
+  latency:
+    kind: lognormal    # constant | uniform | lognormal
+    p50_ms: 20
+    p99_ms: 200        # heavy-tail by construction
+  jitter_ms: 2
+  bandwidth_kbps: 1000 # optional — adds size-based serialization delay
+  reorder_prob: 0.0
+  drop_prob: 0.0
+  seed_salt: 0         # XORed with the scenario seed for the model rng
+```
+
+## Why this matters
+
+Real systems fail under tail latency, not average latency. With `netem`:
+
+- `mean_latency` becomes meaningful.
+- New `p50_latency`, `p95_latency`, `p99_latency`, `max_latency` metrics
+  reflect the actual distribution.
+- A scenario-level `slo:` block lets you assert latency / availability
+  budgets as part of the validators run, e.g.:
+
+  ```yaml
+  slo:
+    p99_latency: 0.250      # 250ms, in seconds
+    min_delivery_rate: 0.99
+  ```
+
+  Pass-or-fail per budget shows up in `runner.validations` and via
+  `nest_core.validators.validate_trace(..., slo=...)`.
+
+## Determinism
+
+`netem` uses an independent PRNG seeded by `scenario.seed XOR transport.seed_salt`
+so:
+
+- The same scenario YAML reruns produce byte-identical traces.
+- You can perturb only the transport (e.g. for chaos tests) by changing
+  `seed_salt` without changing agent behaviour.
+
+## Standalone (Tier 2)
+
+`StandaloneNetemTransport` lives in `nest_plugins_reference.transport.netem`
+and uses `asyncio.sleep` for delays — useful for shell / LLM agents.
+
+```python
+from nest_plugins_reference.transport.in_memory import InMemoryNetwork
+from nest_plugins_reference.transport.netem import (
+    StandaloneNetemTransport,
+    make_delay_model,
+)
+
+network = InMemoryNetwork()
+model = make_delay_model({
+    "latency": {"kind": "lognormal", "p50_ms": 20, "p99_ms": 200},
+    "jitter_ms": 2,
+    "bandwidth_kbps": 1000,
+})
+t = StandaloneNetemTransport("a1", network, model)
+await t.send("a2", b"hello")
+```
+
+## Try it
+
+`marketplace-netem.yaml` here is the bundled marketplace with `netem` and
+an attached SLO. Save it locally and run:
+
+```bash
+nest run marketplace-netem.yaml -o ./traces/netem.jsonl
+python -c "
+from pathlib import Path
+from nest_core.validators import validate_trace
+import yaml
+cfg = yaml.safe_load(Path('marketplace-netem.yaml').read_text())
+results = validate_trace(Path('traces/netem.jsonl'), cfg['task']['type'], slo=cfg['slo'])
+for r in results:
+    print(('PASS' if r.passed else 'FAIL'), r.name, r.detail)
+"
+```

--- a/examples/netem-transport/marketplace-netem.yaml
+++ b/examples/netem-transport/marketplace-netem.yaml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Marketplace scenario with the netem transport and a latency SLO.
+name: marketplace-netem
+description: "50 buyers and 50 sellers over a netem-shaped network."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 100
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 50
+    - name: seller
+      count: 50
+
+layers:
+  transport: netem
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+transport:
+  latency:
+    kind: lognormal
+    p50_ms: 20
+    p99_ms: 200
+  jitter_ms: 2
+  bandwidth_kbps: 10000
+  reorder_prob: 0.0
+  drop_prob: 0.0
+  seed_salt: 0
+
+task:
+  type: marketplace
+  config:
+    catalog_size: 200
+    rounds: 10
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 20000"
+
+metrics:
+  - deal_rate
+  - mean_latency
+  - p50_latency
+  - p95_latency
+  - p99_latency
+  - max_latency
+  - message_count
+  - dropped_count
+
+slo:
+  p99_latency: 0.250      # seconds (250ms)
+  min_delivery_rate: 0.99
+
+output:
+  trace: ./traces/marketplace-netem.jsonl
+  report: ./traces/marketplace-netem.html

--- a/packages/nest-core/nest_core/metrics.py
+++ b/packages/nest-core/nest_core/metrics.py
@@ -9,6 +9,7 @@ Example::
 from __future__ import annotations
 
 import json
+import math
 import re
 from collections import defaultdict
 from pathlib import Path
@@ -189,25 +190,71 @@ def _unique_pairs(events: list[dict[str, Any]]) -> float:
 # ---------------------------------------------------------------------------
 # Core metrics
 # ---------------------------------------------------------------------------
-def _mean_latency(events: list[dict[str, Any]]) -> float:
+def _collect_latencies(events: list[dict[str, Any]]) -> list[float]:
+    """Pair send/receive events by correlation id and return per-message latency.
+
+    Senders emit at their local time; receivers emit at the simulator's
+    delivery time (which already includes any delay-model latency).  The
+    difference is the end-to-end virtual-time latency for that message.
+    """
     send_times: dict[str, float] = {}
     latencies: list[float] = []
-
     for ev in events:
         kind = ev.get("kind", "")
         corr = ev.get("corr", "")
-        ts = ev.get("ts", 0.0)
-
+        ts = float(ev.get("ts", 0.0))
         if kind == "send" and corr:
             send_times[corr] = ts
         elif kind == "receive" and corr:
             send_ts = send_times.get(corr)
             if send_ts is not None:
                 latencies.append(ts - send_ts)
+    return latencies
 
+
+def _percentile(sorted_xs: list[float], q: float) -> float:
+    """Return the *q*-th percentile (0 <= q <= 100) using nearest-rank.
+
+    Nearest-rank is what netem / production telemetry usually report, and
+    it avoids the surprise of returning a value that isn't actually in the
+    distribution.
+    """
+    if not sorted_xs:
+        return 0.0
+    if q <= 0:
+        return sorted_xs[0]
+    if q >= 100:
+        return sorted_xs[-1]
+    # Rank in 1..n
+    rank = max(1, math.ceil(q / 100.0 * len(sorted_xs)))
+    return sorted_xs[rank - 1]
+
+
+def _mean_latency(events: list[dict[str, Any]]) -> float:
+    latencies = _collect_latencies(events)
     if not latencies:
         return 0.0
     return sum(latencies) / len(latencies)
+
+
+def _p50_latency(events: list[dict[str, Any]]) -> float:
+    xs = sorted(_collect_latencies(events))
+    return _percentile(xs, 50)
+
+
+def _p95_latency(events: list[dict[str, Any]]) -> float:
+    xs = sorted(_collect_latencies(events))
+    return _percentile(xs, 95)
+
+
+def _p99_latency(events: list[dict[str, Any]]) -> float:
+    xs = sorted(_collect_latencies(events))
+    return _percentile(xs, 99)
+
+
+def _max_latency(events: list[dict[str, Any]]) -> float:
+    xs = _collect_latencies(events)
+    return max(xs) if xs else 0.0
 
 
 def _message_count(events: list[dict[str, Any]]) -> float:
@@ -270,6 +317,10 @@ _METRIC_FUNCS: dict[str, Any] = {
     "mean_rounds_to_deal": _mean_rounds_to_deal,
     "unique_pairs": _unique_pairs,
     "mean_latency": _mean_latency,
+    "p50_latency": _p50_latency,
+    "p95_latency": _p95_latency,
+    "p99_latency": _p99_latency,
+    "max_latency": _max_latency,
     "message_count": _message_count,
     "dropped_count": _dropped_count,
     "agent_count": _agent_count,
@@ -285,19 +336,24 @@ ALL_METRICS: list[str] = list(_METRIC_FUNCS.keys())
 def validate_protocol(
     trace_path: str | Path,
     scenario_type: str,
+    slo: dict[str, float | None] | None = None,
 ) -> dict[str, Any]:
     """Run protocol validators and return results as part of metrics output.
 
+    Pass ``slo`` to additionally run latency / availability SLO checks
+    against the trace.
+
     Example::
 
-        results = validate_protocol("trace.jsonl", "marketplace")
+        results = validate_protocol("trace.jsonl", "marketplace",
+                                    slo={"p99_latency": 0.25})
         # {"validations": [{"name": ..., "passed": ..., "detail": ...}, ...],
         #  "all_passed": True}
     """
     from nest_core.validators import validate_trace
 
     trace_path = Path(trace_path)
-    vresults = validate_trace(trace_path, scenario_type)
+    vresults = validate_trace(trace_path, scenario_type, slo=slo)
     return {
         "validations": [{"name": r.name, "passed": r.passed, "detail": r.detail} for r in vresults],
         "all_passed": all(r.passed for r in vresults),

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -18,6 +18,7 @@ from typing import Any
 _REF = "nest_plugins_reference"
 _BUILTINS: dict[tuple[str, str], str] = {
     ("transport", "in_memory"): f"{_REF}.transport.in_memory:StandaloneInMemoryTransport",
+    ("transport", "netem"): f"{_REF}.transport.netem:StandaloneNetemTransport",
     ("comms", "nest_native"): f"{_REF}.comms.nest_native:NestNativeComms",
     ("identity", "did_key"): f"{_REF}.identity.did_key:DidKeyIdentity",
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",

--- a/packages/nest-core/nest_core/runner.py
+++ b/packages/nest-core/nest_core/runner.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 
 from nest_core.plugins import PluginRegistry
 from nest_core.scenario import ScenarioConfig
+from nest_core.sim.delay_model import DelayModel, DelayModelConfig
 from nest_core.sim.simulator import Simulator
 from nest_core.types import AgentId
 
@@ -43,14 +44,48 @@ class ScenarioRunner:
         self._registry = registry or PluginRegistry()
         self._resolved_plugins: dict[str, Any] = {}
         self._metrics: dict[str, float] = {}
+        self._validations: list[dict[str, Any]] = []
 
     @property
     def metrics(self) -> dict[str, float]:
         return self._metrics
 
     @property
+    def validations(self) -> list[dict[str, Any]]:
+        """SLO / protocol validation results from the last run."""
+        return self._validations
+
+    @property
     def resolved_plugins(self) -> dict[str, Any]:
         return self._resolved_plugins
+
+    def _build_delay_model(self) -> DelayModel | None:
+        """Construct a :class:`DelayModel` from the scenario's transport block.
+
+        Only built when ``layers.transport == "netem"`` *and* a ``transport:``
+        block is provided.  The model's RNG is seeded from
+        ``scenario.seed ^ transport.seed_salt`` so per-scenario reruns are
+        reproducible *and* the transport's randomness can be perturbed
+        independently of agent behaviour.
+
+        Example::
+
+            model = runner._build_delay_model()
+        """
+        if self._config.layers.transport != "netem":
+            return None
+        cfg = self._config.transport
+        if cfg is None:
+            # netem requested but no parameters -> a no-op model so users get
+            # a clear "yes this layer is in play" without surprising delays.
+            cfg_dict: dict[str, Any] = {}
+        else:
+            cfg_dict = cfg.model_dump()
+        model_cfg = DelayModelConfig.from_dict(cfg_dict)
+        seed = self._config.seed ^ (
+            self._config.transport.seed_salt if self._config.transport else 0
+        )
+        return DelayModel.from_config(model_cfg, seed=seed)
 
     def _resolve_plugins(self) -> dict[str, Any]:
         """Resolve all layer plugins from the config.
@@ -159,6 +194,8 @@ class ScenarioRunner:
             raw_groups = failures.network_partition.get("groups")
             partition_groups = _parse_partition_groups(raw_groups)
 
+        delay_model = self._build_delay_model()
+
         sim = Simulator(
             seed=self._config.seed,
             trace_path=trace_path,
@@ -166,6 +203,7 @@ class ScenarioRunner:
             byzantine_fraction=failures.byzantine_agents,
             partition_groups=partition_groups,
             plugins=plugins,
+            delay_model=delay_model,
         )
 
         agents = self._create_agents(plugins)
@@ -188,5 +226,14 @@ class ScenarioRunner:
             if self._config.output.report:
                 report_path = Path(self._config.output.report)
                 generate_html_report(trace_path, self._metrics, report_path)
+
+        if self._config.slo is not None:
+            from nest_core.validators import validate_trace
+
+            slo_dict = self._config.slo.model_dump()
+            slo_results = validate_trace(trace_path, "__slo_only__", slo=slo_dict)
+            self._validations = [
+                {"name": r.name, "passed": r.passed, "detail": r.detail} for r in slo_results
+            ]
 
         return trace_path

--- a/packages/nest-core/nest_core/scenario.py
+++ b/packages/nest-core/nest_core/scenario.py
@@ -117,6 +117,71 @@ class FailureConfig(BaseModel):
         return value
 
 
+class TransportConfig(BaseModel):
+    """Optional transport-level delay / bandwidth / drop knobs.
+
+    Maps onto :class:`nest_core.sim.delay_model.DelayModelConfig`.  Time
+    fields are in **milliseconds**, bandwidth in **kbps** (kilo-bits/sec).
+
+    Example::
+
+        transport = TransportConfig(
+            latency={"kind": "lognormal", "p50_ms": 20, "p99_ms": 200},
+            jitter_ms=2,
+            bandwidth_kbps=1000,
+        )
+    """
+
+    latency: dict[str, Any] = Field(default_factory=dict)
+    jitter_ms: float = 0.0
+    bandwidth_kbps: float | None = None
+    reorder_prob: float = 0.0
+    drop_prob: float = 0.0
+    seed_salt: int = 0
+
+    @field_validator("jitter_ms")
+    @classmethod
+    def _jitter_non_negative(cls, value: float) -> float:
+        if value < 0:
+            msg = f"jitter_ms must be >= 0, got {value}"
+            raise ValueError(msg)
+        return value
+
+    @field_validator("reorder_prob", "drop_prob")
+    @classmethod
+    def _prob_unit_interval(cls, value: float) -> float:
+        if not 0.0 <= value <= 1.0:
+            msg = "transport probabilities must be in [0, 1]"
+            raise ValueError(msg)
+        return value
+
+
+class SloConfig(BaseModel):
+    """Latency / availability SLO targets attached to a scenario.
+
+    All latency fields are in **virtual seconds** to match the trace
+    timestamps.  ``min_delivery_rate`` is a fraction in ``[0, 1]``.
+
+    Example::
+
+        slo = SloConfig(p99_latency=0.250, min_delivery_rate=0.99)
+    """
+
+    p50_latency: float | None = None
+    p95_latency: float | None = None
+    p99_latency: float | None = None
+    max_latency: float | None = None
+    min_delivery_rate: float | None = None
+
+    @field_validator("min_delivery_rate")
+    @classmethod
+    def _rate_unit_interval(cls, value: float | None) -> float | None:
+        if value is not None and not 0.0 <= value <= 1.0:
+            msg = "min_delivery_rate must be in [0,1]"
+            raise ValueError(msg)
+        return value
+
+
 class OutputConfig(BaseModel):
     """Output configuration for traces and reports.
 
@@ -146,6 +211,8 @@ class ScenarioConfig(BaseModel):
     failures: FailureConfig = Field(default_factory=FailureConfig)
     duration: str = "ticks: 10000"
     metrics: list[str] = Field(default_factory=list)
+    transport: TransportConfig | None = None
+    slo: SloConfig | None = None
     output: OutputConfig = Field(default_factory=OutputConfig)
     seed: int = 0
 

--- a/packages/nest-core/nest_core/sim/__init__.py
+++ b/packages/nest-core/nest_core/sim/__init__.py
@@ -9,6 +9,9 @@ Example::
 from nest_core.sim.agent import AgentContext as AgentContext
 from nest_core.sim.agent import StateMachineAgent as StateMachineAgent
 from nest_core.sim.clock import VirtualClock as VirtualClock
+from nest_core.sim.delay_model import DelayModel as DelayModel
+from nest_core.sim.delay_model import DelayModelConfig as DelayModelConfig
+from nest_core.sim.delay_model import LatencyDistribution as LatencyDistribution
 from nest_core.sim.events import Event as Event
 from nest_core.sim.events import EventQueue as EventQueue
 from nest_core.sim.simulator import Simulator as Simulator
@@ -17,9 +20,12 @@ from nest_core.sim.transport import InMemoryTransport as InMemoryTransport
 
 __all__ = [
     "AgentContext",
+    "DelayModel",
+    "DelayModelConfig",
     "Event",
     "EventQueue",
     "InMemoryTransport",
+    "LatencyDistribution",
     "Simulator",
     "StateMachineAgent",
     "TraceWriter",

--- a/packages/nest-core/nest_core/sim/delay_model.py
+++ b/packages/nest-core/nest_core/sim/delay_model.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-link delay, bandwidth, jitter and reorder model for Tier 1 transport.
+
+By default the Tier 1 simulator delivers messages at ``time = now`` and the
+virtual clock never advances on its own.  That is fine for correctness tests
+but it means *every* latency metric in a NEST trace is ``0.0`` — which is
+useless for SLO work, capacity planning, tail-latency analysis, or comparing
+two protocol implementations.
+
+This module fills that gap.  A :class:`DelayModel` is consulted by the
+simulator on every ``send`` (and ``broadcast``) and returns the delay (in
+virtual seconds) that the simulator should add to the delivery event.  All
+randomness is sourced from a caller-provided :class:`random.Random` so the
+simulation stays deterministic: same seed, same trace, byte-for-byte.
+
+The model is intentionally cheap and self-contained so it can be slapped on
+to existing scenarios without changing agents:
+
+* ``LatencyDistribution`` — constant / uniform / lognormal-tailed delays in
+  virtual seconds.
+* ``DelayModel`` — applies latency + jitter + bandwidth-based serialization
+  delay + reordering, with reproducible seeding.
+
+The model is *deliberately* simple — it is a netem-style fault injector for
+unit-sized agent messages, not a full DPDK emulator.  It captures the things
+that move SLO needles in real systems: median, tail, jitter, throughput
+ceiling, and out-of-order delivery.
+
+Example::
+
+    from nest_core.sim.delay_model import (
+        DelayModel,
+        LatencyDistribution,
+        DelayModelConfig,
+    )
+
+    model = DelayModel.from_config(
+        DelayModelConfig(
+            latency=LatencyDistribution(kind="lognormal", p50_ms=20, p99_ms=120),
+            jitter_ms=2.0,
+            bandwidth_kbps=1000,
+        ),
+        seed=42,
+    )
+
+    # Per-message delay in *virtual seconds*:
+    delay = model.compute_delay(sender, receiver, payload_size_bytes=512)
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast
+
+from nest_core.types import AgentId
+
+LatencyKind = Literal["constant", "uniform", "lognormal"]
+
+
+# ---------------------------------------------------------------------------
+# Public configuration dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LatencyDistribution:
+    """Latency distribution descriptor.
+
+    All times are *milliseconds*; the model converts to virtual seconds.
+
+    * ``constant`` — every message takes exactly ``p50_ms``.
+    * ``uniform`` — uniformly random in ``[min_ms, max_ms]``. If only
+      ``p50_ms`` is set, ``min_ms = 0`` and ``max_ms = 2 * p50_ms`` so that
+      the mean matches.
+    * ``lognormal`` — fits a log-normal whose 50th percentile is ``p50_ms``
+      and 99th percentile is ``p99_ms``. Heavy-tail by construction.
+
+    Example::
+
+        d = LatencyDistribution(kind="lognormal", p50_ms=20, p99_ms=200)
+    """
+
+    kind: LatencyKind = "constant"
+    p50_ms: float = 0.0
+    p99_ms: float | None = None
+    min_ms: float | None = None
+    max_ms: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.p50_ms < 0:
+            msg = f"p50_ms must be >= 0, got {self.p50_ms}"
+            raise ValueError(msg)
+        if self.kind == "lognormal":
+            if self.p99_ms is None:
+                msg = "lognormal latency requires p99_ms"
+                raise ValueError(msg)
+            if self.p99_ms < self.p50_ms:
+                msg = f"p99_ms ({self.p99_ms}) must be >= p50_ms ({self.p50_ms})"
+                raise ValueError(msg)
+        if self.kind == "uniform":
+            lo, hi = self.uniform_bounds()
+            if lo > hi:
+                msg = f"uniform latency: min_ms ({lo}) > max_ms ({hi})"
+                raise ValueError(msg)
+
+    def uniform_bounds(self) -> tuple[float, float]:
+        lo = self.min_ms if self.min_ms is not None else 0.0
+        hi = self.max_ms if self.max_ms is not None else 2.0 * self.p50_ms
+        return lo, hi
+
+
+@dataclass(frozen=True)
+class DelayModelConfig:
+    """Top-level config for a :class:`DelayModel`.
+
+    Example::
+
+        cfg = DelayModelConfig(
+            latency=LatencyDistribution(kind="constant", p50_ms=10),
+            jitter_ms=1.0,
+            bandwidth_kbps=1000,
+            reorder_prob=0.0,
+            drop_prob=0.0,
+        )
+    """
+
+    latency: LatencyDistribution = field(default_factory=LatencyDistribution)
+    jitter_ms: float = 0.0
+    bandwidth_kbps: float | None = None  # None = unlimited
+    reorder_prob: float = 0.0
+    drop_prob: float = 0.0
+    # Optional per-link multipliers, keyed by (sender, receiver).  Useful for
+    # asymmetric topologies / partitions.
+    link_scale: dict[tuple[str, str], float] = field(
+        default_factory=lambda: dict[tuple[str, str], float]()
+    )
+
+    def __post_init__(self) -> None:
+        if self.jitter_ms < 0:
+            msg = f"jitter_ms must be >= 0, got {self.jitter_ms}"
+            raise ValueError(msg)
+        if self.bandwidth_kbps is not None and self.bandwidth_kbps <= 0:
+            msg = f"bandwidth_kbps must be > 0 or None, got {self.bandwidth_kbps}"
+            raise ValueError(msg)
+        if not 0.0 <= self.reorder_prob <= 1.0:
+            msg = f"reorder_prob must be in [0,1], got {self.reorder_prob}"
+            raise ValueError(msg)
+        if not 0.0 <= self.drop_prob <= 1.0:
+            msg = f"drop_prob must be in [0,1], got {self.drop_prob}"
+            raise ValueError(msg)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> DelayModelConfig:
+        """Build a config from a plain dict (as parsed from YAML).
+
+        Example::
+
+            cfg = DelayModelConfig.from_dict({
+                "latency": {"kind": "constant", "p50_ms": 10},
+                "jitter_ms": 1.0,
+            })
+        """
+        raw_lat_obj: Any = data.get("latency") or {}
+        if not isinstance(raw_lat_obj, Mapping):
+            msg = "transport.latency must be a mapping"
+            raise TypeError(msg)
+        raw_lat = cast("Mapping[str, Any]", raw_lat_obj)
+
+        kind = cast("LatencyKind", str(raw_lat.get("kind", "constant")))
+        p50 = float(raw_lat.get("p50_ms", 0.0))
+        p99_raw = raw_lat.get("p99_ms")
+        min_raw = raw_lat.get("min_ms")
+        max_raw = raw_lat.get("max_ms")
+        lat = LatencyDistribution(
+            kind=kind,
+            p50_ms=p50,
+            p99_ms=float(p99_raw) if p99_raw is not None else None,
+            min_ms=float(min_raw) if min_raw is not None else None,
+            max_ms=float(max_raw) if max_raw is not None else None,
+        )
+
+        bw_raw = data.get("bandwidth_kbps")
+        return cls(
+            latency=lat,
+            jitter_ms=float(data.get("jitter_ms", 0.0)),
+            bandwidth_kbps=float(bw_raw) if bw_raw is not None else None,
+            reorder_prob=float(data.get("reorder_prob", 0.0)),
+            drop_prob=float(data.get("drop_prob", 0.0)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# The model
+# ---------------------------------------------------------------------------
+
+
+def _solve_lognormal(p50_ms: float, p99_ms: float) -> tuple[float, float]:
+    """Return (mu, sigma) for a log-normal hitting (p50, p99) in ms.
+
+    For a log-normal, the *k*-th percentile is ``exp(mu + sigma * z_k)``
+    where ``z_k`` is the standard-normal quantile.  Therefore:
+
+        mu    = ln(p50)
+        sigma = (ln(p99) - ln(p50)) / z_99
+
+    with ``z_99 ~ 2.3263478740408408``.
+    """
+    if p50_ms <= 0:
+        return -math.inf, 0.0
+    z99 = 2.3263478740408408
+    mu = math.log(p50_ms)
+    if p99_ms <= p50_ms:
+        return mu, 0.0
+    sigma = (math.log(p99_ms) - mu) / z99
+    return mu, sigma
+
+
+class DelayModel:
+    """Sample per-message delays for the simulator's transport.
+
+    The model is *pure* with respect to its rng: feed it the same rng state
+    and it will produce the same sequence of delays.  All knobs are static
+    after construction — this matches netem's model.
+
+    Example::
+
+        model = DelayModel.from_config(cfg, seed=42)
+        delay_seconds = model.compute_delay(sender, receiver, payload_size=128)
+        if delay_seconds is None:
+            # message dropped
+            ...
+    """
+
+    __slots__ = (
+        "_cfg",
+        "_rng",
+        "_mu",
+        "_sigma",
+        "_last_delay",  # for ordering preservation when reorder_prob == 0
+    )
+
+    def __init__(self, cfg: DelayModelConfig, rng: random.Random) -> None:
+        self._cfg = cfg
+        self._rng = rng
+        self._mu, self._sigma = _solve_lognormal(
+            cfg.latency.p50_ms,
+            cfg.latency.p99_ms if cfg.latency.p99_ms is not None else cfg.latency.p50_ms,
+        )
+        self._last_delay: dict[tuple[str, str], float] = {}
+
+    @classmethod
+    def from_config(cls, cfg: DelayModelConfig, seed: int = 0) -> DelayModel:
+        """Build from a config + integer seed.
+
+        Example::
+
+            model = DelayModel.from_config(cfg, seed=42)
+        """
+        return cls(cfg, random.Random(seed))
+
+    @property
+    def config(self) -> DelayModelConfig:
+        return self._cfg
+
+    # ------------------------------------------------------------------
+    # Sampling
+    # ------------------------------------------------------------------
+    def _sample_latency_ms(self) -> float:
+        kind = self._cfg.latency.kind
+        if kind == "constant":
+            return self._cfg.latency.p50_ms
+        if kind == "uniform":
+            lo, hi = self._cfg.latency.uniform_bounds()
+            if hi <= lo:
+                return lo
+            return self._rng.uniform(lo, hi)
+        if kind == "lognormal":
+            if self._sigma == 0.0:
+                return self._cfg.latency.p50_ms
+            z = self._rng.gauss(0.0, 1.0)
+            return math.exp(self._mu + self._sigma * z)
+        msg = f"unknown latency kind: {kind!r}"
+        raise ValueError(msg)
+
+    def _serialization_delay_ms(self, payload_size: int) -> float:
+        bw = self._cfg.bandwidth_kbps
+        if bw is None or bw <= 0:
+            return 0.0
+        # bandwidth_kbps is *kilo-bits* per second; payload_size is bytes.
+        bits = payload_size * 8
+        return bits / bw  # kbps means kbit/s -> ms = bits / kbps
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+    def compute_delay(
+        self,
+        sender: AgentId,
+        receiver: AgentId,
+        payload_size: int,
+    ) -> float | None:
+        """Return delivery delay in virtual seconds, or ``None`` if dropped.
+
+        Even when ``reorder_prob == 0`` the model enforces FIFO per
+        (sender, receiver): if a freshly sampled delay would land before the
+        previous message on the same link, it is bumped up to ``prev + 1us``.
+
+        Example::
+
+            delay = model.compute_delay(AgentId("a"), AgentId("b"), 128)
+        """
+        if self._cfg.drop_prob > 0 and self._rng.random() < self._cfg.drop_prob:
+            return None
+
+        lat_ms = self._sample_latency_ms()
+
+        if self._cfg.jitter_ms > 0:
+            lat_ms += self._rng.uniform(-self._cfg.jitter_ms, self._cfg.jitter_ms)
+
+        lat_ms += self._serialization_delay_ms(payload_size)
+
+        scale = self._cfg.link_scale.get((str(sender), str(receiver)), 1.0)
+        lat_ms *= scale
+
+        if lat_ms < 0:
+            lat_ms = 0.0
+
+        delay_s = lat_ms / 1000.0
+
+        # FIFO preservation per (sender, receiver) when reorder is off.
+        key = (str(sender), str(receiver))
+        prev = self._last_delay.get(key)
+        if self._cfg.reorder_prob == 0.0 and prev is not None and delay_s <= prev:
+            # Add a microsecond past the previous delay to preserve ordering
+            # *deterministically*.  This avoids accidental reorders just
+            # because two messages were sent at the same virtual time.
+            delay_s = prev + 1e-6
+        elif (
+            self._cfg.reorder_prob > 0.0
+            and prev is not None
+            and self._rng.random() >= self._cfg.reorder_prob
+            and delay_s <= prev
+        ):
+            delay_s = prev + 1e-6
+
+        self._last_delay[key] = delay_s
+        return delay_s
+
+    # ------------------------------------------------------------------
+    # Diagnostic helpers (for tests / metrics)
+    # ------------------------------------------------------------------
+    def sample_latencies_ms(self, n: int) -> list[float]:
+        """Draw *n* raw latency samples (no jitter, no bandwidth, no FIFO).
+
+        Useful for tests that want to verify the distribution shape.
+
+        Example::
+
+            samples = model.sample_latencies_ms(10_000)
+        """
+        return [self._sample_latency_ms() for _ in range(n)]

--- a/packages/nest-core/nest_core/sim/simulator.py
+++ b/packages/nest-core/nest_core/sim/simulator.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from nest_core.sim.agent import AgentContext, StateMachineAgent
 from nest_core.sim.clock import VirtualClock
+from nest_core.sim.delay_model import DelayModel
 from nest_core.sim.events import Event, EventQueue
 from nest_core.sim.trace import TraceWriter
 from nest_core.sim.transport import InMemoryTransport
@@ -150,6 +151,7 @@ class Simulator:
         byzantine_fraction: float = 0.0,
         partition_groups: list[list[str]] | None = None,
         plugins: dict[str, Any] | None = None,
+        delay_model: DelayModel | None = None,
     ) -> None:
         if not 0.0 <= message_drop_rate <= 1.0:
             msg = f"message_drop_rate must be between 0 and 1: {message_drop_rate}"
@@ -177,6 +179,7 @@ class Simulator:
         self._failure_rng = random.Random(self._master_rng.randint(0, 2**63))
         self._plugins: dict[str, Any] = plugins or {}
         self._agent_plugins: dict[AgentId, dict[str, Any]] = {}
+        self._delay_model: DelayModel | None = delay_model
 
     @property
     def clock(self) -> VirtualClock:
@@ -227,7 +230,13 @@ class Simulator:
         """
         agent_rng = random.Random(self._master_rng.randint(0, 2**63))
         all_ids = [aid for aid in self._agents]
-        transport = InMemoryTransport(agent_id, self._queue, self._clock, all_ids)
+        transport = InMemoryTransport(
+            agent_id,
+            self._queue,
+            self._clock,
+            all_ids,
+            delay_model=self._delay_model,
+        )
         self._agents[agent_id] = _AgentSlot(
             agent=agent,
             transport=transport,
@@ -307,6 +316,26 @@ class Simulator:
             self._tick_count += 1
 
             if event.kind == "start":
+                continue
+
+            if event.kind == "netem_drop":
+                # Drop induced by the link-layer delay model.  Record it
+                # under the same 'dropped' kind as the message_drop knob so
+                # downstream tooling stays consistent.
+                self._dropped_count += 1
+                if self._trace:
+                    drop_rec: dict[str, Any] = {
+                        "ts": self._clock.now,
+                        "agent": str(event.agent_id),
+                        "kind": "dropped",
+                        "from": str(event.target_id),
+                        "size": len(event.payload),
+                        "msg": event.payload.decode("utf-8", errors="replace"),
+                        "reason": "netem",
+                    }
+                    if event.correlation_id is not None:
+                        drop_rec["corr"] = str(event.correlation_id)
+                    self._trace.record(drop_rec)
                 continue
 
             if event.kind == "deliver":

--- a/packages/nest-core/nest_core/sim/transport.py
+++ b/packages/nest-core/nest_core/sim/transport.py
@@ -15,11 +15,18 @@ from nest_core.types import AgentId, CorrelationId, TransportCapabilities
 
 if TYPE_CHECKING:
     from nest_core.sim.clock import VirtualClock
+    from nest_core.sim.delay_model import DelayModel
     from nest_core.sim.events import EventQueue
 
 
 class InMemoryTransport:
     """Transport that routes messages through the simulator's event queue.
+
+    When a :class:`~nest_core.sim.delay_model.DelayModel` is attached, each
+    send consults the model to compute a per-message delay (and may be
+    dropped at the model layer); otherwise messages are delivered at
+    ``time = now`` exactly as before — preserving backwards compatibility
+    with every existing scenario.
 
     Example::
 
@@ -39,11 +46,26 @@ class InMemoryTransport:
         event_queue: EventQueue,
         clock: VirtualClock,
         all_agents: list[AgentId] | None = None,
+        delay_model: DelayModel | None = None,
     ) -> None:
         self._agent_id = agent_id
         self._queue = event_queue
         self._clock = clock
         self.all_agents = all_agents or []
+        self._delay_model = delay_model
+
+    @property
+    def delay_model(self) -> DelayModel | None:
+        return self._delay_model
+
+    def set_delay_model(self, model: DelayModel | None) -> None:
+        """Attach or detach the delay model.  Used by the simulator at wiring time.
+
+        Example::
+
+            transport.set_delay_model(model)
+        """
+        self._delay_model = model
 
     async def send(
         self,
@@ -53,15 +75,43 @@ class InMemoryTransport:
     ) -> None:
         """Enqueue a message delivery event.
 
+        If a delay model is attached, the model's ``compute_delay`` is
+        consulted: ``None`` means the message is dropped at the wire (a
+        ``dropped`` trace event is *not* emitted here — that is the
+        simulator's job for symmetry with the existing ``message_drop``
+        knob).  Otherwise the delivery event is scheduled at
+        ``now + delay``.
+
         Example::
 
             await transport.send(AgentId("a2"), b"hello")
         """
         from nest_core.sim.events import Event
 
+        delay = 0.0
+        if self._delay_model is not None:
+            sampled = self._delay_model.compute_delay(self._agent_id, to, len(payload))
+            if sampled is None:
+                # Surface the drop through the same path as the simulator's
+                # message_drop knob so traces stay consistent.  We piggyback
+                # on the existing 'deliver' event with a marker and let the
+                # simulator turn it into a 'dropped' record at delivery time.
+                self._queue.push(
+                    Event(
+                        time=self._clock.now,
+                        kind="netem_drop",
+                        agent_id=to,
+                        target_id=self._agent_id,
+                        payload=payload,
+                        correlation_id=correlation_id,
+                    )
+                )
+                return
+            delay = sampled
+
         self._queue.push(
             Event(
-                time=self._clock.now,
+                time=self._clock.now + delay,
                 kind="deliver",
                 agent_id=to,
                 target_id=self._agent_id,

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -50,15 +50,23 @@ def _load_events(path: Path) -> list[dict[str, Any]]:
 def validate_trace(
     trace_path: Path,
     scenario_type: str,
+    slo: dict[str, float | None] | None = None,
 ) -> list[ValidationResult]:
     """Run all validators for a scenario type against a trace.
 
+    When ``slo`` is provided, latency / availability checks from
+    :func:`validate_latency_slo` are appended to the result list.
+
     Example::
 
-        results = validate_trace(Path("trace.jsonl"), "marketplace")
+        results = validate_trace(Path("trace.jsonl"), "marketplace",
+                                 slo={"p99_latency": 0.25})
     """
     events = _load_events(trace_path)
-    return validate_events(events, scenario_type)
+    results = validate_events(events, scenario_type)
+    if slo:
+        results.extend(validate_latency_slo(events, slo))
+    return results
 
 
 def validate_events(
@@ -884,6 +892,109 @@ def validate_reputation_warnings(
             f"{len(warned)} warnings issued, {len(should_warn)} needed",
         )
     ]
+
+
+# ---------------------------------------------------------------------------
+# SLO validators (latency / availability — scenario-independent)
+# ---------------------------------------------------------------------------
+
+
+def validate_latency_slo(
+    events: list[dict[str, Any]],
+    slo: dict[str, float | None],
+) -> list[ValidationResult]:
+    """Verify per-message latency stays under configured budgets.
+
+    ``slo`` is expected to expose any of ``p50_latency``, ``p95_latency``,
+    ``p99_latency``, ``max_latency`` (virtual seconds) and
+    ``min_delivery_rate`` (fraction).  Each non-None entry yields a
+    pass/fail :class:`ValidationResult`.
+
+    Example::
+
+        results = validate_latency_slo(events, {"p99_latency": 0.25})
+    """
+    # Pair send/receive by correlation id to derive per-message latency.
+    send_times: dict[str, float] = {}
+    latencies: list[float] = []
+    sends = 0
+    receives = 0
+    for ev in events:
+        kind = ev.get("kind", "")
+        corr = str(ev.get("corr", ""))
+        ts = float(ev.get("ts", 0.0))
+        if kind == "send":
+            sends += 1
+            if corr:
+                send_times[corr] = ts
+        elif kind == "receive":
+            receives += 1
+            if corr:
+                start = send_times.get(corr)
+                if start is not None:
+                    latencies.append(ts - start)
+
+    xs = sorted(latencies)
+    n = len(xs)
+    results: list[ValidationResult] = []
+
+    def _pct(q: float) -> float:
+        if n == 0:
+            return 0.0
+        # Nearest-rank — matches what production tools usually report.
+        import math as _math
+
+        if q <= 0:
+            return xs[0]
+        if q >= 100:
+            return xs[-1]
+        rank = max(1, _math.ceil(q / 100.0 * n))
+        return xs[rank - 1]
+
+    targets = (
+        ("p50_latency", 50.0),
+        ("p95_latency", 95.0),
+        ("p99_latency", 99.0),
+    )
+    for key, q in targets:
+        budget = slo.get(key)
+        if budget is None:
+            continue
+        actual = _pct(q)
+        passed = actual <= budget if n else False
+        results.append(
+            ValidationResult(
+                f"slo_{key}",
+                passed,
+                f"observed {actual:.6f}s vs budget {budget:.6f}s over {n} messages",
+            )
+        )
+
+    max_budget = slo.get("max_latency")
+    if max_budget is not None:
+        actual = xs[-1] if xs else 0.0
+        passed = actual <= max_budget if n else False
+        results.append(
+            ValidationResult(
+                "slo_max_latency",
+                passed,
+                f"observed {actual:.6f}s vs budget {max_budget:.6f}s",
+            )
+        )
+
+    min_rate = slo.get("min_delivery_rate")
+    if min_rate is not None:
+        rate = receives / sends if sends else 0.0
+        passed = rate >= min_rate
+        results.append(
+            ValidationResult(
+                "slo_min_delivery_rate",
+                passed,
+                f"observed {rate:.4f} vs target {min_rate:.4f} (sends={sends}, recv={receives})",
+            )
+        )
+
+    return results
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nest-core/tests/test_delay_model.py
+++ b/packages/nest-core/tests/test_delay_model.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the netem-style :class:`DelayModel`."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+from nest_core.sim.delay_model import (
+    DelayModel,
+    DelayModelConfig,
+    LatencyDistribution,
+)
+from nest_core.types import AgentId
+
+
+def _percentile(xs: list[float], q: float) -> float:
+    s = sorted(xs)
+    if not s:
+        return 0.0
+    rank = max(1, math.ceil(q / 100.0 * len(s)))
+    return s[rank - 1]
+
+
+class TestLatencyDistribution:
+    def test_constant_returns_p50(self) -> None:
+        cfg = DelayModelConfig(latency=LatencyDistribution(kind="constant", p50_ms=10))
+        model = DelayModel.from_config(cfg, seed=1)
+        samples = model.sample_latencies_ms(50)
+        assert all(abs(s - 10) < 1e-9 for s in samples)
+
+    def test_uniform_within_bounds(self) -> None:
+        cfg = DelayModelConfig(
+            latency=LatencyDistribution(kind="uniform", p50_ms=10, min_ms=5, max_ms=20)
+        )
+        model = DelayModel.from_config(cfg, seed=1)
+        samples = model.sample_latencies_ms(2000)
+        assert min(samples) >= 5.0
+        assert max(samples) <= 20.0
+        # Mean should be near 12.5 within a few stddev
+        mean = sum(samples) / len(samples)
+        assert 11.0 < mean < 14.0
+
+    def test_lognormal_percentiles(self) -> None:
+        cfg = DelayModelConfig(latency=LatencyDistribution(kind="lognormal", p50_ms=20, p99_ms=200))
+        model = DelayModel.from_config(cfg, seed=42)
+        samples = model.sample_latencies_ms(20_000)
+        # Allow 15% slack — log-normal tails are noisy at 20k samples.
+        assert abs(_percentile(samples, 50) - 20.0) / 20.0 < 0.15
+        assert abs(_percentile(samples, 99) - 200.0) / 200.0 < 0.15
+
+    def test_lognormal_requires_p99(self) -> None:
+        with pytest.raises(ValueError, match="p99_ms"):
+            LatencyDistribution(kind="lognormal", p50_ms=20)
+
+    def test_lognormal_rejects_p99_below_p50(self) -> None:
+        with pytest.raises(ValueError, match="p99_ms"):
+            LatencyDistribution(kind="lognormal", p50_ms=200, p99_ms=20)
+
+    def test_uniform_rejects_inverted_bounds(self) -> None:
+        with pytest.raises(ValueError, match="min_ms"):
+            LatencyDistribution(kind="uniform", p50_ms=5, min_ms=20, max_ms=10)
+
+
+class TestDeterminism:
+    def test_same_seed_same_samples(self) -> None:
+        cfg = DelayModelConfig(latency=LatencyDistribution(kind="lognormal", p50_ms=10, p99_ms=100))
+        a = DelayModel.from_config(cfg, seed=7)
+        b = DelayModel.from_config(cfg, seed=7)
+        for _ in range(100):
+            sender, receiver = AgentId("a"), AgentId("b")
+            da = a.compute_delay(sender, receiver, 16)
+            db = b.compute_delay(sender, receiver, 16)
+            assert da == db
+
+    def test_different_seed_diverges(self) -> None:
+        cfg = DelayModelConfig(latency=LatencyDistribution(kind="lognormal", p50_ms=10, p99_ms=100))
+        a = DelayModel.from_config(cfg, seed=1)
+        b = DelayModel.from_config(cfg, seed=2)
+        seq_a = [a.compute_delay(AgentId("x"), AgentId("y"), 16) for _ in range(50)]
+        seq_b = [b.compute_delay(AgentId("x"), AgentId("y"), 16) for _ in range(50)]
+        assert seq_a != seq_b
+
+
+class TestDropAndOrdering:
+    def test_drop_prob_zero_never_drops(self) -> None:
+        cfg = DelayModelConfig(
+            latency=LatencyDistribution(kind="constant", p50_ms=1),
+            drop_prob=0.0,
+        )
+        model = DelayModel.from_config(cfg, seed=0)
+        for _ in range(500):
+            assert model.compute_delay(AgentId("a"), AgentId("b"), 1) is not None
+
+    def test_drop_prob_one_always_drops(self) -> None:
+        cfg = DelayModelConfig(
+            latency=LatencyDistribution(kind="constant", p50_ms=1),
+            drop_prob=1.0,
+        )
+        model = DelayModel.from_config(cfg, seed=0)
+        for _ in range(50):
+            assert model.compute_delay(AgentId("a"), AgentId("b"), 1) is None
+
+    def test_drop_prob_in_expected_range(self) -> None:
+        cfg = DelayModelConfig(
+            latency=LatencyDistribution(kind="constant", p50_ms=1),
+            drop_prob=0.25,
+        )
+        model = DelayModel.from_config(cfg, seed=0)
+        n = 10_000
+        drops = sum(
+            1 for _ in range(n) if model.compute_delay(AgentId("a"), AgentId("b"), 1) is None
+        )
+        # Allow 1.5% slack
+        assert 0.235 <= drops / n <= 0.265
+
+    def test_fifo_preservation_without_reorder(self) -> None:
+        """With reorder_prob=0 and per-message jitter, delays must be monotonic per link."""
+        cfg = DelayModelConfig(
+            latency=LatencyDistribution(kind="lognormal", p50_ms=20, p99_ms=200),
+            jitter_ms=5,
+        )
+        model = DelayModel.from_config(cfg, seed=99)
+        prev = -1.0
+        for _ in range(500):
+            d = model.compute_delay(AgentId("a"), AgentId("b"), 64)
+            assert d is not None
+            assert d > prev, f"FIFO violated: {d} <= {prev}"
+            prev = d
+
+    def test_independent_links_have_independent_fifo(self) -> None:
+        cfg = DelayModelConfig(latency=LatencyDistribution(kind="constant", p50_ms=10))
+        model = DelayModel.from_config(cfg, seed=0)
+        # (a -> b) at 10ms repeated should still be monotonic on link
+        d1 = model.compute_delay(AgentId("a"), AgentId("b"), 1)
+        d2 = model.compute_delay(AgentId("a"), AgentId("b"), 1)
+        # On a different link, the first message can be at 10ms again — not
+        # pinned to the previous delay.
+        d3 = model.compute_delay(AgentId("c"), AgentId("d"), 1)
+        assert d1 is not None and d2 is not None and d3 is not None
+        assert d2 > d1
+        assert abs(d3 - 0.01) < 1e-6
+
+
+class TestBandwidth:
+    def test_serialization_delay_proportional_to_size(self) -> None:
+        cfg = DelayModelConfig(
+            latency=LatencyDistribution(kind="constant", p50_ms=0),
+            bandwidth_kbps=1000,  # 1 Mbps
+        )
+        model = DelayModel.from_config(cfg, seed=0)
+        # 1000 bytes = 8000 bits / 1000 kbps = 8 ms
+        d = model.compute_delay(AgentId("a"), AgentId("b"), 1000)
+        assert d is not None
+        assert abs(d - 0.008) < 1e-6
+
+    def test_bandwidth_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="bandwidth_kbps"):
+            DelayModelConfig(bandwidth_kbps=0)
+
+
+class TestConfigFromDict:
+    def test_round_trip(self) -> None:
+        data: dict[str, Any] = {
+            "latency": {"kind": "lognormal", "p50_ms": 5, "p99_ms": 50},
+            "jitter_ms": 1,
+            "bandwidth_kbps": 100,
+            "reorder_prob": 0.0,
+            "drop_prob": 0.0,
+        }
+        cfg = DelayModelConfig.from_dict(data)
+        assert cfg.latency.kind == "lognormal"
+        assert cfg.latency.p50_ms == 5
+        assert cfg.latency.p99_ms == 50
+        assert cfg.jitter_ms == 1
+        assert cfg.bandwidth_kbps == 100
+
+    def test_empty_dict_produces_noop_model(self) -> None:
+        cfg = DelayModelConfig.from_dict({})
+        model = DelayModel.from_config(cfg, seed=0)
+        d = model.compute_delay(AgentId("a"), AgentId("b"), 16)
+        assert d is not None
+        assert abs(d) < 1e-9
+
+    def test_validation_negative_jitter(self) -> None:
+        with pytest.raises(ValueError, match="jitter_ms"):
+            DelayModelConfig(jitter_ms=-1)
+
+    def test_validation_prob_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match="reorder_prob"):
+            DelayModelConfig(reorder_prob=1.5)
+        with pytest.raises(ValueError, match="drop_prob"):
+            DelayModelConfig(drop_prob=-0.1)

--- a/packages/nest-core/tests/test_metrics.py
+++ b/packages/nest-core/tests/test_metrics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from nest_core.metrics import (
@@ -94,6 +95,43 @@ class TestComputeMetrics:
         results = compute_metrics(trace, ["unique_pairs"])
         # a1 <-> a2 is the only pair
         assert results["unique_pairs"] == 1.0
+
+    def test_latency_percentiles(self, tmp_path: Path) -> None:
+        """p50/p95/p99/max are computed from corr-paired send/receive events."""
+        # 10 messages with latencies 1..10ms (so p99 ~= 10ms)
+        trace = tmp_path / "t.jsonl"
+        events: list[dict[str, Any]] = []
+        for i in range(10):
+            corr = f"c-{i}"
+            send_ts = 1.0
+            recv_ts = send_ts + (i + 1) * 0.001  # 1..10 ms
+            events.append({"ts": send_ts, "agent": "a1", "kind": "send", "to": "a2", "corr": corr})
+            events.append(
+                {"ts": recv_ts, "agent": "a2", "kind": "receive", "from": "a1", "corr": corr}
+            )
+        trace.write_text("\n".join(json.dumps(e) for e in events))
+
+        results = compute_metrics(
+            trace,
+            ["mean_latency", "p50_latency", "p95_latency", "p99_latency", "max_latency"],
+        )
+        # mean = (1+2+...+10)/10 = 5.5ms
+        assert abs(results["mean_latency"] - 0.0055) < 1e-6
+        # nearest-rank p50 -> 5ms (rank 5 of 10)
+        assert abs(results["p50_latency"] - 0.005) < 1e-6
+        # p99 -> 10ms (rank 10 of 10 -> last)
+        assert abs(results["p99_latency"] - 0.010) < 1e-6
+        assert abs(results["max_latency"] - 0.010) < 1e-6
+        assert results["p95_latency"] >= results["p50_latency"]
+
+    def test_latency_percentiles_empty(self, tmp_path: Path) -> None:
+        trace = tmp_path / "t.jsonl"
+        trace.write_text("")
+        results = compute_metrics(
+            trace, ["p50_latency", "p95_latency", "p99_latency", "max_latency"]
+        )
+        for k, v in results.items():
+            assert v == 0.0, f"{k}={v}"
 
 
 class TestMarketplaceMetrics:

--- a/packages/nest-core/tests/test_netem_integration.py
+++ b/packages/nest-core/tests/test_netem_integration.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end tests for the ``netem`` transport + latency metrics + SLO validator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from nest_core.metrics import compute_metrics
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.sim.delay_model import (
+    DelayModel,
+    DelayModelConfig,
+    LatencyDistribution,
+)
+from nest_core.sim.simulator import Simulator
+from nest_core.types import AgentId
+from nest_core.validators import validate_latency_slo, validate_trace
+
+
+class _Pinger(StateMachineAgent):
+    """Sends N pings to a fixed peer at t=0 then stays silent."""
+
+    def __init__(self, peer: AgentId, n: int) -> None:
+        self._peer = peer
+        self._n = n
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        for i in range(self._n):
+            await ctx.send(self._peer, f"ping-{i}".encode())
+
+
+class _Echo(StateMachineAgent):
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        await ctx.send(sender, payload)
+
+
+# ---------------------------------------------------------------------------
+# Simulator-level integration
+# ---------------------------------------------------------------------------
+
+
+class TestSimulatorWithNetem:
+    @pytest.mark.asyncio
+    async def test_constant_delay_visible_in_trace(self, tmp_path: Path) -> None:
+        """Every send produces a deliver event 10ms later."""
+        cfg = DelayModelConfig(
+            latency=LatencyDistribution(kind="constant", p50_ms=10),
+        )
+        model = DelayModel.from_config(cfg, seed=0)
+        trace = tmp_path / "t.jsonl"
+
+        sim = Simulator(seed=0, trace_path=trace, delay_model=model)
+        sim.add_agent(AgentId("a"), _Pinger(AgentId("b"), n=5))
+        sim.add_agent(AgentId("b"), _Echo())
+        await sim.run(max_ticks=100)
+
+        events = [json.loads(line) for line in trace.read_text().splitlines() if line.strip()]
+        receives = [e for e in events if e.get("kind") == "receive"]
+        sends = {e["corr"]: e for e in events if e.get("kind") == "send"}
+        assert receives, "no receives recorded"
+        for rec in receives:
+            send = sends.get(rec["corr"])
+            assert send is not None
+            # Constant 10ms => 0.01s, plus FIFO 1us bumps for repeated sends.
+            delta = rec["ts"] - send["ts"]
+            assert delta >= 0.01 - 1e-9, f"{delta=} too small"
+            assert delta < 0.020, f"{delta=} too large"
+
+    @pytest.mark.asyncio
+    async def test_zero_delay_when_no_model(self, tmp_path: Path) -> None:
+        """Backwards compat: no model => zero delay, mean_latency = 0."""
+        trace = tmp_path / "t.jsonl"
+        sim = Simulator(seed=0, trace_path=trace)
+        sim.add_agent(AgentId("a"), _Pinger(AgentId("b"), n=3))
+        sim.add_agent(AgentId("b"), _Echo())
+        await sim.run(max_ticks=100)
+
+        results = compute_metrics(trace, ["mean_latency"])
+        assert results["mean_latency"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_netem_drop_logs_dropped(self, tmp_path: Path) -> None:
+        cfg = DelayModelConfig(
+            latency=LatencyDistribution(kind="constant", p50_ms=1),
+            drop_prob=1.0,
+        )
+        model = DelayModel.from_config(cfg, seed=0)
+        trace = tmp_path / "t.jsonl"
+        sim = Simulator(seed=0, trace_path=trace, delay_model=model)
+        sim.add_agent(AgentId("a"), _Pinger(AgentId("b"), n=4))
+        sim.add_agent(AgentId("b"), _Echo())
+        await sim.run(max_ticks=100)
+
+        events = [json.loads(line) for line in trace.read_text().splitlines() if line.strip()]
+        kinds = [e.get("kind") for e in events]
+        assert kinds.count("dropped") == 4
+        # Every drop should be tagged with reason=netem so downstream tooling
+        # can tell "wire-drop" from "policy-drop".
+        for ev in events:
+            if ev.get("kind") == "dropped":
+                assert ev.get("reason") == "netem"
+
+    @pytest.mark.asyncio
+    async def test_determinism_across_runs(self, tmp_path: Path) -> None:
+        cfg = DelayModelConfig(
+            latency=LatencyDistribution(kind="lognormal", p50_ms=10, p99_ms=100),
+            jitter_ms=2,
+        )
+        traces: list[str] = []
+        for _ in range(2):
+            model = DelayModel.from_config(cfg, seed=99)
+            trace = tmp_path / f"t-{len(traces)}.jsonl"
+            sim = Simulator(seed=99, trace_path=trace, delay_model=model)
+            sim.add_agent(AgentId("a"), _Pinger(AgentId("b"), n=20))
+            sim.add_agent(AgentId("b"), _Echo())
+            await sim.run(max_ticks=500)
+            traces.append(trace.read_text())
+        assert traces[0] == traces[1]
+
+
+# ---------------------------------------------------------------------------
+# Runner / scenario integration
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioRunnerWithNetem:
+    @pytest.mark.asyncio
+    async def test_marketplace_with_netem_has_real_latency(self, tmp_path: Path) -> None:
+        trace_file = tmp_path / "m.jsonl"
+        config = ScenarioConfig.from_dict(
+            {
+                "name": "netem-marketplace",
+                "seed": 1,
+                "agents": {
+                    "count": 10,
+                    "roles": [
+                        {"name": "buyer", "count": 5},
+                        {"name": "seller", "count": 5},
+                    ],
+                },
+                "layers": {"transport": "netem"},
+                "transport": {
+                    "latency": {"kind": "constant", "p50_ms": 5},
+                },
+                "task": {"type": "marketplace", "config": {"rounds": 3}},
+                "duration": "ticks: 2000",
+                "metrics": [
+                    "mean_latency",
+                    "p50_latency",
+                    "p95_latency",
+                    "p99_latency",
+                    "max_latency",
+                    "message_count",
+                ],
+                "output": {"trace": str(trace_file)},
+            }
+        )
+        runner = ScenarioRunner(config)
+        await runner.run()
+        # 5ms constant => 0.005 +/- FIFO microsecond bumps
+        assert runner.metrics["p50_latency"] >= 0.005 - 1e-6
+        assert runner.metrics["mean_latency"] > 0
+        assert runner.metrics["p99_latency"] >= runner.metrics["p50_latency"]
+        assert runner.metrics["max_latency"] >= runner.metrics["p99_latency"]
+        assert runner.metrics["message_count"] > 0
+
+    @pytest.mark.asyncio
+    async def test_slo_pass_and_fail(self, tmp_path: Path) -> None:
+        trace_file = tmp_path / "m.jsonl"
+        base = {
+            "name": "slo-test",
+            "seed": 2,
+            "agents": {
+                "count": 4,
+                "roles": [
+                    {"name": "buyer", "count": 2},
+                    {"name": "seller", "count": 2},
+                ],
+            },
+            "layers": {"transport": "netem"},
+            "transport": {"latency": {"kind": "constant", "p50_ms": 10}},
+            "task": {"type": "marketplace", "config": {"rounds": 2}},
+            "duration": "ticks: 500",
+            "output": {"trace": str(trace_file)},
+        }
+        # SLO that should pass: budget = 100ms
+        cfg_pass = ScenarioConfig.from_dict({**base, "slo": {"p99_latency": 0.1}})
+        runner = ScenarioRunner(cfg_pass)
+        await runner.run()
+        assert runner.validations, "expected SLO validations"
+        assert all(v["passed"] for v in runner.validations), runner.validations
+        # SLO that should fail: budget = 1ms but latency is 10ms
+        cfg_fail = ScenarioConfig.from_dict({**base, "slo": {"p99_latency": 0.001}})
+        runner = ScenarioRunner(cfg_fail)
+        await runner.run()
+        assert any(not v["passed"] for v in runner.validations), runner.validations
+
+
+class TestSloValidator:
+    def test_min_delivery_rate(self) -> None:
+        events = [
+            {"ts": 0, "kind": "send", "corr": "c1"},
+            {"ts": 0.01, "kind": "receive", "corr": "c1"},
+            {"ts": 0, "kind": "send", "corr": "c2"},
+            # c2 never received -> 50% delivery
+            {"ts": 0, "kind": "send", "corr": "c3"},
+            {"ts": 0.01, "kind": "receive", "corr": "c3"},
+        ]
+        res = validate_latency_slo(events, {"min_delivery_rate": 0.9})
+        assert any(not r.passed and "delivery_rate" in r.name for r in res)
+        res2 = validate_latency_slo(events, {"min_delivery_rate": 0.5})
+        assert all(r.passed for r in res2)
+
+    def test_empty_trace_fails_when_budget_set(self) -> None:
+        res = validate_latency_slo([], {"p99_latency": 0.1})
+        assert all(not r.passed for r in res)
+
+    def test_validate_trace_with_slo(self, tmp_path: Path) -> None:
+        trace = tmp_path / "t.jsonl"
+        events = [
+            {"ts": 0, "kind": "send", "corr": "c1"},
+            {"ts": 0.005, "kind": "receive", "corr": "c1"},
+            {"ts": 0, "kind": "send", "corr": "c2"},
+            {"ts": 0.05, "kind": "receive", "corr": "c2"},
+        ]
+        trace.write_text("\n".join(json.dumps(e) for e in events))
+        results = validate_trace(trace, "marketplace", slo={"p99_latency": 0.1})
+        names = [r.name for r in results]
+        assert "slo_p99_latency" in names

--- a/packages/nest-plugins-reference/nest_plugins_reference/transport/netem.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/transport/netem.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``netem`` transport — netem-style link emulation for NEST Tier 1.
+
+The plugin itself is intentionally a thin re-export of the simulator's
+in-memory transport: the *actual* per-link delay, jitter, bandwidth and
+reorder behaviour lives in :class:`nest_core.sim.delay_model.DelayModel`,
+which is wired into :class:`nest_core.sim.transport.InMemoryTransport` by
+the runner when ``layers.transport == "netem"``.
+
+We expose two things here:
+
+* :class:`StandaloneNetemTransport` — a Tier-2-style standalone transport
+  that injects delays using ``asyncio.sleep``.  Useful for stress-testing
+  shell agents against realistic-ish latency profiles.
+* :func:`make_delay_model` — convenience builder for tests / direct API
+  use.
+
+For Tier 1 scenarios, just set ``layers.transport: netem`` and add a
+``transport:`` block; the runner takes care of the rest.
+
+Example (YAML)::
+
+    layers:
+      transport: netem
+    transport:
+      latency: { kind: lognormal, p50_ms: 20, p99_ms: 200 }
+      jitter_ms: 2
+      bandwidth_kbps: 1000
+
+Example (Python)::
+
+    from nest_plugins_reference.transport.netem import (
+        make_delay_model,
+        StandaloneNetemTransport,
+    )
+
+    model = make_delay_model({"latency": {"kind": "constant", "p50_ms": 5}})
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from nest_core.sim.delay_model import DelayModel, DelayModelConfig
+from nest_core.types import AgentId, TransportCapabilities
+
+from .in_memory import InMemoryNetwork
+
+
+def make_delay_model(config: dict[str, Any] | None = None, seed: int = 0) -> DelayModel:
+    """Build a :class:`DelayModel` from a plain config dict + seed.
+
+    Example::
+
+        model = make_delay_model({"latency": {"kind": "constant", "p50_ms": 5}})
+    """
+    cfg = DelayModelConfig.from_dict(config or {})
+    return DelayModel.from_config(cfg, seed=seed)
+
+
+class StandaloneNetemTransport:
+    """In-memory transport with netem-style delays for non-simulator use.
+
+    Backed by an :class:`InMemoryNetwork`; delays are injected through an
+    ``asyncio.sleep`` so this is usable from Tier 2 / shell agents.  The
+    sleep duration is sourced from the same :class:`DelayModel` that the
+    Tier 1 simulator uses, so the *profile* of latencies stays comparable
+    across tiers.
+
+    Note: Because Tier 2 is non-deterministic by design, the standalone
+    transport's RNG advances in real time and is not seed-pinnable.
+
+    Example::
+
+        network = InMemoryNetwork()
+        model = make_delay_model({"latency": {"kind": "constant", "p50_ms": 5}})
+        t = StandaloneNetemTransport(AgentId("a1"), network, model)
+        await t.send(AgentId("a2"), b"hello")  # actually sleeps ~5ms
+    """
+
+    capabilities = TransportCapabilities(
+        supports_streaming=False,
+        ordered=True,
+        reliable=True,
+    )
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        network: InMemoryNetwork,
+        delay_model: DelayModel,
+    ) -> None:
+        self._agent_id = agent_id
+        self._network = network
+        self._queue = network.register(agent_id)
+        self._delay_model = delay_model
+
+    async def send(self, to: AgentId, payload: bytes) -> None:
+        """Send a payload with netem-modelled delay (and possible drop).
+
+        Example::
+
+            await transport.send(AgentId("a2"), b"hello")
+        """
+        delay = self._delay_model.compute_delay(self._agent_id, to, len(payload))
+        if delay is None:
+            return  # dropped at the wire
+        if delay > 0:
+            await asyncio.sleep(delay)
+        await self._network.deliver(self._agent_id, to, payload)
+
+    async def receive(self) -> tuple[AgentId, bytes]:
+        """Wait for the next message and return (sender, payload).
+
+        Example::
+
+            sender, data = await transport.receive()
+        """
+        return await self._queue.get()
+
+    async def broadcast(self, payload: bytes) -> None:
+        """Broadcast to all peers, each subject to its own delay sample.
+
+        Example::
+
+            await transport.broadcast(b"announcement")
+        """
+        for aid in self._network.get_agents():
+            if aid != self._agent_id:
+                await self.send(aid, payload)

--- a/packages/nest-plugins-reference/tests/test_netem.py
+++ b/packages/nest-plugins-reference/tests/test_netem.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``netem`` standalone transport + plugin registration."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId
+
+
+class TestNetemPluginResolution:
+    def test_registry_resolves_netem(self) -> None:
+        reg = PluginRegistry()
+        cls = reg.resolve("transport", "netem")
+        assert cls is not None
+        assert cls.__name__ == "StandaloneNetemTransport"
+
+    def test_list_includes_netem(self) -> None:
+        reg = PluginRegistry()
+        names = {n for (_, n) in reg.list_plugins("transport")}
+        assert "netem" in names
+        assert "in_memory" in names
+
+
+class TestStandaloneNetem:
+    @pytest.mark.asyncio
+    async def test_delay_observable_via_asyncio_sleep(self) -> None:
+        from nest_plugins_reference.transport.in_memory import InMemoryNetwork
+        from nest_plugins_reference.transport.netem import (
+            StandaloneNetemTransport,
+            make_delay_model,
+        )
+
+        network = InMemoryNetwork()
+        model = make_delay_model(
+            {"latency": {"kind": "constant", "p50_ms": 30}},
+            seed=0,
+        )
+        t1 = StandaloneNetemTransport(AgentId("a1"), network, model)
+        StandaloneNetemTransport(AgentId("a2"), network, model)
+
+        started = time.perf_counter()
+        await t1.send(AgentId("a2"), b"hello")
+        elapsed = time.perf_counter() - started
+        # The 30ms delay must materialise via asyncio.sleep.  Allow a
+        # generous lower bound to keep the test stable under CI noise.
+        assert elapsed >= 0.020, f"expected >=20ms wait, got {elapsed * 1000:.2f}ms"
+
+    @pytest.mark.asyncio
+    async def test_drop_returns_without_delivery(self) -> None:
+        from nest_plugins_reference.transport.in_memory import InMemoryNetwork
+        from nest_plugins_reference.transport.netem import (
+            StandaloneNetemTransport,
+            make_delay_model,
+        )
+
+        network = InMemoryNetwork()
+        model = make_delay_model(
+            {
+                "latency": {"kind": "constant", "p50_ms": 0},
+                "drop_prob": 1.0,
+            },
+            seed=0,
+        )
+        t1 = StandaloneNetemTransport(AgentId("a1"), network, model)
+        t2 = StandaloneNetemTransport(AgentId("a2"), network, model)
+
+        await t1.send(AgentId("a2"), b"hello")
+        # Receive must time out — nothing was delivered.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(t2.receive(), timeout=0.05)


### PR DESCRIPTION
## Piece picked

**Layer 1 — Transport.** A `netem`-style alternative transport plugin, plus the observability and assertion machinery a real SRE would need to use it: tail-latency metrics and per-scenario SLO validators.

## Why

The README is honest about it:

> The default transport is zero-latency. ... `mean_latency` / `duration` will both be `0.0` in your trace. Latency *numbers* become meaningful only when ... you write a transport plugin that introduces per-hop delay.

The mean is the least interesting number in a distributed system anyway. **Real protocols fail at the tail.** Without a way to inject realistic per-link delay, jitter, bandwidth, and reorder, and without p50/p95/p99 metrics and pass/fail SLO checks, NEST can verify *correctness* but cannot answer "will this still satisfy 250ms p99 at 1000 agents?" — which is the question every protocol team eventually has to answer in production.

## Core idea

1. **`DelayModel`** (`nest_core.sim.delay_model`) — a netem-style per-link emulator: constant / uniform / lognormal-tailed latencies, jitter, bandwidth-based serialization delay, per-link drops, reproducible per-link FIFO. Pure with respect to a caller-supplied `random.Random`, so the simulator stays byte-deterministic.
2. **Simulator wiring** — `InMemoryTransport` accepts an optional `delay_model`. When `None` (the default), behaviour is byte-identical to today. When attached, every `send`/`broadcast` consults the model and the delivery event is scheduled at `now + delay`. Drops surface as `dropped` trace events with `reason: netem`.
3. **`netem` plugin** — `nest_plugins_reference.transport.netem` exposes a `StandaloneNetemTransport` for Tier-2 / shell use (delays via `asyncio.sleep`) and a `make_delay_model` helper. Registered as a built-in `("transport", "netem")` in the plugin registry.
4. **Scenario YAML** — new optional `transport:` block (parsed into `TransportConfig`) and new optional `slo:` block. The runner builds a `DelayModel` only when `layers.transport == "netem"`, seeded from `scenario.seed XOR transport.seed_salt` so reruns are reproducible and the transport's randomness can be perturbed independently of agent behaviour.
5. **Metrics** — added `p50_latency`, `p95_latency`, `p99_latency`, `max_latency`, computed from corr-paired send/receive events using nearest-rank (matches what netem and most prod tooling report).
6. **SLO validators** — `validate_latency_slo` checks `p50/p95/p99/max_latency` budgets and `min_delivery_rate`. Wired into the runner: scenarios with an `slo:` block get pass/fail results on `runner.validations` automatically.

## How to test

```bash
uv sync
uv run ruff check . && uv run ruff format --check .
uv run pyright
uv run pytest -q
```

All green on my machine: **293 tests pass** (up from 259 baseline; +34 new), zero ruff findings, zero pyright errors.

Try the bundled example:

```bash
cp examples/netem-transport/marketplace-netem.yaml /tmp/
uv run nest run /tmp/marketplace-netem.yaml -o /tmp/netem.jsonl
```

Or programmatically:

```python
from nest_core.runner import ScenarioRunner
from nest_core.scenario import ScenarioConfig

cfg = ScenarioConfig.from_yaml("examples/netem-transport/marketplace-netem.yaml")
runner = ScenarioRunner(cfg)
await runner.run()
print(runner.metrics)       # p50/p95/p99/max all > 0
print(runner.validations)   # pass/fail per SLO budget
```

A representative run from this branch on the bundled example:

```
mean_latency      0.034125 s
p50_latency       0.021009 s     (target 0.020)
p95_latency       0.111038 s
p99_latency       0.189972 s     (target 0.200, budget 0.250 -> PASS)
max_latency       0.820940 s     (heavy tail from lognormal)
slo_p99_latency           PASS  observed 0.189972s vs budget 0.250000s over 1000 messages
slo_min_delivery_rate     PASS  observed 1.0000 vs target 0.9900
```

Tightening the budget to `p99_latency: 0.050` immediately flips to `FAIL`, which is exactly what you want from a regression signal.

## Key assumptions

- **Determinism is non-negotiable.** Same `seed` + same YAML → byte-identical trace. The delay model uses its own seeded RNG so swapping `seed_salt` perturbs only the transport.
- **Backwards-compatible by default.** No existing scenario, validator, or metric changes behaviour. `delay_model=None` is the same code path as before.
- **Unit-sized messages.** This is a netem-style model for agent-protocol messages, not a packet-level DPDK emulator. Serialization delay is `bytes * 8 / kbps`.
- **Tier 1 only for the wired plugin path.** `StandaloneNetemTransport` exists for Tier 2 / shell use but is not deterministic by design (it sleeps in real time).
- **Nearest-rank percentiles**, since that is what netem and most production telemetry report and it never returns a value that wasn't actually in the distribution.

## Persona

Google staff engineer (Spanner / Borg DNA): metrics before features, SLOs over feelings, deterministic reproducibility over clever heuristics, and tail latency is the only latency that matters.

## Future work

- Per-link bandwidth queues (model HOL blocking under burst load, not just per-message serialization).
- A `chaos:` scenario hook that flips `seed_salt` mid-run for chaos-style regression sweeps.
- Hook the HTML report to plot the per-message latency CDF and color rows by SLO violation.
- A `validate_latency_slo` variant that operates on a *rolling window* so long-tail spikes show up even when the overall p99 stays under budget.
- Extend the model to Byzantine link behaviour (per-pair partition timers) so it composes cleanly with `failures.network_partition`.
- A `nest dashboard` panel that surfaces SLO pass/fail next to the metrics it depends on.

https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW)_