### PR TITLE
feat(comms): versioned message envelopes with forward/backward compat…

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -19,6 +19,7 @@ _REF = "nest_plugins_reference"
 _BUILTINS: dict[tuple[str, str], str] = {
     ("transport", "in_memory"): f"{_REF}.transport.in_memory:StandaloneInMemoryTransport",
     ("comms", "nest_native"): f"{_REF}.comms.nest_native:NestNativeComms",
+    ("comms", "versioned"): f"{_REF}.comms.versioned:VersionedComms",
     ("identity", "did_key"): f"{_REF}.identity.did_key:DidKeyIdentity",
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -71,3 +71,7 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.reputation import reputation_factory
 
         register_scenario("reputation", reputation_factory)
+    elif name == "comms_versioning":
+        from nest_core.scenarios_builtin.comms_versioning import comms_versioning_factory
+
+        register_scenario("comms_versioning", comms_versioning_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/comms_versioning.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/comms_versioning.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Comms schema-versioning scenario.
+
+Mixed-version agents exchange envelopes through the configured comms plugin to
+exercise cross-version interop. A v1 sender emits a legacy envelope (no schema
+version); a v2 sender emits a v2.1 envelope carrying an unknown ``priority``
+field plus an unsupported-major v3 envelope. A forwarder round-trips each
+message through the comms plugin (deserialize -> reserialize) and forwards what
+it accepts to a sink.
+
+Because the round-tripped envelopes land in the JSONL trace, the
+``comms_versioning`` validators can check that the wire format survived:
+
+- under ``versioned``: schema versions and unknown fields are preserved, and the
+  unsupported-major message is rejected (validators PASS);
+- under ``nest_native``: the version/unknown fields are silently dropped and the
+  v3 message is blindly forwarded (validators FAIL).
+
+Example::
+
+    agents = comms_versioning_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+from nest_plugins_reference.comms.versioned import UnsupportedSchemaError
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId
+
+
+def _raw_envelope(
+    *,
+    sender: AgentId,
+    receiver: AgentId,
+    payload: bytes,
+    version: str | None = None,
+    kind: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> bytes:
+    """Build a raw JSON envelope on the wire (independent of any comms plugin).
+
+    Used to inject specific versions/fields regardless of which comms plugin the
+    agents use to read them.
+
+    Example::
+
+        raw = _raw_envelope(sender=AgentId("a"), receiver=AgentId("b"), payload=b"hi")
+    """
+    data: dict[str, Any] = {
+        "id": f"msg-{sender}-{kind or 'legacy'}",
+        "sender": str(sender),
+        "receiver": str(receiver),
+        "payload": base64.b64encode(payload).decode("ascii"),
+        "correlation_id": None,
+        "timestamp": 0,
+        "metadata": {},
+    }
+    if version is not None:
+        data["schema_version"] = version
+    if kind is not None:
+        data["kind"] = kind
+    if extra:
+        data.update(extra)
+    return json.dumps(data, sort_keys=True).encode("utf-8")
+
+
+class V1SenderAgent(StateMachineAgent):
+    """Emits a legacy (no schema_version) envelope to the forwarder."""
+
+    def __init__(self, agent_id: AgentId, forwarder: AgentId) -> None:
+        self._id = agent_id
+        self._forwarder = forwarder
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Send one legacy envelope.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        raw = _raw_envelope(sender=self._id, receiver=self._forwarder, payload=b"greeting-v1")
+        await ctx.send(self._forwarder, raw)
+
+
+class V2SenderAgent(StateMachineAgent):
+    """Emits a v2.1 envelope (with an unknown field) and an unsupported v3 envelope."""
+
+    def __init__(self, agent_id: AgentId, forwarder: AgentId) -> None:
+        self._id = agent_id
+        self._forwarder = forwarder
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Send a forward-compatible v2.1 message and an unsupported-major v3 message.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        v2 = _raw_envelope(
+            sender=self._id,
+            receiver=self._forwarder,
+            payload=b"greeting-v2",
+            version="2.1",
+            kind="greeting",
+            extra={"priority": "high"},
+        )
+        await ctx.send(self._forwarder, v2)
+
+        v3 = _raw_envelope(
+            sender=self._id,
+            receiver=self._forwarder,
+            payload=b"probe-v3",
+            version="3.0",
+            kind="probe",
+        )
+        await ctx.send(self._forwarder, v3)
+
+
+class ForwarderAgent(StateMachineAgent):
+    """Round-trips each envelope through the comms plugin and forwards accepted ones."""
+
+    def __init__(self, agent_id: AgentId, sink: AgentId) -> None:
+        self._id = agent_id
+        self._sink = sink
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Deserialize then re-serialize via comms; forward unless the major is unsupported.
+
+        Example::
+
+            await agent.on_message(ctx, sender, payload)
+        """
+        comms = ctx.plugins["comms"]
+        try:
+            msg = comms.deserialize(payload)
+        except UnsupportedSchemaError:
+            return  # reject unsupported-major messages instead of forwarding
+        out = comms.serialize(msg)
+        await ctx.send(self._sink, out)
+
+
+class SinkAgent(StateMachineAgent):
+    """Terminal agent; records nothing beyond the trace it receives."""
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """No-op sink.
+
+        Example::
+
+            await agent.on_message(ctx, sender, payload)
+        """
+        return
+
+
+def comms_versioning_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create mixed-version sender agents, a forwarder, and a sink.
+
+    Instantiates the configured comms plugin (versioned or nest_native) as a
+    shared serializer the agents use for the deserialize -> reserialize round trip.
+
+    Example::
+
+        agents = comms_versioning_factory(config, plugins)
+    """
+    _instantiate_comms(plugins)
+
+    forwarder_id = AgentId("forwarder-0")
+    sink_id = AgentId("sink-0")
+    v1_sender = AgentId("v1sender-0")
+    v2_sender = AgentId("v2sender-0")
+
+    return {
+        v1_sender: V1SenderAgent(v1_sender, forwarder=forwarder_id),
+        v2_sender: V2SenderAgent(v2_sender, forwarder=forwarder_id),
+        forwarder_id: ForwarderAgent(forwarder_id, sink=sink_id),
+        sink_id: SinkAgent(sink_id),
+    }
+
+
+def _instantiate_comms(plugins: dict[str, Any]) -> None:
+    """Instantiate the comms plugin class into a shared serializer instance, in place.
+
+    Example::
+
+        _instantiate_comms(plugins)
+    """
+    comms_cls = plugins.get("comms")
+    if isinstance(comms_cls, type):
+        plugins["comms"] = comms_cls(AgentId("comms-helper"))

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -17,11 +17,12 @@ Example::
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import json
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 
 class ValidationResult:
@@ -887,6 +888,116 @@ def validate_reputation_warnings(
 
 
 # ---------------------------------------------------------------------------
+# Comms schema-versioning validators
+# ---------------------------------------------------------------------------
+
+
+def _forwarded_envelopes(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return the JSON envelopes re-emitted by the forwarder agent in a trace."""
+    out: list[dict[str, Any]] = []
+    for ev in events:
+        if ev.get("kind") != "send" or ev.get("agent") != "forwarder-0":
+            continue
+        try:
+            raw = json.loads(str(ev.get("msg", "")))
+        except (ValueError, TypeError):
+            continue
+        if isinstance(raw, dict):
+            out.append(cast("dict[str, Any]", raw))
+    return out
+
+
+def _envelope_payload(envelope: dict[str, Any]) -> str:
+    """Decode the base64 payload of an envelope to text (best effort)."""
+    try:
+        return base64.b64decode(str(envelope.get("payload", ""))).decode("utf-8", errors="replace")
+    except (ValueError, TypeError):
+        return ""
+
+
+def validate_comms_schema_version(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every forwarded envelope carries an explicit ``schema_version``.
+
+    The name-addressed ``nest_native`` plugin emits no version field, so a
+    forwarded message loses its version — this check FAILS against it.
+    """
+    envs = _forwarded_envelopes(events)
+    missing = [e for e in envs if "schema_version" not in e]
+    if missing:
+        return [
+            ValidationResult(
+                "comms_schema_version",
+                False,
+                f"{len(missing)} forwarded envelope(s) missing schema_version",
+            )
+        ]
+    return [
+        ValidationResult(
+            "comms_schema_version",
+            True,
+            f"all {len(envs)} forwarded envelope(s) carry schema_version",
+        )
+    ]
+
+
+def validate_comms_unknown_field_preserved(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Unknown (future-minor) fields survive a round trip instead of being dropped.
+
+    The v2 message carries an unknown ``priority`` field; a compliant plugin
+    preserves and re-emits it. ``nest_native`` silently drops it — FAIL.
+    """
+    envs = _forwarded_envelopes(events)
+    dropped = [e for e in envs if _envelope_payload(e) == "greeting-v2" and "priority" not in e]
+    checked = sum(1 for e in envs if _envelope_payload(e) == "greeting-v2")
+    if dropped:
+        return [
+            ValidationResult(
+                "comms_unknown_field_preserved",
+                False,
+                f"{len(dropped)} v2 envelope(s) silently dropped the unknown 'priority' field",
+            )
+        ]
+    return [
+        ValidationResult(
+            "comms_unknown_field_preserved",
+            True,
+            f"unknown field preserved across {checked} v2 envelope(s)",
+        )
+    ]
+
+
+def validate_comms_unsupported_major_rejected(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Unsupported-major (v3) messages are rejected, not blindly forwarded.
+
+    A compliant plugin raises on an unknown major version; the forwarder then
+    drops it. ``nest_native`` ignores the version and forwards it anyway — FAIL.
+    """
+    envs = _forwarded_envelopes(events)
+    forwarded_v3 = [e for e in envs if _envelope_payload(e) == "probe-v3"]
+    if forwarded_v3:
+        return [
+            ValidationResult(
+                "comms_unsupported_major_rejected",
+                False,
+                f"{len(forwarded_v3)} unsupported-major (v3) message(s) forwarded, not rejected",
+            )
+        ]
+    return [
+        ValidationResult(
+            "comms_unsupported_major_rejected",
+            True,
+            "unsupported-major messages were rejected (not forwarded)",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -919,5 +1030,10 @@ VALIDATORS: dict[str, list[Any]] = {
     "reputation": [
         validate_reputation_scoring,
         validate_reputation_warnings,
+    ],
+    "comms_versioning": [
+        validate_comms_schema_version,
+        validate_comms_unknown_field_preserved,
+        validate_comms_unsupported_major_rejected,
     ],
 }

--- a/packages/nest-core/tests/test_comms_versioning_validators.py
+++ b/packages/nest-core/tests/test_comms_versioning_validators.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the comms schema-versioning validators.
+
+The validators must PASS on a versioned-style trace (schema + unknown fields
+preserved, unsupported-major rejected) and FAIL on a nest_native-style trace
+(version/unknown fields dropped, v3 blindly forwarded).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+from nest_core.validators import (
+    VALIDATORS,
+    validate_comms_schema_version,
+    validate_comms_unknown_field_preserved,
+    validate_comms_unsupported_major_rejected,
+    validate_events,
+)
+
+type Event = dict[str, Any]
+
+
+def _forwarded(
+    payload: str, schema: str | None = None, extra: dict[str, Any] | None = None
+) -> Event:
+    env: dict[str, Any] = {
+        "id": "m",
+        "sender": "forwarder-0",
+        "receiver": "sink-0",
+        "payload": base64.b64encode(payload.encode()).decode("ascii"),
+        "kind": "x",
+        "metadata": {},
+    }
+    if schema is not None:
+        env["schema_version"] = schema
+    if extra:
+        env.update(extra)
+    return {
+        "ts": 0.0,
+        "agent": "forwarder-0",
+        "kind": "send",
+        "to": "sink-0",
+        "msg": json.dumps(env),
+    }
+
+
+# A compliant (versioned) trace: schema present, priority preserved, no v3 forwarded.
+def _versioned_trace() -> list[Event]:
+    return [
+        _forwarded("greeting-v1", schema="2.0"),
+        _forwarded("greeting-v2", schema="2.0", extra={"priority": "high"}),
+    ]
+
+
+class TestPassesOnVersioned:
+    def test_all_validators_pass(self) -> None:
+        results = validate_events(_versioned_trace(), "comms_versioning")
+        assert results
+        assert all(r.passed for r in results)
+
+    def test_registered(self) -> None:
+        assert "comms_versioning" in VALIDATORS
+        assert len(VALIDATORS["comms_versioning"]) == 3
+
+
+class TestFailsOnNestNative:
+    def test_missing_schema_version_fails(self) -> None:
+        [result] = validate_comms_schema_version([_forwarded("greeting-v1")])
+        assert result.passed is False
+
+    def test_dropped_unknown_field_fails(self) -> None:
+        # v2 envelope forwarded WITHOUT the priority field
+        [result] = validate_comms_unknown_field_preserved([_forwarded("greeting-v2", schema="2.0")])
+        assert result.passed is False
+
+    def test_v3_forwarded_fails(self) -> None:
+        # an unsupported-major message reached the sink
+        [result] = validate_comms_unsupported_major_rejected([_forwarded("probe-v3")])
+        assert result.passed is False
+
+
+class TestUnsupportedMajorRejected:
+    def test_no_v3_forwarded_passes(self) -> None:
+        [result] = validate_comms_unsupported_major_rejected(_versioned_trace())
+        assert result.passed is True

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -629,6 +629,7 @@ class TestValidatorRegistry:
             "consensus",
             "supply_chain",
             "reputation",
+            "comms_versioning",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/comms/versioned.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/comms/versioned.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Versioned communication plugin — schema-versioned JSON envelopes.
+
+Unlike :class:`~nest_plugins_reference.comms.nest_native.NestNativeComms`, which
+emits a fixed JSON envelope with **no schema version and no unknown-field
+handling**, this plugin stamps every envelope with an explicit ``schema_version``
+(semver) and a ``kind`` tag, and handles cross-version traffic safely:
+
+- **Forward compatibility** — a message whose *minor* version is newer than this
+  plugin knows is still accepted; any unknown top-level fields are preserved
+  (round-tripped) instead of silently dropped.
+- **Major-version safety** — a message whose *major* version is newer is rejected
+  with a typed :class:`UnsupportedSchemaError` instead of being misinterpreted.
+- **Backward compatibility** — a legacy (``nest_native``) envelope with no
+  ``schema_version`` is still accepted.
+
+This makes rolling upgrades and third-party plugin evolution possible: the wire
+format can grow without breaking older or newer peers. Determinism is preserved
+(pure JSON, sorted keys, no clock, no randomness).
+
+Example::
+
+    comms = VersionedComms(AgentId("a1"))
+    raw = comms.serialize(msg)          # includes schema_version + kind
+    msg2 = comms.deserialize(raw)       # unknown future fields preserved
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, cast
+
+from nest_core.types import (
+    AgentCard,
+    AgentId,
+    Message,
+    MessageId,
+    Query,
+    Response,
+)
+
+#: Semver this plugin speaks. Same-major minor bumps stay compatible.
+SCHEMA_VERSION = "2.0"
+SUPPORTED_MAJOR = 2
+
+#: Envelope keys this plugin understands; anything else is an "unknown" field.
+_KNOWN_FIELDS = frozenset(
+    {
+        "schema_version",
+        "kind",
+        "id",
+        "sender",
+        "receiver",
+        "payload",
+        "correlation_id",
+        "timestamp",
+        "metadata",
+    }
+)
+
+# Reserved metadata keys used to round-trip envelope fields through the
+# (unversioned) ``Message`` model without colliding with user metadata.
+_META_UNKNOWN = "_unknown"
+_META_KIND = "_kind"
+
+
+class UnsupportedSchemaError(Exception):
+    """Raised when a message declares a major schema version this plugin can't read.
+
+    Example::
+
+        raise UnsupportedSchemaError("got major 3, support 2")
+    """
+
+
+def _major_of(version: str) -> int:
+    """Return the integer major component of a semver string.
+
+    Example::
+
+        _major_of("2.3")  # 2
+    """
+    head = version.split(".", 1)[0]
+    try:
+        return int(head)
+    except ValueError as exc:
+        msg = f"Malformed schema_version: {version!r}"
+        raise UnsupportedSchemaError(msg) from exc
+
+
+class VersionedComms:
+    """Schema-versioned JSON communication protocol.
+
+    Example::
+
+        comms = VersionedComms(AgentId("a1"))
+        raw = comms.serialize(msg)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        transport: Any = None,
+        registry: Any = None,
+    ) -> None:
+        self._agent_id = agent_id
+        self._transport = transport
+        self._registry = registry
+
+    def serialize(self, msg: Message) -> bytes:
+        """Serialize a Message into a versioned JSON envelope.
+
+        Re-emits any preserved unknown fields (forward compatibility) and stamps
+        the current ``schema_version`` and ``kind``.
+
+        Example::
+
+            raw = comms.serialize(msg)
+        """
+        meta = dict(msg.metadata)
+        unknown = meta.pop(_META_UNKNOWN, {})
+        kind = meta.pop(_META_KIND, "message")
+
+        data: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "kind": kind,
+            "id": str(msg.id),
+            "sender": str(msg.sender),
+            "receiver": str(msg.receiver),
+            "payload": base64.b64encode(msg.payload).decode("ascii"),
+            "correlation_id": str(msg.correlation_id) if msg.correlation_id else None,
+            "timestamp": msg.timestamp,
+            "metadata": meta,
+        }
+        # Forward compat: re-emit preserved unknown fields at the top level.
+        if isinstance(unknown, dict):
+            for key, value in cast("dict[str, Any]", unknown).items():
+                if key not in _KNOWN_FIELDS:
+                    data[key] = value
+        return json.dumps(data, sort_keys=True).encode("utf-8")
+
+    def deserialize(self, raw: bytes) -> Message:
+        """Deserialize a versioned (or legacy) envelope into a Message.
+
+        Rejects unknown-major versions with :class:`UnsupportedSchemaError`;
+        preserves unknown top-level fields from newer minor versions.
+
+        Example::
+
+            msg = comms.deserialize(raw)
+        """
+        data = json.loads(raw)
+
+        version = data.get("schema_version")
+        if version is not None and _major_of(str(version)) > SUPPORTED_MAJOR:
+            msg = f"Unsupported major version {version!r}; this plugin speaks {SCHEMA_VERSION}"
+            raise UnsupportedSchemaError(msg)
+
+        meta = dict(data.get("metadata", {}) or {})
+        unknown = {k: v for k, v in data.items() if k not in _KNOWN_FIELDS}
+        if unknown:
+            meta[_META_UNKNOWN] = unknown
+        if "kind" in data:
+            meta[_META_KIND] = data["kind"]
+
+        return Message(
+            id=MessageId(str(data["id"])),
+            sender=AgentId(str(data["sender"])),
+            receiver=AgentId(str(data["receiver"])),
+            payload=base64.b64decode(data["payload"]),
+            correlation_id=data.get("correlation_id"),
+            timestamp=data.get("timestamp"),
+            metadata=meta,
+        )
+
+    async def send(self, to: AgentId, msg: Message) -> Response:
+        """Send a message via the transport layer.
+
+        Example::
+
+            resp = await comms.send(AgentId("a2"), msg)
+        """
+        raw = self.serialize(msg)
+        if self._transport is not None:
+            await self._transport.send(to, raw)
+        return Response(success=True)
+
+    async def advertise(self, card: AgentCard) -> None:
+        """Advertise an agent card to the registry.
+
+        Example::
+
+            await comms.advertise(my_card)
+        """
+        if self._registry is not None:
+            await self._registry.register(card)
+
+    async def discover(self, query: Query) -> list[AgentCard]:
+        """Discover agents via the registry.
+
+        Example::
+
+            cards = await comms.discover(Query(capabilities=["sell"]))
+        """
+        if self._registry is not None:
+            result: list[AgentCard] = await self._registry.lookup(query)
+            return result
+        return []

--- a/packages/nest-plugins-reference/tests/test_versioned_comms.py
+++ b/packages/nest-plugins-reference/tests/test_versioned_comms.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the versioned comms plugin."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import pytest
+from nest_core.types import AgentId, Message, MessageId
+from nest_plugins_reference.comms.versioned import (
+    SCHEMA_VERSION,
+    UnsupportedSchemaError,
+    VersionedComms,
+)
+
+
+def _msg(payload: bytes = b"hi", metadata: dict[str, Any] | None = None) -> Message:
+    return Message(
+        id=MessageId("m1"),
+        sender=AgentId("a1"),
+        receiver=AgentId("a2"),
+        payload=payload,
+        metadata=metadata or {},
+    )
+
+
+def _raw(**fields: Any) -> bytes:
+    base: dict[str, Any] = {
+        "id": "m1",
+        "sender": "a1",
+        "receiver": "a2",
+        "payload": base64.b64encode(b"x").decode("ascii"),
+        "correlation_id": None,
+        "timestamp": 0,
+        "metadata": {},
+    }
+    base.update(fields)
+    return json.dumps(base).encode("utf-8")
+
+
+class TestRoundTrip:
+    def test_serialize_stamps_schema_version_and_kind(self) -> None:
+        comms = VersionedComms(AgentId("a1"))
+        data = json.loads(comms.serialize(_msg()))
+        assert data["schema_version"] == SCHEMA_VERSION
+        assert "kind" in data
+
+    def test_roundtrip_preserves_payload_and_parties(self) -> None:
+        comms = VersionedComms(AgentId("a1"))
+        msg = comms.deserialize(comms.serialize(_msg(b"hello")))
+        assert msg.payload == b"hello"
+        assert msg.sender == AgentId("a1")
+        assert msg.receiver == AgentId("a2")
+
+    def test_serialize_is_deterministic(self) -> None:
+        comms = VersionedComms(AgentId("a1"))
+        assert comms.serialize(_msg(b"x")) == comms.serialize(_msg(b"x"))
+
+
+class TestForwardCompat:
+    def test_unknown_field_preserved_through_roundtrip(self) -> None:
+        comms = VersionedComms(AgentId("a1"))
+        msg = comms.deserialize(_raw(schema_version="2.5", kind="greeting", priority="high"))
+        out = json.loads(comms.serialize(msg))
+        assert out["priority"] == "high"
+        assert out["kind"] == "greeting"
+
+    def test_higher_minor_version_accepted(self) -> None:
+        comms = VersionedComms(AgentId("a1"))
+        msg = comms.deserialize(_raw(schema_version="2.9"))
+        assert msg.sender == AgentId("a1")
+
+
+class TestMajorSafety:
+    def test_unsupported_major_raises(self) -> None:
+        comms = VersionedComms(AgentId("a1"))
+        with pytest.raises(UnsupportedSchemaError):
+            comms.deserialize(_raw(schema_version="3.0"))
+
+    def test_malformed_version_raises(self) -> None:
+        comms = VersionedComms(AgentId("a1"))
+        with pytest.raises(UnsupportedSchemaError):
+            comms.deserialize(_raw(schema_version="not-a-version"))
+
+
+class TestBackwardCompat:
+    def test_legacy_envelope_without_version_accepted(self) -> None:
+        comms = VersionedComms(AgentId("a1"))
+        msg = comms.deserialize(_raw())  # no schema_version (nest_native style)
+        assert msg.payload == b"x"
+
+    def test_v1_major_accepted(self) -> None:
+        comms = VersionedComms(AgentId("a1"))
+        msg = comms.deserialize(_raw(schema_version="1.4"))
+        assert msg.sender == AgentId("a1")

--- a/scenarios/comms_versioning.yaml
+++ b/scenarios/comms_versioning.yaml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# Comms schema-versioning scenario: mixed-version agents exchange envelopes.
+# Swap `comms: versioned` for `nest_native` to watch the comms_versioning
+# validators flip from PASS to FAIL (version + unknown fields get dropped, and
+# the unsupported-major message gets blindly forwarded).
+name: comms_versioning
+description: "Mixed v1/v2 agents over a schema-versioned wire format with forward/backward compat."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 4
+  brain: state-machine
+  roles:
+    - name: sender
+      count: 2
+    - name: forwarder
+      count: 1
+    - name: sink
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: versioned
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: comms_versioning
+  config: {}
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 5000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/comms_versioning.jsonl


### PR DESCRIPTION
- plugin: VersionedComms (registered as comms/versioned)
- scenario: comms_versioning + factory (mixed v1/v2 senders, a forwarder that round-trips each envelope through comms, a sink) -> scenarios/comms_versioning.yaml
- validators: 3 adversarial checks (schema_version present, unknown-field preserved, unsupported-major rejected) -- FAIL on nest_native, PASS on versioned
- tests: 17 new (plugin round-trip / forward / backward / major-safety + validators)

Deterministic across seeds 42/7/1337. DoD green: ruff check, ruff format, pyright (0 errors), pytest (356 passed).

## Summary by Sourcery

Introduce a versioned comms plugin and scenario to exercise schema-versioned JSON message envelopes and validate cross-version compatibility and safety.

New Features:
- Add a VersionedComms plugin that serializes messages as schema-versioned JSON envelopes with forward, backward, and major-version safety semantics.
- Add a comms_versioning scenario and YAML configuration to simulate mixed-version agents communicating through the configured comms plugin.

Enhancements:
- Add comms_versioning validators to assert schema_version presence, preservation of unknown fields, and rejection of unsupported major versions.
- Register the new comms plugin and scenario in the core plugin and scenario registries.

Tests:
- Add unit tests for the VersionedComms plugin covering round-trip behavior, forward compatibility, backward compatibility, and major-version rejection semantics.
- Add tests for comms_versioning validators to ensure they pass on versioned traces and fail on legacy nest_native-style traces.
- Extend validator registration tests to cover the new comms_versioning validator group.