### PR TITLE
[Hackathon] wire-compat: versioned comms layer with forward/backward …

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -19,6 +19,7 @@ _REF = "nest_plugins_reference"
 _BUILTINS: dict[tuple[str, str], str] = {
     ("transport", "in_memory"): f"{_REF}.transport.in_memory:StandaloneInMemoryTransport",
     ("comms", "nest_native"): f"{_REF}.comms.nest_native:NestNativeComms",
+    ("comms", "versioned"): f"{_REF}.comms.versioned:VersionedComms",
     ("identity", "did_key"): f"{_REF}.identity.did_key:DidKeyIdentity",
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -71,3 +71,7 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.reputation import reputation_factory
 
         register_scenario("reputation", reputation_factory)
+    elif name == "comms_versioning":
+        from nest_core.scenarios_builtin.comms_versioning import comms_versioning_factory
+
+        register_scenario("comms_versioning", comms_versioning_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/comms_versioning.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/comms_versioning.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Comms schema-versioning scenario — mixed-version agents on one wire.
+
+A swarm mid-rolling-upgrade: half the peers speak the old wire format and half
+speak a newer one. Each peer sends to a single ``auditor`` that decodes every
+envelope with the configured ``comms`` plugin and reports, in an ``ack``, what
+it did with it. The trace this produces is what
+``validate_trace(..., "comms_versioning")`` inspects.
+
+The peers build raw envelopes *directly* (not through any comms plugin) so the
+injected traffic is byte-identical regardless of which comms layer the auditor
+runs. That is what lets the same scenario demonstrate both directions:
+
+* with ``comms: versioned`` the auditor preserves unknown fields and rejects the
+  breaking major bump -> the adversarial validators pass;
+* with ``comms: nest_native`` the auditor silently drops the unknown field and
+  accepts the breaking major as if it were v1 -> the validators fail.
+
+Three envelope shapes are injected:
+
+* ``1.0`` — an old-format peer (no unknown fields);
+* ``1.1`` — a newer-*minor* peer carrying an unknown ``x-trace-id`` field
+  (forward compat: must be preserved);
+* ``2.0`` — a newer-*major* "future" peer (breaking: must be rejected).
+
+Example::
+
+    agents = comms_versioning_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, cast
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId
+
+
+def _envelope(
+    *,
+    version: str,
+    kind: str,
+    mid: str,
+    sender: str,
+    receiver: str,
+    payload: bytes,
+    extra: dict[str, Any] | None = None,
+) -> bytes:
+    """Build a canonical (sorted-key) JSON envelope as raw wire bytes.
+
+    ``extra`` injects top-level fields a newer peer would add; they are unknown
+    to an older reader. Output is deterministic for Tier 1 replay.
+
+    Example::
+
+        raw = _envelope(version="1.1", kind="offer", mid="m-1", sender="a",
+                        receiver="b", payload=b"x", extra={"x-trace-id": "t1"})
+    """
+    env: dict[str, Any] = {
+        "schema_version": version,
+        "kind": kind,
+        "id": mid,
+        "sender": sender,
+        "receiver": receiver,
+        "payload": base64.b64encode(payload).decode("ascii"),
+        "correlation_id": None,
+        "timestamp": None,
+        "metadata": {},
+    }
+    if extra:
+        env.update(extra)
+    return json.dumps(env, sort_keys=True).encode("utf-8")
+
+
+def _best_effort_id(raw: bytes) -> str:
+    """Pull the ``id`` out of a possibly-undecodable envelope for ack labelling.
+
+    Example::
+
+        assert _best_effort_id(b'{"id": "m-1"}') == "m-1"
+    """
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return "unknown"
+    if isinstance(data, dict):
+        return str(cast("dict[str, Any]", data).get("id", "unknown"))
+    return "unknown"
+
+
+class PeerAgent(StateMachineAgent):
+    """Sends versioned envelopes to the auditor at start.
+
+    A ``v1`` peer sends one ``1.0`` envelope; a ``v2`` peer sends a ``1.1``
+    envelope with an unknown field *and* a breaking ``2.0`` envelope.
+
+    Example::
+
+        peer = PeerAgent(AgentId("peer-1"), index=1, is_v2=True,
+                         auditor=AgentId("auditor-0"))
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        index: int,
+        is_v2: bool,
+        auditor: AgentId,
+    ) -> None:
+        self._id = agent_id
+        self._index = index
+        self._is_v2 = is_v2
+        self._auditor = auditor
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Arm a self-timer so this peer emits on its own tick.
+
+        The default transport is zero-latency, so without staggering every
+        event lands at ``t=0``. Scheduling each peer onto tick ``index + 1``
+        gives the trace real virtual time (a rolling upgrade unfolding over
+        ticks) while keeping the run deterministic.
+
+        Example::
+
+            await peer.on_start(ctx)
+        """
+        await ctx.schedule(float(self._index + 1), b"emit")
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Emit envelopes when our timer fires; ignore the auditor's ack.
+
+        Example::
+
+            await peer.on_message(ctx, AgentId("peer-1"), b"emit")
+        """
+        if payload != b"emit":
+            return
+        me, to = str(self._id), str(self._auditor)
+        if not self._is_v2:
+            await ctx.send(
+                self._auditor,
+                _envelope(
+                    version="1.0",
+                    kind="offer",
+                    mid=f"m-{self._index}-base",
+                    sender=me,
+                    receiver=to,
+                    payload=b"v1-offer",
+                ),
+            )
+            return
+        # Forward-compatible minor bump: carries a field older readers don't know.
+        await ctx.send(
+            self._auditor,
+            _envelope(
+                version="1.1",
+                kind="offer",
+                mid=f"m-{self._index}-minor",
+                sender=me,
+                receiver=to,
+                payload=b"v2-offer",
+                extra={"x-trace-id": f"trace-{self._index}"},
+            ),
+        )
+        # Breaking major bump from a hypothetical future build: must be rejected.
+        await ctx.send(
+            self._auditor,
+            _envelope(
+                version="2.0",
+                kind="offer",
+                mid=f"m-{self._index}-major",
+                sender=me,
+                receiver=to,
+                payload=b"v_future-offer",
+            ),
+        )
+
+
+class AuditorAgent(StateMachineAgent):
+    """Decodes every envelope with the configured comms plugin and acks the outcome.
+
+    The ack format is ``ack:<id>:<status>:<preserved fields>`` where status is
+    ``accepted`` (with the comma-separated unknown fields the decoder preserved)
+    or ``rejected_major`` (decode refused). This is the evidence the comms
+    validators score.
+
+    Example::
+
+        auditor = AuditorAgent(AgentId("auditor-0"), comms=VersionedComms(...))
+    """
+
+    def __init__(self, agent_id: AgentId, comms: Any) -> None:
+        self._id = agent_id
+        self._comms = comms
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Decode one envelope and report what happened back to the sender.
+
+        Example::
+
+            await auditor.on_message(ctx, AgentId("peer-1"), raw)
+        """
+        try:
+            msg = self._comms.deserialize(payload)
+        except (ValueError, KeyError):
+            # UnsupportedSchemaError (a ValueError) or a structurally invalid
+            # envelope: the decoder refused, which is the correct behaviour for
+            # an unknown major.
+            mid = _best_effort_id(payload)
+            await ctx.send(sender, f"ack:{mid}:rejected_major:".encode())
+            return
+        preserved = sorted(cast("dict[str, Any]", msg.metadata.get("_unknown") or {}))
+        await ctx.send(
+            sender,
+            f"ack:{msg.id}:accepted:{','.join(preserved)}".encode(),
+        )
+
+
+def comms_versioning_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create one auditor and a mix of v1/v2 peer agents.
+
+    The auditor decodes with ``plugins["comms"]`` so the scenario exercises
+    whichever comms plugin the YAML selected. Peer count comes from the
+    ``peer`` role (default: all agents but the auditor); even indices speak v1,
+    odd indices speak v2.
+
+    Example::
+
+        agents = comms_versioning_factory(config, plugins)
+    """
+    peer_count = 0
+    if config.agents.roles:
+        for role in config.agents.roles:
+            if role.name == "peer":
+                peer_count = role.count
+    if peer_count == 0:
+        peer_count = max(2, config.agents.count - 1)
+
+    auditor_id = AgentId("auditor-0")
+    comms_cls = plugins["comms"]
+    auditor_comms = comms_cls(auditor_id)
+
+    agents: dict[AgentId, StateMachineAgent] = {
+        auditor_id: AuditorAgent(auditor_id, comms=auditor_comms),
+    }
+    for i in range(peer_count):
+        aid = AgentId(f"peer-{i}")
+        agents[aid] = PeerAgent(aid, index=i, is_v2=bool(i % 2), auditor=auditor_id)
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -21,7 +21,7 @@ import contextlib
 import json
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 
 class ValidationResult:
@@ -887,11 +887,200 @@ def validate_reputation_warnings(
 
 
 # ---------------------------------------------------------------------------
+# Comms schema-versioning validators (adversarial)
+# ---------------------------------------------------------------------------
+
+# The wire contract a versioned comms layer must honour, encoded here
+# independently of any plugin so these checks can judge *any* comms
+# implementation -- including the default ``nest_native``, which fails both.
+_COMMS_KNOWN_MAJOR = 1
+_COMMS_KNOWN_ENVELOPE_FIELDS = frozenset(
+    {
+        "schema_version",
+        "kind",
+        "id",
+        "sender",
+        "receiver",
+        "payload",
+        "correlation_id",
+        "timestamp",
+        "metadata",
+    }
+)
+
+
+def _parse_comms_envelope(msg: str) -> dict[str, Any] | None:
+    """Parse a trace ``msg`` as a comms envelope, or return ``None``.
+
+    Receiver acks and non-JSON payloads are not envelopes and yield ``None``.
+
+    Example::
+
+        env = _parse_comms_envelope('{"id": "m1", "schema_version": "1.1"}')
+    """
+    if not msg.startswith("{"):
+        return None
+    try:
+        loaded = json.loads(msg)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(loaded, dict) or "id" not in loaded:
+        return None
+    return cast("dict[str, Any]", loaded)
+
+
+def _comms_major(version: str) -> int | None:
+    """Return the integer major of a SemVer string, or ``None`` if malformed.
+
+    Example::
+
+        assert _comms_major("2.3") == 2
+    """
+    try:
+        return int(version.split(".", 1)[0])
+    except (ValueError, AttributeError):
+        return None
+
+
+def _collect_comms_wire(
+    events: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Map each envelope id to its on-the-wire ``version``/``major``/unknowns.
+
+    Reads ground truth from the bytes a receiver actually *received*,
+    independent of how it then chose to decode them. Only delivered envelopes
+    are judged, so a dropped message never counts as a missing ack.
+    """
+    wire: dict[str, dict[str, Any]] = {}
+    for ev in events:
+        if ev.get("kind") != "receive":
+            continue
+        env = _parse_comms_envelope(str(ev.get("msg", "")))
+        if env is None:
+            continue
+        mid = str(env.get("id"))
+        version = str(env.get("schema_version", "1.0"))
+        unknown = {k for k in env if k not in _COMMS_KNOWN_ENVELOPE_FIELDS}
+        wire[mid] = {
+            "version": version,
+            "major": _comms_major(version),
+            "unknown_fields": unknown,
+        }
+    return wire
+
+
+def _collect_comms_acks(
+    events: list[dict[str, Any]],
+) -> dict[str, tuple[str, set[str]]]:
+    """Map each envelope id to the receiver's ``(status, preserved_fields)``.
+
+    Receivers emit ``ack:<id>:<status>:<comma-separated preserved fields>``
+    where ``status`` is ``accepted`` or ``rejected_major``.
+    """
+    acks: dict[str, tuple[str, set[str]]] = {}
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        msg = str(ev.get("msg", ""))
+        if not msg.startswith("ack:"):
+            continue
+        parts = msg.split(":", 3)
+        if len(parts) < 3:
+            continue
+        mid, status = parts[1], parts[2]
+        preserved = {f for f in parts[3].split(",") if f} if len(parts) > 3 else set[str]()
+        acks[mid] = (status, preserved)
+    return acks
+
+
+def validate_comms_reject_unknown_major(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Receivers must reject envelopes whose major version they don't speak.
+
+    Catches the *silent-accept* attack: ``nest_native`` ignores
+    ``schema_version`` and decodes a breaking v2.0 envelope into a
+    plausible-but-wrong message, whereas ``versioned`` rejects it.
+
+    Example::
+
+        results = validate_comms_reject_unknown_major(events)
+    """
+    wire = _collect_comms_wire(events)
+    acks = _collect_comms_acks(events)
+    violations: list[str] = []
+    checked = 0
+    for mid, info in wire.items():
+        major = info["major"]
+        if major is None or major <= _COMMS_KNOWN_MAJOR:
+            continue
+        checked += 1
+        status = acks.get(mid)
+        if status is None or status[0] != "rejected_major":
+            got = "no ack" if status is None else status[0]
+            violations.append(f"{mid}: unknown major {info['version']} not rejected (got {got})")
+    if violations:
+        return [ValidationResult("comms_reject_unknown_major", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "comms_reject_unknown_major",
+            True,
+            f"{checked} unknown-major envelope(s) correctly rejected",
+        )
+    ]
+
+
+def validate_comms_no_silent_drop(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Receivers must preserve unknown fields from newer-minor peers.
+
+    Catches the *silent-drop* attack: ``nest_native`` reads only the fields it
+    knows and discards a field a newer peer added with no trace, whereas
+    ``versioned`` preserves it for round-trip re-emission.
+
+    Example::
+
+        results = validate_comms_no_silent_drop(events)
+    """
+    wire = _collect_comms_wire(events)
+    acks = _collect_comms_acks(events)
+    violations: list[str] = []
+    checked = 0
+    for mid, info in wire.items():
+        if info["major"] != _COMMS_KNOWN_MAJOR or not info["unknown_fields"]:
+            continue
+        checked += 1
+        status = acks.get(mid)
+        if status is None:
+            unknown = sorted(info["unknown_fields"])
+            violations.append(f"{mid}: carried unknown {unknown} but no ack")
+            continue
+        outcome, preserved = status
+        if outcome != "accepted" or not info["unknown_fields"] <= preserved:
+            dropped = sorted(info["unknown_fields"] - preserved)
+            violations.append(f"{mid}: silently dropped {dropped} (status {outcome})")
+    if violations:
+        return [ValidationResult("comms_no_silent_drop", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "comms_no_silent_drop",
+            True,
+            f"{checked} forward-compat envelope(s) preserved all unknown fields",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
 
 VALIDATORS: dict[str, list[Any]] = {
+    "comms_versioning": [
+        validate_comms_reject_unknown_major,
+        validate_comms_no_silent_drop,
+    ],
     "marketplace": [
         validate_marketplace_no_double_sell,
         validate_marketplace_responses,

--- a/packages/nest-core/tests/test_comms_versioning.py
+++ b/packages/nest-core/tests/test_comms_versioning.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the comms_versioning adversarial validators and scenario.
+
+The core claim under test: the validators FAIL against the default
+``nest_native`` comms layer (which drops unknown fields and accepts breaking
+majors) and PASS against ``versioned`` -- driven both from synthetic traces and
+from a real simulator run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from pathlib import Path
+from typing import Any
+
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import (
+    validate_comms_no_silent_drop,
+    validate_comms_reject_unknown_major,
+    validate_trace,
+)
+
+type Event = dict[str, Any]
+
+
+def _envelope(mid: str, version: str, extra: dict[str, Any] | None = None) -> str:
+    env: dict[str, Any] = {
+        "schema_version": version,
+        "kind": "offer",
+        "id": mid,
+        "sender": "peer-1",
+        "receiver": "auditor-0",
+        "payload": base64.b64encode(b"x").decode("ascii"),
+        "correlation_id": None,
+        "timestamp": None,
+        "metadata": {},
+    }
+    if extra:
+        env.update(extra)
+    return json.dumps(env, sort_keys=True)
+
+
+def _recv(mid: str, version: str, extra: dict[str, Any] | None = None) -> Event:
+    return {
+        "ts": 1.0,
+        "agent": "auditor-0",
+        "kind": "receive",
+        "from": "peer-1",
+        "msg": _envelope(mid, version, extra),
+    }
+
+
+def _ack(mid: str, status: str, preserved: str = "") -> Event:
+    return {
+        "ts": 2.0,
+        "agent": "auditor-0",
+        "kind": "send",
+        "to": "peer-1",
+        "msg": f"ack:{mid}:{status}:{preserved}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests (synthetic traces)
+# ---------------------------------------------------------------------------
+
+
+class TestRejectUnknownMajor:
+    def test_pass_when_future_major_rejected(self) -> None:
+        events = [_recv("m1", "2.0"), _ack("m1", "rejected_major")]
+        results = validate_comms_reject_unknown_major(events)
+        assert results[0].passed is True
+
+    def test_fail_when_future_major_accepted(self) -> None:
+        # nest_native behaviour: no rejection, decoded as if valid.
+        events = [_recv("m1", "2.0"), _ack("m1", "accepted")]
+        results = validate_comms_reject_unknown_major(events)
+        assert results[0].passed is False
+
+    def test_fail_when_future_major_unacked(self) -> None:
+        events = [_recv("m1", "2.0")]
+        results = validate_comms_reject_unknown_major(events)
+        assert results[0].passed is False
+
+    def test_same_major_is_ignored(self) -> None:
+        events = [_recv("m1", "1.5"), _ack("m1", "accepted")]
+        results = validate_comms_reject_unknown_major(events)
+        assert results[0].passed is True
+
+
+class TestNoSilentDrop:
+    def test_pass_when_unknown_preserved(self) -> None:
+        events = [_recv("m1", "1.1", {"x-trace-id": "t"}), _ack("m1", "accepted", "x-trace-id")]
+        results = validate_comms_no_silent_drop(events)
+        assert results[0].passed is True
+
+    def test_fail_when_unknown_dropped(self) -> None:
+        # nest_native behaviour: accepted, but the unknown field vanished.
+        events = [_recv("m1", "1.1", {"x-trace-id": "t"}), _ack("m1", "accepted")]
+        results = validate_comms_no_silent_drop(events)
+        assert results[0].passed is False
+
+    def test_no_unknown_fields_is_trivially_ok(self) -> None:
+        events = [_recv("m1", "1.0"), _ack("m1", "accepted")]
+        results = validate_comms_no_silent_drop(events)
+        assert results[0].passed is True
+
+    def test_dropped_message_is_not_a_violation(self) -> None:
+        """An envelope never delivered (no receive event) is not judged."""
+        events = [_ack("m1", "accepted")]
+        results = validate_comms_no_silent_drop(events)
+        assert results[0].passed is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real simulator run
+# ---------------------------------------------------------------------------
+
+
+def _run(comms: str, out: Path, seed: int = 42) -> None:
+    cfg = ScenarioConfig.from_yaml("scenarios/comms_versioning.yaml")
+    cfg.layers.comms = comms
+    cfg.seed = seed
+    cfg.output.trace = str(out)
+    asyncio.run(ScenarioRunner(cfg).run())
+
+
+class TestScenarioEndToEnd:
+    def test_versioned_passes(self, tmp_path: Path) -> None:
+        out = tmp_path / "versioned.jsonl"
+        _run("versioned", out)
+        results = validate_trace(out, "comms_versioning")
+        assert results, "expected validators to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_nest_native_fails_both_checks(self, tmp_path: Path) -> None:
+        out = tmp_path / "native.jsonl"
+        _run("nest_native", out)
+        results = {r.name: r.passed for r in validate_trace(out, "comms_versioning")}
+        assert results["comms_reject_unknown_major"] is False
+        assert results["comms_no_silent_drop"] is False
+
+    def test_deterministic_across_required_seeds(self, tmp_path: Path) -> None:
+        for seed in (42, 7, 1337):
+            a, b = tmp_path / f"{seed}a.jsonl", tmp_path / f"{seed}b.jsonl"
+            _run("versioned", a, seed=seed)
+            _run("versioned", b, seed=seed)
+            assert a.read_bytes() == b.read_bytes(), f"seed {seed} not deterministic"
+            assert all(r.passed for r in validate_trace(a, "comms_versioning"))

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -629,6 +629,7 @@ class TestValidatorRegistry:
             "consensus",
             "supply_chain",
             "reputation",
+            "comms_versioning",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/comms/versioned.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/comms/versioned.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Versioned communication plugin — forward/backward-compatible wire envelopes.
+
+The default :class:`~nest_plugins_reference.comms.nest_native.NestNativeComms`
+envelope has no version field, so two swarms running different NEST builds
+silently mis-read each other's wire format: a newer field is dropped without a
+trace, and a breaking (major) format bump deserializes into a plausible-but-wrong
+:class:`~nest_core.types.Message`. This plugin adds an explicit, in-band
+``schema_version`` (SemVer) and a ``kind`` tag to every envelope and gives
+``deserialize`` a precise compatibility contract:
+
+* **Same major, any minor (forward compat).** Unknown top-level fields from a
+  *newer minor* peer are preserved verbatim into ``metadata["_unknown"]`` and
+  re-emitted on the next ``serialize`` — the MUST-ignore-but-preserve rule that
+  lets a v1.1 message survive a round-trip through a v1.0 reader. This mirrors
+  Protobuf's unknown-field retention, expressed in JSON.
+* **Higher major (breaking).** A major version this build does not understand is
+  rejected with a typed :class:`UnsupportedSchemaError` instead of being decoded
+  into a wrong message. Refusing is the safe failure: a breaking change means we
+  *cannot* know what the bytes mean.
+
+Compatibility matrix (this build speaks ``1.1``)::
+
+    wire version   behaviour
+    -----------    ---------------------------------------------
+    1.0            accept (older minor, no unknown fields)
+    1.1            accept (exact)
+    1.7            accept, preserve unknown fields  (forward compat)
+    2.0            reject -> UnsupportedSchemaError (breaking)
+    "garbage"      reject -> UnsupportedSchemaError (malformed)
+
+Example::
+
+    comms = VersionedComms(AgentId("a1"))
+    raw = comms.serialize(msg)
+    assert comms.deserialize(raw) == msg          # lossless round-trip
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, cast
+
+from nest_core.types import (
+    AgentCard,
+    AgentId,
+    Message,
+    MessageId,
+    Query,
+    Response,
+)
+
+#: Major version this build understands. Bumping it is a *breaking* change:
+#: peers on an older major will reject our envelopes, and we reject theirs.
+SCHEMA_MAJOR = 1
+#: Minor version this build emits. Bumping it must stay backward compatible:
+#: older-minor peers MUST still be able to read our envelopes.
+SCHEMA_MINOR = 1
+#: SemVer string stamped onto every outgoing envelope, e.g. ``"1.1"``.
+SCHEMA_VERSION = f"{SCHEMA_MAJOR}.{SCHEMA_MINOR}"
+
+#: Top-level envelope keys this build assigns meaning to. Anything else on the
+#: wire is an *unknown field* from a newer peer and is preserved, not dropped.
+KNOWN_FIELDS: frozenset[str] = frozenset(
+    {
+        "schema_version",
+        "kind",
+        "id",
+        "sender",
+        "receiver",
+        "payload",
+        "correlation_id",
+        "timestamp",
+        "metadata",
+    }
+)
+
+#: ``metadata`` keys this plugin reserves for carrying envelope control data in
+#: and out of the :class:`~nest_core.types.Message` model. Callers should treat
+#: these as read-only: ``schema_version`` and ``kind`` report what arrived (and
+#: select what is emitted), and ``_unknown`` holds preserved forward-compat
+#: fields.
+RESERVED_METADATA_KEYS: frozenset[str] = frozenset({"schema_version", "kind", "_unknown"})
+
+
+class UnsupportedSchemaError(ValueError):
+    """Raised when an envelope's schema version cannot be safely decoded.
+
+    Carries the offending ``version`` string so callers can log or branch on it
+    rather than string-matching the message. Subclasses :class:`ValueError` so
+    existing ``except ValueError`` deserialization guards keep working.
+
+    Example::
+
+        try:
+            comms.deserialize(future_major_bytes)
+        except UnsupportedSchemaError as exc:
+            assert exc.version == "2.0"
+    """
+
+    def __init__(self, version: str, detail: str = "") -> None:
+        self.version = version
+        suffix = f": {detail}" if detail else ""
+        super().__init__(f"unsupported schema version {version!r}{suffix}")
+
+
+def _parse_major(version: str) -> int:
+    """Return the integer major component of a SemVer string.
+
+    Example::
+
+        assert _parse_major("2.7") == 2
+    """
+    head = version.split(".", 1)[0]
+    try:
+        return int(head)
+    except ValueError as exc:
+        raise UnsupportedSchemaError(version, "malformed version") from exc
+
+
+class VersionedComms:
+    """JSON communication protocol with explicit, in-band schema versioning.
+
+    Drop-in replacement for ``nest_native`` that survives rolling upgrades:
+    unknown fields from newer-minor peers are preserved, and unknown-major
+    peers are rejected rather than silently mis-decoded.
+
+    Example::
+
+        comms = VersionedComms(AgentId("a1"), transport=t, registry=r)
+        resp = await comms.send(AgentId("a2"), msg)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        transport: Any = None,
+        registry: Any = None,
+    ) -> None:
+        self._agent_id = agent_id
+        self._transport = transport
+        self._registry = registry
+
+    def serialize(self, msg: Message) -> bytes:
+        """Serialize a Message into a versioned JSON envelope.
+
+        Stamps :data:`SCHEMA_VERSION` and a ``kind`` tag (read from
+        ``metadata['kind']``, default ``"message"``), and re-emits any
+        forward-compat fields previously parked in ``metadata['_unknown']``.
+        Output is ``sort_keys``-canonical so the same message always produces
+        byte-identical wire bytes (Tier 1 determinism).
+
+        Example::
+
+            raw = comms.serialize(msg)
+        """
+        meta: dict[str, Any] = dict(msg.metadata)
+        version = str(meta.pop("schema_version", SCHEMA_VERSION))
+        kind = str(meta.pop("kind", "message"))
+        unknown: dict[str, Any] = meta.pop("_unknown", {}) or {}
+
+        envelope: dict[str, Any] = {
+            "schema_version": version,
+            "kind": kind,
+            "id": str(msg.id),
+            "sender": str(msg.sender),
+            "receiver": str(msg.receiver),
+            "payload": base64.b64encode(msg.payload).decode("ascii"),
+            "correlation_id": str(msg.correlation_id) if msg.correlation_id else None,
+            "timestamp": msg.timestamp,
+            "metadata": meta,
+        }
+        # Re-emit preserved unknown fields at the top level. Never let them
+        # clobber a field this build owns -- our semantics win on collision.
+        for key, value in unknown.items():
+            if key not in envelope:
+                envelope[key] = value
+        return json.dumps(envelope, sort_keys=True).encode("utf-8")
+
+    def deserialize(self, raw: bytes) -> Message:
+        """Deserialize a versioned envelope, enforcing the compatibility contract.
+
+        Accepts any envelope whose major version equals :data:`SCHEMA_MAJOR`
+        (preserving unknown fields from newer minors) and raises
+        :class:`UnsupportedSchemaError` for a higher major or a malformed/
+        non-object envelope. A missing ``schema_version`` is treated as the
+        oldest known release, ``"1.0"`` (backward compat with pre-versioning
+        peers).
+
+        Example::
+
+            msg = comms.deserialize(raw)
+            assert msg.metadata["schema_version"]  # always populated
+        """
+        try:
+            loaded = json.loads(raw)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise UnsupportedSchemaError("<unparseable>", str(exc)) from exc
+        if not isinstance(loaded, dict):
+            raise UnsupportedSchemaError("<non-object>", "envelope is not a JSON object")
+        data = cast("dict[str, Any]", loaded)
+
+        version = str(data.get("schema_version", "1.0"))
+        if _parse_major(version) > SCHEMA_MAJOR:
+            raise UnsupportedSchemaError(version, f"this build speaks major {SCHEMA_MAJOR}")
+
+        unknown = {k: v for k, v in data.items() if k not in KNOWN_FIELDS}
+        meta: dict[str, Any] = dict(data.get("metadata") or {})
+        meta["schema_version"] = version
+        meta["kind"] = str(data.get("kind", "message"))
+        if unknown:
+            meta["_unknown"] = unknown
+
+        return Message(
+            id=MessageId(data["id"]),
+            sender=AgentId(data["sender"]),
+            receiver=AgentId(data["receiver"]),
+            payload=base64.b64decode(data["payload"]),
+            correlation_id=data.get("correlation_id"),
+            timestamp=data.get("timestamp"),
+            metadata=meta,
+        )
+
+    async def send(self, to: AgentId, msg: Message) -> Response:
+        """Serialize and route a message through the transport layer.
+
+        Example::
+
+            resp = await comms.send(AgentId("a2"), msg)
+        """
+        raw = self.serialize(msg)
+        if self._transport is not None:
+            await self._transport.send(to, raw)
+        return Response(success=True)
+
+    async def advertise(self, card: AgentCard) -> None:
+        """Advertise an agent card to the registry.
+
+        Example::
+
+            await comms.advertise(my_card)
+        """
+        if self._registry is not None:
+            await self._registry.register(card)
+
+    async def discover(self, query: Query) -> list[AgentCard]:
+        """Discover agents via the registry.
+
+        Example::
+
+            cards = await comms.discover(Query(capabilities=["sell"]))
+        """
+        if self._registry is not None:
+            result: list[AgentCard] = await self._registry.lookup(query)
+            return result
+        return []

--- a/packages/nest-plugins-reference/tests/test_comms_versioned.py
+++ b/packages/nest-plugins-reference/tests/test_comms_versioned.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the versioned comms plugin: round-trip, compat, and rejection.
+
+Persona note (wire-compat engineer): the invariants under test are the ones a
+rolling upgrade lives or dies on -- lossless round-trip, MUST-preserve unknown
+fields from newer minors, and a hard refusal of breaking majors.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import string
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.layers.comms import CommsProtocol
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, Message, MessageId
+from nest_plugins_reference.comms.versioned import (
+    KNOWN_FIELDS,
+    RESERVED_METADATA_KEYS,
+    SCHEMA_MAJOR,
+    SCHEMA_VERSION,
+    UnsupportedSchemaError,
+    VersionedComms,
+)
+
+_AGENT = AgentId("auditor-0")
+
+
+def _comms() -> VersionedComms:
+    return VersionedComms(_AGENT)
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis strategies for canonical envelopes
+# ---------------------------------------------------------------------------
+
+_NAME = st.text(alphabet=string.ascii_letters + string.digits + "-", min_size=1, max_size=10)
+_JSON_SCALAR = st.none() | st.booleans() | st.integers() | st.text(max_size=12)
+_META_KEY = st.text(alphabet=string.ascii_letters, min_size=1, max_size=8).filter(
+    lambda k: k not in RESERVED_METADATA_KEYS
+)
+_UNKNOWN_KEY = st.text(alphabet=string.ascii_letters + "-", min_size=1, max_size=8).filter(
+    lambda k: k not in KNOWN_FIELDS
+)
+
+
+@st.composite
+def _envelopes(draw: st.DrawFn) -> dict[str, Any]:
+    """Draw a canonical same-major (1.x) envelope, possibly with unknown fields."""
+    minor = draw(st.integers(min_value=0, max_value=99))
+    payload = draw(st.binary(max_size=24))
+    env: dict[str, Any] = {
+        "schema_version": f"1.{minor}",
+        "kind": draw(st.text(alphabet=string.ascii_letters, min_size=1, max_size=8)),
+        "id": draw(_NAME),
+        "sender": draw(_NAME),
+        "receiver": draw(_NAME),
+        "payload": base64.b64encode(payload).decode("ascii"),
+        "correlation_id": draw(st.none() | _NAME),
+        "timestamp": draw(
+            st.none()
+            | st.floats(min_value=0.0, max_value=1e9, allow_nan=False, allow_infinity=False)
+        ),
+        "metadata": draw(st.dictionaries(_META_KEY, _JSON_SCALAR, max_size=3)),
+    }
+    for key, value in draw(st.dictionaries(_UNKNOWN_KEY, _JSON_SCALAR, max_size=3)).items():
+        env[key] = value
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Round-trip properties
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    @settings(max_examples=200, deadline=None)
+    @given(env=_envelopes())
+    def test_wire_round_trip_is_canonical_and_stable(self, env: dict[str, Any]) -> None:
+        """serialize(deserialize(raw)) reproduces the canonical bytes exactly."""
+        comms = _comms()
+        raw = json.dumps(env, sort_keys=True).encode("utf-8")
+        msg = comms.deserialize(raw)
+        assert comms.serialize(msg) == raw
+        assert comms.deserialize(comms.serialize(msg)) == msg
+
+    @settings(max_examples=200, deadline=None)
+    @given(env=_envelopes())
+    def test_unknown_fields_are_preserved(self, env: dict[str, Any]) -> None:
+        """Every top-level field this build doesn't own survives the round-trip."""
+        comms = _comms()
+        expected_unknown = {k: v for k, v in env.items() if k not in KNOWN_FIELDS}
+        msg = comms.deserialize(json.dumps(env).encode("utf-8"))
+        assert msg.metadata.get("_unknown", {}) == expected_unknown
+        # ...and they reappear at the top level when re-serialized.
+        reemitted = json.loads(comms.serialize(msg))
+        for key, value in expected_unknown.items():
+            assert reemitted[key] == value
+
+
+# ---------------------------------------------------------------------------
+# Compatibility contract
+# ---------------------------------------------------------------------------
+
+
+class TestCompatibility:
+    def test_basic_payload_round_trip(self) -> None:
+        comms = _comms()
+        msg = Message(
+            id=MessageId("m1"),
+            sender=AgentId("a1"),
+            receiver=AgentId("a2"),
+            payload=b"hello world",
+            metadata={"kind": "offer"},
+        )
+        back = comms.deserialize(comms.serialize(msg))
+        assert back.payload == b"hello world"
+        assert back.metadata["kind"] == "offer"
+        assert back.metadata["schema_version"] == SCHEMA_VERSION
+
+    def test_higher_minor_is_accepted(self) -> None:
+        comms = _comms()
+        env = _wire(version="1.99", extra={"future_flag": True})
+        msg = comms.deserialize(env)
+        assert msg.metadata["_unknown"] == {"future_flag": True}
+
+    def test_missing_version_treated_as_oldest(self) -> None:
+        """A pre-versioning envelope (no schema_version) is read as 1.0."""
+        comms = _comms()
+        raw = json.dumps(
+            {
+                "id": "m1",
+                "sender": "a1",
+                "receiver": "a2",
+                "payload": base64.b64encode(b"x").decode("ascii"),
+                "correlation_id": None,
+                "timestamp": None,
+                "metadata": {},
+            }
+        ).encode("utf-8")
+        msg = comms.deserialize(raw)
+        assert msg.metadata["schema_version"] == "1.0"
+
+
+class TestRejection:
+    def test_higher_major_is_rejected(self) -> None:
+        comms = _comms()
+        with pytest.raises(UnsupportedSchemaError) as exc:
+            comms.deserialize(_wire(version="2.0"))
+        assert exc.value.version == "2.0"
+
+    @settings(max_examples=50, deadline=None)
+    @given(major=st.integers(min_value=SCHEMA_MAJOR + 1, max_value=99))
+    def test_any_future_major_is_rejected(self, major: int) -> None:
+        comms = _comms()
+        with pytest.raises(UnsupportedSchemaError):
+            comms.deserialize(_wire(version=f"{major}.0"))
+
+    def test_malformed_version_is_rejected(self) -> None:
+        comms = _comms()
+        with pytest.raises(UnsupportedSchemaError):
+            comms.deserialize(_wire(version="not-a-version"))
+
+    def test_unparseable_envelope_is_rejected(self) -> None:
+        comms = _comms()
+        with pytest.raises(UnsupportedSchemaError):
+            comms.deserialize(b"{not json")
+
+    def test_non_object_envelope_is_rejected(self) -> None:
+        comms = _comms()
+        with pytest.raises(UnsupportedSchemaError):
+            comms.deserialize(b"[1, 2, 3]")
+
+    def test_error_is_a_value_error(self) -> None:
+        """Existing ``except ValueError`` guards keep catching us."""
+        assert issubclass(UnsupportedSchemaError, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# API fit
+# ---------------------------------------------------------------------------
+
+
+class TestApiFit:
+    def test_satisfies_comms_protocol(self) -> None:
+        assert isinstance(_comms(), CommsProtocol)
+
+    def test_resolvable_from_registry(self) -> None:
+        cls = PluginRegistry().resolve("comms", "versioned")
+        assert cls is VersionedComms
+
+
+def _wire(*, version: str, extra: dict[str, Any] | None = None) -> bytes:
+    """Build envelope bytes at a given version for rejection/compat tests."""
+    env: dict[str, Any] = {
+        "schema_version": version,
+        "kind": "offer",
+        "id": "m1",
+        "sender": "a1",
+        "receiver": "a2",
+        "payload": base64.b64encode(b"x").decode("ascii"),
+        "correlation_id": None,
+        "timestamp": None,
+        "metadata": {},
+    }
+    if extra:
+        env.update(extra)
+    return json.dumps(env).encode("utf-8")

--- a/scenarios/comms_versioning.yaml
+++ b/scenarios/comms_versioning.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Comms schema-versioning scenario: a swarm mid-rolling-upgrade.
+#
+# 8 peers (half on the old 1.0 wire format, half on a newer one) send envelopes
+# to a single auditor that decodes them with the `versioned` comms plugin. The
+# newer peers carry an unknown `x-trace-id` field (must be preserved) and a
+# breaking 2.0 envelope (must be rejected).
+#
+# Verify::
+#
+#     nest run scenarios/comms_versioning.yaml
+#     python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
+#         [print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail) \
+#          for r in validate_trace(Path('traces/comms_versioning.jsonl'), 'comms_versioning')]"
+name: comms_versioning
+description: "8 mixed-version peers send to an auditor; unknown fields preserved, breaking majors rejected."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 9
+  brain: state-machine
+  roles:
+    - name: peer
+      count: 8
+    - name: auditor
+      count: 1
+
+layers:
+  comms: versioned
+
+task:
+  type: comms_versioning
+  config: {}
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 1000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/comms_versioning.jsonl


### PR DESCRIPTION
…compat

Problem #01 (comms): the default nest_native envelope carries no schema version, so across NEST builds a newer field is silently dropped and a breaking-major message is silently mis-decoded.

This adds:
- comms/versioned.py: a VersionedComms plugin that stamps an explicit SemVer schema_version + kind on every envelope, preserves unknown fields from newer-minor peers (re-emitting them on round-trip), and rejects unknown majors with a typed UnsupportedSchemaError instead of mis-decoding.
- Two adversarial validators (comms_reject_unknown_major, comms_no_silent_drop) that FAIL against nest_native and PASS against versioned, encoded independently of any plugin.
- A comms_versioning scenario + agents (mixed v1/v2 peers + an auditor) and scenarios/comms_versioning.yaml demonstrating it.
- Property-based and end-to-end tests; deterministic under seeds 42/7/1337.

make ci-local: all 5 checks pass (365 tests, 0 type errors, lint+format clean).

## Summary by Sourcery

Introduce a versioned communications plugin and scenario to enforce forward/backward wire compatibility and validate comms behaviour.

New Features:
- Add a VersionedComms plugin that stamps schema versions on envelopes, preserves unknown minor-version fields, and rejects unsupported major versions.
- Add a comms_versioning scenario with mixed-version peers and an auditor to exercise comms plugins against versioning rules.
- Register the versioned comms plugin and comms_versioning scenario in the core plugin and scenario registries, including a new YAML scenario definition.

Enhancements:
- Add adversarial validators that ensure unknown-major envelopes are rejected and unknown fields from newer minors are not silently dropped.
- Extend validator tests to cover the new comms validators and verify deterministic traces across seeds for the comms_versioning scenario.

Tests:
- Add property-based and compatibility tests for the VersionedComms plugin, including round-trip stability, unknown-field preservation, and rejection semantics.
- Add end-to-end simulator tests that compare behaviour of nest_native vs versioned comms using the comms_versioning scenario.