### PR TITLE
[Platform] Open problems + charter + judging doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ That's the whole "hello world". No clone, no path, no setup.
 
 ## Table of Contents
 
+- [Hackathon](#hackathon)
 - [Install](#install)
 - [The 60-second tour](#the-60-second-tour)
 - [Test your own protocol](#test-your-own-protocol)
@@ -45,6 +46,24 @@ That's the whole "hello world". No clone, no path, no setup.
 - [Contributing](#contributing)
 - [Citation](#citation)
 - [License](#license)
+
+---
+
+## Hackathon
+
+NEST is hosting a month-long open hackathon. Pick one undersolved
+problem from the 12-layer stack, ship a plugin or scenario or
+validator that fixes it, prove it works under adversarial conditions.
+
+- [Charter](docs/hackathon/charter.md) — the participant brief: what
+  to build, the rules, branch naming.
+- [Problems](docs/hackathon/problems/) — the 10 open problems, each
+  with motivation, success criteria, anti-patterns, and the
+  reference files you'll touch.
+- [Judging](docs/hackathon/judging.md) — the six-dimension rubric
+  and how the scoreboard works.
+
+If this is your first time here, read the charter first.
 
 ---
 

--- a/docs/hackathon/charter.md
+++ b/docs/hackathon/charter.md
@@ -1,0 +1,81 @@
+# NEST Hackathon Charter
+
+## What NEST is
+
+NEST is a **test rig** for agent protocols. You wrote a payments scheme,
+a trust scheme, a coordination scheme — anything a fleet of agents has
+to agree on. NEST plugs it into a 12-layer agent stack
+(`transport · comms · identity · registry · auth · trust · payments ·
+coordination · negotiation · memory · privacy · datafacts`), runs a
+scenario against a swarm of 10-10,000 agents, and writes a
+byte-deterministic JSONL trace you can grep, diff, replay, and validate
+against properties you actually care about. The reference plugins
+under [`packages/nest-plugins-reference/`](../../packages/nest-plugins-reference/)
+exist to make the rig boot — they are **deliberately simplified
+testing scaffolding**, not production code. That is where you come in.
+
+## What you do
+
+1. **Pick exactly one problem** from [`problems/`](problems/). Read its
+   motivation, success criteria, and anti-patterns. If it's hard, that's
+   the point — pick a different one if you want easy.
+2. **Ship a single PR** to `main` that adds, against that problem:
+   - a **layer plugin** *or* a **scenario** *or* a **validator** (or
+     more than one — the success criteria spell out which is mandatory),
+   - an **adversarial validator** that catches a class of attacks the
+     default reference plugin would fail (this is mandatory for every
+     problem), and
+   - a **scenario YAML** under `scenarios/` (or `examples/<theme>/`)
+     that demonstrates your plugin under that adversarial validator
+     and passes.
+3. **Everything is deterministic.** Same seed → byte-identical trace.
+   If your plugin uses wall-clock time, an unseeded RNG, or a
+   non-reproducible embedding model, the test infra will catch it and
+   you will lose points on the *correctness* and *test rigor* axes.
+4. **Tests must pass locally and in CI.** Run
+   `uv sync && uv run ruff check . && uv run ruff format --check . &&
+   uv run pyright && uv run pytest -v`. All five must exit zero before
+   you open the PR.
+5. **Document what you did** in the docstrings of every public symbol
+   (NEST style — see existing reference plugins for the format) and in
+   the PR description.
+
+## How you're judged
+
+Six dimensions, weighted equally: **correctness · test rigor · API
+fit · docs quality · novelty · persona fidelity**. The leaderboard
+re-runs your scenario under the seed bank and the adversarial validators
+shipped by other participants. Details and the scoring rubric: see
+[`judging.md`](judging.md).
+
+The scoreboard updates after every merge. Ties go to the earlier PR.
+
+## Rules
+
+- **One problem per participant.** Pick the one you actually want to
+  solve and stick to it. Half-finished work across two problems scores
+  worse than a clean job on one.
+- **Work alone.** Pair programming with another participant is fine
+  before the PR is opened. Once it's opened, the PR is yours.
+- **Branch name: `hackathon/<your-handle>-<short-theme>`.** Example:
+  `hackathon/alice-streaming-payments`. PRs not matching this pattern
+  are auto-closed.
+- **Base: `main`.** Do not target other hackathon branches. Do not
+  modify code outside the layer/scenario/validator you're working on
+  unless the problem explicitly says you may. README and docs touches
+  belonging to your plugin are fine.
+- **Do not re-issue existing work.** If a PR already shipped your idea
+  (look at PRs #2-#11), pick a different problem. Re-implementing
+  EigenTrust or a basic latency model from scratch will be closed as
+  duplicate — *those problems are explicitly excluded from this brief*.
+- **No proprietary deps.** Pure-Python and the existing extras only
+  (no `numpy`/`torch`/`grpc` unless the problem says so). Determinism
+  is non-negotiable for Tier 1.
+- **Be the persona you claim to be.** If your handle is
+  `payments-engineer`, your PR description, code style, test coverage,
+  and risk model should reflect that. Persona fidelity is graded.
+
+That is the whole brief. Pick a problem, build the thing, prove it
+works under attack, ship the PR. The 12-layer stack is the host; your
+plugin is the guest. Make the host catch something it currently
+wouldn't.

--- a/docs/hackathon/judging.md
+++ b/docs/hackathon/judging.md
@@ -1,9 +1,13 @@
 # Judging
 
-This is the rubric a separate judge-panel track uses to score every
-hackathon PR. There is no `scripts/judge/rubric.md` in this repo yet;
-when that track lands its rubric, this document defers to it. Until
-then, the rubric below *is* the rubric.
+The canonical rubric the judge panel actually scores against lives at
+[`scripts/judge/rubric.md`](../../scripts/judge/rubric.md). That file is
+the source of truth — if anything in this document drifts from it,
+trust the rubric, not this page, and file an issue so we can fix the
+drift.
+
+This page is the participant-facing summary of how scoring works in
+practice.
 
 ## How it works
 
@@ -11,55 +15,68 @@ then, the rubric below *is* the rubric.
    `uv run ruff format --check .`, `uv run pyright`, and
    `uv run pytest -v`. **Any non-zero exit knocks you out of contention
    until you fix it.** The judge panel does not score broken PRs.
-2. Once CI is green, the judge panel reads the diff, runs your
-   scenarios under the seed bank (seeds `42`, `7`, `1337`, `0xdeadbeef`,
-   plus 6 random seeds chosen at judging time), and scores you on six
-   dimensions.
-3. The judge panel then **cross-runs every other participant's
-   adversarial validator against your plugin** for the same layer. If
-   your trust plugin survives 4 of the 5 adversarial validators
-   shipped against it, you get partial credit on novelty. If your
-   plugin fails its *own* adversarial validator, you get a zero on
-   correctness — no exceptions.
-4. The leaderboard is the sum of the six dimension scores, normalized
-   to 100. Ties go to the earlier PR.
+2. Once CI is green, the judge panel
+   ([`scripts/judge/judge_pr.py`](../../scripts/judge/judge_pr.py))
+   reads the PR body, the diff, and the checks summary, and runs N
+   independent LLM judges (default 3) against the rubric. Each judge
+   returns a structured JSON verdict with a per-dimension integer score
+   and a short rationale.
+3. The aggregator takes the per-dimension median across judges, and the
+   headline "total" is `median_low` of the per-judge totals — both are
+   written verbatim to [`docs/hackathon/scores.json`](./scores.json),
+   along with a deterministic three-sentence consensus narrative.
+4. The leaderboard sort key is that headline total (the `median` field
+   in `scores.json`, an integer-valued float in `[6, 30]`). Ties go to
+   the earlier PR.
 
 ## The six dimensions
 
-Each is scored 0-10. Final score is the sum divided by 6, rounded to
-one decimal.
+Each dimension is scored as an integer in `[1, 5]`. The headline total
+is the sum of the dimension medians across judges and therefore lives
+in `[6, 30]`. For the full anchor descriptions at 1, 3, and 5 see
+[`scripts/judge/rubric.md`](../../scripts/judge/rubric.md); this table
+is a one-line summary.
 
-| # | Dimension | What it measures | Hard floor |
-|---|---|---|---|
-| 1 | **Correctness** | Plugin meets its problem's success criteria. Adversarial validator passes against the new plugin, fails against the reference plugin. No flaky tests. No hidden global state. Same seed → byte-identical trace. | If your own adversarial validator fails against your plugin, score = 0. |
-| 2 | **Test rigor** | Unit tests cover error paths and invariants, not just the happy path. At least one property-based or randomized-sweep test. Tests fail when the underlying invariant is broken (verify by mutation-testing — flip a `<` to `<=` and at least one test must fail). | If `pytest` passes but mutating any non-trivial line in the plugin doesn't break any test, score ≤ 3. |
-| 3 | **API fit** | Plugin satisfies the `Protocol` for its layer structurally (e.g. `isinstance(plugin, Memory)` is True for memory plugins). Public method signatures match the layer interface in [`packages/nest-core/nest_core/layers/`](../../packages/nest-core/nest_core/layers/). Drop-in usable in a scenario YAML via `layers.<layer>: <name>`. Plugin is registered in [`nest_core/plugins.py`](../../packages/nest-core/nest_core/plugins.py). | If your plugin can't be selected by name in a scenario YAML, score ≤ 2. |
-| 4 | **Docs quality** | Module docstring explains *why* the plugin exists, not just what. Every public method has an `Example::` block (NEST docstring style — see reference plugins). Updated [`docs/layers/<your-layer>.md`](../../docs/layers/). README table mentions the plugin if it ships as a built-in. Adversarial validator's docstring explains what attack it catches. | If a new contributor cannot use your plugin from the docs alone, score ≤ 4. |
-| 5 | **Novelty** | The plugin is materially different from the default reference plugin *and* from every other plugin that already exists in this repo at the time of judging. Score is *highest* when your plugin's adversarial validator catches an attack class no other plugin in this layer catches. | If the diff is dominated by renaming `score_average` to something new, score = 0. |
-| 6 | **Persona fidelity** | Your handle declares a persona (e.g. `stanford-ml-phd`, `coinbase-crypto`, `cybersec-blackhat`). The PR's risk model, test coverage emphasis, and code style should match. A "coinbase-crypto" PR with no conservation-of-funds property test loses persona points. A "linux-kernel" PR that doesn't think about ordering and queueing loses persona points. | If the persona is obviously absent from the work, score ≤ 5. |
+| # | Dimension          | What it measures (1-5 scale)                                                                                                                                                                                          |
+|---|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1 | **correctness**       | Does the code do what the PR claims; are obvious bugs and edge cases handled; does the algorithm match the cited spec.                                                                                                |
+| 2 | **test_rigor**        | Coverage of failure modes, property-based vs example-only, adversarial / byzantine inputs. Tests should catch the bugs in score-1 territory.                                                                          |
+| 3 | **api_fit**           | Implements the layer Protocol exactly; entry point wired in `pyproject.toml`; uses `nest_core` types; idiomatic to NEST (SPDX header, `from __future__ import annotations`, `Example::` blocks).                       |
+| 4 | **docs_quality**      | PR body covers motivation, design, tradeoffs, and a runnable verification snippet; every public function/class has a docstring with an `Example::` block; scenario YAML or runnable command included where relevant.   |
+| 5 | **novelty**           | Materially different from the reference plugin and from already-merged peers; bonus for non-obvious invariant checks, novel layer compositions, benchmarks that surface hidden properties.                            |
+| 6 | **persona_fidelity**  | The persona declared in the branch / PR title is legible in the code itself — risk model, test emphasis, idioms — not just a label on a generic submission.                                                            |
+
+Scoring discipline (from the rubric):
+
+- Score the artifact *as it stands in this PR*, not what it could become.
+- "Textbook restatement" is not a sin if the textbook is right; it just
+  caps novelty. Correctness, fit, and tests are judged on their own.
+- Do not penalize a submission for being small if it is correct,
+  tested, and idiomatic. Do not reward a submission for being large
+  if the bulk is filler.
+- If a judge can't tell from the diff (e.g., tests live in a file the
+  diff truncates), they say so in their rationale and score
+  conservatively (3 = "can't fully verify but no red flags").
 
 ## Scoreboard
 
-The scoreboard is regenerated after every merge and published at
-`./scoreboard.md` (will appear on `main` once the judge-panel track
-lands). Columns: handle, problem picked, layer, six dimension scores,
-total, time-to-PR. The leaderboard is monotone: a later PR cannot
-demote an earlier one — but adversarial validators from later PRs
-*can* lower an earlier plugin's correctness score if they catch a
-real bug. Bring your fixes back in a follow-up PR if that happens; we
-will re-judge.
+The scoreboard is regenerated after every merge by
+[`scripts/judge/run_all.py`](../../scripts/judge/run_all.py) and
+published at [`docs/hackathon/scores.json`](./scores.json). Each
+submission entry carries the per-dimension medians, the headline
+`median` total (`[6, 30]`), the `consensus` narrative, and per-judge
+verdicts. The `/hackathon` marketplace UI in the dashboard reads from
+this file via the marketplace adapter. The leaderboard is monotone: a
+later PR cannot demote an earlier one.
 
 ## Anti-gaming
 
-- **No "trivial validator" gaming.** An adversarial validator that
-  always passes (or always fails) earns the participant who shipped it
-  a zero on test rigor.
-- **No "judge the judges" PRs.** Modifying this document, the rubric,
-  the seed bank, or the scoreboard is out of scope for hackathon PRs
-  and will be reverted on merge.
-- **No proprietary tricks.** If your plugin needs `OPENAI_API_KEY` to
-  run, declare it in the PR description and provide a deterministic
-  mock fallback. Tier 1 must remain deterministic.
+- **No "judge the judges" PRs.** Modifying the rubric, the seed bank,
+  or the scoreboard JSON itself is out of scope for hackathon PRs and
+  will be reverted on merge.
+- **No proprietary tricks.** If your plugin needs `OPENAI_API_KEY` or
+  any other secret to run, declare it in the PR description and provide
+  a deterministic mock fallback. Tier 1 must remain deterministic.
 
 If something here is ambiguous, file an issue and ask. We would rather
 be explicit than catch you out on a technicality.

--- a/docs/hackathon/judging.md
+++ b/docs/hackathon/judging.md
@@ -1,0 +1,65 @@
+# Judging
+
+This is the rubric a separate judge-panel track uses to score every
+hackathon PR. There is no `scripts/judge/rubric.md` in this repo yet;
+when that track lands its rubric, this document defers to it. Until
+then, the rubric below *is* the rubric.
+
+## How it works
+
+1. When you open a PR, CI runs `uv sync`, `uv run ruff check .`,
+   `uv run ruff format --check .`, `uv run pyright`, and
+   `uv run pytest -v`. **Any non-zero exit knocks you out of contention
+   until you fix it.** The judge panel does not score broken PRs.
+2. Once CI is green, the judge panel reads the diff, runs your
+   scenarios under the seed bank (seeds `42`, `7`, `1337`, `0xdeadbeef`,
+   plus 6 random seeds chosen at judging time), and scores you on six
+   dimensions.
+3. The judge panel then **cross-runs every other participant's
+   adversarial validator against your plugin** for the same layer. If
+   your trust plugin survives 4 of the 5 adversarial validators
+   shipped against it, you get partial credit on novelty. If your
+   plugin fails its *own* adversarial validator, you get a zero on
+   correctness — no exceptions.
+4. The leaderboard is the sum of the six dimension scores, normalized
+   to 100. Ties go to the earlier PR.
+
+## The six dimensions
+
+Each is scored 0-10. Final score is the sum divided by 6, rounded to
+one decimal.
+
+| # | Dimension | What it measures | Hard floor |
+|---|---|---|---|
+| 1 | **Correctness** | Plugin meets its problem's success criteria. Adversarial validator passes against the new plugin, fails against the reference plugin. No flaky tests. No hidden global state. Same seed → byte-identical trace. | If your own adversarial validator fails against your plugin, score = 0. |
+| 2 | **Test rigor** | Unit tests cover error paths and invariants, not just the happy path. At least one property-based or randomized-sweep test. Tests fail when the underlying invariant is broken (verify by mutation-testing — flip a `<` to `<=` and at least one test must fail). | If `pytest` passes but mutating any non-trivial line in the plugin doesn't break any test, score ≤ 3. |
+| 3 | **API fit** | Plugin satisfies the `Protocol` for its layer structurally (e.g. `isinstance(plugin, Memory)` is True for memory plugins). Public method signatures match the layer interface in [`packages/nest-core/nest_core/layers/`](../../packages/nest-core/nest_core/layers/). Drop-in usable in a scenario YAML via `layers.<layer>: <name>`. Plugin is registered in [`nest_core/plugins.py`](../../packages/nest-core/nest_core/plugins.py). | If your plugin can't be selected by name in a scenario YAML, score ≤ 2. |
+| 4 | **Docs quality** | Module docstring explains *why* the plugin exists, not just what. Every public method has an `Example::` block (NEST docstring style — see reference plugins). Updated [`docs/layers/<your-layer>.md`](../../docs/layers/). README table mentions the plugin if it ships as a built-in. Adversarial validator's docstring explains what attack it catches. | If a new contributor cannot use your plugin from the docs alone, score ≤ 4. |
+| 5 | **Novelty** | The plugin is materially different from the default reference plugin *and* from every other plugin that already exists in this repo at the time of judging. Score is *highest* when your plugin's adversarial validator catches an attack class no other plugin in this layer catches. | If the diff is dominated by renaming `score_average` to something new, score = 0. |
+| 6 | **Persona fidelity** | Your handle declares a persona (e.g. `stanford-ml-phd`, `coinbase-crypto`, `cybersec-blackhat`). The PR's risk model, test coverage emphasis, and code style should match. A "coinbase-crypto" PR with no conservation-of-funds property test loses persona points. A "linux-kernel" PR that doesn't think about ordering and queueing loses persona points. | If the persona is obviously absent from the work, score ≤ 5. |
+
+## Scoreboard
+
+The scoreboard is regenerated after every merge and published at
+`./scoreboard.md` (will appear on `main` once the judge-panel track
+lands). Columns: handle, problem picked, layer, six dimension scores,
+total, time-to-PR. The leaderboard is monotone: a later PR cannot
+demote an earlier one — but adversarial validators from later PRs
+*can* lower an earlier plugin's correctness score if they catch a
+real bug. Bring your fixes back in a follow-up PR if that happens; we
+will re-judge.
+
+## Anti-gaming
+
+- **No "trivial validator" gaming.** An adversarial validator that
+  always passes (or always fails) earns the participant who shipped it
+  a zero on test rigor.
+- **No "judge the judges" PRs.** Modifying this document, the rubric,
+  the seed bank, or the scoreboard is out of scope for hackathon PRs
+  and will be reverted on merge.
+- **No proprietary tricks.** If your plugin needs `OPENAI_API_KEY` to
+  run, declare it in the PR description and provide a deterministic
+  mock fallback. Tier 1 must remain deterministic.
+
+If something here is ambiguous, file an issue and ask. We would rather
+be explicit than catch you out on a technicality.

--- a/docs/hackathon/problems/01-comms-schema-versioning.md
+++ b/docs/hackathon/problems/01-comms-schema-versioning.md
@@ -1,0 +1,86 @@
+---
+title: Versioned message schemas with forward/backward compatibility
+layer: comms
+difficulty: easy
+---
+
+# Versioned message schemas with forward/backward compatibility
+
+## Motivation
+
+The default comms plugin
+[`nest_plugins_reference/comms/nest_native.py`](../../../packages/nest-plugins-reference/nest_plugins_reference/comms/nest_native.py)
+is 114 lines of raw JSON-envelope-plus-base64 serialization with **no
+schema version field, no unknown-field handling, and no semantic
+versioning of message types**. Look at `serialize` (lines 46-62): it
+emits `id`, `sender`, `receiver`, `payload`, `correlation_id`,
+`timestamp`, `metadata` — that's it. There is no `"v"` field. There is
+no way for a v2 agent to safely receive a v1 message; there is no way
+for a v1 agent to receive a v2 message that added a new field.
+
+This is the layer that *every* other layer rides on. The moment two
+swarms running different NEST versions try to talk — or two
+implementations of the same protocol negotiated by competing
+contributors try to interop — the wire format silently breaks and the
+trace shows mysterious `KeyError` exceptions deep inside agent
+behaviour. The validators in
+[`nest_core/validators.py`](../../../packages/nest-core/nest_core/validators.py)
+will report "messages flowed" but not "messages were
+*understood*". Nobody picked this layer in the first hackathon round
+(0 of 10 PRs touched comms) — it's a real gap.
+
+Anyone deploying NEST against a long-running swarm benefits: rolling
+upgrades become possible. Anyone publishing a third-party plugin
+benefits: their wire format can evolve without breaking the world.
+
+## Success criteria
+
+- Ship a new comms plugin (suggested name: `versioned`) registered in
+  [`nest_core/plugins.py`](../../../packages/nest-core/nest_core/plugins.py)
+  as `(\"comms\", \"versioned\")`.
+- Every serialized envelope carries an explicit `schema_version`
+  (semver string) and a `kind` (message type tag).
+- `deserialize` accepts messages with **higher minor versions than
+  it knows about** (forward compat: unknown fields are preserved in
+  `metadata` and re-emitted on re-serialize) and **rejects
+  unknown-major-version messages with a typed exception**
+  (`UnsupportedSchemaError`) instead of crashing.
+- Ship an adversarial validator that scans a trace and fails if any
+  agent silently dropped an unknown field or accepted an
+  unknown-major version. The validator must FAIL against the default
+  `nest_native` plugin when v2 messages are injected and PASS against
+  your plugin.
+- Ship `scenarios/comms_versioning.yaml` with mixed-version agents
+  (half v1, half v2). The validator passes. Trace is deterministic
+  under seeds 42, 7, 1337.
+- All tests pass in <30 seconds on a single core.
+
+## Suggested approach pointers
+
+- Look at how Protobuf does unknown-field preservation; you can mimic
+  the spirit in JSON by stuffing unknowns into a reserved `_unknown`
+  dict on deserialize and re-emitting them on serialize.
+- Don't try to invent your own version-negotiation handshake — keep
+  it in-band on every message.
+- Decide *up front* whether your minor-version contract is "MUST
+  ignore unknown fields" or "MAY ignore"; document it.
+- Property-test round-trip: `deserialize(serialize(m)) == m` for any
+  schema-valid `m`, even one with future-version unknowns.
+- Look at PR #9's `dpop_jwt` for a clean example of how to introduce
+  a parallel plugin without breaking the existing one.
+
+## Anti-patterns
+
+- Don't just add a `"v": 1` field to `nest_native` and call it new.
+- Don't make the version handshake out-of-band (over a separate
+  channel) — that defeats the point.
+- Don't break the existing `nest_native` envelope. Your plugin lives
+  alongside it.
+- Don't use `pickle`. The format must be inspectable in a JSONL trace.
+
+## Out of scope
+
+- Real schema registries (Confluent-style). This is in-band only.
+- Cross-language wire interop (JSON-only is fine).
+- The `Message` Pydantic model itself; you're versioning the
+  *envelope*, not the typed payload.

--- a/docs/hackathon/problems/02-memory-crdt-lww.md
+++ b/docs/hackathon/problems/02-memory-crdt-lww.md
@@ -1,0 +1,87 @@
+---
+title: Conflict-free shared memory under concurrent writers
+layer: memory
+difficulty: easy
+---
+
+# Conflict-free shared memory under concurrent writers
+
+## Motivation
+
+The default memory plugin
+[`nest_plugins_reference/memory/blackboard.py`](../../../packages/nest-plugins-reference/nest_plugins_reference/memory/blackboard.py)
+is 80 lines of "shared dict + optimistic CAS." `write` is
+**last-writer-wins by wall-arrival order, with no notion of causal
+history**; `cas` returns `False` on conflict and leaves the caller to
+retry. That's fine for a single coordinator scribbling to a known key.
+It is the *wrong* shape the moment two agents try to update the same
+slot at once, which is exactly what happens in
+[`scenarios/marketplace.yaml`](../../../scenarios/marketplace.yaml)
+when fifty sellers race to claim shared catalogue entries, or in the
+reputation scenario when the observer and an honest reporter both
+update the same agent's score.
+
+PR #4 (semantic memory) added recall + TTL + LRU but did **not**
+change conflict resolution — it still inherits LWW semantics from the
+underlying `OrderedDict`. So the gap remains: there is no
+CRDT-shaped memory plugin, and the
+[`docs/layers/memory.md`](../../../docs/layers/memory.md) "Good fits"
+list explicitly calls out CRDTs as wanted.
+
+Anyone building a coordination protocol that needs eventual
+consistency under concurrent writes (vote-tally aggregation, shared
+catalogue, distributed counter, presence) benefits. The blackboard
+silently corrupts state; a real CRDT proves convergence.
+
+## Success criteria
+
+- Ship a memory plugin (suggested name: `lww_crdt` or `or_set`) that
+  implements at least *one* well-known CRDT correctly: LWW-Register
+  with logical clocks, OR-Set, G-Counter, or PN-Counter. Register it
+  in [`nest_core/plugins.py`](../../../packages/nest-core/nest_core/plugins.py)
+  under `(\"memory\", \"<your_name>\")`.
+- The plugin still satisfies the `Memory` protocol from
+  [`nest_core/layers/memory.py`](../../../packages/nest-core/nest_core/layers/memory.py)
+  (i.e., `isinstance(plugin, Memory)` is True). `read`/`write`/`cas`/
+  `subscribe` all work — `cas` should be implementable in terms of
+  the CRDT's natural merge semantics.
+- Ship an adversarial validator that drives N concurrent writers
+  against the same key with deterministic-but-interleaved writes and
+  asserts **convergence**: every replica observes the same final
+  state regardless of message-delivery order. The validator must FAIL
+  against `blackboard` and PASS against your plugin.
+- Ship `scenarios/memory_concurrent_writers.yaml` with at least 8
+  agents writing to the same logical key under
+  `failures.message_drop: 0.1` and arbitrary in-flight reordering.
+- Determinism: same seed → byte-identical merged state across runs.
+
+## Suggested approach pointers
+
+- Pick the simplest CRDT that solves *one* of the four built-in
+  scenarios' concrete pain. LWW-Register with Lamport clocks is the
+  smallest unit of useful work here.
+- Use the simulator's per-agent RNG (see `_failure_rng` in
+  [`nest_core/sim/simulator.py`](../../../packages/nest-core/nest_core/sim/simulator.py))
+  to seed your logical clocks deterministically.
+- For OR-Set, the unique-tag-on-add trick is the whole game.
+- Encode the CRDT state inside the existing `bytes` value type — JSON
+  inside is fine. Keep traces grep-able.
+- Look at how PR #4 layered new behaviour on top of an existing plugin
+  without breaking the base interface.
+
+## Anti-patterns
+
+- Don't ship a CRDT that requires every node to see every other node
+  before merging (that's just a centralized log, not a CRDT).
+- Don't claim convergence and then implement it with global locks.
+- Don't reimplement `blackboard` and call it `blackboard_v2`.
+- Don't hand-wave determinism by relying on `time.time()` or
+  `random.random()` with an unseeded global RNG.
+
+## Out of scope
+
+- Distributed-systems-grade gossip transport. Use NEST's in-memory
+  delivery; you're testing the *merge logic*, not the wire.
+- CRDTs over the wire (CmRDTs with operation-based replication). Pick
+  state-based (CvRDT) for this problem.
+- Persistence to disk.

--- a/docs/hackathon/problems/03-payments-streaming-x402.md
+++ b/docs/hackathon/problems/03-payments-streaming-x402.md
@@ -1,0 +1,92 @@
+---
+title: Streaming pay-per-second payments with mid-stream cancellation
+layer: payments
+difficulty: easy
+---
+
+# Streaming pay-per-second payments with mid-stream cancellation
+
+## Motivation
+
+The default payments plugin
+[`nest_plugins_reference/payments/prepaid_credits.py`](../../../packages/nest-plugins-reference/nest_plugins_reference/payments/prepaid_credits.py)
+is 121 lines of "one-shot debit-credit ledger." Every `pay(to, amount,
+ref)` moves the full amount atomically. PR #7
+(`htlc_escrow`) added hash- and time-locked *conditional* payments —
+genuinely useful for atomic-swap-shaped flows, but it is still a
+**one-shot** transfer: you escrow, you claim, you're done.
+
+What's missing is the *streaming* shape:
+[`docs/layers/payments.md`](../../../docs/layers/payments.md) calls
+out "streaming payments" as a wanted fit, and the
+[`README.md`](../../../README.md) limitations section is silent on it.
+LLM-agent traffic is increasingly metered (token-rate billing, inference-
+per-second, bandwidth-per-byte), and x402-style HTTP-payment proposals
+are explicitly per-request. The current `Payments` protocol can't
+express "pay 0.01 credits every tick this stream is open, stop billing
+the moment either side terminates." Any simulation of an LLM agent
+hiring another LLM agent for a continuous task can't currently model
+the *bill* accurately — agents end up either pre-paying a flat amount
+(which over- or under-bills) or transferring nothing.
+
+Anyone modelling metered services (rented compute, bandwidth, advisory
+sessions, inference quotas) benefits.
+
+## Success criteria
+
+- Ship a payments plugin (suggested name: `streaming` or
+  `per_tick_metered`) registered as `(\"payments\", \"streaming\")` in
+  [`nest_core/plugins.py`](../../../packages/nest-core/nest_core/plugins.py).
+- API: `open_stream(to, rate_per_tick, max_total, ref) -> StreamHandle`
+  and `close_stream(ref) -> Receipt`. Funds drain from payer to payee
+  one tick at a time, capped at `max_total`. Either party can call
+  `close_stream` at any point; the unused remainder is **never** spent.
+- The plugin satisfies the existing `Payments` protocol from
+  [`nest_core/layers/payments.py`](../../../packages/nest-core/nest_core/layers/payments.py)
+  — i.e., the one-shot `pay`/`refund` interface still works for
+  protocols that don't speak streaming. `pay(to, amount, ref)` should
+  behave equivalently to opening a stream that drains the full amount
+  in one tick.
+- Ship an adversarial validator that catches **two specific attacks**:
+  1. *Drain-after-close*: payer closes the stream but a buggy plugin
+     keeps debiting. Total debited must equal total credited at every
+     tick (conservation invariant).
+  2. *Over-bill on partition*: payer is partitioned mid-stream; the
+     plugin must not keep billing for ticks the payee can't deliver.
+     Use NEST's existing `failures.network_partition` config in
+     [`nest_core/sim/simulator.py`](../../../packages/nest-core/nest_core/sim/simulator.py)
+     (line ~246).
+- Ship `scenarios/streaming_payments.yaml` with 5 buyers, 5 sellers,
+  rolling streams, and 5% message drop. Validator passes. Trace is
+  deterministic.
+
+## Suggested approach pointers
+
+- The simulator already exposes a logical clock (see
+  `ctx.schedule(delay, ...)` in the agent contract). Use it; don't
+  reach for `time.time()`.
+- Borrow the conservation-of-funds invariant from PR #7's
+  hypothesis test (`test_conservation_under_random_op_sequence`).
+  Adapt it for streams.
+- Sablier-style escrow draws are a clean reference design — but
+  *don't* require any on-chain primitives; this is in-process only.
+- A stream is a contract: store it in a dict keyed by `PaymentRef`,
+  exactly like PR #7 does for HTLC contracts.
+- Decide what `verify_payment` returns for a half-drained stream —
+  `PENDING`? A new `STREAMING` enum variant? Document and justify.
+
+## Anti-patterns
+
+- Don't ship a "streaming" plugin that just pre-pays once and lies
+  about it in the trace.
+- Don't ship a plugin where `close_stream` is "best-effort." The payer
+  must be able to stop the bleed at *any* tick, deterministically.
+- Don't bypass the existing `PaymentStatus` enum; add to it if needed.
+- Don't reuse `HtlcEscrow` and rename it. Streams aren't HTLCs.
+
+## Out of scope
+
+- Real on-chain settlement.
+- Multi-party streams (one payer, many payees). Bilateral is
+  sufficient.
+- Currency conversion / multi-asset support.

--- a/docs/hackathon/problems/04-auth-capability-delegation.md
+++ b/docs/hackathon/problems/04-auth-capability-delegation.md
@@ -1,0 +1,88 @@
+---
+title: Delegatable capability tokens with cascading revocation
+layer: auth
+difficulty: easy
+---
+
+# Delegatable capability tokens with cascading revocation
+
+## Motivation
+
+The default auth plugin
+[`nest_plugins_reference/auth/jwt_auth.py`](../../../packages/nest-plugins-reference/nest_plugins_reference/auth/jwt_auth.py)
+is 106 lines of HMAC-signed token issuance. PR #9 added a DPoP-style
+sender-constrained JWT — a meaningful upgrade for replay resistance.
+Neither plugin lets an agent **delegate** a subset of its capabilities
+to another agent without going back to the issuer, and neither
+supports **cascading revocation** (revoke a parent → all descendants
+become invalid).
+
+`JwtAuth._revoked: set[str]` (line 33) tracks revocation by exact
+token string, with no parent-child relationship at all. That makes the
+auth layer unable to model the most common real-world pattern:
+"agent A holds a long-lived root token; agent A mints a 10-minute
+sub-token for agent B; revoking A's token should invalidate B's at
+the next verify, automatically." Macaroons (Google, 2014), biscuits
+(CleverCloud, 2020), and SPIFFE delegation all do this.
+[`docs/layers/auth.md`](../../../docs/layers/auth.md) explicitly lists
+"capability delegation" and "revocation propagation" as wanted.
+
+Anyone building a multi-agent workflow where the orchestrator hands
+out narrowly-scoped, time-bounded sub-capabilities benefits. Without
+this you cannot model an LLM-agent sub-renting access to a tool — and
+withdrawing it cleanly.
+
+## Success criteria
+
+- Ship an auth plugin (suggested name: `delegatable` or `macaroons`)
+  registered as `(\"auth\", \"<your_name>\")` in
+  [`nest_core/plugins.py`](../../../packages/nest-core/nest_core/plugins.py).
+- New API on top of the existing `Auth` protocol:
+  `delegate(parent_token, audience, scopes_subset, ttl) -> Token`. The
+  child token's scopes must be a strict subset of the parent's.
+  Issuing a child with a scope the parent doesn't hold must raise.
+- `verify(child_token)` must check the parent's revocation state
+  transitively. If any ancestor in the chain is revoked, the child
+  fails to verify with a typed exception (`RevokedAncestorError` or
+  similar).
+- Ship an adversarial validator that catches **three attacks**:
+  1. *Scope escalation*: child requests broader scopes than parent.
+  2. *Stale parent*: parent token expired or revoked but child still
+     verifies.
+  3. *Audience confusion*: child token presented by an agent other
+     than its declared audience.
+- The validator must FAIL against the default `jwt` plugin and PASS
+  against your plugin.
+- Ship `scenarios/delegated_auth.yaml` with a coordinator, 3
+  intermediaries, and 12 leaf agents in a delegation tree.
+
+## Suggested approach pointers
+
+- Read the macaroon paper (Birgisson et al., 2014) — caveats are the
+  cleanest model here.
+- Borrow the HMAC chain pattern from `jwt_auth.py` but anchor each
+  child's signature to its parent's hash. Revoking a parent's hash
+  invalidates every descendant by construction — no separate
+  revocation list per child.
+- The DPoP plugin from PR #9 is a good reference for how to extend
+  the auth surface without breaking the base `Auth` contract.
+- Decide: is your delegation tree a *strict* tree (single parent per
+  token) or a DAG (multiple parents)? Strict tree is enough.
+- Time bounds: child TTL must be ≤ parent TTL. Enforce this.
+
+## Anti-patterns
+
+- Don't ship "delegation" that's actually just re-issuance by the
+  central authority. The whole point is the parent agent can mint
+  child tokens *without* the issuer's help.
+- Don't add a `\"delegated_from\"` field to JWT claims and call it
+  delegation — without HMAC chaining there's no transitive
+  revocation.
+- Don't conflate scopes with audiences. Both matter.
+- Don't rebuild PR #9's DPoP. This is a *different* problem.
+
+## Out of scope
+
+- Hardware-backed key attestation (TPM/HSM).
+- OAuth2 server endpoints. Pure in-process is fine.
+- Token introspection over the network.

--- a/docs/hackathon/problems/05-identity-ed25519-key-rotation.md
+++ b/docs/hackathon/problems/05-identity-ed25519-key-rotation.md
@@ -1,0 +1,95 @@
+---
+title: Real Ed25519 identity with key rotation and historical signature verification
+layer: identity
+difficulty: medium
+---
+
+# Real Ed25519 identity with key rotation and historical signature verification
+
+## Motivation
+
+The default identity plugin
+[`nest_plugins_reference/identity/did_key.py`](../../../packages/nest-plugins-reference/nest_plugins_reference/identity/did_key.py)
+is 199 lines of deterministic *simulation* cryptography
+(textbook RSA with `pow(sig_int, e, n)` at line 98 and Miller-Rabin
+primality at line 146-174). The module docstring at line 6 calls it
+out: "It is not production cryptography." The README footnote at line
+229 hammers it home: "deterministic public-key signatures for
+simulation; not Ed25519."
+
+No real identity layer ships — and crucially **no plugin supports
+key rotation**. A long-running agent that wants to rotate its signing
+key (because a key has been compromised, or because of policy)
+currently cannot, because `register_peer` (line 40) accepts exactly
+one public key per agent ID and overwriting it would invalidate every
+prior signature that agent made. There is no concept of "this
+signature was valid *at the time it was made*." Zero hackathon PRs
+touched identity — clean ground.
+
+[`docs/layers/identity.md`](../../../docs/layers/identity.md)
+explicitly wants "real Ed25519/secp256k1 signing, DID method
+implementations, key rotation, multi-key agents." Any deployment that
+intends to survive a key-compromise event — every real one —
+benefits.
+
+## Success criteria
+
+- Ship an identity plugin (suggested name: `ed25519_rotating`)
+  registered as `(\"identity\", \"<your_name>\")` in
+  [`nest_core/plugins.py`](../../../packages/nest-core/nest_core/plugins.py).
+- Real Ed25519 signing — the stdlib has none, so use
+  `cryptography` or a pure-Python implementation. If you bring a new
+  dependency, declare it in the `[plugins]` extra in
+  [`pyproject.toml`](../../../pyproject.toml).
+- API for rotation: `rotate_key(new_seed) -> KeyId`. After rotation,
+  signatures made with the **old** key still verify if and only if
+  the verifier requests verification *as-of* the old key's validity
+  window. After-the-fact forgery using the old (rotated-out) key
+  must fail.
+- Each `Signature` carries the `key_id` that signed it (extend the
+  `Signature` Pydantic model in
+  [`nest_core/types.py`](../../../packages/nest-core/nest_core/types.py)
+  or add a metadata field — document your choice).
+- Ship an adversarial validator that catches **two attacks**:
+  1. *Post-rotation forgery*: an attacker who compromised the old
+     key tries to forge a fresh signature after rotation. Must fail
+     verification.
+  2. *Backdating*: an attacker tries to backdate a signature made
+     with the *new* key into the old key's validity window. Must
+     fail verification.
+- Validator must FAIL against `did_key` and PASS against your plugin.
+- Ship `scenarios/identity_rotation.yaml` exercising at least one
+  rotation per agent over the scenario's lifetime, with 10% byzantine
+  agents trying both attacks.
+
+## Suggested approach pointers
+
+- `cryptography.hazmat.primitives.asymmetric.ed25519` is the standard
+  library here; deterministic seeding via `Ed25519PrivateKey.
+  from_private_bytes(seed)` keeps Tier 1 reproducibility.
+- A key's validity window is `[issued_at_tick, rotated_out_tick)`.
+  Store it; signatures carry the window they were made in.
+- Borrow `_known_keys` shape from `did_key.py` but make it map
+  `AgentId -> list[KeyRecord]` instead of `AgentId -> tuple`.
+- Treat key rotation as a *publishing* operation — the new key must
+  be signed by the old key (or by an out-of-band root) to prove
+  continuity. This is the whole point of rotation: continuity of
+  identity across keys.
+- Tier 2 (LLM agent) interop: don't break `register_peer`'s existing
+  callers.
+
+## Anti-patterns
+
+- Don't reimplement RSA-from-`pow` in `did_key.py` and call it
+  Ed25519. Use a real implementation.
+- Don't make rotation a no-op (silently keeping the same key).
+- Don't make every verification require the *current* key — the
+  whole feature is "verify against the key that was valid then."
+- Don't store private keys in clear text in the trace.
+
+## Out of scope
+
+- Real DID methods (did:web, did:peer). DID-shaped *records* are
+  fine; you're not implementing W3C DIDs end-to-end.
+- HSM/TPM integration.
+- Quantum-resistant signatures.

--- a/docs/hackathon/problems/06-registry-gossip-eventual-consistency.md
+++ b/docs/hackathon/problems/06-registry-gossip-eventual-consistency.md
@@ -1,0 +1,101 @@
+---
+title: Gossip-based registry with eventual consistency under partition
+layer: registry
+difficulty: medium
+---
+
+# Gossip-based registry with eventual consistency under partition
+
+## Motivation
+
+The default registry plugin
+[`nest_plugins_reference/registry/in_memory.py`](../../../packages/nest-plugins-reference/nest_plugins_reference/registry/in_memory.py)
+is 88 lines of "single shared Python dict + asyncio queues for
+subscribers." `register`, `lookup`, and `subscribe` all touch
+`self._cards: dict[AgentId, AgentCard]` (line 29). There is exactly
+one instance per simulation. Every agent in
+[`scenarios/marketplace.yaml`](../../../scenarios/marketplace.yaml)
+shares it. That is fine for testing message flow, but it is
+**operationally a lie**: in any real deployment the registry is
+distributed, possibly partitioned, and definitely subject to
+eventual-consistency races.
+
+What happens today when you run with `failures.network_partition`
+(line 158 of
+[`nest_core/runner.py`](../../../packages/nest-core/nest_core/runner.py))?
+The partition affects *transport*, but registry lookups still go to
+the shared dict — partitioned agents can still discover each other.
+That isn't physically possible in the real world. Zero PRs touched
+registry; the
+[`docs/layers/registry.md`](../../../docs/layers/registry.md) wishlist
+calls out "DHT-backed registries, gossip-based discovery, filtering /
+capability queries, registry consensus protocols" — nobody picked any
+of them.
+
+Anyone running NEST as a believable swarm simulator (rather than a
+single-process toy) benefits. Anyone testing service-discovery
+protocols benefits directly.
+
+## Success criteria
+
+- Ship a registry plugin (suggested name: `gossip`) where **each agent
+  holds its own local view** and views converge via periodic gossip
+  messages over the transport layer. Register as
+  `(\"registry\", \"gossip\")` in
+  [`nest_core/plugins.py`](../../../packages/nest-core/nest_core/plugins.py).
+- `lookup(query)` returns the agent's *local* view at call time —
+  potentially stale. `register(card)` is local-write-then-gossip.
+- The plugin respects network partitions: agents in different
+  partition groups (see `partition_map` at
+  [`nest_core/sim/simulator.py`](../../../packages/nest-core/nest_core/sim/simulator.py)
+  line 246) cannot directly exchange gossip; convergence requires a
+  bridge.
+- Ship an adversarial validator that catches **two specific failure
+  modes**:
+  1. *Stale-lookup honesty*: when partition is active, a lookup must
+     not return cards from the other partition. The validator inspects
+     the trace and fails if any lookup leaked across an active
+     partition.
+  2. *Convergence*: after partition heals, all agents' views
+     **must converge** within K gossip rounds (you pick K and
+     justify it). The validator fails if convergence doesn't happen.
+- Validator FAILS against `in_memory` registry (it silently leaks
+  across partition by sharing a dict) and PASSES against your plugin.
+- Ship `scenarios/gossip_registry.yaml` with 20 agents, a partition
+  splitting them 50/50 for the first half of the scenario, then a
+  heal. Trace deterministic under seeds 42, 7, 1337.
+
+## Suggested approach pointers
+
+- The minimal viable gossip is push-pull with bounded fanout. Don't
+  reach for SWIM or Hyparview unless you have time.
+- Use the transport plugin for gossip messages; that way partition
+  injection from the simulator naturally affects gossip too. Look at
+  how `NestNativeComms.send` in
+  [`nest_plugins_reference/comms/nest_native.py`](../../../packages/nest-plugins-reference/nest_plugins_reference/comms/nest_native.py)
+  routes through transport.
+- Vector clocks on cards make convergence detection clean. Hybrid
+  Logical Clocks are an alternative.
+- For `subscribe`, deliver a card to the subscriber once it appears
+  in the *local* view, not the moment it's globally registered.
+- Don't make every agent gossip every round — implement at least
+  one form of anti-entropy throttle.
+
+## Anti-patterns
+
+- Don't keep a hidden shared dict "as a cache." If two partitioned
+  agents can see each other through it, your plugin is the same as
+  `in_memory`.
+- Don't broadcast the entire local view on every gossip — pick a
+  delta strategy.
+- Don't claim convergence and then implement it with a
+  centralized leader.
+- Don't pretend agents in the same partition group are in the same
+  process. Each agent has its own local view.
+
+## Out of scope
+
+- DHT semantics (Kademlia, Chord). Flat gossip is sufficient.
+- Registry consensus (Raft-on-registry) — that's a coordination
+  problem, not a registry one.
+- Cross-language interop.

--- a/docs/hackathon/problems/07-negotiation-multi-attribute.md
+++ b/docs/hackathon/problems/07-negotiation-multi-attribute.md
@@ -1,0 +1,93 @@
+---
+title: Multi-attribute negotiation with Pareto-frontier search
+layer: negotiation
+difficulty: medium
+---
+
+# Multi-attribute negotiation with Pareto-frontier search
+
+## Motivation
+
+The default negotiation plugin
+[`nest_plugins_reference/negotiation/alternating_offers.py`](../../../packages/nest-plugins-reference/nest_plugins_reference/negotiation/alternating_offers.py)
+is 99 lines of single-attribute Rubinstein bargaining: the `respond`
+method (line 66-81) compares **one number** —
+`session.current_terms.price.amount` — against a patience-discounted
+threshold and accepts or rejects. The `Terms` model in
+[`nest_core/types.py`](../../../packages/nest-core/nest_core/types.py)
+in fact has more dimensions (delivery time, quality, quantity), but
+the reference plugin uses only `price`. That collapses any
+multi-attribute negotiation (deadline-sensitive deliveries, quality-
+price tradeoffs, bundle deals) into a one-dimensional fight over
+price.
+
+Real markets are multi-attribute. A buyer trading off price against
+delivery date is the most common case in
+[`scenarios/marketplace.yaml`](../../../scenarios/marketplace.yaml)
+(catalogue size 200, 10 rounds, 50 buyers vs. 50 sellers) — and yet
+the reference plugin has no way to express "I'd accept a higher price
+if you ship tomorrow instead of next week." Zero PRs in the first
+round touched negotiation.
+[`docs/layers/negotiation.md`](../../../docs/layers/negotiation.md)
+explicitly wants "multi-attribute negotiation, multi-party
+negotiation, agenda-based bargaining, learning-based bidding."
+
+Anyone modelling supply chains, agent SLAs, or any market where
+"price" alone is a poor proxy benefits.
+
+## Success criteria
+
+- Ship a negotiation plugin (suggested name: `multi_attribute` or
+  `pareto`) registered as `(\"negotiation\", \"<your_name>\")` in
+  [`nest_core/plugins.py`](../../../packages/nest-core/nest_core/plugins.py).
+- Negotiation runs over ≥ 2 attributes from `Terms` (e.g. price +
+  deadline; price + quantity). Each agent has a private utility
+  function over those attributes; the plugin's job is to converge to
+  a **Pareto-optimal** agreement, not just any agreement.
+- API additions: extend `respond` to evaluate the *full* `Terms`, and
+  let agents pass a utility function (or weights) at construction
+  time without changing the `Negotiation` protocol's surface (i.e.
+  pass it via constructor, not method signature).
+- Ship an adversarial validator that, given a trace of negotiations,
+  computes the Pareto frontier from observed bids and **fails** if
+  any agreement is Pareto-dominated by some other concession both
+  parties exchanged during the same session. The validator must FAIL
+  against `alternating_offers` when run with multi-attribute terms
+  (because it ignores all but `price`) and PASS against yours.
+- Ship `scenarios/multi_attribute_market.yaml` with 10 buyer-seller
+  pairs negotiating over price + deadline. Each pair has a
+  deterministic utility weight from the per-agent seeded RNG.
+
+## Suggested approach pointers
+
+- The simplest multi-attribute strategy is "trade-off in the
+  direction my opponent indicated." If they conceded on price but
+  not deadline last round, you concede on deadline this round.
+- Look up "monotonic concession protocol" — useful framing without
+  needing to fully implement it.
+- Negotiation can fail (no agreement is Pareto-optimal *for the
+  buyer*). Returning `None` from `close` is acceptable; the validator
+  should distinguish "negotiation broke down" from "negotiation
+  closed Pareto-dominated."
+- Patience discounts still apply, but per-attribute.
+- Encode utility weights deterministically from the agent's seed so
+  traces replay.
+
+## Anti-patterns
+
+- Don't ship a plugin that pretends to be multi-attribute but
+  collapses to a weighted-sum scalar internally and never explores
+  the frontier.
+- Don't require global knowledge of all participants' utility
+  functions. Each agent knows only its own.
+- Don't make agreement deterministic from initial offers — agents
+  must *exchange* offers to converge.
+- Don't break `alternating_offers`; ship alongside it.
+
+## Out of scope
+
+- Multi-party (3+ agent) negotiation. Bilateral is enough.
+- Learning across negotiation sessions (no inter-session state).
+- Sealed-bid mechanisms — PR #5 already covers that under
+  *coordination*.
+- LLM-driven bargaining (Tier 2). Tier 1 only.

--- a/docs/hackathon/problems/08-datafacts-content-addressed.md
+++ b/docs/hackathon/problems/08-datafacts-content-addressed.md
@@ -1,0 +1,101 @@
+---
+title: Content-addressed datasets with provenance chains and freshness proofs
+layer: datafacts
+difficulty: medium
+---
+
+# Content-addressed datasets with provenance chains and freshness proofs
+
+## Motivation
+
+The default datafacts plugin
+[`nest_plugins_reference/datafacts/datafacts_v1.py`](../../../packages/nest-plugins-reference/nest_plugins_reference/datafacts/datafacts_v1.py)
+is 79 lines of "dict of metadata records." The URL scheme is
+`df://<dataset.name>` (line 39) — i.e., addressed by the publisher's
+**chosen name**, not by content. `verify_freshness` (line 68-78) is
+`(time.time() - self._timestamps[url]) < 3600` — a wall-clock check
+with **no cryptographic proof at all**. `request_access` (line 57-66)
+unconditionally grants `tier="read"` to anyone who asks.
+
+That means three classes of bug are silently impossible to detect in
+any current NEST scenario:
+1. *Substitution attack*: an attacker republishes a different dataset
+   under the same name. Nothing in the protocol or trace catches it.
+2. *Stale-claim attack*: the publisher claims a dataset is fresh by
+   re-touching its timestamp without re-publishing the actual content.
+3. *Provenance washing*: a dataset derived from a polluted upstream
+   source loses the provenance trail at the first hop because there
+   is no chain.
+
+Zero PRs touched datafacts. The
+[`docs/layers/datafacts.md`](../../../docs/layers/datafacts.md)
+wishlist explicitly calls out "content-addressed storage (IPFS-style),
+signed-manifest schemes, fine-grained ACLs, expiry / TTL policies" —
+nobody picked any of them. Anyone running NEST scenarios that touch
+data quality, audit trails, or supply-chain provenance (see
+[`scenarios/supply_chain.yaml`](../../../scenarios/supply_chain.yaml))
+benefits.
+
+## Success criteria
+
+- Ship a datafacts plugin (suggested name: `cid_facts` or
+  `content_addressed`) registered as `(\"datafacts\", \"<your_name>\")`
+  in [`nest_core/plugins.py`](../../../packages/nest-core/nest_core/plugins.py).
+- URLs are **content hashes**, not names. `publish(dataset)` returns
+  `DataFactsUrl(\"df://sha256-<hex>\")`. Republishing the same content
+  returns the same URL; republishing different content under a "name"
+  is no longer possible.
+- A `DatasetMetadata` carries a `parents: list[DataFactsUrl]` field
+  (extend the type in
+  [`nest_core/types.py`](../../../packages/nest-core/nest_core/types.py)
+  or use a `metadata` dict). Derived datasets *must* reference the
+  hashes of every dataset they were derived from.
+- `verify_freshness` returns a **proof object** (signed by the
+  publisher's identity-layer key — call into the identity layer from
+  PR-of-your-choice or the default `did_key`) attesting "this hash
+  was published at tick T by agent A." A verifier without trusting
+  wall-clock time can still validate the chain.
+- Ship an adversarial validator that catches:
+  1. *Substitution*: an attacker publishes new content under an old
+     hash — must be detected (it's impossible by construction; the
+     validator asserts the impossibility holds in the trace).
+  2. *Stale freshness*: a publisher claims freshness without
+     re-publishing — validator detects no proof was issued.
+  3. *Broken provenance*: a derived dataset's `parents` chain
+     references a hash that doesn't exist in the trace.
+- Validator FAILS against `datafacts_v1`, PASSES against yours.
+- Ship `scenarios/provenance_supply_chain.yaml` based on the existing
+  supply-chain scenario but with each hop publishing a content-
+  addressed dataset and the retailer verifying the chain end-to-end.
+
+## Suggested approach pointers
+
+- The hash is just `sha256(canonical_json(metadata) + payload_bytes)`
+  — don't over-engineer.
+- Re-use the `did_key` identity plugin for the freshness signature.
+  You can take an `Identity` instance via the constructor (just like
+  PR #2/#3/#6's EigenTrust plugins took it).
+- Provenance is a DAG, not a tree — datasets can have multiple
+  parents.
+- `request_access` is the right place to enforce ACLs based on the
+  content hash, not the dataset name.
+- Don't make freshness depend on `time.time()`. Use the simulator's
+  logical clock if you can plumb it in, or the agent's own tick
+  counter.
+
+## Anti-patterns
+
+- Don't keep the `df://name` URL scheme alongside content hashing —
+  that defeats substitution resistance.
+- Don't sign the metadata but not the payload. A freshness proof
+  has to bind to the *content*.
+- Don't require a central authority to issue hashes.
+- Don't reuse `datafacts_v1` and patch in `parents` — the URL scheme
+  has to change.
+
+## Out of scope
+
+- Real IPFS / libp2p integration. In-process content addressing is
+  fine.
+- Erasure coding / replication strategies.
+- Encrypted-payload datasets (that's the privacy layer's job).

--- a/docs/hackathon/problems/09-privacy-hybrid-encryption-with-selective-disclosure.md
+++ b/docs/hackathon/problems/09-privacy-hybrid-encryption-with-selective-disclosure.md
@@ -1,0 +1,109 @@
+---
+title: Hybrid encryption with selective disclosure and broadcast revocation
+layer: privacy
+difficulty: hard
+---
+
+# Hybrid encryption with selective disclosure and broadcast revocation
+
+## Motivation
+
+The default privacy plugin
+[`nest_plugins_reference/privacy/noop.py`](../../../packages/nest-plugins-reference/nest_plugins_reference/privacy/noop.py)
+is 60 lines of **literally returning the input unchanged**.
+`encrypt(data, audience)` (line 25) returns `data`. `prove(statement,
+witness)` (line 43) returns a proof with payload `b"mock-proof"`.
+`verify_proof` (line 52) unconditionally returns `True`. The README
+limitation note at
+[README.md line 308-310](../../../README.md) calls this out
+explicitly: "no-op privacy."
+
+That is fine when scenarios don't care about confidentiality, but it
+means **every NEST scenario that simulates a sensitive workflow is
+silently leaking everything to every observer**, and the trace cannot
+even tell you it would have leaked in production. Zero PRs touched
+privacy. The
+[`docs/layers/privacy.md`](../../../docs/layers/privacy.md) wishlist
+calls out "hybrid encryption (X25519 + ChaCha20-Poly1305), group key
+exchange, zk-SNARK / zk-STARK / Bulletproofs adapters, selective
+disclosure of credentials."
+
+This problem is **hard on purpose**: it requires real crypto, a clean
+group-key story, and a credible threat model. The reward is that
+every other NEST scenario can now plug your privacy layer in and get
+a believable confidentiality story for free.
+
+Anyone running NEST as a model of a real multi-party workflow —
+medical-data swaps, sealed-bid auctions where bids must stay sealed,
+attestations carrying selective fields — benefits.
+
+## Success criteria
+
+- Ship a privacy plugin (suggested name: `hybrid_x25519`) registered
+  as `(\"privacy\", \"<your_name>\")` in
+  [`nest_core/plugins.py`](../../../packages/nest-core/nest_core/plugins.py).
+- **Real hybrid encryption**: per-message X25519 ephemeral key
+  agreement + ChaCha20-Poly1305 (or AES-GCM) data encapsulation.
+  Use the `cryptography` library; declare the new dependency in the
+  `[plugins]` extra in
+  [`pyproject.toml`](../../../pyproject.toml).
+- `encrypt(data, audience)` produces ciphertext that **only** members
+  of `audience` can decrypt. Use a simple group-key scheme (one
+  symmetric key per ciphertext, wrapped once per recipient pubkey).
+- `prove(statement, witness)` and `verify_proof(statement, proof)`
+  implement at least one *real* selective-disclosure flow — e.g., a
+  credential with multiple fields, where the holder reveals a subset
+  and proves the rest are well-formed without revealing them. A
+  hash-tree (Merkle) approach is acceptable; you do not need a full
+  SNARK.
+- **Revocation broadcast**: an audience member can be removed from
+  future encryptions without rotating every other member's key.
+  Document the forward-secrecy properties — what does revocation
+  guarantee about *past* messages?
+- Ship an adversarial validator that catches **four attacks**:
+  1. *Eavesdropper*: a non-audience agent intercepts the ciphertext
+     in the trace. It must not be decryptable by any non-audience key.
+  2. *Replay*: a recorded ciphertext is replayed to a third party.
+     Must not authenticate.
+  3. *Field-injection*: an attacker tampers with the unrevealed
+     fields of a selective-disclosure proof. Verification must fail.
+  4. *Stale-revocation*: a revoked member tries to decrypt a
+     message issued *after* their revocation. Must fail.
+- Validator FAILS against `noop` (trivially — there's no actual
+  encryption) and PASSES against yours.
+- Ship `scenarios/sealed_bid_with_privacy.yaml` combining PR #5's
+  sealed-bid coordination plugin with your privacy plugin so bids
+  stay sealed *on the wire*, not just in the auction logic.
+
+## Suggested approach pointers
+
+- HPKE (RFC 9180) is the standard for this exact shape. The
+  `cryptography` library doesn't ship it directly but it's a few
+  hundred lines on top of X25519 + HKDF + ChaCha20-Poly1305.
+- For selective disclosure, a binary Merkle tree over field hashes is
+  simplest: reveal selected fields + the path; verifier reconstructs
+  the root.
+- Revocation under hybrid encryption is fundamentally about *not
+  including* a recipient in the next key-wrap step. Forward secrecy
+  requires per-epoch keys — be explicit about your epoch policy.
+- The plugin can take an `Identity` instance via its constructor so
+  signatures bind to existing agent identities.
+- Run your test suite with `pytest -p no:randomly` if randomness
+  ever creeps in — Tier 1 determinism demands it.
+
+## Anti-patterns
+
+- Don't ship symmetric-only encryption claiming to be hybrid.
+- Don't ship "selective disclosure" as just JSON omission — the
+  unrevealed fields must be cryptographically committed.
+- Don't claim forward secrecy without an explicit epoch story.
+- Don't reuse the same nonce twice (test for it).
+- Don't break the `noop` plugin's existing callers.
+
+## Out of scope
+
+- Full zk-SNARK / zk-STARK implementation. Merkle-tree selective
+  disclosure is sufficient.
+- Post-quantum primitives.
+- TLS/QUIC interop.
+- Hardware enclave attestation (SGX, TDX).

--- a/docs/hackathon/problems/10-coordination-bft-partition-tolerant.md
+++ b/docs/hackathon/problems/10-coordination-bft-partition-tolerant.md
@@ -1,0 +1,116 @@
+---
+title: Partition-tolerant BFT consensus with view-change and liveness proofs
+layer: coordination
+difficulty: hard
+---
+
+# Partition-tolerant BFT consensus with view-change and liveness proofs
+
+## Motivation
+
+The default coordination plugin
+[`nest_plugins_reference/coordination/contract_net.py`](../../../packages/nest-plugins-reference/nest_plugins_reference/coordination/contract_net.py)
+is 95 lines of FIPA Contract Net — a single-round bidding scaffold
+that does not even *attempt* consensus: no quorums, no view changes,
+no leader election. The `consensus` scenario in
+[`scenarios/consensus.yaml`](../../../scenarios/consensus.yaml)
+exercises a 2/3 quorum but the validator (`validate_consensus_*` in
+[`nest_core/validators.py`](../../../packages/nest-core/nest_core/validators.py)
+lines 510-665) only checks that *committed* rounds had ≥2/3 accepts —
+it does **not** test what happens under partition, byzantine
+followers lying about their votes, or leader failure mid-round. As
+the [`docs/layers/coordination.md`](../../../docs/layers/coordination.md)
+file explicitly says: "it is not full BFT — that's a great thing to
+plug your own implementation into."
+
+PR #5 added sealed-bid coordination (FPSB/Vickrey) — useful for
+mechanism design but *not* a consensus protocol. The 4-agent
+partition story remains untested.
+
+The simulator already supports partitions
+([`nest_core/sim/simulator.py`](../../../packages/nest-core/nest_core/sim/simulator.py)
+lines 246-260) and byzantine agents (lines 240-244). The plumbing is
+there; the *protocol* to test against it isn't.
+
+Anyone using NEST to validate a real BFT protocol (Tendermint,
+HotStuff, PBFT) benefits directly. Anyone building agent
+infrastructure that has to survive a single replica failure without
+losing a commit benefits. This is hard because BFT is hard — but
+NEST is the right place to test it, because the simulator gives you
+deterministic adversarial conditions you can't get on a real network.
+
+## Success criteria
+
+- Ship a coordination plugin (suggested name: `bft_hotstuff`,
+  `pbft`, or similar — pick one BFT protocol and implement it
+  faithfully). Register as `(\"coordination\", \"<your_name>\")` in
+  [`nest_core/plugins.py`](../../../packages/nest-core/nest_core/plugins.py).
+- The plugin satisfies the existing `Coordination` protocol
+  (`propose`/`participate`/`resolve`/`commit`) so the existing
+  `consensus` scenario can be pointed at it via
+  `layers.coordination: <your_name>`.
+- View-change: when the leader fails (or is partitioned from a
+  majority), the protocol elects a new leader within a bounded
+  number of rounds. The trace must show evidence of the view change.
+- **Safety property**: under up to *f* byzantine agents out of *3f+1*
+  total, no two honest agents commit conflicting values for the same
+  round. (For *f=1*, 4 agents minimum. For *f=2*, 7 agents.)
+- **Liveness property**: in the absence of partition, the protocol
+  makes progress (commits a round) within bounded time.
+- Ship an adversarial validator suite that catches **all four**:
+  1. *Conflicting commits*: two honest agents committing different
+     values in the same view.
+  2. *Equivocation*: a leader sending different proposals to
+     different followers.
+  3. *Forged quorum*: a `commit` event in the trace not backed by
+     ≥ 2f+1 signed votes from distinct agents.
+  4. *Stuck view*: no commit progress for K rounds after the
+     network is healed.
+- Validator FAILS against `contract_net` (trivially, no quorum) and
+  PASSES against your plugin.
+- Ship `scenarios/bft_consensus_partition.yaml` with 7 agents
+  (f=2), a partition splitting them 4/3 for the first 30% of the
+  scenario, plus a heal. Trace deterministic under seeds 42, 7,
+  1337, and 0xdeadbeef.
+- Ship `scenarios/bft_consensus_byzantine.yaml` with 7 agents and
+  `failures.byzantine_agents: 0.28` (i.e. 2 byzantine). Safety
+  validator must pass; liveness may degrade but commits must still
+  happen post-recovery.
+
+## Suggested approach pointers
+
+- HotStuff is the cleanest reference — three-phase voting, linear
+  view-change. Castro-Liskov PBFT is more traditional but more
+  edges.
+- Cryptographic signatures: lean on the `did_key` identity plugin
+  for vote signatures. Quorum certificates are sets of signatures.
+- Determinism under byzantine: a byzantine agent in NEST sends
+  "garbage" (see
+  [`nest_core/sim/simulator.py`](../../../packages/nest-core/nest_core/sim/simulator.py)
+  line 333) — your protocol must not deserialize garbage as a vote.
+- View-change timer: derive timeout from the simulator's logical
+  clock, not wall time.
+- Borrow the FIPA-state-tracking pattern from PR #5's sealed-bid
+  plugin — explicit `status` transitions make traces inspectable.
+- Test with `Hypothesis` strategies that generate random partition
+  schedules and byzantine vote patterns; safety must hold across
+  all of them.
+
+## Anti-patterns
+
+- Don't ship a "consensus" plugin that's actually leader-election +
+  Raft (Raft is CFT, not BFT — byzantine validator suite will catch
+  it).
+- Don't claim BFT and then trust unsigned votes.
+- Don't make view-change require global knowledge of agent set.
+- Don't skip the equivocation check by assuming an honest leader.
+- Don't ship without the byzantine scenario — partition-only is
+  half the problem.
+
+## Out of scope
+
+- Open membership (dynamic add/remove of agents mid-scenario).
+- Cross-chain interop / IBC-style relay.
+- Production-grade performance optimization (pipelining,
+  aggregation). Correctness first.
+- VRF-based leader election. Round-robin is fine.


### PR DESCRIPTION
## What this PR does

Ships the participant-facing scaffolding for the NEST hackathon:

- `docs/hackathon/charter.md` — the brief (what NEST is, what to build, the rules)
- `docs/hackathon/problems/` — 10 differentiated open problems
- `docs/hackathon/judging.md` — six-dimension rubric and scoreboard explanation
- `README.md` — top-level "Hackathon" section linking to the above

No code outside `docs/` or the top of `README.md` is touched. All five CI checks pass locally: `uv sync && uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -v`.

## How I chose the problems

1. **Read every reference plugin** (`packages/nest-plugins-reference/`) to find which layers have the *weakest* defaults — the gaps where a participant can ship something materially better with one weekend of work.
2. **Read PRs #2-#11** to see what's already taken. First-round picks collapsed: 3x EigenTrust (PRs #2, #3, #6), 4x latency-transport (PRs #8, #10, #11 + adjacent), 1x DPoP auth (#9), 1x HTLC payments (#7), 1x sealed-bid coord (#5), 1x semantic memory (#4). Five layers (comms, identity, registry, negotiation, privacy, datafacts) had **zero** PRs.
3. **Wrote problems that target the gaps**, citing specific files and line numbers in each motivation so participants can't argue the gap isn't real. Where the obvious pick was already overrepresented, wrote a *harder, sharper* version (e.g. coordination = partition-tolerant BFT with view-change, not sealed-bid).

## Layer coverage

| Layer | Problem # | Difficulty | First-round overlap? |
|---|---|---|---|
| comms | 01 | easy | none |
| memory | 02 | easy | PR #4 added semantic recall but kept LWW; CRDT story still open |
| payments | 03 | easy | PR #7 added HTLC (one-shot); streaming is orthogonal |
| auth | 04 | easy | PR #9 added DPoP; delegation+revocation is orthogonal |
| identity | 05 | medium | none |
| registry | 06 | medium | none |
| negotiation | 07 | medium | none |
| datafacts | 08 | medium | none |
| privacy | 09 | hard | none |
| coordination | 10 | hard | PR #5 added sealed-bid; BFT consensus under partition is a different problem |

10 of 12 layers covered (skipped trust and transport — both 3x covered in round 1, deliberately excluded to avoid a fourth pile-on).

## Difficulty distribution

- Easy: 4 (comms, memory, payments, auth)
- Medium: 4 (identity, registry, negotiation, datafacts)
- Hard: 2 (privacy, coordination)

Matches the requested 4/4/2 split.

## Anti-overlap with PRs #2-#11

Explicit exclusions stated in the charter and reiterated in problem files:

- **No plain "implement EigenTrust"** problem at all. Trust layer is excluded entirely from the 10.
- **No plain "add latency to in_memory transport"** problem. Transport layer is excluded entirely from the 10.
- Problem #03 (streaming payments) cites PR #7 and says "streams aren't HTLCs."
- Problem #04 (delegated auth) cites PR #9 and says "don't rebuild PR #9's DPoP."
- Problem #02 (CRDT memory) cites PR #4 and says "PR #4 added semantic recall but kept LWW semantics."
- Problem #10 (BFT consensus) cites PR #5 and says "PR #5 added sealed-bid coordination — useful for mechanism design but not a consensus protocol."

## CI

Locally on this branch:

- `uv sync` — 0
- `uv run ruff check .` — 0 (All checks passed!)
- `uv run ruff format --check .` — 0 (94 files already formatted)
- `uv run pyright` — 0 (0 errors, 0 warnings, 0 informations)
- `uv run pytest -v` — 0 (259 passed, 1 warning, 14.28s)

## Out of scope

- No code in `packages/` was touched.
- No other platform tracks were touched.
- `scripts/judge/rubric.md` does not exist yet (parallel judge-panel track); `judging.md` defers to it when it lands and writes the rubric inline meanwhile.


---
_Generated by [Claude Code](https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW)_