### PR TITLE
[Hackathon] stellarminds-ai: Receipt-corroborated reputation with collusion-ring severance

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -26,6 +26,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
+    ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
     ("coordination", "contract_net"): f"{_REF}.coordination.contract_net:ContractNet",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -91,3 +91,9 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.comms_versioning import comms_versioning_factory
 
         register_scenario("comms_versioning", comms_versioning_factory)
+    elif name == "receipt_reputation":
+        from nest_core.scenarios_builtin.receipt_reputation import (
+            receipt_reputation_factory,
+        )
+
+        register_scenario("receipt_reputation", receipt_reputation_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/receipt_reputation.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/receipt_reputation.py
@@ -1,0 +1,391 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Counterparty-corroborated receipt-reputation scenario with a collusion ring.
+
+Three populations issue cross-signed receipts of their interactions, all routed
+to a single **auditor** that owns one live instance of the configured ``trust:``
+plugin (resolved from ``plugins["trust"]``, exactly as the identity-rotation
+scenario resolves the identity class). The auditor ``report()``s every receipt
+into that one global ledger, then — on a final scheduled pulse, strictly after
+all reports are delivered — ``score()``s every agent and emits the score into
+the trace. Because the auditor holds one shared instance, the ledger is global,
+which is what the whole-graph collusion severance needs.
+
+Populations (classified by agent-id prefix so the validator can tell them apart):
+
+* ``honest-<i>`` — N >= 5 honest agents wired into a **directed cycle**
+  (``honest-0 -> honest-1 -> ... -> honest-0``, plus a chord) of valid,
+  mutually-cosigned ``purchase`` receipts. They form a single strongly-connected
+  component strictly larger than the ring, so they are the honest *anchor*.
+* ``ring-<i>`` — a 4-agent **collusion ring** that co-signs *only each other*
+  (all-pairs, both directions) and has **no corroborated edge to the honest
+  anchor**. Every ring receipt is individually valid and corroborated — the
+  attack naive averaging rewards — yet the ring is an isolated dense SCC, so
+  ``agent_receipts`` severs it to score 0.
+* ``byz-<i>`` — ~10% byzantine agents that issue receipts with a **broken
+  co-signature** (a corrupted witness signature). These fail corroboration, so
+  they never enter the corroboration graph and cannot accidentally bridge the
+  ring to the anchor.
+
+Every reported ``Evidence`` carries **both** ``kind="positive"`` (which drives
+the ``score_average`` baseline to reward the ring) **and** ``detail`` = the
+JSON receipt (which drives ``agent_receipts`` to sever it). The same scenario
+therefore fails the adversarial validator under ``trust: score_average`` and
+passes it under ``trust: agent_receipts``.
+
+Trace line protocol (carried in message bodies, ``:``-delimited):
+
+* ``score:<agent>:<score>:<confidence>:<role>`` — the live trust plugin's score
+  for ``agent`` after every receipt was reported. ``role`` is ``honest``,
+  ``ring``, or ``byz``. Scores are formatted to 6 decimals for determinism.
+
+Example::
+
+    agents = receipt_reputation_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Evidence
+
+# The auditor instantiates the trust plugin lazily and imports the receipt
+# builders from the reference plugin so honest/ring receipts are constructed the
+# same way the plugin verifies them. These are scenario-only helpers; importing
+# them here keeps the receipt format in exactly one place.
+from nest_plugins_reference.trust.agent_receipts import (
+    cosign_receipt,
+    did_for_pubkey,
+    sign_receipt,
+)
+
+try:  # pragma: no cover - import guard
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+    _HAVE_CRYPTO = True
+except ImportError:  # pragma: no cover - cryptography is a declared dependency
+    _HAVE_CRYPTO = False
+
+
+def _seed_for(agent: AgentId) -> bytes:
+    """Deterministic 32-byte Ed25519 seed for an agent (matches the plugin).
+
+    Example::
+
+        seed = _seed_for(AgentId("honest-0"))
+    """
+    return hashlib.sha256(str(agent).encode()).digest()[:32]
+
+
+def _did_for(agent: AgentId) -> str:
+    """The receipt identity (hex pubkey) for an agent — matches the plugin's map.
+
+    Example::
+
+        did = _did_for(AgentId("honest-0"))
+    """
+    sk = Ed25519PrivateKey.from_private_bytes(_seed_for(agent))
+    pub = sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    return did_for_pubkey(pub)
+
+
+def _build_receipt(
+    issuer: AgentId,
+    counterparty: AgentId,
+    *,
+    receipt_id: str,
+    category: str = "purchase",
+    valid_cosign: bool = True,
+) -> dict[str, Any]:
+    """Build a signed receipt of ``issuer``'s interaction with ``counterparty``.
+
+    With ``valid_cosign=True`` the counterparty's genuine co-signature is
+    attached (corroborated). With ``valid_cosign=False`` a corrupted witness
+    signature is attached instead, so :func:`is_corroborated` rejects it — the
+    byzantine case.
+
+    Example::
+
+        r = _build_receipt(AgentId("honest-0"), AgentId("honest-1"), receipt_id="r0")
+    """
+    receipt: dict[str, Any] = {
+        "receipt_id": receipt_id,
+        "issuer_did": _did_for(issuer),
+        "action": {"category": category, "counterparty_did": _did_for(counterparty)},
+    }
+    receipt = sign_receipt(receipt, issuer_seed=_seed_for(issuer))
+    if valid_cosign:
+        return cosign_receipt(receipt, counterparty_seed=_seed_for(counterparty))
+    # Byzantine: attach a structurally-present but invalid co-signature.
+    receipt.setdefault("evidence", {})["witness_signatures"] = [
+        {"witness_did": _did_for(counterparty), "signature": "00" * 64}
+    ]
+    return receipt
+
+
+class ReceiptIssuer(StateMachineAgent):
+    """An agent that issues cross-signed receipts of its assigned interactions.
+
+    On start it sends each of its pre-computed receipts to the auditor as a
+    ``receipt:`` message. The agent does no scoring itself — all reputation is
+    computed centrally by the auditor against the configured trust plugin, so
+    the scenario behaves identically regardless of which ``trust:`` plugin the
+    YAML selects.
+
+    Example::
+
+        agent = ReceiptIssuer(AgentId("honest-0"), auditor, receipts)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        auditor: AgentId,
+        receipts: list[dict[str, Any]],
+    ) -> None:
+        self._id = agent_id
+        self._auditor = auditor
+        self._receipts = receipts
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Send every assigned receipt to the auditor.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        for receipt in self._receipts:
+            await ctx.send(self._auditor, b"receipt:" + json.dumps(receipt).encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Issuers receive no messages; present for Protocol completeness.
+
+        Example::
+
+            await agent.on_message(ctx, auditor, b"noop")
+        """
+        return
+
+
+class AuditorAgent(StateMachineAgent):
+    """Owns the single trust instance, reports all receipts, then scores everyone.
+
+    The auditor resolves the configured trust plugin *class* from
+    ``ctx.plugins["trust"]`` on first use and instantiates exactly one instance,
+    so every receipt lands in one global ledger. It schedules a ``finalize:``
+    pulse one tick ahead of the issuers' ``on_start`` so scoring happens strictly
+    after every ``receipt:`` has been reported. On finalize it scores every known
+    agent and emits a ``score:`` line per agent into the trace; the
+    ``receipt_reputation`` validator reads those lines.
+
+    Example::
+
+        auditor = AuditorAgent(AgentId("auditor-0"), roster)
+    """
+
+    def __init__(self, agent_id: AgentId, roster: dict[AgentId, str]) -> None:
+        self._id = agent_id
+        # AgentId -> role ("honest" | "ring" | "byz"), the population labels.
+        self._roster = roster
+        self._trust: Any = None
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Instantiate the trust plugin and schedule the finalize pulse.
+
+        Example::
+
+            await auditor.on_start(ctx)
+        """
+        trust_cls = ctx.plugins.get("trust")
+        # The runner passes the resolved class; instantiate one shared instance.
+        self._trust = trust_cls() if isinstance(trust_cls, type) else trust_cls
+        # Finalize after all issuers' on_start receipts are delivered.
+        await ctx.schedule(1.0, b"finalize:")
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Report each received receipt, then score everyone on finalize.
+
+        Example::
+
+            await auditor.on_message(ctx, issuer, b"receipt:{...}")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if msg.startswith("receipt:"):
+            await self._report(sender, msg[len("receipt:") :])
+            return
+        if msg.startswith("finalize:"):
+            await self._finalize(ctx)
+
+    async def _report(self, issuer: AgentId, receipt_json: str) -> None:
+        """Report one receipt to the trust plugin under its issuer.
+
+        The ``Evidence`` carries ``kind="positive"`` (so ``score_average``
+        rewards it) and ``detail`` = the JSON receipt (so ``agent_receipts``
+        gates it). ``subject`` is the issuer — the agent the receipt is *about*.
+        """
+        if self._trust is None:  # pragma: no cover - on_start always runs first
+            return
+        await self._trust.report(
+            issuer,
+            Evidence(
+                reporter=self._id,
+                subject=issuer,
+                kind="positive",
+                detail=receipt_json,
+            ),
+        )
+
+    async def _finalize(self, ctx: AgentContext) -> None:
+        """Score every agent and emit one ``score:`` trace line per agent."""
+        if self._trust is None:  # pragma: no cover - on_start always runs first
+            return
+        for agent in sorted(self._roster, key=str):
+            role = self._roster[agent]
+            rep = await self._trust.score(agent)
+            await ctx.broadcast(
+                f"score:{agent}:{rep.score:.6f}:{rep.confidence:.6f}:{role}".encode()
+            )
+
+
+def _partition(
+    config: ScenarioConfig,
+) -> tuple[list[AgentId], list[AgentId], list[AgentId]]:
+    """Split the agent budget into honest (>=5), a 4-agent ring, and ~10% byzantine.
+
+    Honest count is whatever remains after reserving the auditor, the 4 ring
+    members, and the byzantine fraction — clamped to a minimum of 5 so the honest
+    anchor is always strictly larger than the ring. ``roles:`` in the YAML, if
+    present, override the honest/ring/byzantine counts.
+
+    Example::
+
+        honest, ring, byz = _partition(config)
+    """
+    task_config = config.task.config
+    ring_size = int(task_config.get("ring_size", 4))
+    byzantine_fraction = config.failures.byzantine_agents or task_config.get(
+        "byzantine_fraction", 0.10
+    )
+
+    issuer_budget = max(1, config.agents.count - 1)  # minus the auditor
+    byz_count = int(issuer_budget * byzantine_fraction)
+    honest_count = max(5, issuer_budget - ring_size - byz_count)
+
+    if config.agents.roles:
+        for role in config.agents.roles:
+            if role.name == "honest":
+                honest_count = max(5, role.count)
+            elif role.name == "ring":
+                ring_size = role.count
+            elif role.name == "byzantine":
+                byz_count = role.count
+
+    honest = [AgentId(f"honest-{i}") for i in range(honest_count)]
+    ring = [AgentId(f"ring-{i}") for i in range(ring_size)]
+    byz = [AgentId(f"byz-{i}") for i in range(byz_count)]
+    return honest, ring, byz
+
+
+def _honest_receipts(honest: list[AgentId]) -> dict[AgentId, list[dict[str, Any]]]:
+    """Assign each honest agent receipts forming a single strongly-connected cycle.
+
+    ``honest-i`` issues a corroborated receipt to ``honest-(i+1)`` and a chord to
+    ``honest-(i+2)``, so the honest population is one SCC of size ``len(honest)``.
+
+    Example::
+
+        receipts = _honest_receipts([AgentId("honest-0"), ...])
+    """
+    n = len(honest)
+    out: dict[AgentId, list[dict[str, Any]]] = {a: [] for a in honest}
+    for i, issuer in enumerate(honest):
+        for k in (1, 2):
+            cp = honest[(i + k) % n]
+            out[issuer].append(
+                _build_receipt(issuer, cp, receipt_id=f"{issuer}->{cp}", valid_cosign=True)
+            )
+    return out
+
+
+def _ring_receipts(ring: list[AgentId]) -> dict[AgentId, list[dict[str, Any]]]:
+    """Assign the ring all-pairs mutual co-signed receipts (a dense isolated SCC).
+
+    Example::
+
+        receipts = _ring_receipts([AgentId("ring-0"), ...])
+    """
+    out: dict[AgentId, list[dict[str, Any]]] = {a: [] for a in ring}
+    for i, issuer in enumerate(ring):
+        for j, cp in enumerate(ring):
+            if i == j:
+                continue
+            out[issuer].append(
+                _build_receipt(issuer, cp, receipt_id=f"{issuer}->{cp}", valid_cosign=True)
+            )
+    return out
+
+
+def _byzantine_receipts(
+    byz: list[AgentId],
+    honest: list[AgentId],
+) -> dict[AgentId, list[dict[str, Any]]]:
+    """Assign byzantine agents receipts with a broken co-signature (uncorroborated).
+
+    Each targets an honest agent but cannot produce a valid co-signature, so the
+    receipt is dropped from the corroboration graph and earns nothing under
+    ``agent_receipts`` while still being reported as ``kind="positive"``.
+
+    Example::
+
+        receipts = _byzantine_receipts([AgentId("byz-0")], honest)
+    """
+    out: dict[AgentId, list[dict[str, Any]]] = {a: [] for a in byz}
+    for i, issuer in enumerate(byz):
+        cp = honest[i % len(honest)] if honest else issuer
+        out[issuer].append(
+            _build_receipt(issuer, cp, receipt_id=f"{issuer}->{cp}", valid_cosign=False)
+        )
+    return out
+
+
+def receipt_reputation_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create honest issuers, a collusion ring, byzantine agents, and one auditor.
+
+    The auditor owns the single configured trust instance and computes every
+    agent's reputation centrally, so the same scenario runs unchanged under
+    ``trust: score_average`` (ring rewarded → validator FAILs) and
+    ``trust: agent_receipts`` (ring severed → validator PASSes).
+
+    Example::
+
+        agents = receipt_reputation_factory(config, plugins)
+    """
+    honest, ring, byz = _partition(config)
+
+    assignments: dict[AgentId, list[dict[str, Any]]] = {}
+    assignments.update(_honest_receipts(honest))
+    assignments.update(_ring_receipts(ring))
+    assignments.update(_byzantine_receipts(byz, honest))
+
+    roster: dict[AgentId, str] = {}
+    for a in honest:
+        roster[a] = "honest"
+    for a in ring:
+        roster[a] = "ring"
+    for a in byz:
+        roster[a] = "byz"
+
+    auditor_id = AgentId("auditor-0")
+    agents: dict[AgentId, StateMachineAgent] = {}
+    for agent, receipts in assignments.items():
+        agents[agent] = ReceiptIssuer(agent, auditor=auditor_id, receipts=receipts)
+    agents[auditor_id] = AuditorAgent(auditor_id, roster=roster)
+    return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/receipt_reputation.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/receipt_reputation.py
@@ -49,9 +49,8 @@ import hashlib
 import json
 from typing import Any
 
-from nest_core.scenario import ScenarioConfig
-from nest_core.sim.agent import AgentContext, StateMachineAgent
-from nest_core.types import AgentId, Evidence
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 # The auditor instantiates the trust plugin lazily and imports the receipt
 # builders from the reference plugin so honest/ring receipts are constructed the
@@ -63,13 +62,9 @@ from nest_plugins_reference.trust.agent_receipts import (
     sign_receipt,
 )
 
-try:  # pragma: no cover - import guard
-    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
-
-    _HAVE_CRYPTO = True
-except ImportError:  # pragma: no cover - cryptography is a declared dependency
-    _HAVE_CRYPTO = False
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Evidence
 
 
 def _seed_for(agent: AgentId) -> bytes:

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1668,6 +1668,173 @@ def validate_comms_no_silent_drop(
 
 
 # ---------------------------------------------------------------------------
+# Receipt-reputation (collusion-ring) validators
+# ---------------------------------------------------------------------------
+
+# An effectively-severed reputation is anything at or below this. A severed ring
+# member scores exactly 0.0 under ``agent_receipts``; ``score_average`` rewards
+# the (all-positive) ring to ~1.0, far above this floor.
+_RING_SEVERED_MAX = 1e-6
+
+
+def _collect_scores(events: list[dict[str, Any]]) -> dict[str, tuple[float, float, str]]:
+    """Parse ``score:<agent>:<score>:<confidence>:<role>`` lines from the trace.
+
+    Returns ``agent -> (score, confidence, role)`` using the *last* score line
+    seen for each agent (the finalize pass emits one per agent). The scores are
+    produced by the live trust plugin, so this dict differs by configured plugin
+    -- which is what lets the validator discriminate.
+
+    Example::
+
+        scores = _collect_scores(events)
+    """
+    scores: dict[str, tuple[float, float, str]] = {}
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("score:"):
+            continue
+        parts = msg.split(":")
+        if len(parts) < 5:
+            continue
+        agent, score_raw, conf_raw, role = parts[1], parts[2], parts[3], parts[4]
+        try:
+            score = float(score_raw)
+            confidence = float(conf_raw)
+        except ValueError:
+            continue
+        scores[agent] = (score, confidence, role)
+    return scores
+
+
+def validate_receipt_reputation_ring_severed(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """The isolated collusion ring is severed while honest agents are retained.
+
+    Reads the trust plugin's own ``score:`` lines from the trace (never recomputes
+    reputation itself -- the discrimination must come from the configured plugin).
+    The protocol holds iff:
+
+    * at least one ``ring`` agent and one ``honest`` agent were scored (the
+      scenario actually exercised both populations),
+    * **every** ``ring`` agent scored ``<= 1e-6`` (its wash-traded reputation was
+      severed to ~0), and
+    * **every** ``honest`` agent scored ``> 1e-6`` (the honest anchor retained
+      its corroborated reputation -- guards against a degenerate all-zero plugin).
+
+    ``trust: score_average`` FAILS this: it has no notion of corroboration and
+    rewards the ring's all-positive reports to ~1.0. ``trust: agent_receipts``
+    PASSES: the ring is an isolated dense SCC that collusion severance voids,
+    while the honest cycle is the anchor. A plugin that emits no ``score:`` lines
+    (or scores everyone 0) also fails -- without crashing.
+
+    Example::
+
+        results = validate_receipt_reputation_ring_severed(events)
+    """
+    scores = _collect_scores(events)
+    ring = {a: s for a, (s, _c, role) in scores.items() if role == "ring"}
+    honest = {a: s for a, (s, _c, role) in scores.items() if role == "honest"}
+
+    if not ring or not honest:
+        return [
+            ValidationResult(
+                "receipt_reputation_ring_severed",
+                False,
+                f"missing populations: {len(ring)} ring, {len(honest)} honest scored",
+            )
+        ]
+
+    rewarded_ring = {a: s for a, s in ring.items() if s > _RING_SEVERED_MAX}
+    dropped_honest = {a: s for a, s in honest.items() if s <= _RING_SEVERED_MAX}
+
+    problems: list[str] = []
+    if rewarded_ring:
+        problems.append(
+            "ring not severed: "
+            + ", ".join(f"{a}={s:.4f}" for a, s in sorted(rewarded_ring.items()))
+        )
+    if dropped_honest:
+        problems.append(
+            "honest not retained: "
+            + ", ".join(f"{a}={s:.4f}" for a, s in sorted(dropped_honest.items()))
+        )
+
+    if problems:
+        return [ValidationResult("receipt_reputation_ring_severed", False, "; ".join(problems))]
+    return [
+        ValidationResult(
+            "receipt_reputation_ring_severed",
+            True,
+            f"{len(ring)} ring agents severed to ~0, {len(honest)} honest agents retained",
+        )
+    ]
+
+
+def validate_receipt_reputation_honest_confidence(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Honest agents carry positive corroboration confidence; the ring does not.
+
+    A second, independent invariant: ``confidence`` (corroboration rate) must be
+    positive for every honest agent and zero for every severed ring agent. This
+    distinguishes a real collusion-resistant plugin from one that merely zeroes
+    the ring's score by accident -- the ring's *confidence* collapsing to 0 is the
+    signal that its corroborations were voided, not just its weights.
+
+    ``score_average`` reports a non-zero confidence for the ring (it counts
+    samples), so it FAILS; ``agent_receipts`` reports ring confidence 0 and
+    honest confidence > 0, so it PASSES.
+
+    Example::
+
+        results = validate_receipt_reputation_honest_confidence(events)
+    """
+    scores = _collect_scores(events)
+    ring_conf = {a: c for a, (_s, c, role) in scores.items() if role == "ring"}
+    honest_conf = {a: c for a, (_s, c, role) in scores.items() if role == "honest"}
+
+    if not ring_conf or not honest_conf:
+        return [
+            ValidationResult(
+                "receipt_reputation_honest_confidence",
+                False,
+                f"missing populations: {len(ring_conf)} ring, {len(honest_conf)} honest scored",
+            )
+        ]
+
+    ring_corroborated = {a: c for a, c in ring_conf.items() if c > _RING_SEVERED_MAX}
+    honest_uncorroborated = {a: c for a, c in honest_conf.items() if c <= _RING_SEVERED_MAX}
+
+    problems: list[str] = []
+    if ring_corroborated:
+        problems.append(
+            "ring retains corroboration confidence: "
+            + ", ".join(f"{a}={c:.4f}" for a, c in sorted(ring_corroborated.items()))
+        )
+    if honest_uncorroborated:
+        problems.append(
+            "honest lacks corroboration confidence: "
+            + ", ".join(f"{a}={c:.4f}" for a, c in sorted(honest_uncorroborated.items()))
+        )
+
+    if problems:
+        return [
+            ValidationResult("receipt_reputation_honest_confidence", False, "; ".join(problems))
+        ]
+    return [
+        ValidationResult(
+            "receipt_reputation_honest_confidence",
+            True,
+            f"{len(honest_conf)} honest corroborated, {len(ring_conf)} ring collapsed to 0",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -1717,5 +1884,9 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_streaming_conservation,
         validate_streaming_no_drain_after_close,
         validate_streaming_no_overbill_on_partition,
+    ],
+    "receipt_reputation": [
+        validate_receipt_reputation_ring_severed,
+        validate_receipt_reputation_honest_confidence,
     ],
 }

--- a/packages/nest-core/tests/test_receipt_reputation.py
+++ b/packages/nest-core/tests/test_receipt_reputation.py
@@ -26,11 +26,13 @@ _SCENARIO_YAML = (
 )
 
 
-def _config(trust: str, trace: Path) -> ScenarioConfig:
-    """Load the scenario YAML, override the trust plugin and trace path."""
+def _config(trust: str, trace: Path, seed: int | None = None) -> ScenarioConfig:
+    """Load the scenario YAML, override the trust plugin, seed, and trace path."""
     config = ScenarioConfig.from_yaml(_SCENARIO_YAML)
     config.layers.trust = trust
     config.output.trace = str(trace)
+    if seed is not None:
+        config.seed = seed
     return config
 
 
@@ -39,10 +41,13 @@ def _results(trace: Path) -> dict[str, bool]:
 
 
 class TestAdversarialProof:
+    # Seed-bank robustness: the leaderboard re-runs under multiple seeds, so the
+    # adversarial proof must hold across the bank, not just the default seed.
     @pytest.mark.asyncio
-    async def test_validator_passes_under_agent_receipts(self, tmp_path: Path) -> None:
-        trace = tmp_path / "ours.jsonl"
-        await ScenarioRunner(_config("agent_receipts", trace)).run()
+    @pytest.mark.parametrize("seed", [1, 7, 42, 123, 9999])
+    async def test_validator_passes_under_agent_receipts(self, tmp_path: Path, seed: int) -> None:
+        trace = tmp_path / f"ours_{seed}.jsonl"
+        await ScenarioRunner(_config("agent_receipts", trace, seed=seed)).run()
         results = _results(trace)
         assert results["receipt_reputation_ring_severed"] is True
         assert results["receipt_reputation_honest_confidence"] is True

--- a/packages/nest-core/tests/test_receipt_reputation.py
+++ b/packages/nest-core/tests/test_receipt_reputation.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end tests for the receipt_reputation scenario + adversarial validator.
+
+The headline assertions are the adversarial proof the charter requires:
+
+* the ``receipt_reputation`` validator **FAILS** under ``trust: score_average``
+  (the collusion ring is rewarded), and
+* **PASSES** under ``trust: agent_receipts`` (the ring is severed to ~0, honest
+  agents retained),
+
+plus a byte-level determinism check (same seed -> identical trace sha256).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+
+_SCENARIO_YAML = (
+    Path(__file__).parent.parent.parent.parent / "scenarios" / "receipt_reputation.yaml"
+)
+
+
+def _config(trust: str, trace: Path) -> ScenarioConfig:
+    """Load the scenario YAML, override the trust plugin and trace path."""
+    config = ScenarioConfig.from_yaml(_SCENARIO_YAML)
+    config.layers.trust = trust
+    config.output.trace = str(trace)
+    return config
+
+
+def _results(trace: Path) -> dict[str, bool]:
+    return {r.name: r.passed for r in validate_trace(trace, "receipt_reputation")}
+
+
+class TestAdversarialProof:
+    @pytest.mark.asyncio
+    async def test_validator_passes_under_agent_receipts(self, tmp_path: Path) -> None:
+        trace = tmp_path / "ours.jsonl"
+        await ScenarioRunner(_config("agent_receipts", trace)).run()
+        results = _results(trace)
+        assert results["receipt_reputation_ring_severed"] is True
+        assert results["receipt_reputation_honest_confidence"] is True
+
+    @pytest.mark.asyncio
+    async def test_validator_fails_under_score_average(self, tmp_path: Path) -> None:
+        trace = tmp_path / "baseline.jsonl"
+        await ScenarioRunner(_config("score_average", trace)).run()
+        results = _results(trace)
+        # The whole point: the naive baseline rewards the wash-trading ring.
+        assert results["receipt_reputation_ring_severed"] is False
+        assert results["receipt_reputation_honest_confidence"] is False
+
+
+class TestDeterminism:
+    @pytest.mark.asyncio
+    async def test_same_seed_identical_trace(self, tmp_path: Path) -> None:
+        t1 = tmp_path / "run1.jsonl"
+        t2 = tmp_path / "run2.jsonl"
+        await ScenarioRunner(_config("agent_receipts", t1)).run()
+        await ScenarioRunner(_config("agent_receipts", t2)).run()
+        h1 = hashlib.sha256(t1.read_bytes()).hexdigest()
+        h2 = hashlib.sha256(t2.read_bytes()).hexdigest()
+        assert h1 == h2
+
+
+class TestScenarioShape:
+    @pytest.mark.asyncio
+    async def test_emits_score_lines_for_every_population(self, tmp_path: Path) -> None:
+        trace = tmp_path / "shape.jsonl"
+        await ScenarioRunner(_config("agent_receipts", trace)).run()
+        text = trace.read_text()
+        assert "score:honest-0:" in text
+        assert "score:ring-0:" in text
+        assert "score:byz-0:" in text
+
+    @pytest.mark.asyncio
+    async def test_byzantine_uncorroborated_scores_zero(self, tmp_path: Path) -> None:
+        """Byzantine receipts have broken co-signatures, so they earn nothing."""
+        trace = tmp_path / "byz.jsonl"
+        await ScenarioRunner(_config("agent_receipts", trace)).run()
+        # the byzantine agent's emitted score must be 0 under our plugin
+        line = next(ln for ln in trace.read_text().splitlines() if "score:byz-0:" in ln)
+        # ...:score:byz-0:<score>:<conf>:byz...
+        body = line.split("score:byz-0:", 1)[1]
+        score = float(body.split(":")[0])
+        assert score == 0.0

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -753,6 +753,7 @@ class TestValidatorRegistry:
             "memory_concurrent_writers",
             "streaming_payments",
             "comms_versioning",
+            "receipt_reputation",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py
@@ -103,7 +103,7 @@ DEFAULT_CATEGORY_WEIGHTS: dict[str, float] = {
 # from saturating too fast preserves ordering between agents with more history.
 NORMALIZATION_K = 10.0
 
-# Collusion thresholds (VRP nanda-rep/0.2 §B). A non-anchor component isolated
+# Collusion-ring severance thresholds. A non-anchor component isolated
 # from the honest anchor is severed if it is a dense ring or a mutual-only pair.
 RING_MIN_SIZE = 3
 RING_MIN_DENSITY = 0.8

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py
@@ -1,0 +1,640 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Counterparty-corroborated receipt reputation with collusion-ring severance.
+
+This trust plugin derives an agent's reputation from **cross-signed receipts**
+of real interactions, not from a running mean of self-asserted feedback (the
+``score_average`` reference baseline). The threat it is built to defeat is
+**wash-traded reputation**: a Sybil/collusion ring whose members co-sign each
+other's receipts to manufacture a glowing history. Naive averaging (and an
+undefended EigenTrust seeded uniformly) *rewards* that ring; this plugin
+**severs** it.
+
+A receipt only builds reputation if it clears three independent gates:
+
+1. **Valid** — its Ed25519 issuer signature verifies (:func:`_verify_receipt`).
+2. **Corroborated** — the *distinct* counterparty named in the receipt
+   co-signed the same interaction (:func:`is_corroborated`). One party cannot
+   fabricate a corroborated receipt alone; it needs the counterparty's key.
+3. **Not collusion-severed** — the receipt does not sit inside a collusion
+   component that the corroboration graph isolates from the honest anchor
+   (:func:`_severed_dids`, Tarjan strongly-connected components).
+
+Gate 3 is the novel part. Corroboration alone is gameable: a set of
+distinct-but-colluding identities can mutually co-sign. So we build the directed
+corroboration graph over all agents (issuer -> counterparty, over valid +
+corroborated receipts), take its strongly-connected components, treat the
+**largest** SCC as the honest anchor, and void corroborations from any *other*
+component that is (a) isolated from the anchor (no cross-traffic) and (b) either
+a dense ring (size >= 3, internal density >= 0.8) or a mutual-only pair. A
+severed member's wash-traded receipts — individually corroborated though they
+are — contribute nothing, so it collapses to score 0 / confidence 0, while
+honest agents in the anchor retain their full corroborated score.
+
+This is **self-contained**: it depends only on the standard library and
+``cryptography`` (already used by the ``ed25519_rotating`` reference identity).
+Receipts are plain ``dict`` documents; canonicalization is sorted-key JSON; an
+agent's identity is the lowercase hex of its raw 32-byte Ed25519 public key.
+
+NEST's ``Evidence`` has no receipt field, so a cross-signed receipt rides as
+JSON in ``evidence.detail``. Stock scenarios (e.g. the marketplace) pass a
+plain-string ``detail``; those fall back to the reference score-average
+heuristic so this plugin still works as a drop-in ``trust:`` replacement.
+
+Registered under ``("trust", "agent_receipts")`` in ``nest_core.plugins``.
+
+Example::
+
+    trust = AgentReceiptsTrust()
+    await trust.report(
+        AgentId("a1"),
+        Evidence(reporter=r, subject=s, kind="positive", detail=json.dumps(receipt)),
+    )
+    rep = await trust.score(AgentId("a1"))
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+from typing import Any, cast
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from nest_core.types import (
+    AgentId,
+    Attestation,
+    Claim,
+    Evidence,
+    ReputationScore,
+    Signature,
+)
+
+logger = logging.getLogger(__name__)
+
+ALGORITHM = "ed25519"
+
+# Per-category weights, published as part of the scoring method. Consequential
+# actions count for more than routine ones; administrative categories are
+# reputation-neutral; a breached commitment earns nothing. A wash-trading ring
+# typically mints high-value categories (purchase/payment), so the severance is
+# what stops those weights from accruing.
+DEFAULT_CATEGORY_WEIGHTS: dict[str, float] = {
+    "purchase": 5.0,
+    "payment_sent": 5.0,
+    "payment_received": 5.0,
+    "commitment_fulfilled": 4.0,
+    "commitment_breached": 0.0,
+    "attestation_issued": 2.0,
+    "data_shared": 2.0,
+    "message_sent": 1.0,
+    "other": 0.0,
+}
+
+# Saturation constant for the unbounded weight sum -> [0, 1] map
+# (``1 - exp(-raw/K)``). A single corroborated 'purchase' receipt is raw=5.0,
+# which K=10 maps to ~0.39; raw=10 -> 0.63; raw=30 -> 0.95. Keeping the curve
+# from saturating too fast preserves ordering between agents with more history.
+NORMALIZATION_K = 10.0
+
+# Collusion thresholds (VRP nanda-rep/0.2 §B). A non-anchor component isolated
+# from the honest anchor is severed if it is a dense ring or a mutual-only pair.
+RING_MIN_SIZE = 3
+RING_MIN_DENSITY = 0.8
+
+
+# ---------------------------------------------------------------------------
+# Self-contained Ed25519 + canonicalization helpers
+# ---------------------------------------------------------------------------
+
+
+def did_for_pubkey(pubkey: bytes) -> str:
+    """Return the lowercase-hex identity string for a raw 32-byte Ed25519 key.
+
+    A receipt names its issuer and counterparty by this string. Using hex of
+    the raw public key (rather than a base58 ``did:key``) keeps the plugin
+    dependency-free while remaining a stable, collision-free identity.
+
+    Example::
+
+        did = did_for_pubkey(pubkey_bytes)
+    """
+    return pubkey.hex()
+
+
+def _canonical(obj: Any) -> bytes:
+    """Deterministically serialize ``obj`` to bytes for signing/verification.
+
+    Sorted keys + compact separators give byte-identical output for equal
+    documents across processes and runs, which both the issuer and the
+    counterparty rely on so their signatures cover identical bytes.
+
+    Example::
+
+        payload = _canonical({"action": {"category": "purchase"}})
+    """
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _issuer_payload(receipt: dict[str, Any]) -> bytes:
+    """Canonical bytes the *issuer* signs: the receipt minus its signatures.
+
+    Drops the top-level ``signature`` and ``evidence.witness_signatures`` so the
+    signed bytes describe *what happened* (action, parties) independent of any
+    signature carrier.
+
+    Example::
+
+        payload = _issuer_payload(receipt)
+    """
+    core = {k: v for k, v in receipt.items() if k != "signature"}
+    evidence = core.get("evidence")
+    if isinstance(evidence, dict):
+        trimmed = {k: v for k, v in evidence.items() if k != "witness_signatures"}
+        if trimmed:
+            core["evidence"] = trimmed
+        else:
+            core.pop("evidence", None)
+    return _canonical(core)
+
+
+def _corroboration_payload(receipt: dict[str, Any]) -> bytes:
+    """Canonical bytes a *counterparty* co-signs.
+
+    Identical to :func:`_issuer_payload`: the counterparty attests the same
+    interaction the issuer signed, without depending on the issuer's signature.
+
+    Example::
+
+        payload = _corroboration_payload(receipt)
+    """
+    return _issuer_payload(receipt)
+
+
+def _verify_ed25519(pubkey_hex: str, signature_hex: str, payload: bytes) -> bool:
+    """Verify a hex Ed25519 signature over ``payload`` under a hex public key.
+
+    Returns ``False`` (never raises) on malformed hex, a wrong-length key, or an
+    invalid signature, so a hostile receipt can never crash verification.
+
+    Example::
+
+        ok = _verify_ed25519(pub_hex, sig_hex, b"payload")
+    """
+    try:
+        pub = bytes.fromhex(pubkey_hex)
+        sig = bytes.fromhex(signature_hex)
+        Ed25519PublicKey.from_public_bytes(pub).verify(sig, payload)
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+    return True
+
+
+def _verify_receipt(receipt: dict[str, Any]) -> bool:
+    """Return whether a receipt's issuer signature verifies.
+
+    The issuer is named by ``issuer_did`` (hex pubkey) and signs
+    :func:`_issuer_payload`; the signature rides in top-level ``signature``.
+
+    Example::
+
+        ok = _verify_receipt(receipt)
+    """
+    issuer = receipt.get("issuer_did")
+    sig = receipt.get("signature")
+    if not isinstance(issuer, str) or not isinstance(sig, str):
+        return False
+    return _verify_ed25519(issuer, sig, _issuer_payload(receipt))
+
+
+def _counterparty(receipt: dict[str, Any]) -> str | None:
+    """The counterparty did iff present and distinct from the issuer.
+
+    Self-corroboration (issuer == counterparty) is rejected: an agent cannot
+    corroborate its own receipt.
+
+    Example::
+
+        cp = _counterparty(receipt)
+    """
+    cp = (receipt.get("action") or {}).get("counterparty_did")
+    if isinstance(cp, str) and cp and cp != receipt.get("issuer_did"):
+        return cp
+    return None
+
+
+def is_corroborated(receipt: dict[str, Any]) -> bool:
+    """Return whether a *distinct* counterparty co-signed this receipt.
+
+    There must be a ``evidence.witness_signatures`` entry whose ``witness_did``
+    equals the receipt's ``counterparty_did`` and whose signature verifies over
+    the corroboration payload. Fully recomputable from the receipt alone.
+
+    Example::
+
+        corroborated = is_corroborated(receipt)
+    """
+    cp = _counterparty(receipt)
+    if cp is None:
+        return False
+    witnesses = (receipt.get("evidence") or {}).get("witness_signatures") or []
+    payload = _corroboration_payload(receipt)
+    for entry in witnesses:
+        if not isinstance(entry, dict) or entry.get("witness_did") != cp:
+            continue
+        if _verify_ed25519(cp, str(entry.get("signature", "")), payload):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Collusion severance (Tarjan SCC over the corroboration graph)
+# ---------------------------------------------------------------------------
+
+
+def _corroboration_graph(receipts: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+    """Directed multigraph over valid, corroborated receipts: issuer -> counterparty.
+
+    Example::
+
+        graph = _corroboration_graph(receipts)
+    """
+    graph: dict[str, dict[str, int]] = {}
+    for r in receipts:
+        if not _verify_receipt(r) or not is_corroborated(r):
+            continue
+        a = str(r.get("issuer_did", ""))
+        b = _counterparty(r) or ""
+        graph.setdefault(a, {})
+        graph.setdefault(b, {})
+        graph[a][b] = graph[a].get(b, 0) + 1
+    return graph
+
+
+def _sccs(graph: dict[str, dict[str, int]]) -> list[list[str]]:
+    """Tarjan strongly-connected components, deterministic; largest first.
+
+    Iterative (explicit stack) so deep graphs cannot blow the recursion limit.
+    Components are sorted internally and the result is ordered by descending
+    size then lexicographically, so the honest anchor (the largest SCC) is
+    always ``result[0]`` for a given graph.
+
+    Example::
+
+        comps = _sccs({"a": {"b": 1}, "b": {"a": 1}})
+    """
+    index: dict[str, int] = {}
+    low: dict[str, int] = {}
+    on_stack: set[str] = set()
+    scc_stack: list[str] = []
+    comps: list[list[str]] = []
+    counter = 0
+
+    for root in sorted(graph):
+        if root in index:
+            continue
+        # work stack holds (vertex, iterator-position over sorted successors)
+        work: list[tuple[str, int]] = [(root, 0)]
+        while work:
+            v, i = work[-1]
+            if i == 0:
+                index[v] = low[v] = counter
+                counter += 1
+                scc_stack.append(v)
+                on_stack.add(v)
+            succ = sorted(graph.get(v, {}))
+            if i < len(succ):
+                work[-1] = (v, i + 1)
+                w = succ[i]
+                if w not in index:
+                    work.append((w, 0))
+                elif w in on_stack:
+                    low[v] = min(low[v], index[w])
+            else:
+                if low[v] == index[v]:
+                    comp: list[str] = []
+                    while True:
+                        w = scc_stack.pop()
+                        on_stack.discard(w)
+                        comp.append(w)
+                        if w == v:
+                            break
+                    comps.append(sorted(comp))
+                work.pop()
+                if work:
+                    parent = work[-1][0]
+                    low[parent] = min(low[parent], low[v])
+
+    return sorted(comps, key=lambda c: (-len(c), c))
+
+
+def _internal_density(graph: dict[str, dict[str, int]], members: set[str]) -> float:
+    """Fraction of possible directed intra-component edges that are present.
+
+    Example::
+
+        d = _internal_density(graph, {"a", "b", "c"})
+    """
+    if len(members) < 2:
+        return 0.0
+    edges = sum(1 for a in members for b in graph.get(a, {}) if b in members and b != a)
+    possible = len(members) * (len(members) - 1)
+    return edges / possible if possible else 0.0
+
+
+def _cross_edges(graph: dict[str, dict[str, int]], comp: set[str], other: set[str]) -> int:
+    """Count directed edges crossing between ``comp`` and ``other`` (either way).
+
+    Example::
+
+        n = _cross_edges(graph, ring, anchor)
+    """
+    out = sum(1 for a in comp for b in graph.get(a, {}) if b in other)
+    inc = sum(1 for a in other for b in graph.get(a, {}) if b in comp)
+    return out + inc
+
+
+def _severed_dids(graph: dict[str, dict[str, int]]) -> set[str]:
+    """Dids in collusion structure isolated from the honest anchor.
+
+    The largest SCC is the honest anchor. Any *other* SCC with no cross-edges to
+    the anchor is severed iff it is a dense ring (size >= ``RING_MIN_SIZE``,
+    density >= ``RING_MIN_DENSITY``) or a mutual-only pair. Returns the set of
+    severed identities.
+
+    Example::
+
+        severed = _severed_dids(_corroboration_graph(receipts))
+    """
+    comps = _sccs(graph)
+    if not comps:
+        return set()
+    anchor = set(comps[0])
+    severed: set[str] = set()
+    for comp in comps[1:]:
+        members = set(comp)
+        if _cross_edges(graph, members, anchor) > 0:
+            continue  # an honest agent transacted with it — not isolated
+        if len(members) >= RING_MIN_SIZE and _internal_density(graph, members) >= RING_MIN_DENSITY:
+            severed |= members
+        elif len(members) == 2:
+            a, b = comp
+            if b in graph.get(a, {}) and a in graph.get(b, {}):
+                severed |= members
+    return severed
+
+
+def _effective_receipts(receipts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Receipts that are valid, corroborated, and not collusion-severed.
+
+    Example::
+
+        eff = _effective_receipts(ledger)
+    """
+    severed = _severed_dids(_corroboration_graph(receipts))
+    out: list[dict[str, Any]] = []
+    for r in receipts:
+        if not _verify_receipt(r) or not is_corroborated(r):
+            continue
+        if str(r.get("issuer_did", "")) in severed or _counterparty(r) in severed:
+            continue
+        out.append(r)
+    return out
+
+
+def _raw_reputation(receipts: list[dict[str, Any]], weights: dict[str, float]) -> float:
+    """Sum category weights over the effective receipts (unbounded).
+
+    Example::
+
+        raw = _raw_reputation(eff, DEFAULT_CATEGORY_WEIGHTS)
+    """
+    return sum(
+        weights.get((r.get("action") or {}).get("category", ""), 0.0)
+        for r in receipts
+    )
+
+
+def _normalize(raw: float) -> float:
+    """Map an unbounded non-negative reputation to ``[0, 1]`` via ``1 - exp(-raw/K)``.
+
+    Example::
+
+        s = _normalize(5.0)  # ~0.39 at K=10
+    """
+    if raw <= 0.0:
+        return 0.0
+    return 1.0 - math.exp(-raw / NORMALIZATION_K)
+
+
+# ---------------------------------------------------------------------------
+# Receipt construction (used by scenarios and tests)
+# ---------------------------------------------------------------------------
+
+
+def sign_receipt(receipt: dict[str, Any], *, issuer_seed: bytes) -> dict[str, Any]:
+    """Return ``receipt`` with the issuer's Ed25519 signature attached.
+
+    ``issuer_seed`` is the issuer's 32-byte private seed; its ``issuer_did`` must
+    already be set to the hex of the matching public key. The signature covers
+    :func:`_issuer_payload`.
+
+    Example::
+
+        signed = sign_receipt(receipt, issuer_seed=seed)
+    """
+    sk = Ed25519PrivateKey.from_private_bytes(issuer_seed)
+    sig = sk.sign(_issuer_payload(receipt))
+    return {**receipt, "signature": sig.hex()}
+
+
+def cosign_receipt(receipt: dict[str, Any], *, counterparty_seed: bytes) -> dict[str, Any]:
+    """Return ``receipt`` with a counterparty co-signature appended.
+
+    Appends ``{"witness_did", "signature"}`` to ``evidence.witness_signatures``,
+    where ``witness_did`` is the hex of the counterparty's public key and the
+    signature covers :func:`_corroboration_payload`. The signer SHOULD be the
+    receipt's ``counterparty_did``.
+
+    Example::
+
+        corroborated = cosign_receipt(signed, counterparty_seed=cp_seed)
+    """
+    sk = Ed25519PrivateKey.from_private_bytes(counterparty_seed)
+    witness_did = sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw).hex()
+    sig = sk.sign(_corroboration_payload(receipt))
+    entry = {"witness_did": witness_did, "signature": sig.hex()}
+    out = json.loads(json.dumps(receipt))  # deep copy via round-trip
+    evidence = out.setdefault("evidence", {})
+    evidence.setdefault("witness_signatures", []).append(entry)
+    return cast("dict[str, Any]", out)
+
+
+# ---------------------------------------------------------------------------
+# The trust plugin
+# ---------------------------------------------------------------------------
+
+
+class AgentReceiptsTrust:
+    """Receipt-based, collusion-resistant reputation implementing the ``Trust`` Protocol.
+
+    The constructor is no-arg-callable — the NEST runner does ``trust_cls()`` — so
+    this plugin mints its own deterministic Ed25519 identity (for attestations)
+    and holds one global ledger of every reported receipt. Because severance is a
+    whole-graph property, scoring any single agent reduces the *whole* ledger to
+    its globally-effective subset first.
+
+    Example::
+
+        trust = AgentReceiptsTrust()
+        rep = await trust.score(AgentId("a1"))
+    """
+
+    _SYSTEM_AGENT = AgentId("trust:agent_receipts")
+
+    def __init__(self, identity: Any = None) -> None:
+        # ``identity`` is accepted for parity with ScoreAverageTrust's ctor (the
+        # runner calls trust_cls() with no args; some callers pass an identity).
+        self._identity = identity
+        # Deterministic system seed for signing attestations.
+        self._system_seed = hashlib.sha256(b"trust:agent_receipts").digest()[:32]
+        # One global ledger of verified-on-report receipts.
+        self._ledger: list[dict[str, Any]] = []
+        # Plain-string-detail fallback scores (stock-scenario compatibility).
+        self._fallback_scores: dict[AgentId, list[float]] = {}
+        # Parity-only stake tracking.
+        self._stakes: dict[AgentId, int] = {}
+
+    def _did_of(self, agent: AgentId) -> str:
+        """Map a NEST ``AgentId`` to its receipt identity (deterministic hex pubkey).
+
+        Example::
+
+            did = trust._did_of(AgentId("a1"))
+        """
+        seed = hashlib.sha256(str(agent).encode()).digest()[:32]
+        pub = (
+            Ed25519PrivateKey.from_private_bytes(seed)
+            .public_key()
+            .public_bytes(Encoding.Raw, PublicFormat.Raw)
+        )
+        return did_for_pubkey(pub)
+
+    async def score(self, agent: AgentId) -> ReputationScore:
+        """Reputation for an agent from its corroborated, non-severed receipts.
+
+        Gathers the agent's receipts (those it issued), applies global collusion
+        severance over the whole ledger, keeps only the agent's surviving
+        receipts, and scores them. A severed ring member therefore drops to
+        ``score == 0.0`` with ``confidence == 0.0`` even though it issued
+        receipts (``sample_count > 0``), while honest anchor agents keep their
+        full corroborated score. Agents with no receipts fall back to the
+        plain-string heuristic, or the reference neutral prior (0.5).
+
+        Example::
+
+            rep = await trust.score(AgentId("a1"))
+        """
+        did = self._did_of(agent)
+        mine = [r for r in self._ledger if str(r.get("issuer_did", "")) == did]
+        if mine:
+            effective = _effective_receipts(self._ledger)
+            mine_eff = [r for r in effective if str(r.get("issuer_did", "")) == did]
+            raw = _raw_reputation(mine_eff, DEFAULT_CATEGORY_WEIGHTS)
+            confidence = len(mine_eff) / len(mine) if mine else 0.0
+            return ReputationScore(
+                agent_id=agent,
+                score=_normalize(raw),
+                confidence=confidence,
+                sample_count=len(mine),
+            )
+        fallback = self._fallback_scores.get(agent)
+        if fallback:
+            avg = sum(fallback) / len(fallback)
+            return ReputationScore(
+                agent_id=agent,
+                score=avg,
+                confidence=min(1.0, len(fallback) / 100.0),
+                sample_count=len(fallback),
+            )
+        return ReputationScore(agent_id=agent, score=0.5, confidence=0.0, sample_count=0)
+
+    async def attest(self, agent: AgentId, claim: Claim) -> Attestation:
+        """Issue an Ed25519-signed attestation about an agent.
+
+        Signs ``claim.model_dump_json()`` with this plugin's own system key,
+        mirroring the reference plugin's shape.
+
+        Example::
+
+            att = await trust.attest(AgentId("a1"), claim)
+        """
+        sk = Ed25519PrivateKey.from_private_bytes(self._system_seed)
+        raw = sk.sign(claim.model_dump_json().encode())
+        sig = Signature(signer=self._SYSTEM_AGENT, value=raw, algorithm=ALGORITHM)
+        return Attestation(issuer=self._SYSTEM_AGENT, claim=claim, signature=sig)
+
+    async def report(self, agent: AgentId, evidence: Evidence) -> None:
+        """Report evidence — a cross-signed receipt, or a stock heuristic.
+
+        ``evidence.detail`` is tried as JSON. If it decodes to a dict that passes
+        :func:`_verify_receipt`, it enters the global ledger. A decoded dict that
+        fails verification is logged (never silently dropped) and falls through
+        to the heuristic. A plain-string ``detail`` (stock scenarios) uses the
+        reference score-average heuristic so this plugin stays a drop-in.
+
+        Example::
+
+            await trust.report(AgentId("a1"), Evidence(reporter=r, subject=s,
+                kind="positive", detail=json.dumps(receipt)))
+        """
+        try:
+            parsed: object = json.loads(evidence.detail)
+        except (json.JSONDecodeError, TypeError):
+            self._record_fallback(agent, evidence)
+            return
+
+        if isinstance(parsed, dict):
+            receipt = cast("dict[str, Any]", parsed)
+            if _verify_receipt(receipt):
+                self._ledger.append(receipt)
+                return
+            logger.warning(
+                "report: detail decoded to a dict but failed receipt verification "
+                "for agent=%s; using heuristic fallback",
+                agent,
+            )
+
+        self._record_fallback(agent, evidence)
+
+    def _record_fallback(self, agent: AgentId, evidence: Evidence) -> None:
+        """Apply the reference score-average heuristic for non-receipt evidence.
+
+        Example::
+
+            trust._record_fallback(AgentId("a1"), evidence)
+        """
+        score_val = 0.5
+        if evidence.kind == "positive":
+            score_val = 1.0
+        elif evidence.kind in ("negative", "byzantine"):
+            score_val = 0.0
+        self._fallback_scores.setdefault(agent, []).append(score_val)
+
+    async def stake(self, agent: AgentId, amount: int) -> None:
+        """Stake reputation on an agent (parity-only no-op).
+
+        There is no staking primitive in this scheme; the amount is recorded in
+        memory purely for Protocol parity with the reference plugin.
+
+        Example::
+
+            await trust.stake(AgentId("a1"), 100)
+        """
+        self._stakes[agent] = self._stakes.get(agent, 0) + amount

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py
@@ -54,6 +54,7 @@ Example::
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -66,7 +67,6 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PublicKey,
 )
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
-
 from nest_core.types import (
     AgentId,
     Attestation,
@@ -153,10 +153,12 @@ def _issuer_payload(receipt: dict[str, Any]) -> bytes:
 
         payload = _issuer_payload(receipt)
     """
-    core = {k: v for k, v in receipt.items() if k != "signature"}
+    core: dict[str, Any] = {k: v for k, v in receipt.items() if k != "signature"}
     evidence = core.get("evidence")
     if isinstance(evidence, dict):
-        trimmed = {k: v for k, v in evidence.items() if k != "witness_signatures"}
+        trimmed: dict[str, Any] = {
+            k: v for k, v in cast("dict[str, Any]", evidence).items() if k != "witness_signatures"
+        }
         if trimmed:
             core["evidence"] = trimmed
         else:
@@ -213,6 +215,22 @@ def _verify_receipt(receipt: dict[str, Any]) -> bool:
     return _verify_ed25519(issuer, sig, _issuer_payload(receipt))
 
 
+def _action_field(receipt: dict[str, Any], key: str) -> Any:
+    """Return ``receipt["action"][key]`` (or ``None``) with a concrete dict type.
+
+    Centralizes the loosely-typed ``action`` access so the typed call sites stay
+    free of partially-unknown ``.get()`` chains.
+
+    Example::
+
+        cat = _action_field(receipt, "category")
+    """
+    action = receipt.get("action")
+    if isinstance(action, dict):
+        return cast("dict[str, Any]", action).get(key)
+    return None
+
+
 def _counterparty(receipt: dict[str, Any]) -> str | None:
     """The counterparty did iff present and distinct from the issuer.
 
@@ -223,7 +241,7 @@ def _counterparty(receipt: dict[str, Any]) -> str | None:
 
         cp = _counterparty(receipt)
     """
-    cp = (receipt.get("action") or {}).get("counterparty_did")
+    cp = _action_field(receipt, "counterparty_did")
     if isinstance(cp, str) and cp and cp != receipt.get("issuer_did"):
         return cp
     return None
@@ -243,12 +261,20 @@ def is_corroborated(receipt: dict[str, Any]) -> bool:
     cp = _counterparty(receipt)
     if cp is None:
         return False
-    witnesses = (receipt.get("evidence") or {}).get("witness_signatures") or []
+    evidence = receipt.get("evidence")
+    if not isinstance(evidence, dict):
+        return False
+    witnesses = cast("dict[str, Any]", evidence).get("witness_signatures")
+    if not isinstance(witnesses, list):
+        return False
     payload = _corroboration_payload(receipt)
-    for entry in witnesses:
-        if not isinstance(entry, dict) or entry.get("witness_did") != cp:
+    for entry in cast("list[Any]", witnesses):
+        if not isinstance(entry, dict):
             continue
-        if _verify_ed25519(cp, str(entry.get("signature", "")), payload):
+        typed: dict[str, Any] = cast("dict[str, Any]", entry)
+        if typed.get("witness_did") != cp:
+            continue
+        if _verify_ed25519(cp, str(typed.get("signature", "")), payload):
             return True
     return False
 
@@ -415,10 +441,7 @@ def _raw_reputation(receipts: list[dict[str, Any]], weights: dict[str, float]) -
 
         raw = _raw_reputation(eff, DEFAULT_CATEGORY_WEIGHTS)
     """
-    return sum(
-        weights.get((r.get("action") or {}).get("category", ""), 0.0)
-        for r in receipts
-    )
+    return sum(weights.get(str(_action_field(r, "category") or ""), 0.0) for r in receipts)
 
 
 def _normalize(raw: float) -> float:
@@ -469,11 +492,18 @@ def cosign_receipt(receipt: dict[str, Any], *, counterparty_seed: bytes) -> dict
     sk = Ed25519PrivateKey.from_private_bytes(counterparty_seed)
     witness_did = sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw).hex()
     sig = sk.sign(_corroboration_payload(receipt))
-    entry = {"witness_did": witness_did, "signature": sig.hex()}
-    out = json.loads(json.dumps(receipt))  # deep copy via round-trip
+    entry: dict[str, str] = {"witness_did": witness_did, "signature": sig.hex()}
+    out: dict[str, Any] = copy.deepcopy(receipt)
     evidence = out.setdefault("evidence", {})
-    evidence.setdefault("witness_signatures", []).append(entry)
-    return cast("dict[str, Any]", out)
+    if not isinstance(evidence, dict):
+        evidence = {}
+        out["evidence"] = evidence
+    witnesses = cast("dict[str, Any]", evidence).setdefault("witness_signatures", [])
+    if not isinstance(witnesses, list):
+        witnesses = []
+        cast("dict[str, Any]", evidence)["witness_signatures"] = witnesses
+    cast("list[Any]", witnesses).append(entry)
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -19,8 +19,9 @@ dependencies = [
     "nest-core",
     "nest-sdk",
     # Real Ed25519 signing for the ed25519_rotating identity plugin
-    # (RFC 8032, deterministic). Required at runtime, so it lives in the
-    # package's hard dependencies — a bare `uv sync` installs it.
+    # (RFC 8032, deterministic) and the agent_receipts trust plugin.
+    # Required at runtime, so it lives in the package's hard
+    # dependencies — a bare `uv sync` installs it.
     "cryptography>=42.0",
 ]
 

--- a/packages/nest-plugins-reference/tests/test_agent_receipts.py
+++ b/packages/nest-plugins-reference/tests/test_agent_receipts.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportPrivateUsage=false
+"""Unit tests for the agent_receipts trust plugin.
+
+Covers receipt verification, counterparty corroboration, Tarjan-SCC collusion
+severance (honest anchor vs isolated ring), the no-receipt fallback, and the
+Trust-protocol surface. The make-or-break invariant -- that the honest
+population is the *largest* SCC and only the ring is severed -- is asserted
+directly against the severance primitive.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from nest_core.types import AgentId, Claim, Evidence
+from nest_plugins_reference.trust.agent_receipts import (
+    AgentReceiptsTrust,
+    _corroboration_graph,
+    _normalize,
+    _sccs,
+    _severed_dids,
+    _verify_receipt,
+    cosign_receipt,
+    did_for_pubkey,
+    is_corroborated,
+    sign_receipt,
+)
+
+
+def _seed(name: str) -> bytes:
+    return hashlib.sha256(name.encode()).digest()[:32]
+
+
+def _did(name: str) -> str:
+    sk = Ed25519PrivateKey.from_private_bytes(_seed(name))
+    return did_for_pubkey(sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw))
+
+
+def _receipt(issuer: str, cp: str, *, rid: str, category: str = "purchase") -> dict[str, object]:
+    r: dict[str, object] = {
+        "receipt_id": rid,
+        "issuer_did": _did(issuer),
+        "action": {"category": category, "counterparty_did": _did(cp)},
+    }
+    return sign_receipt(r, issuer_seed=_seed(issuer))
+
+
+def _corroborated(
+    issuer: str, cp: str, *, rid: str, category: str = "purchase"
+) -> dict[str, object]:
+    return cosign_receipt(
+        _receipt(issuer, cp, rid=rid, category=category), counterparty_seed=_seed(cp)
+    )
+
+
+class TestReceiptVerification:
+    def test_valid_issuer_signature_verifies(self) -> None:
+        assert _verify_receipt(_receipt("a", "b", rid="r0")) is True
+
+    def test_tampered_action_fails_verification(self) -> None:
+        r = _receipt("a", "b", rid="r0")
+        r["action"] = {"category": "payment_sent", "counterparty_did": _did("b")}  # post-sign edit
+        assert _verify_receipt(r) is False
+
+    def test_missing_signature_fails_without_crashing(self) -> None:
+        r = {"receipt_id": "r0", "issuer_did": _did("a"), "action": {"category": "purchase"}}
+        assert _verify_receipt(r) is False
+
+    def test_garbage_signature_fails_without_crashing(self) -> None:
+        r = _receipt("a", "b", rid="r0")
+        r["signature"] = "not-hex"
+        assert _verify_receipt(r) is False
+
+
+class TestCorroboration:
+    def test_counterparty_cosignature_is_corroborated(self) -> None:
+        assert is_corroborated(_corroborated("a", "b", rid="r0")) is True
+
+    def test_uncosigned_receipt_not_corroborated(self) -> None:
+        assert is_corroborated(_receipt("a", "b", rid="r0")) is False
+
+    def test_self_corroboration_rejected(self) -> None:
+        # counterparty == issuer: not a distinct corroborator.
+        assert is_corroborated(_corroborated("a", "a", rid="r0")) is False
+
+    def test_wrong_witness_signature_not_corroborated(self) -> None:
+        r = _receipt("a", "b", rid="r0")
+        r.setdefault("evidence", {})["witness_signatures"] = [  # type: ignore[index]
+            {"witness_did": _did("b"), "signature": "00" * 64}
+        ]
+        assert is_corroborated(r) is False
+
+
+class TestSeverance:
+    def _honest_and_ring(self) -> list[dict[str, object]]:
+        honest = [f"h{i}" for i in range(5)]
+        ring = [f"r{i}" for i in range(4)]
+        receipts: list[dict[str, object]] = []
+        # honest directed cycle + chord -> single SCC of size 5
+        for i in range(5):
+            for k in (1, 2):
+                receipts.append(_corroborated(honest[i], honest[(i + k) % 5], rid=f"h{i}-{k}"))
+        # isolated dense ring (all-pairs both directions)
+        for i in range(4):
+            for j in range(4):
+                if i != j:
+                    receipts.append(_corroborated(ring[i], ring[j], rid=f"r{i}-{j}"))
+        return receipts
+
+    def test_anchor_is_largest_honest_scc(self) -> None:
+        """The honest population must be the anchor (largest SCC), strictly > ring."""
+        graph = _corroboration_graph(self._honest_and_ring())
+        comps = _sccs(graph)
+        anchor = set(comps[0])
+        assert anchor == {_did(f"h{i}") for i in range(5)}
+        assert len(anchor) > 4  # strictly larger than the 4-agent ring
+
+    def test_isolated_ring_is_severed(self) -> None:
+        severed = _severed_dids(_corroboration_graph(self._honest_and_ring()))
+        assert severed == {_did(f"r{i}") for i in range(4)}
+
+    def test_ring_with_edge_to_anchor_not_severed(self) -> None:
+        """A ring that actually transacts with an honest agent is not isolated."""
+        receipts = self._honest_and_ring()
+        # add a real corroborated edge ring->honest, bridging the ring to the anchor
+        receipts.append(_corroborated("r0", "h0", rid="bridge"))
+        severed = _severed_dids(_corroboration_graph(receipts))
+        assert severed == set()
+
+    def test_empty_graph_severs_nothing(self) -> None:
+        assert _severed_dids({}) == set()
+
+
+class TestScore:
+    @pytest.mark.asyncio
+    async def test_honest_scored_ring_severed(self) -> None:
+        trust = AgentReceiptsTrust()
+        honest = [f"honest-{i}" for i in range(5)]
+        ring = [f"ring-{i}" for i in range(4)]
+        for i in range(5):
+            for k in (1, 2):
+                r = _corroborated(honest[i], honest[(i + k) % 5], rid=f"h{i}-{k}")
+                await trust.report(
+                    AgentId(honest[i]),
+                    Evidence(
+                        reporter=AgentId(honest[i]),
+                        subject=AgentId(honest[i]),
+                        kind="positive",
+                        detail=json.dumps(r),
+                    ),
+                )
+        for i in range(4):
+            for j in range(4):
+                if i != j:
+                    r = _corroborated(ring[i], ring[j], rid=f"r{i}-{j}")
+                    await trust.report(
+                        AgentId(ring[i]),
+                        Evidence(
+                            reporter=AgentId(ring[i]),
+                            subject=AgentId(ring[i]),
+                            kind="positive",
+                            detail=json.dumps(r),
+                        ),
+                    )
+        honest_score = await trust.score(AgentId("honest-0"))
+        ring_score = await trust.score(AgentId("ring-0"))
+        assert honest_score.score > 0.0
+        assert honest_score.confidence == 1.0
+        # severed: zero score AND zero confidence, but sample_count records the claim
+        assert ring_score.score == 0.0
+        assert ring_score.confidence == 0.0
+        assert ring_score.sample_count > 0
+
+    @pytest.mark.asyncio
+    async def test_no_receipts_returns_neutral_prior(self) -> None:
+        rep = await AgentReceiptsTrust().score(AgentId("nobody"))
+        assert rep.score == 0.5
+        assert rep.confidence == 0.0
+        assert rep.sample_count == 0
+
+    @pytest.mark.asyncio
+    async def test_plain_string_detail_falls_back(self) -> None:
+        """Stock-scenario plain-string detail uses the score-average heuristic."""
+        trust = AgentReceiptsTrust()
+        await trust.report(
+            AgentId("a"),
+            Evidence(reporter=AgentId("r"), subject=AgentId("a"), kind="positive", detail="ok"),
+        )
+        rep = await trust.score(AgentId("a"))
+        assert rep.score == 1.0
+        assert rep.sample_count == 1
+
+    @pytest.mark.asyncio
+    async def test_invalid_receipt_dict_falls_back_not_crashes(self) -> None:
+        trust = AgentReceiptsTrust()
+        bad = json.dumps({"issuer_did": _did("a"), "signature": "deadbeef", "action": {}})
+        await trust.report(
+            AgentId("a"),
+            Evidence(reporter=AgentId("r"), subject=AgentId("a"), kind="negative", detail=bad),
+        )
+        rep = await trust.score(AgentId("a"))
+        # fell back to heuristic (negative -> 0.0), did not enter the ledger
+        assert rep.score == 0.0
+        assert rep.sample_count == 1
+
+
+class TestProtocolSurface:
+    @pytest.mark.asyncio
+    async def test_attest_produces_signed_attestation(self) -> None:
+        trust = AgentReceiptsTrust()
+        claim = Claim(subject=AgentId("a"), predicate="completed", value="task-1")
+        att = await trust.attest(AgentId("a"), claim)
+        assert att.claim == claim
+        assert att.signature.algorithm == "ed25519"
+        assert len(att.signature.value) == 64
+
+    @pytest.mark.asyncio
+    async def test_stake_is_noop_parity(self) -> None:
+        trust = AgentReceiptsTrust()
+        await trust.stake(AgentId("a"), 100)  # must not raise
+
+    def test_normalize_bounds(self) -> None:
+        assert _normalize(0.0) == 0.0
+        assert 0.0 < _normalize(5.0) < 1.0
+        assert _normalize(5.0) == pytest.approx(0.39346934, abs=1e-6)

--- a/packages/nest-plugins-reference/tests/test_agent_receipts_properties.py
+++ b/packages/nest-plugins-reference/tests/test_agent_receipts_properties.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportPrivateUsage=false
+"""Hypothesis property-based tests for the agent_receipts trust plugin.
+
+These complement the example-based ``test_agent_receipts.py`` by asserting
+structural invariants over *generated* ledgers and receipt sets:
+
+1. score in [0, 1] for any ledger (the ``1 - exp(-raw/K)`` normalization).
+2. confidence (corroboration rate) in [0, 1].
+3. Empty ledger -> raw 0, score 0, no severance, and ``score()`` never raises.
+4. Permutation invariance: report order does not change score/confidence
+   (severance + scoring are order-independent).
+5. Corroboration gate: adding an *uncorroborated* receipt never raises an
+   agent's score above its corroborated-only score.
+6. Isolated-ring severance: any isolated dense clique (size >= 3) collapses to
+   score ~0 for every ring member.
+7. Anchor safety: bolting an isolated colluding ring onto the ledger never
+   lowers an honest anchor agent's score.
+
+The plugin signs/verifies Ed25519 per receipt, so generated sizes are kept
+small and every property carries ``deadline=None`` to stay non-flaky on CI.
+Determinism is exact: weights are exact floats, bounded sums are exact, and
+severance is ``sorted()``-deterministic, so permutation invariance is asserted
+with ``==`` (not ``approx``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Evidence
+from nest_plugins_reference.trust.agent_receipts import (
+    DEFAULT_CATEGORY_WEIGHTS,
+    AgentReceiptsTrust,
+    _corroboration_graph,
+    _effective_receipts,
+    _normalize,
+    _raw_reputation,
+    _severed_dids,
+    cosign_receipt,
+    did_for_pubkey,
+    sign_receipt,
+)
+
+# ---------------------------------------------------------------------------
+# Deterministic Ed25519 helpers (mirroring test_agent_receipts.py)
+# ---------------------------------------------------------------------------
+
+# Category names the plugin assigns weight to; "other"/breached weigh 0.
+_WEIGHTED_CATEGORIES = sorted(DEFAULT_CATEGORY_WEIGHTS)
+
+
+def _seed(name: str) -> bytes:
+    return hashlib.sha256(name.encode()).digest()[:32]
+
+
+def _did(name: str) -> str:
+    sk = Ed25519PrivateKey.from_private_bytes(_seed(name))
+    return did_for_pubkey(sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw))
+
+
+def _receipt(issuer: str, cp: str, *, rid: str, category: str = "purchase") -> dict[str, Any]:
+    r: dict[str, Any] = {
+        "receipt_id": rid,
+        "issuer_did": _did(issuer),
+        "action": {"category": category, "counterparty_did": _did(cp)},
+    }
+    return sign_receipt(r, issuer_seed=_seed(issuer))
+
+
+def _corroborated(issuer: str, cp: str, *, rid: str, category: str = "purchase") -> dict[str, Any]:
+    return cosign_receipt(
+        _receipt(issuer, cp, rid=rid, category=category), counterparty_seed=_seed(cp)
+    )
+
+
+async def _report(trust: AgentReceiptsTrust, issuer: str, receipt: dict[str, Any]) -> None:
+    """Feed a receipt to the plugin as a JSON-detail Evidence (as scenarios do)."""
+    await trust.report(
+        AgentId(issuer),
+        Evidence(
+            reporter=AgentId(issuer),
+            subject=AgentId(issuer),
+            kind="positive",
+            detail=json.dumps(receipt),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# A small pool of distinct agent names. Issuer must differ from counterparty
+# (self-corroboration is rejected), so we draw issuer/cp from this pool and
+# discard self-pairs at build time.
+_NAME_POOL = [f"agent-{i}" for i in range(6)]
+
+
+@st.composite
+def _ledger_strategy(draw: st.DrawFn) -> list[dict[str, Any]]:
+    """Generate a bounded list of corroborated receipts between distinct agents."""
+    n = draw(st.integers(min_value=0, max_value=12))
+    receipts: list[dict[str, Any]] = []
+    for k in range(n):
+        issuer = draw(st.sampled_from(_NAME_POOL))
+        cp = draw(st.sampled_from([x for x in _NAME_POOL if x != issuer]))
+        category = draw(st.sampled_from(_WEIGHTED_CATEGORIES))
+        # Mix corroborated and bare receipts so confidence varies across [0, 1].
+        if draw(st.booleans()):
+            receipts.append(_corroborated(issuer, cp, rid=f"r{k}", category=category))
+        else:
+            receipts.append(_receipt(issuer, cp, rid=f"r{k}", category=category))
+    return receipts
+
+
+def _honest_anchor(size: int) -> tuple[list[str], list[dict[str, Any]]]:
+    """A cycle+chord SCC of ``size`` honest agents (mirrors _honest_and_ring)."""
+    honest = [f"honest-{i}" for i in range(size)]
+    receipts: list[dict[str, Any]] = []
+    for i in range(size):
+        for step in (1, 2):
+            receipts.append(_corroborated(honest[i], honest[(i + step) % size], rid=f"h{i}-{step}"))
+    return honest, receipts
+
+
+def _isolated_ring(size: int) -> tuple[list[str], list[dict[str, Any]]]:
+    """A dense isolated clique: all distinct ordered pairs, both directions."""
+    ring = [f"ring-{i}" for i in range(size)]
+    receipts: list[dict[str, Any]] = []
+    for i in range(size):
+        for j in range(size):
+            if i != j:
+                receipts.append(_corroborated(ring[i], ring[j], rid=f"ring{i}-{j}"))
+    return ring, receipts
+
+
+# ---------------------------------------------------------------------------
+# 1 & 2. Score and confidence bounds over arbitrary ledgers
+# ---------------------------------------------------------------------------
+
+
+class TestScoreBounds:
+    @settings(max_examples=40, deadline=None)
+    @given(ledger=_ledger_strategy())
+    @pytest.mark.asyncio
+    async def test_score_and_confidence_in_unit_interval(
+        self, ledger: list[dict[str, Any]]
+    ) -> None:
+        """score in [0, 1] and confidence in [0, 1] for every issuer in any ledger."""
+        trust = AgentReceiptsTrust()
+        for r in ledger:
+            await _report(trust, str(r["issuer_did"]), r)
+        for name in _NAME_POOL:
+            rep = await trust.score(AgentId(name))
+            assert 0.0 <= rep.score <= 1.0
+            assert 0.0 <= rep.confidence <= 1.0
+
+    @settings(max_examples=200, deadline=None)
+    @given(raw=st.floats(min_value=0.0, max_value=1e6, allow_nan=False, allow_infinity=False))
+    def test_normalize_always_in_unit_interval(self, raw: float) -> None:
+        """The normalization 1 - exp(-raw/K) maps any raw >= 0 into [0, 1)."""
+        s = _normalize(raw)
+        assert 0.0 <= s <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# 3. Empty ledger
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyLedger:
+    def test_empty_ledger_normalization_layer_is_zero(self) -> None:
+        """No receipts -> raw 0, score 0, no severance (the normalization invariant)."""
+        assert _raw_reputation([], DEFAULT_CATEGORY_WEIGHTS) == 0.0
+        assert _normalize(0.0) == 0.0
+        assert _effective_receipts([]) == []
+        assert _severed_dids(_corroboration_graph([])) == set()
+
+    @pytest.mark.asyncio
+    async def test_score_on_empty_ledger_does_not_raise(self) -> None:
+        """An agent with no receipts returns the neutral prior 0.5 without error."""
+        rep = await AgentReceiptsTrust().score(AgentId("nobody"))
+        assert rep.score == 0.5
+        assert rep.confidence == 0.0
+        assert rep.sample_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 4. Permutation invariance
+# ---------------------------------------------------------------------------
+
+
+class TestPermutationInvariance:
+    @settings(max_examples=30, deadline=None)
+    @given(ledger=_ledger_strategy(), perm_seed=st.integers(min_value=0, max_value=2**31))
+    @pytest.mark.asyncio
+    async def test_report_order_does_not_change_scores(
+        self, ledger: list[dict[str, Any]], perm_seed: int
+    ) -> None:
+        """Reporting the same multiset of receipts in two orders yields identical
+        score and confidence for every agent (exact ==, not approx)."""
+        shuffled = list(ledger)
+        random.Random(perm_seed).shuffle(shuffled)
+
+        trust_a = AgentReceiptsTrust()
+        for r in ledger:
+            await _report(trust_a, str(r["issuer_did"]), r)
+        trust_b = AgentReceiptsTrust()
+        for r in shuffled:
+            await _report(trust_b, str(r["issuer_did"]), r)
+
+        for name in _NAME_POOL:
+            ra = await trust_a.score(AgentId(name))
+            rb = await trust_b.score(AgentId(name))
+            assert ra.score == rb.score
+            assert ra.confidence == rb.confidence
+
+
+# ---------------------------------------------------------------------------
+# 5. Corroboration gate is monotone-down on score
+# ---------------------------------------------------------------------------
+
+
+class TestCorroborationGate:
+    @settings(max_examples=30, deadline=None)
+    @given(
+        issuer=st.sampled_from(_NAME_POOL),
+        cp_idx=st.integers(min_value=0, max_value=len(_NAME_POOL) - 1),
+        category=st.sampled_from(_WEIGHTED_CATEGORIES),
+    )
+    @pytest.mark.asyncio
+    async def test_uncorroborated_receipt_never_raises_score(
+        self, issuer: str, cp_idx: int, category: str
+    ) -> None:
+        """Adding a valid but uncorroborated receipt cannot increase an agent's
+        score above its corroborated-only score (only confidence may fall)."""
+        cp = _NAME_POOL[cp_idx] if _NAME_POOL[cp_idx] != issuer else _NAME_POOL[(cp_idx + 1) % 6]
+        trust = AgentReceiptsTrust()
+        # One corroborated receipt establishes the baseline corroborated-only score.
+        await _report(trust, issuer, _corroborated(issuer, cp, rid="base", category=category))
+        base = await trust.score(AgentId(issuer))
+        # Add an uncorroborated (signed, uncosigned) receipt; it enters the ledger
+        # but is filtered by the corroboration gate.
+        await _report(trust, issuer, _receipt(issuer, cp, rid="extra", category=category))
+        after = await trust.score(AgentId(issuer))
+        assert after.score <= base.score
+
+
+# ---------------------------------------------------------------------------
+# 6. Isolated-ring severance
+# ---------------------------------------------------------------------------
+
+
+class TestIsolatedRingSeverance:
+    @settings(max_examples=20, deadline=None)
+    @given(ring_size=st.integers(min_value=3, max_value=5))
+    @pytest.mark.asyncio
+    async def test_isolated_dense_ring_collapses_to_zero(self, ring_size: int) -> None:
+        """Every member of an isolated dense clique (alongside a strictly larger
+        honest anchor) scores ~0 with zero confidence."""
+        # Anchor must be strictly larger than the ring so the ring is never the
+        # anchor SCC; ring + 2 keeps it strictly larger and avoids size ties.
+        honest, anchor_receipts = _honest_anchor(ring_size + 2)
+        ring, ring_receipts = _isolated_ring(ring_size)
+
+        trust = AgentReceiptsTrust()
+        for r in anchor_receipts:
+            await _report(trust, str(r["issuer_did"]), r)
+        for r in ring_receipts:
+            await _report(trust, str(r["issuer_did"]), r)
+
+        for member in ring:
+            rep = await trust.score(AgentId(member))
+            assert rep.score == 0.0
+            assert rep.confidence == 0.0
+            assert rep.sample_count > 0  # the wash-traded claims are still counted
+        # Sanity: at least one honest anchor agent kept a positive score.
+        anchor_rep = await trust.score(AgentId(honest[0]))
+        assert anchor_rep.score > 0.0
+
+
+# ---------------------------------------------------------------------------
+# 7. Anchor safety
+# ---------------------------------------------------------------------------
+
+
+class TestAnchorSafety:
+    @settings(max_examples=20, deadline=None)
+    @given(ring_size=st.integers(min_value=3, max_value=5))
+    @pytest.mark.asyncio
+    async def test_adding_isolated_ring_never_lowers_anchor_score(self, ring_size: int) -> None:
+        """An honest anchor agent's score is unchanged by bolting on an isolated
+        colluding ring (the ring is severed; the anchor is untouched)."""
+        honest, anchor_receipts = _honest_anchor(ring_size + 2)
+
+        trust_clean = AgentReceiptsTrust()
+        for r in anchor_receipts:
+            await _report(trust_clean, str(r["issuer_did"]), r)
+        before = await trust_clean.score(AgentId(honest[0]))
+
+        trust_poisoned = AgentReceiptsTrust()
+        for r in anchor_receipts:
+            await _report(trust_poisoned, str(r["issuer_did"]), r)
+        _ring, ring_receipts = _isolated_ring(ring_size)
+        for r in ring_receipts:
+            await _report(trust_poisoned, str(r["issuer_did"]), r)
+        after = await trust_poisoned.score(AgentId(honest[0]))
+
+        assert after.score >= before.score

--- a/scenarios/receipt_reputation.yaml
+++ b/scenarios/receipt_reputation.yaml
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Receipt-reputation scenario: honest agents issue counterparty-cosigned receipts
+# while an isolated 4-agent collusion ring wash-trades reputation among itself.
+#
+# Under `trust: agent_receipts` (this submission's plugin) the ring is severed to
+# score ~0 and the honest anchor is retained, so the receipt_reputation
+# adversarial validator PASSES. Swap to `trust: score_average` (below) and the
+# ring's all-positive reports are rewarded to ~1.0, so the same validator FAILS
+# -- the demonstration that naive averaging cannot catch corroboration collusion.
+name: receipt_reputation
+description: "8 honest receipt issuers, a 4-agent collusion ring, ~10% byzantine, 1 auditor."
+
+tier: 1
+seed: 42
+
+agents:
+  # 8 honest + 4 ring + 1 byzantine + 1 auditor = 14
+  count: 14
+  brain: state-machine
+  roles:
+    - name: honest
+      count: 8
+    - name: ring
+      count: 4
+    - name: byzantine
+      count: 1
+    - name: auditor
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  # The whole point: agent_receipts severs the collusion ring. Switch this to
+  # `score_average` to watch the receipt_reputation validator fail on the ring.
+  trust: agent_receipts
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: receipt_reputation
+  config:
+    ring_size: 4
+    byzantine_fraction: 0.10
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/receipt_reputation.jsonl


### PR DESCRIPTION
**Layer:** trust · **Persona:** stellarminds-ai

## Motivation
The reference `trust: score_average` is a naive running mean with no Sybil resistance — a colluding ring can wash-trade its own reputation to the top. Prior trust submissions use EigenTrust (transitive propagation), which still has **no notion of severing an isolated colluding clique**. This submission scores reputation from **counterparty-corroborated receipts** and severs collusion rings structurally.

## Design
A receipt builds reputation only if it clears three gates: (1) **valid** — Ed25519 issuer signature verifies; (2) **corroborated** — the *distinct* counterparty co-signed the same canonical payload; (3) **not collusion-severed**. For gate 3: build the directed corroboration graph (issuer→counterparty), take **strongly-connected components via Tarjan's algorithm** (iterative, no recursion-limit risk), treat the **largest SCC as the honest anchor**, and sever any component isolated from it that is a dense ring (size≥3, density≥0.8) or a mutual-only pair. Score = corroboration-gated category-weighted sum over the globally-effective ledger, mapped to [0,1] via `1-exp(-raw/K)`. Self-contained: stdlib + `cryptography` only (no external reputation lib).

## Adversarial validator (mandatory)
Detects an isolated 4-agent ring wash-trading reputation. **FAILS against `trust: score_average`** (ring scores 1.0000) and **PASSES against `trust: agent_receipts`** (ring severed to ~0, honest agents retained) — no crash either way.

## How to verify
```
make ci-local                 # all 5 green
uv run nest run scenarios/receipt_reputation.yaml -o /tmp/t.jsonl   # deterministic
# validator: PASS on agent_receipts, FAIL on score_average (swap trust: in the yaml)
```
Local: **369 passed**; validator PASS-on-ours (4 ring severed, 8 honest retained) / FAIL-on-score_average; byte-identical reruns; adversarial invariant holds across an 8-seed bank (5 parametrized into CI).

## Tradeoffs
Severance fires only for rings *isolated* from the honest anchor (zero corroborated cross-edges) — a ring that genuinely transacts with honest agents is not severed (correct: it's no longer a pure Sybil). `stake` is a documented parity no-op (this model is corroboration-based, not stake-based).