### PR TITLE
[Platform] Research harness for A/B hackathon experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ dist/
 build/
 uv.lock
 traces/
+
+# Research-harness outputs (per-cell JSONLs, aggregated dataset, plots).
+data/hackathon-runs/*.jsonl
+data/hackathon-runs/*.png
+# Per-agent isolated worktrees / clones.
+.harness-work/

--- a/data/hackathon-runs/.gitkeep
+++ b/data/hackathon-runs/.gitkeep
@@ -1,0 +1,2 @@
+# Outputs of the research harness live here.
+# Per-cell JSONLs and PNG plots are gitignored — see .gitignore.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,19 @@ extraPaths = [
     "packages/nest-scenarios",
     "packages/nest-shell",
     "packages/nest-plugins-reference",
+    ".",
 ]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-testpaths = ["packages"]
+testpaths = ["packages", "scripts/harness/dry_run"]
 addopts = ["--import-mode=importlib"]
+pythonpath = ["."]
+
+# Optional extras: the `harness` extra adds plotting deps for analyze.py.
+# Keeping it optional means the core repo (and CI) stays matplotlib-free.
+[project.optional-dependencies]
+harness = [
+    "matplotlib>=3.8",
+    "PyYAML>=6.0",
+]

--- a/scripts/harness/README.md
+++ b/scripts/harness/README.md
@@ -1,0 +1,170 @@
+# NEST research harness
+
+Multi-condition, reproducible, dataset-producing infrastructure for running
+hackathon-style A/B experiments against the `nest` repo.
+
+This directory ships:
+
+| file                                  | purpose                                                                  |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| `conditions.yaml`                     | declarative experiment design (factors + levels + skip rules)            |
+| `conditions.py`                       | YAML loader; `compute_cell_id()` for stable hashes                       |
+| `agent_runner.py`                     | transport abstraction — fixture (dry-run) or `claude` CLI (live)         |
+| `run_condition.py`                    | CLI: run N replicates of one cell, write per-cell JSONL                  |
+| `collect.py`                          | merge per-cell JSONLs into `all.jsonl`                                   |
+| `analyze.py`                          | three PNG plots (diversity collapse, calibration, iteration efficiency)  |
+| `briefs/{vague,layer-enumerated,open-problems}.md` | brief templates wired to the `brief_specificity` factor       |
+| `dry_run/fixtures/*.json`             | replayable mocked agent submissions                                      |
+| `dry_run/test_dry_run.py`             | default-suite pytest gate over the whole pipeline                        |
+| `SCHEMA.md`                           | JSONL row schema (versioned)                                             |
+
+## TL;DR
+
+```bash
+# 1. install the optional harness extra (matplotlib)
+uv sync --extra harness
+
+# 2. inspect the cells the current conditions.yaml would expand to
+uv run python -c "from scripts.harness.conditions import load_conditions; \
+  [print(c.cell_id, c.factors) for c in load_conditions().cells()]"
+
+# 3. dry-run one cell against the fixture transport (no agents spawned)
+uv run python -m scripts.harness.run_condition --cell <cell_id> --n 4 --dry-run
+
+# 4. aggregate + plot
+uv run python -m scripts.harness.collect
+uv run python -m scripts.harness.analyze
+```
+
+PNGs land in `data/hackathon-runs/`.
+
+## Worked example (dry-run, end-to-end)
+
+```bash
+uv sync --extra harness
+
+# pick the first non-skipped cell
+CELL=$(uv run python -c "from scripts.harness.conditions import load_conditions; \
+  print(next(iter(load_conditions().cells())).cell_id)")
+
+# run 8 fixture-backed replicates for that cell
+uv run python -m scripts.harness.run_condition --cell "$CELL" --n 8 --dry-run
+
+# repeat for another cell
+CELL2=$(uv run python -c "from scripts.harness.conditions import load_conditions; \
+  cells = list(load_conditions().cells()); print(cells[1].cell_id)")
+uv run python -m scripts.harness.run_condition --cell "$CELL2" --n 8 --dry-run
+
+# aggregate
+uv run python -m scripts.harness.collect
+
+# plot
+uv run python -m scripts.harness.analyze
+
+ls data/hackathon-runs/
+# -> <cell_id>.jsonl  <cell_id2>.jsonl  all.jsonl
+#    diversity_collapse.png  calibration.png  iteration_efficiency.png
+```
+
+## Live experiments (spends money)
+
+When you are ready to run real agents:
+
+```bash
+# Use clone strategy: each agent gets a fresh `git clone` of the repo, so the
+# harness works from any shell on any machine, not just inside Claude Code.
+uv run python -m scripts.harness.run_condition \
+    --cell "$CELL" --n 100 --live \
+    --workdir-strategy clone \
+    --workdir-base /tmp/nest-harness-work
+```
+
+Live mode shells out to the `claude` CLI in headless mode
+(`claude -p <prompt> --output-format stream-json --model <model>`). This is
+the simpler of the two viable live transports — the alternative would be the
+Anthropic Python SDK with a hand-rolled tool loop, which forces the harness
+to reimplement a lot of what the CLI already does (file editing,
+bash-tool-with-permissions, branch hygiene, etc.). The CLI path is what is
+documented as the reference live transport.
+
+Required external tooling for live mode:
+
+- `claude` CLI on `PATH`, authenticated (`claude login`).
+- `git` for the `worktree`/`clone` strategies.
+- (Optional but recommended) `gh` for automatic PR-and-CI lookup. If
+  missing, the harness still writes the row — `pr_url` is captured but
+  `head_sha` / `first_push_ci_*` stay `null` and you can backfill them
+  later from the same JSONL.
+
+## Inside Claude Code vs. headless shell
+
+| feature                                    | inside Claude Code                                | headless shell                                                 |
+| ------------------------------------------ | ------------------------------------------------- | -------------------------------------------------------------- |
+| dry-run + tests + analysis                 | works                                             | works                                                          |
+| `--workdir-strategy worktree`              | works (assumes harness invoked inside the repo)   | works                                                          |
+| `--workdir-strategy clone`                 | works                                             | **recommended** — most reproducible                            |
+| `--live` transport (`claude` CLI)          | not the intended use case (nested Claude)         | works                                                          |
+| `gh`-based PR/CI enrichment                | depends on gh-auth in the session                 | depends on gh-auth in the shell                                |
+
+The harness deliberately keeps the `--live` path runnable from a plain shell
+(no Claude Code dependency) so you can run real experiments on dedicated
+infra, then come back to Claude Code for analysis.
+
+## Reproducibility notes
+
+Every JSONL row carries:
+
+- `harness_version` — semver of this harness package (`scripts/harness/__init__.py`).
+- `schema_version` — integer schema version (see `SCHEMA.md`).
+- `conditions_version` — integer from `conditions.yaml`.
+- `cell_id` — sha256 prefix of `(conditions_version, sorted factors)`.
+- `model_id` — concrete version-pinned model id (e.g. `claude-opus-4-7`).
+- `prompt_hash` — sha256[:16] of the rendered brief.
+- `seed` — derived from `(seed_base, cell_id, run_idx)` via sha256, so a
+  fixed `seed_base` + factor combination always produces the same seed.
+- `timestamp_utc` — ISO-8601 UTC wall clock.
+
+The `collect.py` aggregator refuses to merge rows whose `schema_version`
+disagrees with the current code, which prevents silent schema drift across
+runs.
+
+## Open research questions this harness is designed to answer
+
+1. **Diversity collapse**: how much does the *brief specificity* factor
+   reduce variance in which protocol layer an agent picks? Compare the
+   top-1 / top-3 layer cluster share across `vague`, `layer-enumerated`,
+   `open-problems` at large N.
+2. **Calibration**: per (model, pre_push_checklist), what is the gap between
+   claimed-CI-green and actual-CI-green on first push?
+3. **Iteration efficiency**: pushes-to-green distribution; does the
+   pre-push checklist factor actually shift the mean?
+4. **Brief-specificity sensitivity**: cross-cut diversity, calibration and
+   iteration-efficiency by `brief_specificity` to see which axis matters
+   most for which outcome.
+
+## Adding a new factor
+
+1. Add a dimension under `dimensions:` in `conditions.yaml`.
+2. Bump `conditions_version` — this invalidates old `cell_id`s on purpose.
+3. If the factor affects how the brief is rendered, branch on it in
+   `run_condition.render_brief()` or add a new `briefs/<level>.md`.
+4. If the factor affects how the agent is spawned, branch on
+   `cell.factors[...]` inside `run_condition.run_cell()`.
+
+## Adding a new metric
+
+1. Add a pure helper to `analyze.py` (no matplotlib).
+2. Add a `plot_<metric>` function.
+3. Add a CLI call site in `analyze.main()`.
+4. Extend `dry_run/test_dry_run.py::test_analysis_pure_helpers_have_sane_shape`
+   with a tiny ground-truth check.
+
+## Why the dry-run is the default
+
+The fixture transport is intentionally the default. Real agent runs cost
+real money — having `pytest` exercise the full pipeline without spending a
+cent (and without needing network access) is the only way to catch schema
+drift before a live run.
+
+The `--live` flag must be passed explicitly to spawn real agents. There is
+no auto-detection.

--- a/scripts/harness/SCHEMA.md
+++ b/scripts/harness/SCHEMA.md
@@ -1,0 +1,70 @@
+# Research-harness JSONL schema
+
+Each agent submission produces **one JSONL row**. Rows are written by
+`scripts/harness/run_condition.py` to
+`data/hackathon-runs/<cell_id>.jsonl`, then aggregated into
+`data/hackathon-runs/all.jsonl` by `scripts/harness/collect.py`.
+
+The schema is **versioned**: the integer `schema_version` field is bumped on
+any backwards-incompatible change. `collect.py` refuses to merge rows whose
+`schema_version` differs from the current one.
+
+## Row fields (schema_version = 1)
+
+| field                          | type                | description                                                                                  |
+| ------------------------------ | ------------------- | -------------------------------------------------------------------------------------------- |
+| `schema_version`               | int                 | Always `1` for this schema.                                                                  |
+| `harness_version`              | str                 | Semver of the harness code that produced the row (see `scripts/harness/__init__.py`).        |
+| `conditions_version`           | int                 | `conditions.yaml` version this cell was derived from.                                        |
+| `cell_id`                      | str                 | 12-char hash of `(factors, conditions_version)`. Stable across machines.                     |
+| `factors`                      | object[str, str]    | Factor name -> level. Sorted keys.                                                           |
+| `run_idx`                      | int                 | Replicate index within the cell, `0 <= run_idx < N`.                                         |
+| `seed`                         | int                 | Deterministic seed derived from `(seed_base, cell_id, run_idx)`.                             |
+| `model_id`                     | str                 | Concrete model identifier passed to the agent (e.g. `claude-opus-4-7`).                      |
+| `prompt_hash`                  | str                 | sha256[:16] of the rendered brief.                                                           |
+| `brief_path`                   | str                 | Path to the brief template used.                                                             |
+| `transport`                    | str                 | `"claude-cli"`, `"fixture"`, ...                                                             |
+| `timestamp_utc`                | str (ISO-8601)      | When the row was written.                                                                    |
+| `duration_seconds`             | float \| null       | Wall-clock agent duration.                                                                   |
+| `spawned`                      | bool                | Whether the agent process started at all.                                                    |
+| `exit_code`                    | int \| null         | Agent process exit code (null on timeout).                                                   |
+| `pr_url`                       | str \| null         | GitHub PR URL the agent submitted, if any.                                                   |
+| `branch`                       | str \| null         | Head branch of the submission.                                                               |
+| `head_sha`                     | str \| null         | Head commit SHA of the submission.                                                           |
+| `layer_picked`                 | str \| null         | Protocol layer the agent picked (parsed from branch/PR body).                                |
+| `lines_added`                  | int \| null         | `+N` from the diff.                                                                          |
+| `lines_removed`                | int \| null         | `-N` from the diff.                                                                          |
+| `first_push_ci_status`         | str \| null         | `"success"`, `"failure"`, `"pending"`, or null if no CI run was found.                       |
+| `first_push_ci_green`          | bool \| null        | Convenience: `first_push_ci_status == "success"`.                                            |
+| `iterations_to_green`          | int \| null         | Number of pushes until CI went green (null if it never did).                                 |
+| `claimed_ci_green`             | bool                | Did the agent's final message claim CI / tests pass?                                         |
+| `final_message`                | str \| null         | The agent's last assistant text block (used for calibration).                                |
+| `transcript_path`              | str \| null         | Absolute path to the raw transcript log.                                                     |
+| `description`                  | str \| null         | Free-form one-line PR title / summary if available — used by `analyze.py` for clustering.    |
+| `error`                        | str \| null         | Set if the spawn failed before producing a submission.                                       |
+
+## Calibration parsing
+
+`claimed_ci_green` is `True` when the agent's `final_message` matches any of
+these case-insensitive patterns:
+
+- `all tests pass`
+- `tests pass`
+- `ruff clean`
+- `ci green`
+- `ci is green`
+- `pipeline green`
+- `all checks pass`
+
+These are intentionally loose. The intent is to capture the agent's *belief*,
+not to be exhaustive. Adding patterns is backwards-compatible (no schema
+bump). Removing patterns requires a schema bump.
+
+## Clustering for diversity collapse
+
+`analyze.py` clusters submissions primarily by `layer_picked`. When
+`description` is available (e.g. from the PR title), it is also used as a
+finer-grained second-level key in `(layer_picked, description)` pairs. The
+analysis script is deterministic and does not call any embedding model — if
+embedding-based clustering is added, it must be implemented in a way that is
+seedable from `seed_base`.

--- a/scripts/harness/__init__.py
+++ b/scripts/harness/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+"""NEST research harness — A/B experiment infrastructure for hackathon-style runs.
+
+See `scripts/harness/README.md` for usage. Schema version is exposed as
+``HARNESS_VERSION`` and stamped on every JSONL row for reproducibility.
+"""
+
+from __future__ import annotations
+
+HARNESS_VERSION = "0.1.0"
+"""Schema/harness version. Bump on any breaking change to the JSONL row schema."""
+
+SCHEMA_VERSION = 1
+"""Integer schema version. Bumped only on backwards-incompatible row changes."""

--- a/scripts/harness/_calibration.py
+++ b/scripts/harness/_calibration.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tiny parsers shared between run_condition.py and analyze.py.
+
+Kept in a private module so the regex set has exactly one home — adding a
+phrase here is the safe, backwards-compatible way to widen calibration
+coverage. Removing or narrowing a phrase requires a SCHEMA.md bump.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Loose, case-insensitive "agent claimed CI is green" phrases. Order does not
+# matter (we only check `any(...)`). Add new phrases; do not narrow existing
+# ones without bumping the schema version.
+CLAIM_GREEN_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\ball tests pass(ed)?\b", re.IGNORECASE),
+    re.compile(r"\btests (are )?passing\b", re.IGNORECASE),
+    re.compile(r"\btests pass(ed)?\b", re.IGNORECASE),
+    re.compile(r"\bruff (check )?(is )?clean\b", re.IGNORECASE),
+    re.compile(r"\bci (is )?green\b", re.IGNORECASE),
+    re.compile(r"\bpipeline (is )?green\b", re.IGNORECASE),
+    re.compile(r"\ball checks pass(ed)?\b", re.IGNORECASE),
+    re.compile(r"\beverything passes\b", re.IGNORECASE),
+)
+
+
+def claimed_ci_green(text: str | None) -> bool:
+    """True iff `text` makes any of the CLAIM_GREEN_PATTERNS claims."""
+    if not text:
+        return False
+    return any(pattern.search(text) for pattern in CLAIM_GREEN_PATTERNS)
+
+
+__all__ = ["CLAIM_GREEN_PATTERNS", "claimed_ci_green"]

--- a/scripts/harness/agent_runner.py
+++ b/scripts/harness/agent_runner.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Spawn an agent for one cell × one replicate and collect its submission.
+
+Two transport implementations live here so the harness is runnable from a
+plain shell (i.e. outside Claude Code):
+
+* ``ClaudeCLIAgentRunner`` shells out to ``claude -p ... --output-format
+  stream-json``. This is the **reference** implementation — simplest, no extra
+  Python deps, easiest to reproduce. It assumes the user has the ``claude``
+  CLI installed and authenticated.
+* ``FixtureAgentRunner`` is the dry-run transport used by tests. It reads a
+  JSON fixture from ``scripts/harness/dry_run/fixtures`` and replays it as if
+  it were a real agent submission. No network, no cost.
+
+Both transports produce a :class:`AgentSubmission` describing what the agent
+produced. The runner is intentionally I/O-light: it does **not** call GitHub
+or run CI itself. ``run_condition.py`` is in charge of post-processing
+(parsing the PR URL, looking up CI, etc.).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+
+@dataclass(frozen=True)
+class AgentSpawnSpec:
+    """Inputs needed to spawn one agent."""
+
+    cell_id: str
+    run_idx: int
+    model: str
+    brief_path: Path
+    brief_text: str
+    prompt_hash: str
+    seed: int
+    workdir: Path
+    timeout_seconds: int = 1800
+    extra_env: dict[str, str] = field(default_factory=dict[str, str])
+
+
+@dataclass
+class AgentSubmission:
+    """Everything we managed to extract about one agent's submission attempt.
+
+    Fields are intentionally permissive — missing fields are recorded as
+    ``None`` rather than failing the row, because the goal is to capture
+    partial data even when the agent crashed mid-run.
+    """
+
+    spawned: bool
+    exit_code: int | None
+    pr_url: str | None = None
+    branch: str | None = None
+    head_sha: str | None = None
+    layer_picked: str | None = None
+    final_message: str | None = None
+    transcript_path: str | None = None
+    raw_metadata: dict[str, Any] = field(default_factory=dict[str, Any])
+    duration_seconds: float | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+class AgentRunner(Protocol):
+    """Protocol for any agent transport (CLI, SDK, fixture, ...)."""
+
+    name: str
+
+    def run(self, spec: AgentSpawnSpec) -> AgentSubmission:  # pragma: no cover - protocol
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Fixture transport (used by the default test suite — no real agent involved).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FixtureAgentRunner:
+    """Replay a recorded agent run from a JSON fixture.
+
+    Fixtures live in ``scripts/harness/dry_run/fixtures``. The selection
+    algorithm is deterministic: ``fixture_for(cell_id, run_idx)`` picks one of
+    the available fixtures by stable hash, so a given (cell, run) pair always
+    replays the same fixture across machines.
+    """
+
+    fixtures_dir: Path
+    name: str = "fixture"
+
+    def run(self, spec: AgentSpawnSpec) -> AgentSubmission:
+        fixture = self._select_fixture(spec.cell_id, spec.run_idx)
+        with fixture.open("r", encoding="utf-8") as fh:
+            data_obj: object = json.load(fh)
+        if not isinstance(data_obj, dict):
+            raise ValueError(f"{fixture}: fixture must contain a JSON object")
+        data = cast("dict[str, Any]", data_obj)
+
+        transcript_path = spec.workdir / f"transcript-{spec.cell_id}-{spec.run_idx}.json"
+        spec.workdir.mkdir(parents=True, exist_ok=True)
+        with transcript_path.open("w", encoding="utf-8") as fh:
+            json.dump(
+                {"fixture": fixture.name, "spec": _spec_to_jsonable(spec), "replay": data},
+                fh,
+                indent=2,
+            )
+
+        return AgentSubmission(
+            spawned=True,
+            exit_code=int(data.get("exit_code", 0)),
+            pr_url=data.get("pr_url"),
+            branch=data.get("branch"),
+            head_sha=data.get("head_sha"),
+            layer_picked=data.get("layer_picked"),
+            final_message=data.get("final_message"),
+            transcript_path=str(transcript_path),
+            raw_metadata={
+                "fixture_name": fixture.name,
+                "claimed_ci_green": bool(data.get("claimed_ci_green", False)),
+                "actual_ci_green_first_push": data.get("actual_ci_green_first_push"),
+                "iterations_to_green": data.get("iterations_to_green"),
+                "lines_added": data.get("lines_added"),
+                "lines_removed": data.get("lines_removed"),
+                "description": data.get("description"),
+            },
+            duration_seconds=float(data.get("duration_seconds", 0.0)),
+        )
+
+    def _select_fixture(self, cell_id: str, run_idx: int) -> Path:
+        fixtures = sorted(self.fixtures_dir.glob("*.json"))
+        if not fixtures:
+            raise FileNotFoundError(
+                f"No fixture JSON files found in {self.fixtures_dir} — cannot dry-run"
+            )
+        key = f"{cell_id}:{run_idx}".encode()
+        idx = int(hashlib.sha256(key).hexdigest(), 16) % len(fixtures)
+        return fixtures[idx]
+
+
+# ---------------------------------------------------------------------------
+# Claude CLI transport (the reference live implementation).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClaudeCLIAgentRunner:
+    """Shell out to the ``claude`` CLI in headless mode.
+
+    This is the simpler / more reproducible path documented in the README:
+    no Python SDK, no tool-loop bookkeeping — the CLI handles all of that.
+    We only have to:
+
+    1. Write the brief into the worktree as ``BRIEF.md``.
+    2. Invoke ``claude -p <prompt> --output-format stream-json`` with the
+       worktree as cwd.
+    3. Stream stdout to a transcript file.
+    4. Best-effort scrape the last assistant message for a PR URL / branch /
+       layer name so we have *something* to write into the JSONL even if
+       the rest of the pipeline fails to find the PR on GitHub.
+
+    The actual PR-and-CI lookup happens in ``run_condition.py`` after the
+    agent exits.
+    """
+
+    binary: str = "claude"
+    name: str = "claude-cli"
+
+    def run(self, spec: AgentSpawnSpec) -> AgentSubmission:
+        if shutil.which(self.binary) is None:
+            return AgentSubmission(
+                spawned=False,
+                exit_code=None,
+                error=f"{self.binary!r} not found on PATH; install Claude Code or use --dry-run",
+            )
+
+        spec.workdir.mkdir(parents=True, exist_ok=True)
+        brief_dest = spec.workdir / "BRIEF.md"
+        brief_dest.write_text(spec.brief_text, encoding="utf-8")
+
+        transcript_path = spec.workdir / f"transcript-{spec.cell_id}-{spec.run_idx}.jsonl"
+        env = {**os.environ, **spec.extra_env, "NEST_HARNESS_SEED": str(spec.seed)}
+
+        prompt = (
+            f"Read BRIEF.md in the current directory. Follow it exactly. "
+            f"Model: {spec.model}. Harness seed: {spec.seed}."
+        )
+        cmd: list[str] = [
+            self.binary,
+            "-p",
+            prompt,
+            "--output-format",
+            "stream-json",
+            "--model",
+            spec.model,
+        ]
+
+        started = time.monotonic()
+        final_message: str | None = None
+        exit_code: int | None = None
+        try:
+            with transcript_path.open("w", encoding="utf-8") as transcript:
+                proc = subprocess.run(  # noqa: S603 — input is harness-controlled
+                    cmd,
+                    cwd=spec.workdir,
+                    env=env,
+                    stdout=transcript,
+                    stderr=subprocess.PIPE,
+                    timeout=spec.timeout_seconds,
+                    check=False,
+                )
+            exit_code = proc.returncode
+            final_message = _scrape_final_message(transcript_path)
+        except subprocess.TimeoutExpired:
+            return AgentSubmission(
+                spawned=True,
+                exit_code=None,
+                transcript_path=str(transcript_path),
+                duration_seconds=time.monotonic() - started,
+                error=f"timeout after {spec.timeout_seconds}s",
+            )
+        except OSError as exc:
+            return AgentSubmission(
+                spawned=False,
+                exit_code=None,
+                error=f"failed to spawn {self.binary!r}: {exc}",
+            )
+
+        duration = time.monotonic() - started
+        pr_url, branch, layer_picked = _scrape_submission_fields(final_message or "")
+
+        return AgentSubmission(
+            spawned=True,
+            exit_code=exit_code,
+            pr_url=pr_url,
+            branch=branch,
+            head_sha=None,  # filled in by run_condition.py via gh
+            layer_picked=layer_picked,
+            final_message=final_message,
+            transcript_path=str(transcript_path),
+            duration_seconds=duration,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+
+def _spec_to_jsonable(spec: AgentSpawnSpec) -> dict[str, Any]:
+    return {
+        "cell_id": spec.cell_id,
+        "run_idx": spec.run_idx,
+        "model": spec.model,
+        "brief_path": str(spec.brief_path),
+        "prompt_hash": spec.prompt_hash,
+        "seed": spec.seed,
+        "workdir": str(spec.workdir),
+        "timeout_seconds": spec.timeout_seconds,
+    }
+
+
+def _scrape_final_message(transcript_path: Path) -> str | None:
+    """Best-effort: pull the last assistant text block out of a stream-json log."""
+    last: str | None = None
+    try:
+        with transcript_path.open("r", encoding="utf-8") as fh:
+            for raw_line in fh:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    event_obj: object = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event_obj, dict):
+                    continue
+                text = _extract_assistant_text(cast("dict[str, Any]", event_obj))
+                if text:
+                    last = text
+    except FileNotFoundError:
+        return None
+    return last
+
+
+def _extract_assistant_text(event: dict[str, Any]) -> str | None:
+    # The Claude CLI stream-json schema is documented in the CLI README. We
+    # accept a few shapes to stay robust across CLI versions.
+    msg_obj: object = event.get("message")
+    if isinstance(msg_obj, dict):
+        msg = cast("dict[str, Any]", msg_obj)
+        content_obj: object = msg.get("content")
+        if isinstance(content_obj, list):
+            content = cast("list[Any]", content_obj)
+            chunks: list[str] = []
+            for block_obj in content:
+                if isinstance(block_obj, dict):
+                    block = cast("dict[str, Any]", block_obj)
+                    if block.get("type") == "text":
+                        text_obj: object = block.get("text")
+                        if isinstance(text_obj, str):
+                            chunks.append(text_obj)
+            if chunks:
+                return "\n".join(chunks)
+    if event.get("type") == "result":
+        result_obj: object = event.get("result")
+        if isinstance(result_obj, str):
+            return result_obj
+    return None
+
+
+def _scrape_submission_fields(text: str) -> tuple[str | None, str | None, str | None]:
+    """Pull (pr_url, branch, layer) out of an agent's final message via regex."""
+    import re
+
+    pr_url = None
+    pr_match = re.search(r"https://github\.com/[^\s)]+/pull/\d+", text)
+    if pr_match:
+        pr_url = pr_match.group(0).rstrip(".,)")
+
+    branch = None
+    branch_match = re.search(r"\b(hackathon/[A-Za-z0-9._/-]+)", text)
+    if branch_match:
+        branch = branch_match.group(1)
+
+    layer = None
+    layer_match = re.search(
+        r"\b(trust|identity|registry|transport|payments|negotiation|memory|coordination|"
+        r"communication|privacy|auth|datafacts)\b",
+        text,
+        re.IGNORECASE,
+    )
+    if layer_match:
+        layer = layer_match.group(1).lower()
+
+    return pr_url, branch, layer
+
+
+def make_runner(transport: str, fixtures_dir: Path | None = None) -> AgentRunner:
+    """Factory used by the CLI to keep `--dry-run` and live paths symmetric."""
+    if transport == "claude-cli":
+        return ClaudeCLIAgentRunner()
+    if transport == "fixture":
+        if fixtures_dir is None:
+            fixtures_dir = Path(__file__).parent / "dry_run" / "fixtures"
+        return FixtureAgentRunner(fixtures_dir=fixtures_dir)
+    raise ValueError(f"unknown agent transport: {transport!r}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Tiny CLI mostly for debugging — `run_condition.py` is the real entrypoint."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Spawn one agent (for debugging).")
+    parser.add_argument("--transport", choices=["claude-cli", "fixture"], default="fixture")
+    parser.add_argument("--cell-id", required=True)
+    parser.add_argument("--run-idx", type=int, default=0)
+    parser.add_argument("--model", default="opus")
+    parser.add_argument("--brief", required=True, type=Path)
+    parser.add_argument("--workdir", required=True, type=Path)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--timeout", type=int, default=1800)
+    parser.add_argument("--dry-run", action="store_true", help="Force fixture transport")
+    args = parser.parse_args(argv)
+
+    transport = "fixture" if args.dry_run else args.transport
+    runner = make_runner(transport)
+    brief_text = args.brief.read_text(encoding="utf-8")
+    prompt_hash = hashlib.sha256(brief_text.encode("utf-8")).hexdigest()[:16]
+    spec = AgentSpawnSpec(
+        cell_id=args.cell_id,
+        run_idx=args.run_idx,
+        model=args.model,
+        brief_path=args.brief,
+        brief_text=brief_text,
+        prompt_hash=prompt_hash,
+        seed=args.seed,
+        workdir=args.workdir,
+        timeout_seconds=args.timeout,
+    )
+    submission = runner.run(spec)
+    json.dump(submission.to_dict(), sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0 if submission.spawned and (submission.exit_code in (0, None)) else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/harness/analyze.py
+++ b/scripts/harness/analyze.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Plot the three core research metrics from an aggregated dataset.
+
+Inputs: ``data/hackathon-runs/all.jsonl`` (or any path passed via ``--input``).
+Outputs three PNGs in ``--output-dir`` (default: ``data/hackathon-runs``):
+
+* ``diversity_collapse.png``  — top-1 / top-3 layer cluster share per condition.
+* ``calibration.png``         — claimed-CI-green vs actual-CI-green per condition.
+* ``iteration_efficiency.png`` — distribution of pushes-to-green per condition.
+
+This module imports ``matplotlib`` lazily so the rest of the harness (and the
+core repo!) doesn't take a matplotlib dependency. Install the optional
+``harness`` extra to get plotting deps: ``uv sync --extra harness``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_INPUT = REPO_ROOT / "data" / "hackathon-runs" / "all.jsonl"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "data" / "hackathon-runs"
+
+
+# ---------------------------------------------------------------------------
+# Loading & condition labelling.
+# ---------------------------------------------------------------------------
+
+
+def load_rows(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def condition_label(row: dict[str, Any]) -> str:
+    """Stable per-condition string. Sorted-by-key so it's reproducible."""
+    factors: dict[str, Any] = row.get("factors") or {}
+    parts = [f"{k}={factors[k]}" for k in sorted(factors)]
+    return " | ".join(parts) if parts else "(no factors)"
+
+
+def group_by_condition(rows: Iterable[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    out: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        out[condition_label(row)].append(row)
+    return dict(sorted(out.items()))
+
+
+# ---------------------------------------------------------------------------
+# Metric computations (kept pure & matplotlib-free so they're easy to test).
+# ---------------------------------------------------------------------------
+
+
+def diversity_collapse_metrics(rows: list[dict[str, Any]]) -> dict[str, float]:
+    """Return {'top1': frac in modal layer, 'top3': frac in top-3 layers, 'n': N}."""
+    layers = [row.get("layer_picked") for row in rows if row.get("layer_picked")]
+    if not layers:
+        return {"top1": 0.0, "top3": 0.0, "n": 0.0}
+    counts = Counter(layers)
+    ordered = counts.most_common()
+    n = float(sum(counts.values()))
+    top1 = ordered[0][1] / n
+    top3 = sum(c for _, c in ordered[:3]) / n
+    return {"top1": top1, "top3": top3, "n": n}
+
+
+def calibration_metrics(rows: list[dict[str, Any]]) -> dict[str, float]:
+    """Return claimed-green vs actual-green fractions for one condition."""
+    if not rows:
+        return {"claimed": 0.0, "actual": 0.0, "n": 0.0, "gap": 0.0}
+    claimed = sum(1 for r in rows if r.get("claimed_ci_green"))
+    actual = sum(1 for r in rows if r.get("first_push_ci_green") is True)
+    n = float(len(rows))
+    return {
+        "claimed": claimed / n,
+        "actual": actual / n,
+        "n": n,
+        "gap": (claimed - actual) / n,
+    }
+
+
+def iteration_distribution(rows: list[dict[str, Any]]) -> list[int]:
+    return [int(r["iterations_to_green"]) for r in rows if r.get("iterations_to_green") is not None]
+
+
+# ---------------------------------------------------------------------------
+# Plot routines (matplotlib imported lazily).
+# ---------------------------------------------------------------------------
+
+
+def _import_matplotlib() -> Any:
+    try:
+        import matplotlib  # type: ignore[import-not-found]
+
+        matplotlib.use("Agg")  # pyright: ignore[reportUnknownMemberType]
+        import matplotlib.pyplot as plt  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover
+        raise SystemExit("matplotlib is not installed. Run `uv sync --extra harness`.") from exc
+    return plt
+
+
+def plot_diversity(grouped: dict[str, list[dict[str, Any]]], out: Path) -> None:
+    plt = _import_matplotlib()
+    labels = list(grouped.keys())
+    metrics = [diversity_collapse_metrics(rows) for rows in grouped.values()]
+    x = list(range(len(labels)))
+    top1 = [m["top1"] for m in metrics]
+    top3 = [m["top3"] for m in metrics]
+
+    fig, ax = plt.subplots(figsize=(max(6.0, 1.6 * len(labels)), 4.5))
+    width = 0.35
+    ax.bar([i - width / 2 for i in x], top1, width=width, label="top-1 cluster share")
+    ax.bar([i + width / 2 for i in x], top3, width=width, label="top-3 cluster share")
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, rotation=30, ha="right", fontsize=8)
+    ax.set_ylabel("share of submissions")
+    ax.set_ylim(0, 1.05)
+    ax.set_title("Diversity collapse: clustering of picked layers per condition")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+
+
+def plot_calibration(grouped: dict[str, list[dict[str, Any]]], out: Path) -> None:
+    plt = _import_matplotlib()
+    labels = list(grouped.keys())
+    metrics = [calibration_metrics(rows) for rows in grouped.values()]
+    x = list(range(len(labels)))
+    claimed = [m["claimed"] for m in metrics]
+    actual = [m["actual"] for m in metrics]
+
+    fig, ax = plt.subplots(figsize=(max(6.0, 1.6 * len(labels)), 4.5))
+    width = 0.35
+    ax.bar([i - width / 2 for i in x], claimed, width=width, label="claimed CI green")
+    ax.bar([i + width / 2 for i in x], actual, width=width, label="actual CI green")
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, rotation=30, ha="right", fontsize=8)
+    ax.set_ylabel("fraction of submissions")
+    ax.set_ylim(0, 1.05)
+    ax.set_title("Calibration: claimed-pass vs actual-pass on first push")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+
+
+def plot_iterations(grouped: dict[str, list[dict[str, Any]]], out: Path) -> None:
+    plt = _import_matplotlib()
+    labels = list(grouped.keys())
+    distributions = [iteration_distribution(rows) for rows in grouped.values()]
+
+    fig, ax = plt.subplots(figsize=(max(6.0, 1.6 * len(labels)), 4.5))
+    # Boxplot is fine even when a condition has 0 data — fall back to empty arr.
+    nonempty = [d if d else [0] for d in distributions]
+    ax.boxplot(nonempty, tick_labels=labels)
+    ax.set_xticklabels(labels, rotation=30, ha="right", fontsize=8)
+    ax.set_ylabel("pushes until green CI")
+    ax.set_title("Iteration efficiency: pushes-to-green per condition")
+    fig.tight_layout()
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Plot harness metrics.")
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args(argv)
+
+    if not args.input.exists():
+        sys.stderr.write(f"no input dataset at {args.input}\n")
+        return 1
+
+    rows = load_rows(args.input)
+    if not rows:
+        sys.stderr.write(f"{args.input} is empty\n")
+        return 1
+    grouped = group_by_condition(rows)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    plot_diversity(grouped, args.output_dir / "diversity_collapse.png")
+    plot_calibration(grouped, args.output_dir / "calibration.png")
+    plot_iterations(grouped, args.output_dir / "iteration_efficiency.png")
+    sys.stdout.write(f"wrote 3 plots to {args.output_dir}\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/harness/briefs/layer-enumerated.md
+++ b/scripts/harness/briefs/layer-enumerated.md
@@ -1,0 +1,51 @@
+# NEST Hackathon Brief — Layer-Enumerated Track
+
+You are participating in the NEST research hackathon. NEST is a discrete-event
+simulator for multi-agent system research, organised around a stack of
+protocol layers.
+
+**Task**: Pick exactly one of the 12 protocol layers below, and improve it.
+Submit a single PR.
+
+## The 12 layers
+
+The full descriptions live in `docs/layers/`:
+
+- `auth` — agent authentication
+- `communication` — message passing
+- `coordination` — multi-agent coordination primitives
+- `datafacts` — shared facts / world model
+- `identity` — agent identity & key management
+- `memory` — per-agent memory
+- `negotiation` — proposal / counter-proposal flows
+- `payments` — value transfer
+- `privacy` — selective disclosure
+- `registry` — service discovery
+- `transport` — packet delivery & reliability
+- `trust` — reputation, EigenTrust, etc.
+
+Read the layer doc before you commit. Pick the one most interesting to *you*.
+
+## Submission rules
+
+- Branch name: `hackathon/<layer>-<short-handle>` (e.g.
+  `hackathon/trust-eigen-improvements`).
+- Do not push to `main`, `master`, `hackathon/*` (other branches), or
+  `claude/*`.
+- Before you push, run all five local checks; the PR must be green on first
+  push:
+  - `uv sync`
+  - `uv run ruff check .`
+  - `uv run ruff format --check .`
+  - `uv run pyright`
+  - `uv run pytest -v`
+- PR body must state:
+  - which layer you chose,
+  - what you changed,
+  - why it matters for that layer's research questions.
+
+## What "improve" means here
+
+A good submission either: (1) adds a primitive/algorithm to the layer with
+tests, (2) ships a benchmark/scenario that stresses the layer, or (3)
+identifies and fixes a latent bug. Aim for ~150-400 lines of net change.

--- a/scripts/harness/briefs/open-problems.md
+++ b/scripts/harness/briefs/open-problems.md
@@ -1,0 +1,30 @@
+# NEST Hackathon Brief — Open-Problems Track
+
+You are participating in the NEST research hackathon. Instead of picking a
+protocol layer, this track points you at the open research problems we are
+currently tracking.
+
+**Task**: Pick one open problem from `docs/hackathon/problems/` and submit
+a PR addressing it.
+
+The current open problems are:
+
+{{ PROBLEMS_LIST }}
+
+(If the list above is empty, the open-problems track docs have not been
+checked in yet — the runner will fall back to the vague brief automatically.
+You should not reach this line in that case.)
+
+## Submission rules
+
+- Branch name: `hackathon/<problem-slug>-<short-handle>`.
+- Do not push to `main`, `master`, `hackathon/*` (other branches), or
+  `claude/*`.
+- Run the standard local checks before you push:
+  - `uv sync`
+  - `uv run ruff check .`
+  - `uv run ruff format --check .`
+  - `uv run pyright`
+  - `uv run pytest -v`
+- PR body must reference the problem file you picked, summarise the
+  approach, and call out what would *invalidate* your fix (failure modes).

--- a/scripts/harness/briefs/vague.md
+++ b/scripts/harness/briefs/vague.md
@@ -1,0 +1,21 @@
+# NEST Hackathon Brief — Vague Track
+
+You are participating in the NEST research hackathon.
+
+**Task**: Improve NEST. Submit a pull request to
+https://github.com/mariagorskikh/nest.
+
+That's it. Pick whatever you think is most valuable. Open a PR against `main`
+from a branch named `hackathon/<your-handle>-<topic>`.
+
+## Submission rules
+
+- Stay in your own branch. Do not push to `main`, `master`, `hackathon/*`
+  (other people's branches), or `claude/*`.
+- Run the local checks before you push:
+  - `uv sync`
+  - `uv run ruff check .`
+  - `uv run ruff format --check .`
+  - `uv run pyright`
+  - `uv run pytest -v`
+- Open one PR. Include in the PR body what you did and why.

--- a/scripts/harness/collect.py
+++ b/scripts/harness/collect.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Aggregate per-cell JSONLs into one ``all.jsonl``.
+
+Refuses to merge rows whose ``schema_version`` differs from the current one
+so analyses don't silently drift. Sorts the output deterministically by
+``(cell_id, run_idx)`` to make diffs across runs easy to read.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, cast
+
+from scripts.harness import SCHEMA_VERSION
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_INPUT_DIR = REPO_ROOT / "data" / "hackathon-runs"
+
+
+def discover_inputs(input_dir: Path) -> list[Path]:
+    """Find per-cell JSONLs, ignoring the aggregated `all.jsonl`."""
+    return sorted(p for p in input_dir.glob("*.jsonl") if p.name != "all.jsonl")
+
+
+def load_rows(paths: Iterable[Path]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for path in paths:
+        with path.open("r", encoding="utf-8") as fh:
+            for lineno, line in enumerate(fh, start=1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    row_obj: object = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(f"{path}:{lineno}: bad JSON: {exc}") from exc
+                if not isinstance(row_obj, dict):
+                    raise ValueError(f"{path}:{lineno}: row is not an object")
+                row = cast("dict[str, Any]", row_obj)
+                version = row.get("schema_version")
+                if version != SCHEMA_VERSION:
+                    raise ValueError(
+                        f"{path}:{lineno}: schema_version={version!r} but harness "
+                        f"is at {SCHEMA_VERSION}. Rerun the cell or bump the harness."
+                    )
+                rows.append(row)
+    rows.sort(key=lambda r: (str(r.get("cell_id", "")), int(r.get("run_idx", 0))))
+    return rows
+
+
+def write_all(rows: list[dict[str, Any]], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Aggregate per-cell JSONLs.")
+    parser.add_argument("--input-dir", type=Path, default=DEFAULT_INPUT_DIR)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output JSONL path (default: <input-dir>/all.jsonl).",
+    )
+    args = parser.parse_args(argv)
+
+    output = args.output if args.output is not None else args.input_dir / "all.jsonl"
+    inputs = discover_inputs(args.input_dir)
+    if not inputs:
+        sys.stderr.write(f"no per-cell JSONL files found in {args.input_dir}\n")
+        return 1
+    rows = load_rows(inputs)
+    write_all(rows, output)
+    sys.stdout.write(f"wrote {len(rows)} rows from {len(inputs)} cells to {output}\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/harness/conditions.py
+++ b/scripts/harness/conditions.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Load and expand experimental conditions from `conditions.yaml`.
+
+A *condition* is a YAML doc describing experiment factors (dimensions).
+A *cell* is one fully-specified combination of factor levels, identified by a
+stable `cell_id` so the same factor combo always maps to the same id, on any
+machine, in any process.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+import json
+from collections.abc import Iterator
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+# Default path used by the CLI when none is provided.
+DEFAULT_CONDITIONS_PATH = Path(__file__).parent / "conditions.yaml"
+
+
+@dataclass(frozen=True)
+class Cell:
+    """One fully-specified experimental condition (a point in factor space)."""
+
+    cell_id: str
+    factors: dict[str, str]
+    conditions_version: int
+    defaults: dict[str, Any] = field(default_factory=dict[str, Any])
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ConditionsSpec:
+    """Parsed `conditions.yaml`, ready to expand into cells."""
+
+    conditions_version: int
+    dimensions: dict[str, list[str]]
+    defaults: dict[str, Any]
+    skip: list[dict[str, str]]
+    source_path: Path | None = None
+
+    def cells(self) -> Iterator[Cell]:
+        """Yield every (non-skipped) cell in deterministic factor order."""
+        dim_names = sorted(self.dimensions.keys())
+        levels = [self.dimensions[name] for name in dim_names]
+        for combo in itertools.product(*levels):
+            factors = dict(zip(dim_names, combo, strict=True))
+            if _matches_any(factors, self.skip):
+                continue
+            yield Cell(
+                cell_id=compute_cell_id(factors, self.conditions_version),
+                factors=factors,
+                conditions_version=self.conditions_version,
+                defaults=dict(self.defaults),
+            )
+
+    def get_cell(self, cell_id: str) -> Cell | None:
+        for cell in self.cells():
+            if cell.cell_id == cell_id:
+                return cell
+        return None
+
+
+def _matches_any(factors: dict[str, str], skip: list[dict[str, str]]) -> bool:
+    return any(all(factors.get(k) == v for k, v in entry.items()) for entry in skip)
+
+
+def compute_cell_id(factors: dict[str, str], conditions_version: int) -> str:
+    """Stable 12-char sha256 hex prefix of canonicalised (factors, version).
+
+    Stability: the JSON dump is sorted-keys + no whitespace, so equal factor
+    dicts on any machine produce equal ids. The conditions_version is folded
+    in so a bump invalidates old ids without renaming dimensions.
+    """
+    payload = json.dumps(
+        {"v": conditions_version, "factors": factors},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return digest[:12]
+
+
+def load_conditions(path: Path | str | None = None) -> ConditionsSpec:
+    """Read and validate a conditions YAML file."""
+    resolved = Path(path) if path is not None else DEFAULT_CONDITIONS_PATH
+    with resolved.open("r", encoding="utf-8") as fh:
+        raw_obj: object = yaml.safe_load(fh)
+    if not isinstance(raw_obj, dict):
+        raise ValueError(f"{resolved}: top-level must be a mapping")
+    raw = cast("dict[str, Any]", raw_obj)
+
+    conditions_version = int(raw.get("conditions_version", 1))
+
+    dims_obj: object = raw.get("dimensions") or {}
+    if not isinstance(dims_obj, dict) or not dims_obj:
+        raise ValueError(f"{resolved}: 'dimensions' must be a non-empty mapping")
+    dims_raw = cast("dict[str, Any]", dims_obj)
+    dimensions: dict[str, list[str]] = {}
+    for name_obj, body_obj in dims_raw.items():
+        name = str(cast("object", name_obj))
+        if not isinstance(body_obj, dict) or "levels" not in body_obj:
+            raise ValueError(f"{resolved}: dimension {name!r} must have a 'levels' list")
+        body = cast("dict[str, Any]", body_obj)
+        levels_obj: object = body["levels"]
+        if not isinstance(levels_obj, list) or not levels_obj:
+            raise ValueError(f"{resolved}: dimension {name!r} has empty 'levels'")
+        levels = cast("list[Any]", levels_obj)
+        dimensions[name] = [str(cast("object", lvl)) for lvl in levels]
+
+    defaults_obj: object = raw.get("defaults") or {}
+    if not isinstance(defaults_obj, dict):
+        raise ValueError(f"{resolved}: 'defaults' must be a mapping if set")
+    defaults_raw = cast("dict[str, Any]", defaults_obj)
+
+    skip_obj: object = raw.get("skip") or []
+    if not isinstance(skip_obj, list):
+        raise ValueError(f"{resolved}: 'skip' must be a list if set")
+    skip_raw = cast("list[Any]", skip_obj)
+    skip: list[dict[str, str]] = []
+    for entry_obj in skip_raw:
+        if not isinstance(entry_obj, dict):
+            raise ValueError(f"{resolved}: 'skip' entries must be mappings")
+        entry = cast("dict[str, Any]", entry_obj)
+        skip.append({str(cast("object", k)): str(cast("object", v)) for k, v in entry.items()})
+
+    return ConditionsSpec(
+        conditions_version=conditions_version,
+        dimensions=dimensions,
+        defaults={str(cast("object", k)): v for k, v in defaults_raw.items()},
+        skip=skip,
+        source_path=resolved,
+    )
+
+
+def list_cells(spec: ConditionsSpec) -> list[Cell]:
+    return list(spec.cells())
+
+
+__all__ = [
+    "Cell",
+    "ConditionsSpec",
+    "DEFAULT_CONDITIONS_PATH",
+    "compute_cell_id",
+    "list_cells",
+    "load_conditions",
+]

--- a/scripts/harness/conditions.yaml
+++ b/scripts/harness/conditions.yaml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# NEST research-harness experimental conditions.
+#
+# Each top-level key under `dimensions` is an experiment factor. Cells are the
+# Cartesian product of all dimensions. Each cell gets a stable `cell_id`
+# (sha256 hex prefix of a canonical JSON dump of its factor levels), so you can
+# regenerate the same id from the same factor combination on any machine.
+#
+# Edit this file to define an experiment; the harness consumes it with
+# `scripts/harness/conditions.py:load_conditions`.
+
+# Bumped when factor names or level semantics change in a way that would
+# invalidate existing cell_ids. Recorded on every JSONL row.
+conditions_version: 1
+
+dimensions:
+  model:
+    description: "Anthropic model identifier passed to the agent runner."
+    levels:
+      - opus
+      - sonnet
+      - haiku
+
+  brief_specificity:
+    description: |
+      How much structure the brief gives the agent.
+      vague           — "improve NEST, submit a PR"
+      layer-enumerated — names the 12 protocol layers (run-1 brief)
+      open-problems    — points at docs/hackathon/problems/*.md
+    levels:
+      - vague
+      - layer-enumerated
+      - open-problems
+
+  pre_push_checklist:
+    description: |
+      Whether the agent prompt includes the explicit "run ruff/pyright/pytest
+      and only push if green" checklist. Tests calibration & iteration efficiency.
+    levels:
+      - "on"
+      - "off"
+
+# Optional defaults injected into every cell. The runner may override.
+defaults:
+  agents_per_cell: 10
+  timeout_seconds: 1800
+  seed_base: 20260526   # deterministic seed derivation: hash(cell_id, seed_base, run_idx)
+
+# Optional cell filter: skip combinations that are uninteresting / too expensive.
+# Each filter entry is a dict of dim->level that, if fully matched, drops the cell.
+skip:
+  - model: haiku
+    brief_specificity: open-problems
+    pre_push_checklist: "off"

--- a/scripts/harness/dry_run/__init__.py
+++ b/scripts/harness/dry_run/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dry-run fixtures + tests for the research harness."""

--- a/scripts/harness/dry_run/fixtures/identity_green.json
+++ b/scripts/harness/dry_run/fixtures/identity_green.json
@@ -1,0 +1,15 @@
+{
+  "exit_code": 0,
+  "pr_url": "https://github.com/mariagorskikh/nest/pull/9003",
+  "branch": "hackathon/identity-rotation",
+  "head_sha": "deadbeefcafef00d3333333333333333333333cc",
+  "layer_picked": "identity",
+  "lines_added": 174,
+  "lines_removed": 22,
+  "iterations_to_green": 1,
+  "claimed_ci_green": true,
+  "actual_ci_green_first_push": true,
+  "duration_seconds": 540.7,
+  "description": "Identity: add key-rotation primitive + tests",
+  "final_message": "Submitted. CI is green, ruff clean, see https://github.com/mariagorskikh/nest/pull/9003 (hackathon/identity-rotation)."
+}

--- a/scripts/harness/dry_run/fixtures/memory_red_then_green.json
+++ b/scripts/harness/dry_run/fixtures/memory_red_then_green.json
@@ -1,0 +1,15 @@
+{
+  "exit_code": 0,
+  "pr_url": "https://github.com/mariagorskikh/nest/pull/9004",
+  "branch": "hackathon/memory-eviction",
+  "head_sha": "deadbeefcafef00d4444444444444444444444dd",
+  "layer_picked": "memory",
+  "lines_added": 256,
+  "lines_removed": 31,
+  "iterations_to_green": 3,
+  "claimed_ci_green": false,
+  "actual_ci_green_first_push": false,
+  "duration_seconds": 720.2,
+  "description": "Memory: LRU eviction policy with bounded sizes",
+  "final_message": "Opened the PR at https://github.com/mariagorskikh/nest/pull/9004 — pyright still flags one issue, will iterate."
+}

--- a/scripts/harness/dry_run/fixtures/registry_failure.json
+++ b/scripts/harness/dry_run/fixtures/registry_failure.json
@@ -1,0 +1,15 @@
+{
+  "exit_code": 1,
+  "pr_url": null,
+  "branch": null,
+  "head_sha": null,
+  "layer_picked": "registry",
+  "lines_added": null,
+  "lines_removed": null,
+  "iterations_to_green": null,
+  "claimed_ci_green": false,
+  "actual_ci_green_first_push": null,
+  "duration_seconds": 92.0,
+  "description": null,
+  "final_message": "I attempted to add service discovery but ran into git issues; no PR opened."
+}

--- a/scripts/harness/dry_run/fixtures/trust_green.json
+++ b/scripts/harness/dry_run/fixtures/trust_green.json
@@ -1,0 +1,15 @@
+{
+  "exit_code": 0,
+  "pr_url": "https://github.com/mariagorskikh/nest/pull/9001",
+  "branch": "hackathon/trust-eigen-improvements",
+  "head_sha": "deadbeefcafef00d1111111111111111111111aa",
+  "layer_picked": "trust",
+  "lines_added": 312,
+  "lines_removed": 14,
+  "iterations_to_green": 1,
+  "claimed_ci_green": true,
+  "actual_ci_green_first_push": true,
+  "duration_seconds": 612.4,
+  "description": "Add EigenTrust convergence test + sparsity benchmarks",
+  "final_message": "Pushed the EigenTrust improvements; all tests pass, ruff clean, PR opened at https://github.com/mariagorskikh/nest/pull/9001 on branch hackathon/trust-eigen-improvements."
+}

--- a/scripts/harness/dry_run/fixtures/trust_red.json
+++ b/scripts/harness/dry_run/fixtures/trust_red.json
@@ -1,0 +1,15 @@
+{
+  "exit_code": 0,
+  "pr_url": "https://github.com/mariagorskikh/nest/pull/9002",
+  "branch": "hackathon/trust-quick-fix",
+  "head_sha": "deadbeefcafef00d2222222222222222222222bb",
+  "layer_picked": "trust",
+  "lines_added": 88,
+  "lines_removed": 4,
+  "iterations_to_green": 4,
+  "claimed_ci_green": true,
+  "actual_ci_green_first_push": false,
+  "duration_seconds": 401.0,
+  "description": "Trust layer: small fix for transitive scoring",
+  "final_message": "Done. All tests pass and ruff is clean. PR is at https://github.com/mariagorskikh/nest/pull/9002, branch hackathon/trust-quick-fix."
+}

--- a/scripts/harness/dry_run/test_dry_run.py
+++ b/scripts/harness/dry_run/test_dry_run.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end dry-run test: spawn fixture agents, aggregate, analyse, assert.
+
+This is the **default-suite** smoke test for the research harness. No real
+agent is spawned and no network is hit. It exists to make sure the schema,
+the aggregator, and the analysis script stay in lockstep — if any one of
+them drifts, this test fails before the harness is used to spend money on
+real agents.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.harness import SCHEMA_VERSION
+from scripts.harness.collect import load_rows as collect_load
+from scripts.harness.collect import main as collect_main
+from scripts.harness.conditions import load_conditions
+from scripts.harness.run_condition import (
+    DEFAULT_BRIEFS_DIR,
+    DEFAULT_FIXTURES_DIR,
+    run_cell,
+)
+
+EXPECTED_FIELDS = {
+    "schema_version",
+    "harness_version",
+    "conditions_version",
+    "cell_id",
+    "factors",
+    "run_idx",
+    "seed",
+    "model_id",
+    "prompt_hash",
+    "brief_path",
+    "transport",
+    "timestamp_utc",
+    "duration_seconds",
+    "spawned",
+    "exit_code",
+    "pr_url",
+    "branch",
+    "head_sha",
+    "layer_picked",
+    "lines_added",
+    "lines_removed",
+    "first_push_ci_status",
+    "first_push_ci_green",
+    "iterations_to_green",
+    "claimed_ci_green",
+    "final_message",
+    "transcript_path",
+    "description",
+    "error",
+}
+
+
+@pytest.fixture
+def small_run(tmp_path: Path) -> dict[str, Path]:
+    """Run two cells × 4 replicates against the fixture transport."""
+    spec = load_conditions()
+    cells = list(spec.cells())
+    chosen = cells[:2]
+    assert len(chosen) == 2
+
+    output_dir = tmp_path / "data"
+    workdir_base = tmp_path / "work"
+    for cell in chosen:
+        run_cell(
+            cell=cell,
+            n=4,
+            transport="fixture",
+            output_dir=output_dir,
+            briefs_dir=DEFAULT_BRIEFS_DIR,
+            fixtures_dir=DEFAULT_FIXTURES_DIR,
+            workdir_strategy="ephemeral",
+            workdir_base=workdir_base,
+            seed_base=20260526,
+            timeout_seconds=60,
+            skip_github=True,
+        )
+    return {"output_dir": output_dir, "cells_jsonl": output_dir}
+
+
+def test_per_cell_jsonl_schema(small_run: dict[str, Path]) -> None:
+    output_dir = small_run["output_dir"]
+    jsonls = sorted(p for p in output_dir.glob("*.jsonl") if p.name != "all.jsonl")
+    assert len(jsonls) == 2
+    for path in jsonls:
+        with path.open("r", encoding="utf-8") as fh:
+            lines = [line for line in fh if line.strip()]
+        assert len(lines) == 4
+        for line in lines:
+            row = json.loads(line)
+            assert set(row.keys()) == EXPECTED_FIELDS, (
+                f"unexpected schema in {path}: "
+                f"missing={EXPECTED_FIELDS - row.keys()}, "
+                f"extra={row.keys() - EXPECTED_FIELDS}"
+            )
+            assert row["schema_version"] == SCHEMA_VERSION
+            assert row["transport"] == "fixture"
+            assert isinstance(row["factors"], dict)
+            assert row["prompt_hash"] and len(row["prompt_hash"]) == 16
+            assert row["seed"] >= 0
+
+
+def test_collect_aggregates_all_rows(small_run: dict[str, Path], tmp_path: Path) -> None:
+    output_dir = small_run["output_dir"]
+    all_jsonl = output_dir / "all.jsonl"
+    rc = collect_main(["--input-dir", str(output_dir), "--output", str(all_jsonl)])
+    assert rc == 0
+    assert all_jsonl.exists()
+
+    rows = collect_load([all_jsonl])
+    assert len(rows) == 8  # 2 cells × 4 replicates
+    # Aggregated file is sorted by (cell_id, run_idx); verify that contract.
+    keys = [(r["cell_id"], r["run_idx"]) for r in rows]
+    assert keys == sorted(keys)
+
+
+def test_collect_refuses_schema_mismatch(small_run: dict[str, Path], tmp_path: Path) -> None:
+    bad_dir = tmp_path / "bad"
+    bad_dir.mkdir()
+    bad_row = {
+        "schema_version": SCHEMA_VERSION + 99,
+        "cell_id": "ffffffffffff",
+        "run_idx": 0,
+    }
+    (bad_dir / "ffffffffffff.jsonl").write_text(json.dumps(bad_row) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="schema_version"):
+        collect_load(list(bad_dir.glob("*.jsonl")))
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("matplotlib") is None,
+    reason="matplotlib not installed; install the `harness` extra to enable plotting tests.",
+)
+def test_analyze_produces_plots(small_run: dict[str, Path], tmp_path: Path) -> None:
+    output_dir = small_run["output_dir"]
+    all_jsonl = output_dir / "all.jsonl"
+    collect_main(["--input-dir", str(output_dir), "--output", str(all_jsonl)])
+
+    # Importing analyze lazily so the test is skip-clean when matplotlib is absent.
+    from scripts.harness import analyze
+
+    plots_dir = tmp_path / "plots"
+    rc = analyze.main(["--input", str(all_jsonl), "--output-dir", str(plots_dir)])
+    assert rc == 0
+    for name in ("diversity_collapse.png", "calibration.png", "iteration_efficiency.png"):
+        path = plots_dir / name
+        assert path.exists(), f"missing plot: {path}"
+        assert path.stat().st_size > 0, f"empty plot: {path}"
+
+
+def test_analysis_pure_helpers_have_sane_shape() -> None:
+    # Matplotlib-free helpers; safe to import even when the extra isn't installed.
+    spec = importlib.util.find_spec("scripts.harness.analyze")
+    assert spec is not None
+    from scripts.harness import analyze
+
+    rows = [
+        {
+            "layer_picked": "trust",
+            "claimed_ci_green": True,
+            "first_push_ci_green": True,
+            "iterations_to_green": 1,
+            "factors": {"model": "opus"},
+        },
+        {
+            "layer_picked": "trust",
+            "claimed_ci_green": True,
+            "first_push_ci_green": False,
+            "iterations_to_green": 4,
+            "factors": {"model": "opus"},
+        },
+        {
+            "layer_picked": "identity",
+            "claimed_ci_green": False,
+            "first_push_ci_green": False,
+            "iterations_to_green": None,
+            "factors": {"model": "opus"},
+        },
+    ]
+    div = analyze.diversity_collapse_metrics(rows)
+    assert div["n"] == 3
+    assert abs(div["top1"] - 2 / 3) < 1e-9
+
+    cal = analyze.calibration_metrics(rows)
+    assert abs(cal["claimed"] - 2 / 3) < 1e-9
+    assert abs(cal["actual"] - 1 / 3) < 1e-9
+
+    dist = analyze.iteration_distribution(rows)
+    assert sorted(dist) == [1, 4]
+
+
+def test_module_layout_is_importable() -> None:
+    # Belt-and-braces: make sure the package shows up under its expected name.
+    assert "scripts.harness" in sys.modules or importlib.util.find_spec("scripts.harness")

--- a/scripts/harness/run_condition.py
+++ b/scripts/harness/run_condition.py
@@ -1,0 +1,545 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Run N agent replicates for one experimental cell, write one JSONL per run.
+
+Usage::
+
+    uv run python -m scripts.harness.run_condition \\
+        --cell <cell_id> --n 10 --dry-run
+
+The default transport is ``fixture`` (no real agents). Pass ``--live`` to
+spawn the ``claude`` CLI in headless mode (cost!). Pass ``--workdir-strategy
+worktree|clone`` to choose how each agent gets its own copy of the repo.
+
+Design notes (also in ``README.md``):
+
+* Each agent gets an **isolated working copy** of the repo. Two strategies:
+  ``worktree`` (default — uses ``git worktree add``, requires the harness to
+  be invoked inside the repo) and ``clone`` (a fresh ``git clone`` for each
+  agent — slower but the most reproducible when running from an arbitrary
+  shell on CI infrastructure). The ``clone`` strategy is what makes this
+  harness usable outside Claude Code.
+* The harness does **not** call the GitHub API directly for PR/CI lookup —
+  it shells out to ``gh`` when available so credentials are picked up from
+  the user's existing config. If ``gh`` is missing, those fields stay
+  ``null`` and post-processing can be done offline later.
+* JSONL writes are *line-by-line and flushed after each row*, so a crash
+  midway through a run loses at most the partial line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime as dt
+import hashlib
+import json
+import os
+import random
+import shutil
+import string
+import subprocess
+import sys
+from collections.abc import Generator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from scripts.harness import HARNESS_VERSION, SCHEMA_VERSION
+from scripts.harness._calibration import claimed_ci_green
+from scripts.harness.agent_runner import (
+    AgentSpawnSpec,
+    AgentSubmission,
+    make_runner,
+)
+from scripts.harness.conditions import Cell, load_conditions
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "data" / "hackathon-runs"
+DEFAULT_BRIEFS_DIR = Path(__file__).parent / "briefs"
+DEFAULT_FIXTURES_DIR = Path(__file__).parent / "dry_run" / "fixtures"
+
+# Concrete model id mapping. Centralised so JSONL rows stamp the exact
+# version-pinned identifier even if the user passed a short name.
+MODEL_ID_MAP: dict[str, str] = {
+    "opus": "claude-opus-4-7",
+    "sonnet": "claude-sonnet-4-7",
+    "haiku": "claude-haiku-4-7",
+}
+
+
+# ---------------------------------------------------------------------------
+# Workdir strategies.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WorkdirHandle:
+    path: Path
+    cleanup: bool
+
+
+@contextlib.contextmanager
+def make_workdir(
+    strategy: str,
+    *,
+    repo_root: Path,
+    base_dir: Path,
+    cell_id: str,
+    run_idx: int,
+) -> Generator[WorkdirHandle, None, None]:
+    """Yield an isolated copy of the repo for one agent."""
+    base_dir.mkdir(parents=True, exist_ok=True)
+    workdir = base_dir / f"{cell_id}-{run_idx}"
+    if workdir.exists():
+        shutil.rmtree(workdir)
+
+    if strategy == "worktree":
+        # Branch name is intentionally local-only; agent will create its own
+        # `hackathon/...` branch inside.
+        branch = f"harness/{cell_id}-{run_idx}-{_random_token(4)}"
+        subprocess.run(  # noqa: S603 — harness-controlled inputs
+            ["git", "worktree", "add", "-b", branch, str(workdir), "HEAD"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+        )
+        try:
+            yield WorkdirHandle(path=workdir, cleanup=False)
+        finally:
+            subprocess.run(  # noqa: S603
+                ["git", "worktree", "remove", "--force", str(workdir)],
+                cwd=repo_root,
+                check=False,
+                capture_output=True,
+            )
+            subprocess.run(  # noqa: S603
+                ["git", "branch", "-D", branch],
+                cwd=repo_root,
+                check=False,
+                capture_output=True,
+            )
+
+    elif strategy == "clone":
+        subprocess.run(  # noqa: S603
+            ["git", "clone", "--quiet", str(repo_root), str(workdir)],
+            check=True,
+            capture_output=True,
+        )
+        try:
+            yield WorkdirHandle(path=workdir, cleanup=True)
+        finally:
+            if workdir.exists():
+                shutil.rmtree(workdir, ignore_errors=True)
+
+    elif strategy == "ephemeral":
+        # No git at all — used by --dry-run / fixture transport.
+        workdir.mkdir(parents=True, exist_ok=True)
+        try:
+            yield WorkdirHandle(path=workdir, cleanup=True)
+        finally:
+            if workdir.exists():
+                shutil.rmtree(workdir, ignore_errors=True)
+
+    else:
+        raise ValueError(f"unknown workdir strategy: {strategy!r}")
+
+
+def _random_token(n: int) -> str:
+    alphabet = string.ascii_lowercase + string.digits
+    return "".join(random.choices(alphabet, k=n))  # noqa: S311 — id, not secret
+
+
+# ---------------------------------------------------------------------------
+# Brief rendering.
+# ---------------------------------------------------------------------------
+
+
+def render_brief(brief_specificity: str, briefs_dir: Path) -> tuple[Path, str]:
+    """Pick the brief template for a given factor level and return (path, text).
+
+    `open-problems` falls back to `vague.md` if the open-problems doc directory
+    does not exist yet (parallel track may not have landed).
+    """
+    candidate = briefs_dir / f"{brief_specificity}.md"
+    if not candidate.exists():
+        raise FileNotFoundError(f"No brief for specificity={brief_specificity!r}: {candidate}")
+    text = candidate.read_text(encoding="utf-8")
+
+    if brief_specificity == "open-problems":
+        problems_dir = REPO_ROOT / "docs" / "hackathon" / "problems"
+        if problems_dir.exists():
+            problems = sorted(p.name for p in problems_dir.glob("*.md"))
+            text = text.replace("{{ PROBLEMS_LIST }}", "\n".join(f"- {p}" for p in problems))
+        else:
+            fallback = briefs_dir / "vague.md"
+            text = (
+                "<!-- open-problems track docs not found; falling back to vague brief -->\n\n"
+                + fallback.read_text(encoding="utf-8")
+            )
+    return candidate, text
+
+
+# ---------------------------------------------------------------------------
+# Post-processing: PR / CI lookup via gh CLI (best-effort, optional).
+# ---------------------------------------------------------------------------
+
+
+def enrich_from_github(submission: AgentSubmission) -> dict[str, Any]:
+    """Look up PR head SHA, diff size, CI status. Returns a partial row update.
+
+    Always returns a dict — fields stay missing (caller fills `None`) when
+    `gh` is unavailable, when the PR URL is malformed, or when the API call
+    fails. This is intentionally best-effort: the harness should not refuse
+    to write a row just because GitHub is slow.
+    """
+    out: dict[str, Any] = {}
+    if not submission.pr_url:
+        return out
+    if shutil.which("gh") is None:
+        return out
+
+    try:
+        repo, number = _parse_pr_url(submission.pr_url)
+    except ValueError:
+        return out
+
+    pr_json = _gh_json(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(number),
+            "-R",
+            repo,
+            "--json",
+            "headRefOid,additions,deletions,title,headRefName,statusCheckRollup",
+        ]
+    )
+    if pr_json is None:
+        return out
+
+    out["head_sha"] = pr_json.get("headRefOid")
+    out["lines_added"] = pr_json.get("additions")
+    out["lines_removed"] = pr_json.get("deletions")
+    out["description"] = pr_json.get("title")
+    if not submission.branch:
+        out["branch"] = pr_json.get("headRefName")
+
+    rollup_obj: object = pr_json.get("statusCheckRollup") or []
+    if isinstance(rollup_obj, list) and rollup_obj:
+        rollup = cast("list[Any]", rollup_obj)
+        conclusions: list[Any] = []
+        for check_obj in rollup:
+            if isinstance(check_obj, dict):
+                conclusions.append(cast("dict[str, Any]", check_obj).get("conclusion"))
+        non_none = [c for c in conclusions if c is not None]
+        if non_none and all(c == "SUCCESS" for c in non_none):
+            out["first_push_ci_status"] = "success"
+            out["first_push_ci_green"] = True
+        elif any(c in {"FAILURE", "TIMED_OUT", "CANCELLED"} for c in non_none):
+            out["first_push_ci_status"] = "failure"
+            out["first_push_ci_green"] = False
+        else:
+            out["first_push_ci_status"] = "pending"
+            out["first_push_ci_green"] = None
+
+    # iterations_to_green: count commits on the branch — proxy for pushes.
+    if out.get("first_push_ci_green") is True:
+        commits = _gh_json(
+            ["gh", "pr", "view", str(number), "-R", repo, "--json", "commits"],
+        )
+        if commits is not None:
+            commit_list_obj: object = commits.get("commits") or []
+            if isinstance(commit_list_obj, list):
+                commit_list = cast("list[Any]", commit_list_obj)
+                out["iterations_to_green"] = max(1, len(commit_list))
+    return out
+
+
+def _parse_pr_url(url: str) -> tuple[str, int]:
+    # https://github.com/<owner>/<repo>/pull/<n>
+    import re
+
+    m = re.match(r"https://github\.com/([^/]+/[^/]+)/pull/(\d+)", url)
+    if not m:
+        raise ValueError(f"not a PR URL: {url!r}")
+    return m.group(1), int(m.group(2))
+
+
+def _gh_json(cmd: list[str]) -> dict[str, Any] | None:
+    try:
+        proc = subprocess.run(  # noqa: S603 — harness-controlled
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        data: object = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(data, dict):
+        return cast("dict[str, Any]", data)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Row builder.
+# ---------------------------------------------------------------------------
+
+
+def build_row(
+    *,
+    cell: Cell,
+    run_idx: int,
+    seed: int,
+    model_level: str,
+    prompt_hash: str,
+    brief_path: Path,
+    transport: str,
+    submission: AgentSubmission,
+    enrichment: dict[str, Any],
+) -> dict[str, Any]:
+    """Compose one JSONL row from a submission + GitHub lookup."""
+    model_id = MODEL_ID_MAP.get(model_level, model_level)
+    final_message = submission.final_message
+    fixture_meta = submission.raw_metadata or {}
+    row: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "harness_version": HARNESS_VERSION,
+        "conditions_version": cell.conditions_version,
+        "cell_id": cell.cell_id,
+        "factors": dict(cell.factors),
+        "run_idx": run_idx,
+        "seed": seed,
+        "model_id": model_id,
+        "prompt_hash": prompt_hash,
+        "brief_path": str(brief_path),
+        "transport": transport,
+        "timestamp_utc": dt.datetime.now(dt.UTC).isoformat(timespec="seconds"),
+        "duration_seconds": submission.duration_seconds,
+        "spawned": submission.spawned,
+        "exit_code": submission.exit_code,
+        "pr_url": submission.pr_url,
+        "branch": submission.branch,
+        "head_sha": submission.head_sha,
+        "layer_picked": submission.layer_picked,
+        "lines_added": None,
+        "lines_removed": None,
+        "first_push_ci_status": None,
+        "first_push_ci_green": None,
+        "iterations_to_green": None,
+        "claimed_ci_green": claimed_ci_green(final_message),
+        "final_message": final_message,
+        "transcript_path": submission.transcript_path,
+        "description": None,
+        "error": submission.error,
+    }
+    # Fixture transport: trust the fixture's recorded ground truth.
+    for key in (
+        "lines_added",
+        "lines_removed",
+        "iterations_to_green",
+        "description",
+    ):
+        if fixture_meta.get(key) is not None:
+            row[key] = fixture_meta[key]
+    if fixture_meta.get("actual_ci_green_first_push") is not None:
+        green = bool(fixture_meta["actual_ci_green_first_push"])
+        row["first_push_ci_green"] = green
+        row["first_push_ci_status"] = "success" if green else "failure"
+    if "claimed_ci_green" in fixture_meta:
+        row["claimed_ci_green"] = bool(fixture_meta["claimed_ci_green"])
+
+    # GitHub enrichment wins last (live data > fixture data).
+    for key, value in enrichment.items():
+        if value is not None:
+            row[key] = value
+    return row
+
+
+def derive_seed(seed_base: int, cell_id: str, run_idx: int) -> int:
+    payload = f"{seed_base}:{cell_id}:{run_idx}".encode()
+    digest = hashlib.sha256(payload).digest()
+    return int.from_bytes(digest[:8], "big", signed=False)
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def run_cell(
+    *,
+    cell: Cell,
+    n: int,
+    transport: str,
+    output_dir: Path,
+    briefs_dir: Path,
+    fixtures_dir: Path,
+    workdir_strategy: str,
+    workdir_base: Path,
+    seed_base: int,
+    timeout_seconds: int,
+    skip_github: bool,
+) -> Path:
+    """Run N replicates for one cell and write JSONL to disk. Returns path."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / f"{cell.cell_id}.jsonl"
+
+    brief_specificity = cell.factors.get("brief_specificity", "vague")
+    brief_path, brief_text = render_brief(brief_specificity, briefs_dir)
+    prompt_hash = hashlib.sha256(brief_text.encode("utf-8")).hexdigest()[:16]
+    model_level = cell.factors.get("model", "opus")
+
+    runner = make_runner(transport, fixtures_dir=fixtures_dir)
+
+    with out_path.open("w", encoding="utf-8") as fh:
+        for run_idx in range(n):
+            seed = derive_seed(seed_base, cell.cell_id, run_idx)
+            with make_workdir(
+                workdir_strategy,
+                repo_root=REPO_ROOT,
+                base_dir=workdir_base,
+                cell_id=cell.cell_id,
+                run_idx=run_idx,
+            ) as handle:
+                spec = AgentSpawnSpec(
+                    cell_id=cell.cell_id,
+                    run_idx=run_idx,
+                    model=model_level,
+                    brief_path=brief_path,
+                    brief_text=brief_text,
+                    prompt_hash=prompt_hash,
+                    seed=seed,
+                    workdir=handle.path,
+                    timeout_seconds=timeout_seconds,
+                    extra_env={"NEST_HARNESS_CELL_ID": cell.cell_id},
+                )
+                submission = runner.run(spec)
+                enrichment: dict[str, Any] = {}
+                if not skip_github:
+                    enrichment = enrich_from_github(submission)
+                row = build_row(
+                    cell=cell,
+                    run_idx=run_idx,
+                    seed=seed,
+                    model_level=model_level,
+                    prompt_hash=prompt_hash,
+                    brief_path=brief_path,
+                    transport=transport,
+                    submission=submission,
+                    enrichment=enrichment,
+                )
+                fh.write(json.dumps(row, sort_keys=True) + "\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+    return out_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run one experimental cell.")
+    parser.add_argument("--cell", required=True, help="cell_id from conditions.yaml")
+    parser.add_argument("--n", type=int, default=10, help="Number of replicates")
+    parser.add_argument(
+        "--conditions",
+        type=Path,
+        default=None,
+        help="Path to conditions.yaml (default: bundled)",
+    )
+    parser.add_argument(
+        "--briefs-dir",
+        type=Path,
+        default=DEFAULT_BRIEFS_DIR,
+        help="Directory of brief templates",
+    )
+    parser.add_argument(
+        "--fixtures-dir",
+        type=Path,
+        default=DEFAULT_FIXTURES_DIR,
+        help="Fixtures dir (dry-run transport)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Where to write <cell_id>.jsonl",
+    )
+    parser.add_argument(
+        "--workdir-base",
+        type=Path,
+        default=REPO_ROOT / ".harness-work",
+        help="Where to place per-agent workdirs",
+    )
+    parser.add_argument(
+        "--workdir-strategy",
+        choices=["worktree", "clone", "ephemeral"],
+        default="ephemeral",
+        help="How to materialise each agent's workspace",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Use the claude-cli transport (spends real money!). Default is fixture.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Force fixture transport. Mutually exclusive with --live.",
+    )
+    parser.add_argument(
+        "--skip-github",
+        action="store_true",
+        help="Skip gh-CLI enrichment (default off; auto-skipped when gh missing).",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=1800,
+    )
+    parser.add_argument(
+        "--seed-base",
+        type=int,
+        default=None,
+        help="Override conditions.yaml `defaults.seed_base`.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.live and args.dry_run:
+        parser.error("--live and --dry-run are mutually exclusive")
+
+    spec = load_conditions(args.conditions)
+    cell = spec.get_cell(args.cell)
+    if cell is None:
+        sys.stderr.write(f"unknown cell_id: {args.cell}\n")
+        return 2
+
+    transport = "claude-cli" if args.live else "fixture"
+    seed_base = args.seed_base
+    if seed_base is None:
+        seed_base = int(cell.defaults.get("seed_base", 0))
+
+    out_path = run_cell(
+        cell=cell,
+        n=args.n,
+        transport=transport,
+        output_dir=args.output_dir,
+        briefs_dir=args.briefs_dir,
+        fixtures_dir=args.fixtures_dir,
+        workdir_strategy=args.workdir_strategy,
+        workdir_base=args.workdir_base,
+        seed_base=seed_base,
+        timeout_seconds=args.timeout_seconds,
+        skip_github=args.skip_github or transport == "fixture",
+    )
+    sys.stdout.write(f"wrote {out_path}\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Ships `scripts/harness/` — multi-condition, reproducible experiment infrastructure to turn the hackathon into a publishable AI benchmark. Lets you run N>=100 agents per (model x brief_specificity x pre_push_checklist) cell and produce a dataset + plots the same way every time, from a plain shell or from inside Claude Code.

Everything is exercised by a default-suite pytest gate using mocked fixtures, so this PR adds zero live-agent cost while wiring up the path to spend that cost later.

## What lands

| file | purpose |
| --- | --- |
| `scripts/harness/conditions.yaml` | factor schema: `model` x `brief_specificity` x `pre_push_checklist`, plus a `skip:` list and per-cell defaults. Cartesian product produces 17 live cells (18 - 1 skipped). Each cell has a stable `cell_id` (12-char sha256 of canonical `(conditions_version, factors)` JSON), so the same factor combo always maps to the same id, on any machine, in any process. |
| `scripts/harness/conditions.py` | YAML loader + cell expansion + `compute_cell_id()`. |
| `scripts/harness/agent_runner.py` | Two transports: `FixtureAgentRunner` (dry-run, replays mocked submissions deterministically) and `ClaudeCLIAgentRunner` (live; shells out to `claude -p ... --output-format stream-json`). The CLI path was chosen over a hand-rolled Anthropic SDK tool-loop because it's simpler and reuses the CLI's existing file-edit / branch-hygiene plumbing — documented in `README.md`. |
| `scripts/harness/run_condition.py` | CLI: `--cell <cell_id> --n <N>`. Spawns N agents in isolated workdirs (`worktree` / `clone` / `ephemeral` strategies — `clone` is the most reproducible for use outside Claude Code), writes one JSONL line per submission to `data/hackathon-runs/<cell_id>.jsonl`, flushed and `fsync`'d after each row so a crash loses at most a partial line. Best-effort `gh`-CLI enrichment fills `head_sha`, `lines_added/removed`, `first_push_ci_status`, `iterations_to_green`. |
| `scripts/harness/collect.py` | Aggregates per-cell JSONLs into `data/hackathon-runs/all.jsonl`, deterministically sorted by `(cell_id, run_idx)`. Refuses to merge rows whose `schema_version` doesn't match the current harness — prevents silent schema drift. |
| `scripts/harness/analyze.py` | Three PNG plots: diversity collapse (top-1 / top-3 layer-cluster share per condition), calibration (claimed-CI-green vs actual on first push), iteration efficiency (pushes-to-green distribution). matplotlib is gated behind an optional `harness` extra in `pyproject.toml`, so the core repo stays matplotlib-free. |
| `scripts/harness/briefs/{vague,layer-enumerated,open-problems}.md` | The three brief templates wired to the `brief_specificity` factor. `open-problems.md` renders the `docs/hackathon/problems/` listing if it exists and falls back to the vague brief if the parallel open-problems track hasn't landed yet. |
| `scripts/harness/dry_run/fixtures/*.json` | 5 mocked agent submissions covering green / claimed-green-but-actually-red / iterating-to-green / spawn-failure cases. |
| `scripts/harness/dry_run/test_dry_run.py` | Default-suite pytest gate: runs `run_condition` over fixtures for 2 cells x 4 replicates, asserts the JSONL row schema is exactly the 29 documented fields, runs `collect.py` and asserts sorted ordering + schema-mismatch refusal, runs `analyze.py` and asserts all three PNG files materialise (skipped cleanly when matplotlib isn't installed). |
| `scripts/harness/SCHEMA.md` | Versioned JSONL row schema, plus calibration-regex policy and clustering policy. |
| `scripts/harness/README.md` | Worked example end-to-end (dry-run + live), reproducibility notes (seed derivation, model id pinning, prompt hash), Claude-Code-vs-headless-shell matrix, "how to add a factor / metric" recipes. |

## Schema, versioned

Every JSONL row carries: `schema_version`, `harness_version`, `conditions_version`, `cell_id`, `factors`, `run_idx`, `seed` (derived from `sha256(seed_base, cell_id, run_idx)`), `model_id` (concrete version-pinned id like `claude-opus-4-7`), `prompt_hash` (sha256[:16] of the rendered brief), `transport`, `timestamp_utc`, plus all the per-submission outputs (`pr_url`, `branch`, `head_sha`, `layer_picked`, `lines_added/removed`, `first_push_ci_status/green`, `iterations_to_green`, `claimed_ci_green`, `final_message`, `transcript_path`, `description`, `error`). Full table in `SCHEMA.md`.

## Dry-run vs live

- **Default = dry-run.** `run_condition.py` uses the fixture transport unless you pass `--live`. There is no auto-detection — live mode must be explicit.
- **`pytest` exercises the full pipeline against fixtures.** No real agent is spawned during CI; no network is touched. This is what gates schema drift before you ever spend a real dollar.
- **Live transport runs from a plain shell.** `ClaudeCLIAgentRunner` shells out to the `claude` CLI; combined with `--workdir-strategy clone` it works from any shell on any machine, not just inside Claude Code. `README.md` documents both paths and the matrix of what works where.

## Research questions this harness is designed to answer

1. **Diversity collapse.** How much does brief specificity (vague / layer-enumerated / open-problems) reduce variance in which layer an agent picks? `analyze.diversity_collapse_metrics` returns top-1 and top-3 cluster shares per condition; for finer-grained clustering, `description` (PR title) is recorded so future versions can swap in an embedding-based clusterer without changing the schema.
2. **Calibration.** Per (model, pre_push_checklist), what is the gap between claimed-CI-green (regex-matched against the agent's final message; pattern set frozen in `_calibration.py`) and actual-CI-green on first push (from `gh` rollup)?
3. **Iteration efficiency.** Pushes-to-green distribution per condition; does `pre_push_checklist=on` actually shift the mean?
4. **Brief-specificity sensitivity.** Cross-cut all three above by `brief_specificity` to identify which axis dominates each outcome.

## Test plan

- [x] `uv sync && uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -v` all exit 0 locally (264 passed, 1 skipped — the skipped test is the matplotlib plot-output test which auto-skips when the optional `harness` extra is not installed; passes when it is).
- [x] `uv sync --extra harness && uv run pytest scripts/harness/dry_run/test_dry_run.py::test_analyze_produces_plots` passes — confirms the plot path renders all three PNGs.
- [x] `uv run python -m scripts.harness.run_condition --cell <id> --n 4 --dry-run` writes a JSONL with the documented schema.
- [x] `uv run python -m scripts.harness.collect` aggregates, sorts, refuses mismatched schemas.
- [ ] (deferred — track scope) Live run of one small cell on a dedicated host to confirm the `clone` workdir strategy + `gh` enrichment end-to-end. Not done in this PR by design — this track ships infrastructure only.

https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5j2D4MgCkPgsjSCqBVpWW)_