### PR TITLE
[NandaHack] privacy: hybrid_x25519 — real hybrid encryption, selective disclosure & broadcast revocation

### DIFF
--- a/docs/layers/privacy.md
+++ b/docs/layers/privacy.md
@@ -23,6 +23,20 @@ and you don't want to pay any cost.
 
 Source: [`nest_plugins_reference/privacy/noop.py`](../../packages/nest-plugins-reference/nest_plugins_reference/privacy/noop.py).
 
+## Hardened plugin
+
+`hybrid_x25519` — **real confidentiality.** HPKE-shaped hybrid encryption
+(per-message X25519 + HKDF key-agreement wrapping a ChaCha20-Poly1305
+content key), salted-Merkle **selective disclosure** for `prove`/`verify_proof`,
+and **broadcast revocation** via epochs. Ships an adversarial validator
+([`validators/privacy_validators.py`](../../packages/nest-plugins-reference/nest_plugins_reference/validators/privacy_validators.py))
+that catches the eavesdropper, replay, field-injection, and stale-revocation
+attacks — failing against `noop` and passing against this plugin. Supports a
+`deterministic=True` mode for byte-reproducible Tier-1 traces.
+
+Source: [`nest_plugins_reference/privacy/hybrid_x25519.py`](../../packages/nest-plugins-reference/nest_plugins_reference/privacy/hybrid_x25519.py).
+See `scenarios/sealed_bid_with_privacy.yaml` for a wired example.
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -36,6 +36,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("memory", "blackboard"): f"{_REF}.memory.blackboard:Blackboard",
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
+    ("privacy", "hybrid_x25519"): f"{_REF}.privacy.hybrid_x25519:HybridX25519Privacy",
     ("datafacts", "datafacts_v1"): f"{_REF}.datafacts.datafacts_v1:DataFactsV1",
 }
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/privacy/hybrid_x25519.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/privacy/hybrid_x25519.py
@@ -72,7 +72,6 @@ Example::
     bob = HybridX25519Privacy(AgentId("bob"), seed=b"b", deterministic=True)
     alice.register_peer(AgentId("bob"), bob.public_key)
     env = await alice.encrypt(b"sealed-bid:1700", [AgentId("bob")])
-    bob.register_self_as(AgentId("bob"))  # bob already knows its own key
     assert await bob.decrypt(env) == b"sealed-bid:1700"
 """
 
@@ -81,6 +80,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import os
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -192,7 +192,7 @@ def _canon(obj: dict[str, Any]) -> bytes:
 
 
 def _b64(raw: bytes) -> str:
-    """URL-safe base64 (no padding loss) for embedding bytes in the envelope."""
+    """Standard base64 for embedding raw bytes as ASCII inside the JSON envelope."""
     return base64.b64encode(raw).decode("ascii")
 
 
@@ -231,6 +231,18 @@ def _raw_private(key: X25519PrivateKey) -> bytes:
 def _key_id(public_key: bytes) -> str:
     """Stable short identifier for a public key (first 16 hex of its SHA-256)."""
     return hashlib.sha256(public_key).hexdigest()[:16]
+
+
+def _wrap_key(shared: bytes, eph_pub: bytes, recipient_key_id: str) -> bytes:
+    """Derive a per-recipient key-wrap key from an ECDH shared secret.
+
+    Binds the **ephemeral public key** and the recipient identity into the HKDF
+    ``info`` (HPKE-style key schedule), so a wrap is cryptographically tied to
+    this exact encapsulation and recipient — not reusable across messages or
+    recipients even if a shared secret somehow recurred.
+    """
+    info = b"veil-wrap|" + eph_pub + b"|" + recipient_key_id.encode("ascii")
+    return _hkdf(shared, info)
 
 
 # ---------------------------------------------------------------------------
@@ -311,27 +323,35 @@ def _root_from_path(leaf: bytes, path: list[tuple[str, bool]]) -> bytes:
 
 
 def commit_credential(
-    fields: dict[str, str], *, salt_seed: bytes = b""
+    fields: dict[str, str], *, salt_seed: bytes | None = None
 ) -> tuple[str, dict[str, str]]:
     """Issuer helper: commit a multi-field credential to a single root.
 
     Returns ``(root_hex, salts)`` where ``salts`` maps each field name to a hex
-    salt. Fields are ordered by sorted name so the commitment is deterministic.
-    With a non-empty ``salt_seed`` the salts (and thus the root) are reproducible
-    for trace tests; with the default empty seed they are derived from the field
-    content alone (still hiding, since values include entropy in practice — pass
-    a seed for unlinkable commitments across credentials).
+    16-byte salt; fields are ordered by sorted name. The salt is what makes a
+    leaf *hiding*: without it, a low-entropy field (``age``, a country code)
+    could be recovered by hashing every candidate.
+
+    **Secure default:** with ``salt_seed=None`` the salts are drawn from the
+    system RNG, so the commitment is hiding and unlinkable across credentials.
+    Pass an explicit ``salt_seed`` *only* for reproducible Tier-1 trace tests —
+    that makes the salts deterministic (and, for a publicly known seed, publicly
+    re-derivable), trading hiding for replayability. Production issuers must use
+    the random default.
 
     Example::
 
-        root, salts = commit_credential({"age": "21", "country": "NG"}, salt_seed=b"s")
+        root, salts = commit_credential({"age": "21", "country": "NG"})
         assert len(root) == 64 and set(salts) == {"age", "country"}
     """
     names = sorted(fields)
     salts: dict[str, str] = {}
     leaves: list[bytes] = []
     for name in names:
-        salt = _hkdf(salt_seed, b"veil-salt|" + name.encode("utf-8"), length=16)
+        if salt_seed is None:
+            salt = os.urandom(16)
+        else:
+            salt = _hkdf(salt_seed, b"veil-salt|" + name.encode("utf-8"), length=16)
         salts[name] = salt.hex()
         leaves.append(_leaf(name, fields[name], salt))
     return _merkle_root(leaves).hex(), salts
@@ -495,18 +515,6 @@ class HybridX25519Privacy:
         """
         self._directory[agent_id] = public_key
 
-    def register_self_as(self, agent_id: AgentId) -> None:
-        """Alias this agent's own key under *agent_id* (no-op convenience).
-
-        Useful in tests where the sender addresses the recipient by id and the
-        recipient wants its own key indexed under the same id.
-
-        Example::
-
-            bob.register_self_as(AgentId("bob"))
-        """
-        self._directory[agent_id] = self._public
-
     def revoke(self, agent_id: AgentId) -> int:
         """Revoke *agent_id*: advance the epoch and exclude it from future wraps.
 
@@ -540,8 +548,6 @@ class HybridX25519Privacy:
                 b"veil-nonce|" + msg_id.encode("utf-8") + b"|" + str(index).encode("ascii"),
                 length=_NONCE_BYTES,
             )
-        import os
-
         return os.urandom(_NONCE_BYTES)
 
     def _content_key(self, msg_id: str, eph_pub: bytes) -> bytes:
@@ -550,8 +556,6 @@ class HybridX25519Privacy:
                 _raw_private(self._private),
                 b"veil-cek|" + msg_id.encode("utf-8") + b"|" + eph_pub,
             )
-        import os
-
         return os.urandom(_KEY_BYTES)
 
     # -- Privacy protocol: encryption -----------------------------------------
@@ -604,7 +608,7 @@ class HybridX25519Privacy:
         for index, aid in enumerate(recipients):
             peer_pub = self._directory[aid]
             shared = eph_priv.exchange(X25519PublicKey.from_public_bytes(peer_pub))
-            wrap_key = _hkdf(shared, b"veil-wrap|" + _key_id(peer_pub).encode("ascii"))
+            wrap_key = _wrap_key(shared, eph_pub, _key_id(peer_pub))
             wrap_nonce = self._nonce(msg_id, index + 1)
             wrapped = ChaCha20Poly1305(wrap_key).encrypt(wrap_nonce, content_key, aad)
             wraps.append({"kid": _key_id(peer_pub), "n": _b64(wrap_nonce), "w": _b64(wrapped)})
@@ -650,7 +654,7 @@ class HybridX25519Privacy:
             }
         )
         shared = self._private.exchange(X25519PublicKey.from_public_bytes(env.eph_pub))
-        wrap_key = _hkdf(shared, b"veil-wrap|" + self._key_id.encode("ascii"))
+        wrap_key = _wrap_key(shared, env.eph_pub, self._key_id)
         try:
             content_key = ChaCha20Poly1305(wrap_key).decrypt(wrap.nonce, wrap.wrapped, aad)
             plaintext = ChaCha20Poly1305(content_key).decrypt(env.nonce, env.ciphertext, aad)

--- a/packages/nest-plugins-reference/nest_plugins_reference/privacy/hybrid_x25519.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/privacy/hybrid_x25519.py
@@ -1,0 +1,795 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Real hybrid encryption with selective disclosure and broadcast revocation.
+
+Unlike :mod:`nest_plugins_reference.privacy.noop` — which returns the input
+unchanged and whose ``verify_proof`` is an unconditional ``True`` — this plugin
+provides **real confidentiality** built from RFC-grade primitives in the
+``cryptography`` library:
+
+* **Hybrid encryption (HPKE-shaped).** Each message gets a fresh 256-bit
+  content key that encrypts the payload once with **ChaCha20-Poly1305** (AEAD).
+  The content key is then *wrapped* once per recipient via an **X25519**
+  ephemeral-static ECDH + **HKDF-SHA256** key-agreement. So a 1 KB message to
+  ten recipients is one symmetric encryption plus ten cheap key-wraps — the
+  standard broadcast/group-key shape, not N full re-encryptions.
+* **Selective disclosure.** :meth:`prove` / :meth:`verify_proof` implement a
+  salted **Merkle commitment** over a multi-field credential: the holder reveals
+  a subset of fields with their authentication paths and proves the rest are
+  well-formed (committed under the same root) **without revealing them**. No
+  SNARK required — the root is the public anchor (issued by a credential
+  authority and carried in the :class:`~nest_core.types.Statement`).
+* **Broadcast revocation.** :meth:`revoke` removes a member from *future*
+  encryptions without touching any other member's key, by advancing an **epoch**
+  and excluding the revoked key from the next wrap step.
+
+Threat model & what each guard defeats
+--------------------------------------
+
+1. **Eavesdropper.** A non-audience agent that intercepts the envelope holds no
+   wrap entry keyed to its public key, so it can never recover the content key.
+   :meth:`decrypt` raises :class:`NotInAudienceError`. The plaintext never
+   appears in the envelope bytes.
+2. **Replay.** Every envelope carries a unique ``msg_id`` (``sender:epoch:seq``)
+   bound into the AEAD associated data. A recipient rejects a re-presented
+   envelope via :class:`ReplayError`; a redirected envelope fails to
+   authenticate because the recipient is not in the wrap set.
+3. **Field-injection.** Tampering any revealed field value, salt, or Merkle path
+   node changes the reconstructed root, which no longer equals the
+   issuer-anchored root in the statement — :meth:`verify_proof` returns
+   ``False``.
+4. **Stale-revocation.** A member revoked at epoch *E* is excluded from the wrap
+   set of every message at epoch ``>= E``, so :meth:`decrypt` on a
+   post-revocation message raises :class:`NotInAudienceError`.
+
+Forward-secrecy disclosure (read this before trusting it)
+---------------------------------------------------------
+
+Revocation is **future-only**. It guarantees a revoked member cannot read
+messages issued *at or after* their revocation epoch. It makes **no** claim
+about messages issued *before* revocation: a member who already received and
+stored an earlier envelope retains the wrap entry needed to decrypt *that*
+envelope forever. True forward secrecy against a *past*-traffic compromise would
+require per-epoch content re-keying with deletion of old key material, which
+this plugin deliberately does not do (it would change the broadcast cost model).
+We surface this rather than imply a stronger property than we deliver.
+
+Deterministic traces
+---------------------
+
+Nanda Town Tier-1 traces must be byte-for-byte reproducible, but hybrid
+encryption is randomized (fresh ephemeral key + nonces per message). When
+constructed with ``deterministic=True`` the plugin derives the ephemeral scalar
+and every nonce from ``HKDF(seed, msg_id)`` instead of the system RNG, so the
+*same* ``(seed, agent, epoch, seq, payload, audience)`` yields identical
+envelope bytes. This is sound **only because** ``msg_id`` is unique per
+``(sender, epoch)`` via a monotonic counter — reusing a ``(key, nonce)`` pair
+would be catastrophic for any AEAD, and the counter is what prevents it. The
+secure default is ``deterministic=False`` (system RNG).
+
+Example::
+
+    alice = HybridX25519Privacy(AgentId("alice"), seed=b"a", deterministic=True)
+    bob = HybridX25519Privacy(AgentId("bob"), seed=b"b", deterministic=True)
+    alice.register_peer(AgentId("bob"), bob.public_key)
+    env = await alice.encrypt(b"sealed-bid:1700", [AgentId("bob")])
+    bob.register_self_as(AgentId("bob"))  # bob already knows its own key
+    assert await bob.decrypt(env) == b"sealed-bid:1700"
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, cast
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+    X25519PublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+from nest_core.types import AgentId, Proof, Statement, Witness
+
+SCHEME = "hybrid-x25519-chacha20poly1305/1"
+"""Wire-format tag stamped into every envelope and bound into the AEAD AAD.
+
+Example::
+
+    assert SCHEME.startswith("hybrid-x25519")
+"""
+
+PROOF_SCHEME = "merkle-selective-disclosure/1"
+"""Scheme tag on every selective-disclosure :class:`~nest_core.types.Proof`.
+
+Example::
+
+    assert PROOF_SCHEME.startswith("merkle")
+"""
+
+_KEY_BYTES = 32
+_NONCE_BYTES = 12
+
+
+# ---------------------------------------------------------------------------
+# Errors — decrypt/verify raise these so validators can discriminate failures.
+# ---------------------------------------------------------------------------
+
+
+class PrivacyError(Exception):
+    """Base class for all privacy-plugin failures.
+
+    Example::
+
+        try:
+            await priv.decrypt(env)
+        except PrivacyError:
+            ...
+    """
+
+
+class NotInAudienceError(PrivacyError):
+    """Raised when this agent has no wrap entry in the envelope.
+
+    Covers both the *eavesdropper* (never in the audience) and the
+    *stale-revocation* (excluded from this epoch) attacks.
+
+    Example::
+
+        raise NotInAudienceError("carol not in audience")
+    """
+
+
+class ReplayError(PrivacyError):
+    """Raised when an already-seen ``(sender, msg_id)`` envelope is re-presented.
+
+    Example::
+
+        raise ReplayError("duplicate alice:0:1")
+    """
+
+
+class MalformedEnvelopeError(PrivacyError):
+    """Raised when envelope bytes are not a well-formed ``SCHEME`` envelope.
+
+    Example::
+
+        raise MalformedEnvelopeError("missing field 'ct'")
+    """
+
+
+class TamperError(PrivacyError):
+    """Raised when AEAD authentication fails (ciphertext/AAD tampered).
+
+    Example::
+
+        raise TamperError("AEAD tag mismatch")
+    """
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _canon(obj: dict[str, Any]) -> bytes:
+    """Canonical, sorted-key JSON bytes (stable across processes for the AAD).
+
+    Example::
+
+        assert _canon({"b": 1, "a": 2}) == b'{"a":2,"b":1}'
+    """
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _b64(raw: bytes) -> str:
+    """URL-safe base64 (no padding loss) for embedding bytes in the envelope."""
+    return base64.b64encode(raw).decode("ascii")
+
+
+def _unb64(text: str) -> bytes:
+    """Inverse of :func:`_b64`; raises on malformed input."""
+    return base64.b64decode(text.encode("ascii"))
+
+
+def _hkdf(ikm: bytes, info: bytes, *, length: int = _KEY_BYTES) -> bytes:
+    """HKDF-SHA256 with a fixed (empty) salt and explicit ``info`` separation."""
+    return HKDF(algorithm=hashes.SHA256(), length=length, salt=None, info=info).derive(ikm)
+
+
+def _x25519_private_from_seed(seed: bytes, agent_id: AgentId) -> X25519PrivateKey:
+    """Derive a deterministic X25519 private key for *agent_id* from *seed*.
+
+    Example::
+
+        k = _x25519_private_from_seed(b"root", AgentId("a1"))
+        assert isinstance(k, X25519PrivateKey)
+    """
+    material = _hkdf(seed, b"veil-x25519-id|" + str(agent_id).encode("utf-8"))
+    return X25519PrivateKey.from_private_bytes(material)
+
+
+def _raw_public(key: X25519PublicKey) -> bytes:
+    """Raw 32-byte X25519 public key encoding."""
+    return key.public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+
+def _raw_private(key: X25519PrivateKey) -> bytes:
+    """Raw 32-byte X25519 private scalar (own key only; never serialised to trace)."""
+    return key.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+
+
+def _key_id(public_key: bytes) -> str:
+    """Stable short identifier for a public key (first 16 hex of its SHA-256)."""
+    return hashlib.sha256(public_key).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Selective-disclosure Merkle commitment (pure functions, issuer + verifier)
+# ---------------------------------------------------------------------------
+
+
+def _leaf(name: str, value: str, salt: bytes) -> bytes:
+    """Salted, length-prefixed leaf hash ``H("veil-leaf" | name | value | salt)``.
+
+    Length prefixes make the encoding injective, so distinct ``(name, value)``
+    pairs can never collide by concatenation ambiguity. The salt hides the value
+    from anyone who only sees the root.
+
+    Example::
+
+        h = _leaf("age", "21", b"\\x00" * 16)
+        assert len(h) == 32
+    """
+    parts = [
+        b"veil-leaf\x00",
+        len(name).to_bytes(4, "big"),
+        name.encode("utf-8"),
+        len(value).to_bytes(4, "big"),
+        value.encode("utf-8"),
+        salt,
+    ]
+    return hashlib.sha256(b"".join(parts)).digest()
+
+
+def _node(left: bytes, right: bytes) -> bytes:
+    """Inner Merkle node ``H("veil-node" | left | right)`` (domain-separated)."""
+    return hashlib.sha256(b"veil-node\x00" + left + right).digest()
+
+
+def _merkle_levels(leaves: list[bytes]) -> list[list[bytes]]:
+    """Build all tree levels bottom-up; odd nodes are duplicated (Bitcoin-style).
+
+    Returns ``[leaves, ..., [root]]``. An empty credential yields ``[[H("")]]``.
+    """
+    if not leaves:
+        return [[hashlib.sha256(b"veil-empty").digest()]]
+    levels = [leaves]
+    while len(levels[-1]) > 1:
+        cur = levels[-1]
+        nxt = [_node(cur[i], cur[i + 1 if i + 1 < len(cur) else i]) for i in range(0, len(cur), 2)]
+        levels.append(nxt)
+    return levels
+
+
+def _merkle_root(leaves: list[bytes]) -> bytes:
+    """Root of the salted Merkle tree over *leaves*."""
+    return _merkle_levels(leaves)[-1][0]
+
+
+def _merkle_path(leaves: list[bytes], index: int) -> list[tuple[str, bool]]:
+    """Authentication path for ``leaves[index]`` as ``(sibling_hex, sibling_is_right)``."""
+    path: list[tuple[str, bool]] = []
+    levels = _merkle_levels(leaves)
+    idx = index
+    for level in levels[:-1]:
+        sibling_is_right = idx % 2 == 0
+        sib_idx = idx + 1 if sibling_is_right else idx - 1
+        if sib_idx >= len(level):  # odd node duplicated with itself
+            sib_idx = idx
+        path.append((level[sib_idx].hex(), sibling_is_right))
+        idx //= 2
+    return path
+
+
+def _root_from_path(leaf: bytes, path: list[tuple[str, bool]]) -> bytes:
+    """Recompute the root from a leaf and its authentication path."""
+    acc = leaf
+    for sib_hex, sib_is_right in path:
+        sib = bytes.fromhex(sib_hex)
+        acc = _node(acc, sib) if sib_is_right else _node(sib, acc)
+    return acc
+
+
+def commit_credential(
+    fields: dict[str, str], *, salt_seed: bytes = b""
+) -> tuple[str, dict[str, str]]:
+    """Issuer helper: commit a multi-field credential to a single root.
+
+    Returns ``(root_hex, salts)`` where ``salts`` maps each field name to a hex
+    salt. Fields are ordered by sorted name so the commitment is deterministic.
+    With a non-empty ``salt_seed`` the salts (and thus the root) are reproducible
+    for trace tests; with the default empty seed they are derived from the field
+    content alone (still hiding, since values include entropy in practice — pass
+    a seed for unlinkable commitments across credentials).
+
+    Example::
+
+        root, salts = commit_credential({"age": "21", "country": "NG"}, salt_seed=b"s")
+        assert len(root) == 64 and set(salts) == {"age", "country"}
+    """
+    names = sorted(fields)
+    salts: dict[str, str] = {}
+    leaves: list[bytes] = []
+    for name in names:
+        salt = _hkdf(salt_seed, b"veil-salt|" + name.encode("utf-8"), length=16)
+        salts[name] = salt.hex()
+        leaves.append(_leaf(name, fields[name], salt))
+    return _merkle_root(leaves).hex(), salts
+
+
+# ---------------------------------------------------------------------------
+# Envelope model + typed parser (json.loads is Any; we validate every field)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Wrap:
+    """One per-recipient key-wrap entry inside an envelope."""
+
+    key_id: str
+    nonce: bytes
+    wrapped: bytes
+
+
+@dataclass(frozen=True)
+class _Envelope:
+    """Parsed, validated hybrid-encryption envelope."""
+
+    scheme: str
+    sender: str
+    epoch: int
+    msg_id: str
+    eph_pub: bytes
+    nonce: bytes
+    ciphertext: bytes
+    wraps: list[_Wrap]
+
+    def recipient_key_ids(self) -> list[str]:
+        """Sorted recipient key ids — the canonical audience binding for the AAD."""
+        return sorted(w.key_id for w in self.wraps)
+
+
+def _require(mapping: dict[str, Any], key: str) -> Any:
+    if key not in mapping:
+        raise MalformedEnvelopeError(f"missing field {key!r}")
+    return mapping[key]
+
+
+def _parse_envelope(data: bytes) -> _Envelope:
+    """Parse and structurally validate envelope bytes (raises on any defect)."""
+    try:
+        loaded: Any = json.loads(data)
+    except (ValueError, TypeError) as exc:
+        raise MalformedEnvelopeError("not JSON") from exc
+    if not isinstance(loaded, dict):
+        raise MalformedEnvelopeError("envelope is not an object")
+    obj = cast("dict[str, Any]", loaded)
+    if _require(obj, "s") != SCHEME:
+        raise MalformedEnvelopeError("unknown scheme")
+    raw_wraps = _require(obj, "to")
+    if not isinstance(raw_wraps, list):
+        raise MalformedEnvelopeError("'to' is not a list")
+    wraps: list[_Wrap] = []
+    for item in cast("list[Any]", raw_wraps):
+        if not isinstance(item, dict):
+            raise MalformedEnvelopeError("wrap entry is not an object")
+        entry = cast("dict[str, Any]", item)
+        wraps.append(
+            _Wrap(
+                key_id=str(_require(entry, "kid")),
+                nonce=_unb64(str(_require(entry, "n"))),
+                wrapped=_unb64(str(_require(entry, "w"))),
+            )
+        )
+    try:
+        return _Envelope(
+            scheme=SCHEME,
+            sender=str(_require(obj, "from")),
+            epoch=int(_require(obj, "epoch")),
+            msg_id=str(_require(obj, "msg")),
+            eph_pub=_unb64(str(_require(obj, "eph"))),
+            nonce=_unb64(str(_require(obj, "n0"))),
+            ciphertext=_unb64(str(_require(obj, "ct"))),
+            wraps=wraps,
+        )
+    except (ValueError, TypeError) as exc:
+        raise MalformedEnvelopeError("malformed envelope field") from exc
+
+
+# ---------------------------------------------------------------------------
+# The plugin
+# ---------------------------------------------------------------------------
+
+
+class HybridX25519Privacy:
+    """Per-agent hybrid-encryption privacy plugin (implements ``Privacy``).
+
+    Each agent holds its own X25519 key (derived from ``seed``) and a directory
+    of peer public keys registered via :meth:`register_peer`. Construct with
+    ``deterministic=True`` for reproducible Tier-1 traces.
+
+    Example::
+
+        a = HybridX25519Privacy(AgentId("a"), seed=b"a")
+        b = HybridX25519Privacy(AgentId("b"), seed=b"b")
+        a.register_peer(AgentId("b"), b.public_key)
+        env = await a.encrypt(b"hi", [AgentId("b")])
+        assert await b.decrypt(env) == b"hi"
+    """
+
+    def __init__(
+        self, agent_id: AgentId, seed: bytes = b"", *, deterministic: bool = False
+    ) -> None:
+        self._agent_id = agent_id
+        self._deterministic = deterministic
+        self._private = _x25519_private_from_seed(seed, agent_id)
+        self._public = _raw_public(self._private.public_key())
+        self._key_id = _key_id(self._public)
+        # Peer directory: AgentId -> current raw X25519 public key.
+        self._directory: dict[AgentId, bytes] = {agent_id: self._public}
+        # Revocation: AgentId -> epoch from which the member is excluded.
+        self._revoked: dict[AgentId, int] = {}
+        self._epoch = 0
+        self._seq = 0
+        # Anti-replay: (sender, msg_id) already decrypted by this agent.
+        self._seen: set[tuple[str, str]] = set()
+
+    # -- identity / directory -------------------------------------------------
+
+    @property
+    def public_key(self) -> bytes:
+        """This agent's raw X25519 public key.
+
+        Example::
+
+            pk = priv.public_key
+        """
+        return self._public
+
+    @property
+    def key_id(self) -> str:
+        """Short id of this agent's public key (matches envelope wrap entries).
+
+        Example::
+
+            kid = priv.key_id
+        """
+        return self._key_id
+
+    @property
+    def epoch(self) -> int:
+        """Current revocation epoch (advances on :meth:`revoke`).
+
+        Example::
+
+            assert priv.epoch == 0
+        """
+        return self._epoch
+
+    def register_peer(self, agent_id: AgentId, public_key: bytes) -> None:
+        """Register a peer's current public key so messages can be wrapped for it.
+
+        Example::
+
+            priv.register_peer(AgentId("b"), b_public_key)
+        """
+        self._directory[agent_id] = public_key
+
+    def register_self_as(self, agent_id: AgentId) -> None:
+        """Alias this agent's own key under *agent_id* (no-op convenience).
+
+        Useful in tests where the sender addresses the recipient by id and the
+        recipient wants its own key indexed under the same id.
+
+        Example::
+
+            bob.register_self_as(AgentId("bob"))
+        """
+        self._directory[agent_id] = self._public
+
+    def revoke(self, agent_id: AgentId) -> int:
+        """Revoke *agent_id*: advance the epoch and exclude it from future wraps.
+
+        Returns the new epoch. Past envelopes that already wrapped to the member
+        remain decryptable by it (see the module forward-secrecy note).
+
+        Example::
+
+            new_epoch = priv.revoke(AgentId("carol"))
+        """
+        self._epoch += 1
+        self._revoked[agent_id] = self._epoch
+        return self._epoch
+
+    def _is_revoked(self, agent_id: AgentId, epoch: int) -> bool:
+        revoked_at = self._revoked.get(agent_id)
+        return revoked_at is not None and epoch >= revoked_at
+
+    # -- randomness (deterministic or system) ---------------------------------
+
+    def _ephemeral(self, msg_id: str) -> X25519PrivateKey:
+        if self._deterministic:
+            material = _hkdf(_raw_private(self._private), b"veil-eph|" + msg_id.encode("utf-8"))
+            return X25519PrivateKey.from_private_bytes(material)
+        return X25519PrivateKey.generate()
+
+    def _nonce(self, msg_id: str, index: int) -> bytes:
+        if self._deterministic:
+            return _hkdf(
+                _raw_private(self._private),
+                b"veil-nonce|" + msg_id.encode("utf-8") + b"|" + str(index).encode("ascii"),
+                length=_NONCE_BYTES,
+            )
+        import os
+
+        return os.urandom(_NONCE_BYTES)
+
+    def _content_key(self, msg_id: str, eph_pub: bytes) -> bytes:
+        if self._deterministic:
+            return _hkdf(
+                _raw_private(self._private),
+                b"veil-cek|" + msg_id.encode("utf-8") + b"|" + eph_pub,
+            )
+        import os
+
+        return os.urandom(_KEY_BYTES)
+
+    # -- Privacy protocol: encryption -----------------------------------------
+
+    async def encrypt(self, data: bytes, audience: list[AgentId]) -> bytes:
+        """Encrypt *data* so only non-revoked members of *audience* can read it.
+
+        Produces a self-describing envelope (bytes): one ChaCha20-Poly1305
+        encryption of the payload under a fresh content key, plus one X25519+HKDF
+        key-wrap of that content key per recipient. The sender, epoch, message id
+        and the sorted recipient key-ids are bound into the AEAD associated data,
+        so any redirection or field edit breaks authentication.
+
+        Recipients not in the directory, or revoked as of the current epoch, are
+        silently excluded (that is exactly the revocation guarantee).
+
+        Example::
+
+            env = await alice.encrypt(b"secret", [AgentId("bob")])
+        """
+        recipients: list[AgentId] = []
+        seen: set[AgentId] = set()
+        for aid in audience:
+            if aid in seen or aid not in self._directory or self._is_revoked(aid, self._epoch):
+                continue
+            seen.add(aid)
+            recipients.append(aid)
+
+        self._seq += 1
+        msg_id = f"{self._agent_id}:{self._epoch}:{self._seq}"
+        eph_priv = self._ephemeral(msg_id)
+        eph_pub = _raw_public(eph_priv.public_key())
+
+        key_ids = sorted(_key_id(self._directory[aid]) for aid in recipients)
+        aad = _canon(
+            {
+                "s": SCHEME,
+                "from": str(self._agent_id),
+                "epoch": self._epoch,
+                "msg": msg_id,
+                "to": key_ids,
+            }
+        )
+
+        content_key = self._content_key(msg_id, eph_pub)
+        content_nonce = self._nonce(msg_id, 0)
+        ciphertext = ChaCha20Poly1305(content_key).encrypt(content_nonce, data, aad)
+
+        wraps: list[dict[str, str]] = []
+        for index, aid in enumerate(recipients):
+            peer_pub = self._directory[aid]
+            shared = eph_priv.exchange(X25519PublicKey.from_public_bytes(peer_pub))
+            wrap_key = _hkdf(shared, b"veil-wrap|" + _key_id(peer_pub).encode("ascii"))
+            wrap_nonce = self._nonce(msg_id, index + 1)
+            wrapped = ChaCha20Poly1305(wrap_key).encrypt(wrap_nonce, content_key, aad)
+            wraps.append({"kid": _key_id(peer_pub), "n": _b64(wrap_nonce), "w": _b64(wrapped)})
+
+        envelope = {
+            "v": 1,
+            "s": SCHEME,
+            "from": str(self._agent_id),
+            "epoch": self._epoch,
+            "msg": msg_id,
+            "eph": _b64(eph_pub),
+            "n0": _b64(content_nonce),
+            "ct": _b64(ciphertext),
+            "to": wraps,
+        }
+        return _canon(envelope)
+
+    async def decrypt(self, data: bytes) -> bytes:
+        """Decrypt an envelope addressed to this agent.
+
+        Raises :class:`NotInAudienceError` if this agent holds no wrap entry
+        (eavesdropper or stale-revocation), :class:`ReplayError` on a re-presented
+        envelope, and :class:`TamperError` if AEAD authentication fails.
+
+        Example::
+
+            plaintext = await bob.decrypt(env)
+        """
+        env = _parse_envelope(data)
+        wrap = next((w for w in env.wraps if w.key_id == self._key_id), None)
+        if wrap is None:
+            raise NotInAudienceError(f"{self._agent_id} is not in the audience")
+        if (env.sender, env.msg_id) in self._seen:
+            raise ReplayError(f"replayed envelope {env.sender}:{env.msg_id}")
+
+        aad = _canon(
+            {
+                "s": SCHEME,
+                "from": env.sender,
+                "epoch": env.epoch,
+                "msg": env.msg_id,
+                "to": env.recipient_key_ids(),
+            }
+        )
+        shared = self._private.exchange(X25519PublicKey.from_public_bytes(env.eph_pub))
+        wrap_key = _hkdf(shared, b"veil-wrap|" + self._key_id.encode("ascii"))
+        try:
+            content_key = ChaCha20Poly1305(wrap_key).decrypt(wrap.nonce, wrap.wrapped, aad)
+            plaintext = ChaCha20Poly1305(content_key).decrypt(env.nonce, env.ciphertext, aad)
+        except InvalidTag as exc:
+            raise TamperError("AEAD authentication failed") from exc
+
+        self._seen.add((env.sender, env.msg_id))
+        return plaintext
+
+    # -- Privacy protocol: selective-disclosure proofs ------------------------
+
+    async def prove(self, statement: Statement, witness: Witness) -> Proof:
+        """Prove that the revealed fields belong to the committed credential.
+
+        ``statement.public_inputs`` must carry ``root`` (the issuer's committed
+        Merkle root, hex) and ``reveal`` (comma-separated field names to
+        disclose). ``witness.private_inputs`` holds every field value plus a
+        ``__salts__`` entry (JSON ``{name: salt_hex}``) — i.e. the full opened
+        credential. The proof discloses only the requested fields and their
+        authentication paths; the rest stay hidden behind the root.
+
+        Raises ``ValueError`` if the witness does not reconstruct the committed
+        root (an inconsistent credential), so a holder cannot accidentally prove
+        against the wrong commitment.
+
+        Example::
+
+            proof = await priv.prove(stmt, witness)
+        """
+        fields, salts = _split_witness(witness)
+        names = sorted(fields)
+        missing = [n for n in names if n not in salts]
+        if missing:
+            msg = f"witness missing salt(s) for field(s): {', '.join(missing)}"
+            raise ValueError(msg)
+        leaves = [_leaf(n, fields[n], bytes.fromhex(salts[n])) for n in names]
+        root = _merkle_root(leaves).hex()
+        if root != statement.public_inputs.get("root"):
+            msg = "witness does not match the committed root"
+            raise ValueError(msg)
+
+        reveal = _reveal_set(statement)
+        disclosed: dict[str, dict[str, Any]] = {}
+        for name in reveal:
+            idx = names.index(name)
+            disclosed[name] = {
+                "value": fields[name],
+                "salt": salts[name],
+                "index": idx,
+                "path": _merkle_path(leaves, idx),
+            }
+        payload = _canon({"root": root, "n": len(names), "disclosed": disclosed})
+        return Proof(statement=statement, data=payload, scheme=PROOF_SCHEME)
+
+    async def verify_proof(self, statement: Statement, proof: Proof) -> bool:
+        """Verify a selective-disclosure proof against the statement's root.
+
+        Returns ``True`` iff the proof's scheme matches, every disclosed field's
+        salted leaf authenticates to the committed root, the reconstructed root
+        equals ``statement.public_inputs['root']``, and the set of disclosed
+        fields equals the statement's ``reveal`` set. Any tampering with a
+        revealed value, salt, or path node flips a hash and returns ``False``.
+
+        Example::
+
+            ok = await priv.verify_proof(stmt, proof)
+        """
+        if proof.scheme != PROOF_SCHEME:
+            return False
+        anchored_root = statement.public_inputs.get("root")
+        try:
+            parsed: Any = json.loads(proof.data)
+        except (ValueError, TypeError):
+            return False
+        if not isinstance(parsed, dict):
+            return False
+        body = cast("dict[str, Any]", parsed)
+        if body.get("root") != anchored_root:
+            return False
+        raw_disclosed = body.get("disclosed")
+        if not isinstance(raw_disclosed, dict):
+            return False
+        disclosed = cast("dict[str, Any]", raw_disclosed)
+        if set(disclosed) != _reveal_set(statement):
+            return False
+        for name, item in disclosed.items():
+            if not isinstance(item, dict):
+                return False
+            field = cast("dict[str, Any]", item)
+            try:
+                value = str(field["value"])
+                salt = bytes.fromhex(str(field["salt"]))
+                path = _coerce_path(field["path"])
+            except (KeyError, ValueError, TypeError):
+                return False
+            leaf = _leaf(name, value, salt)
+            if _root_from_path(leaf, path).hex() != anchored_root:
+                return False
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Witness / statement decoding helpers
+# ---------------------------------------------------------------------------
+
+
+def _split_witness(witness: Witness) -> tuple[dict[str, str], dict[str, str]]:
+    """Split a witness into ``(fields, salts)``; ``__salts__`` holds the salts."""
+    raw = dict(witness.private_inputs)
+    salts_json = raw.pop("__salts__", "{}")
+    loaded: Any = json.loads(salts_json)
+    if not isinstance(loaded, dict):
+        msg = "__salts__ must be a JSON object"
+        raise ValueError(msg)
+    mapping = cast("dict[str, Any]", loaded)
+    salts: dict[str, str] = {str(k): str(v) for k, v in mapping.items()}
+    fields: dict[str, str] = {k: str(v) for k, v in raw.items()}
+    return fields, salts
+
+
+def _reveal_set(statement: Statement) -> set[str]:
+    """Parse the comma-separated ``reveal`` field-name list from the statement."""
+    raw = statement.public_inputs.get("reveal", "")
+    return {name.strip() for name in raw.split(",") if name.strip()}
+
+
+def _coerce_path(raw: Any) -> list[tuple[str, bool]]:
+    """Coerce a JSON-decoded path back into ``[(sibling_hex, is_right)]``."""
+    if not isinstance(raw, list):
+        msg = "path is not a list"
+        raise TypeError(msg)
+    path: list[tuple[str, bool]] = []
+    for step in cast("list[Any]", raw):
+        if not isinstance(step, list):
+            msg = "path step is not a list"
+            raise TypeError(msg)
+        pair = cast("list[Any]", step)
+        if len(pair) != 2:
+            msg = "path step is not a 2-element list"
+            raise TypeError(msg)
+        path.append((str(pair[0]), bool(pair[1])))
+    return path

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -23,11 +23,23 @@ from nest_plugins_reference.validators.gossip_validators import (
     check_converged,
     check_no_partition_view_leak,
 )
+from nest_plugins_reference.validators.privacy_validators import (
+    check_eavesdropper_blocked,
+    check_field_injection_rejected,
+    check_replay_rejected,
+    check_stale_revocation_blocked,
+    corrupt_proof,
+)
 
 __all__ = [
     "ConvergenceFailureError",
     "PartitionLeakError",
     "ValidatorReport",
     "check_converged",
+    "check_eavesdropper_blocked",
+    "check_field_injection_rejected",
     "check_no_partition_view_leak",
+    "check_replay_rejected",
+    "check_stale_revocation_blocked",
+    "corrupt_proof",
 ]

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/privacy_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/privacy_validators.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for the ``hybrid_x25519`` privacy plugin.
+
+Four attacks the default ``noop`` privacy plugin silently allows — because
+``encrypt`` returns the plaintext unchanged, ``decrypt`` returns its input, and
+``verify_proof`` is an unconditional ``True``:
+
+1. **Eavesdropper.** A non-audience agent decrypts an intercepted envelope.
+   ``check_eavesdropper_blocked`` asserts the outsider cannot recover the
+   plaintext *and* the plaintext never appears verbatim in the envelope bytes.
+2. **Replay.** A recorded envelope is re-presented to its recipient.
+   ``check_replay_rejected`` asserts the first decrypt succeeds and the second
+   (identical) decrypt fails.
+3. **Field-injection.** An attacker edits a revealed field of a
+   selective-disclosure proof. ``check_field_injection_rejected`` asserts the
+   untampered proof verifies and the tampered one does not.
+4. **Stale-revocation.** A member revoked at epoch *E* decrypts a message issued
+   at epoch ``>= E``. ``check_stale_revocation_blocked`` asserts the member can
+   read a pre-revocation envelope but not a post-revocation one.
+
+Each validator is a pure ``async`` function on the :class:`~nest_core.layers.privacy.Privacy`
+protocol surface — it performs only ``encrypt``/``decrypt``/``verify_proof``
+calls and never reaches into plugin internals. That is what lets the *same*
+check run against both plugins:
+
+* against ``hybrid_x25519`` every check **passes**;
+* against ``noop`` every check **fails** — the validators literally cannot be
+  satisfied by the passthrough reference plugin, which is the charter's bar for
+  "adversarial".
+
+The caller supplies the already-built artifacts (envelopes, proofs) so the
+validator stays plugin-agnostic; helpers :func:`corrupt_proof` build the
+tampered proof used by attack 3.
+
+Example::
+
+    report = await check_eavesdropper_blocked(outsider, envelope, secret=b"bid:1700")
+    assert report.passed, report.detail
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, cast
+
+from nest_plugins_reference.validators.gossip_validators import ValidatorReport
+
+if TYPE_CHECKING:
+    from nest_core.layers.privacy import Privacy
+    from nest_core.types import Proof, Statement
+
+
+async def _try_decrypt(privacy: Privacy, envelope: bytes) -> tuple[bool, bytes | None]:
+    """Attempt a decrypt; return ``(ok, plaintext)`` with failures normalised.
+
+    Any exception (not-in-audience, replay, tamper, malformed) is treated as a
+    decrypt failure rather than propagating, so a validator can reason about the
+    *policy outcome* uniformly across plugins.
+
+    Example::
+
+        ok, pt = await _try_decrypt(outsider, envelope)
+    """
+    try:
+        return True, await privacy.decrypt(envelope)
+    except Exception:  # noqa: BLE001 - any failure is, for policy purposes, "blocked"
+        return False, None
+
+
+async def check_eavesdropper_blocked(
+    eavesdropper: Privacy, envelope: bytes, *, secret: bytes
+) -> ValidatorReport:
+    """Assert a non-audience agent cannot recover the plaintext from *envelope*.
+
+    Passes iff the outsider's decrypt does **not** yield ``secret`` and
+    ``secret`` does not appear as a substring of the envelope bytes (so even a
+    passthrough "encryption" that leaks the payload on the wire fails).
+
+    Against ``noop`` the envelope *is* the plaintext, so both conditions fail.
+
+    Example::
+
+        report = await check_eavesdropper_blocked(carol, env, secret=b"bid:1700")
+        assert report.passed, report.detail
+    """
+    ok, recovered = await _try_decrypt(eavesdropper, envelope)
+    leaked_via_decrypt = ok and recovered == secret
+    leaked_on_wire = secret in envelope
+    if leaked_via_decrypt or leaked_on_wire:
+        return ValidatorReport(
+            passed=False,
+            detail="eavesdropper recovered plaintext"
+            if leaked_via_decrypt
+            else "plaintext appears verbatim in the envelope",
+            evidence={"via_decrypt": leaked_via_decrypt, "on_wire": leaked_on_wire},
+        )
+    return ValidatorReport(passed=True, detail="eavesdropper learned nothing")
+
+
+async def check_replay_rejected(recipient: Privacy, envelope: bytes) -> ValidatorReport:
+    """Assert a recipient accepts an envelope once and rejects a replay of it.
+
+    Passes iff the first decrypt succeeds and the second (byte-identical) decrypt
+    fails. Against ``noop`` both succeed (it has no replay memory).
+
+    Example::
+
+        report = await check_replay_rejected(bob, env)
+        assert report.passed, report.detail
+    """
+    first_ok, _ = await _try_decrypt(recipient, envelope)
+    second_ok, _ = await _try_decrypt(recipient, envelope)
+    if not first_ok:
+        return ValidatorReport(passed=False, detail="legitimate first decrypt failed")
+    if second_ok:
+        return ValidatorReport(passed=False, detail="replayed envelope was accepted twice")
+    return ValidatorReport(passed=True, detail="replay rejected on second presentation")
+
+
+async def check_field_injection_rejected(
+    verifier: Privacy, statement: Statement, good_proof: Proof, tampered_proof: Proof
+) -> ValidatorReport:
+    """Assert an untampered proof verifies and a field-tampered proof does not.
+
+    Passes iff ``verify_proof`` accepts ``good_proof`` and rejects
+    ``tampered_proof``. Against ``noop`` (``verify_proof`` is always ``True``)
+    the tampered proof is wrongly accepted.
+
+    Example::
+
+        bad = corrupt_proof(good)
+        report = await check_field_injection_rejected(v, stmt, good, bad)
+        assert report.passed, report.detail
+    """
+    if not await verifier.verify_proof(statement, good_proof):
+        return ValidatorReport(passed=False, detail="honest proof failed to verify")
+    if await verifier.verify_proof(statement, tampered_proof):
+        return ValidatorReport(passed=False, detail="tampered proof was accepted")
+    return ValidatorReport(passed=True, detail="field-injected proof rejected")
+
+
+async def check_stale_revocation_blocked(
+    member: Privacy, pre_revocation: bytes, post_revocation: bytes
+) -> ValidatorReport:
+    """Assert a revoked member can read a pre- but not a post-revocation message.
+
+    Passes iff the member decrypts ``pre_revocation`` (it was in that audience)
+    and fails to decrypt ``post_revocation`` (excluded after revocation). Against
+    ``noop`` both passthrough-"decrypt" successfully.
+
+    Example::
+
+        report = await check_stale_revocation_blocked(carol, pre, post)
+        assert report.passed, report.detail
+    """
+    pre_ok, _ = await _try_decrypt(member, pre_revocation)
+    post_ok, _ = await _try_decrypt(member, post_revocation)
+    if not pre_ok:
+        return ValidatorReport(passed=False, detail="member could not read pre-revocation message")
+    if post_ok:
+        return ValidatorReport(
+            passed=False, detail="revoked member decrypted a post-revocation message"
+        )
+    return ValidatorReport(passed=True, detail="post-revocation message blocked for revoked member")
+
+
+def corrupt_proof(proof: Proof, *, field: str | None = None) -> Proof:
+    """Return a copy of *proof* with one revealed field's value flipped.
+
+    Used to drive :func:`check_field_injection_rejected`. If *field* is ``None``
+    the first disclosed field (sorted) is corrupted. Works on the
+    ``merkle-selective-disclosure`` proof body; on any other body it returns the
+    proof unchanged (so the validator simply observes no tamper effect).
+
+    Example::
+
+        bad = corrupt_proof(good_proof)
+    """
+    try:
+        loaded: Any = json.loads(proof.data)
+    except (ValueError, TypeError):
+        return proof
+    if not isinstance(loaded, dict):
+        return proof
+    body = cast("dict[str, Any]", loaded)
+    raw_disclosed = body.get("disclosed")
+    if not isinstance(raw_disclosed, dict):
+        return proof
+    disclosed = cast("dict[str, Any]", raw_disclosed)
+    if not disclosed:
+        return proof
+    target = field if field is not None else sorted(disclosed)[0]
+    raw_entry = disclosed.get(target)
+    if not isinstance(raw_entry, dict):
+        return proof
+    entry = cast("dict[str, Any]", raw_entry)
+    if "value" not in entry:
+        return proof
+    entry["value"] = str(entry["value"]) + "!tampered"
+    payload = json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return proof.model_copy(update={"data": payload})

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -36,6 +36,9 @@ Repository = "https://github.com/projnanda/nandatown"
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
 
+[project.entry-points."nest.plugins.privacy"]
+hybrid_x25519 = "nest_plugins_reference.privacy.hybrid_x25519:HybridX25519Privacy"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/nest-plugins-reference/tests/test_hybrid_x25519.py
+++ b/packages/nest-plugins-reference/tests/test_hybrid_x25519.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Example-based + adversarial tests for the ``hybrid_x25519`` privacy plugin.
+
+Three layers of coverage (mirrors the gossip plugin's test structure):
+
+1. **Unit / round-trip** — encryption to one and many recipients, selective
+   disclosure prove/verify, and the structural guarantees (plaintext never on
+   the wire, undisclosed fields never in the proof).
+2. **Adversarial discrimination** — the four validators
+   (:mod:`nest_plugins_reference.validators.privacy_validators`) MUST PASS
+   against ``hybrid_x25519`` and MUST FAIL against the ``noop`` reference
+   plugin. This is the charter's bar for "adversarial".
+3. **Sealed-bid-with-privacy scenario** — a 5-bidder first-/second-price auction
+   where bids are encrypted to the auctioneer; an eavesdropper on the wire
+   learns nothing, yet the auctioneer recovers every bid and resolves the
+   winner. This is the ``scenarios/sealed_bid_with_privacy.yaml`` story in
+   runnable form.
+
+Example::
+
+    pytest packages/nest-plugins-reference/tests/test_hybrid_x25519.py
+"""
+
+from __future__ import annotations
+
+from nest_core.types import AgentId, Statement, Witness
+from nest_plugins_reference.privacy.hybrid_x25519 import (
+    HybridX25519Privacy,
+    NotInAudienceError,
+    ReplayError,
+    commit_credential,
+)
+from nest_plugins_reference.privacy.noop import NoopPrivacy
+from nest_plugins_reference.validators import (
+    check_eavesdropper_blocked,
+    check_field_injection_rejected,
+    check_replay_rejected,
+    check_stale_revocation_blocked,
+    corrupt_proof,
+)
+
+
+def _mk(name: str, *, seed: bytes | None = None) -> HybridX25519Privacy:
+    return HybridX25519Privacy(
+        AgentId(name), seed=seed if seed is not None else name.encode(), deterministic=True
+    )
+
+
+def _credential() -> tuple[Statement, Witness, dict[str, str]]:
+    """A 3-field credential committed to a root, revealing age + country only."""
+    fields = {"age": "21", "country": "NG", "salary": "99999"}
+    root, salts = commit_credential(fields, salt_seed=b"issuer-seed")
+    statement = Statement(
+        predicate="selective_disclosure",
+        public_inputs={"root": root, "reveal": "age,country"},
+    )
+    witness = Witness(private_inputs={**fields, "__salts__": _dumps(salts)})
+    return statement, witness, fields
+
+
+def _dumps(mapping: dict[str, str]) -> str:
+    import json
+
+    return json.dumps(mapping, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# 1. Unit / round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptionRoundTrip:
+    async def test_single_recipient_round_trip(self) -> None:
+        alice, bob = _mk("alice"), _mk("bob")
+        alice.register_peer(AgentId("bob"), bob.public_key)
+        env = await alice.encrypt(b"sealed-bid:1700", [AgentId("bob")])
+        assert await bob.decrypt(env) == b"sealed-bid:1700"
+
+    async def test_plaintext_never_on_the_wire(self) -> None:
+        alice, bob = _mk("alice"), _mk("bob")
+        alice.register_peer(AgentId("bob"), bob.public_key)
+        secret = b"the-password-is-hunter2"
+        env = await alice.encrypt(secret, [AgentId("bob")])
+        assert secret not in env
+
+    async def test_broadcast_to_many_recipients(self) -> None:
+        alice = _mk("alice")
+        recipients = {name: _mk(name) for name in ("bob", "carol", "dave")}
+        for name, plugin in recipients.items():
+            alice.register_peer(AgentId(name), plugin.public_key)
+        env = await alice.encrypt(b"group-secret", [AgentId(n) for n in recipients])
+        for plugin in recipients.values():
+            assert await plugin.decrypt(env) == b"group-secret"
+
+    async def test_outsider_cannot_decrypt(self) -> None:
+        alice, bob, snoop = _mk("alice"), _mk("bob"), _mk("snoop")
+        alice.register_peer(AgentId("bob"), bob.public_key)
+        env = await alice.encrypt(b"secret", [AgentId("bob")])
+        try:
+            await snoop.decrypt(env)
+        except NotInAudienceError:
+            pass
+        else:  # pragma: no cover - failure path
+            raise AssertionError("outsider unexpectedly decrypted")
+
+    async def test_tampered_ciphertext_rejected(self) -> None:
+        alice, bob = _mk("alice"), _mk("bob")
+        alice.register_peer(AgentId("bob"), bob.public_key)
+        env = bytearray(await alice.encrypt(b"secret", [AgentId("bob")]))
+        # Flip a byte inside the base64 ciphertext region; still valid JSON shape.
+        marker = env.index(b'"ct":"') + len(b'"ct":"')
+        env[marker] = env[marker] ^ 0x01 if env[marker] != ord("A") else ord("B")
+        try:
+            await bob.decrypt(bytes(env))
+        except Exception:  # noqa: BLE001 - any failure means "not accepted"
+            return
+        raise AssertionError("tampered ciphertext unexpectedly accepted")  # pragma: no cover
+
+    async def test_determinism_same_seed_same_bytes(self) -> None:
+        a1, a2 = _mk("alice"), _mk("alice")
+        b1 = _mk("bob")
+        a1.register_peer(AgentId("bob"), b1.public_key)
+        a2.register_peer(AgentId("bob"), b1.public_key)
+        env1 = await a1.encrypt(b"same", [AgentId("bob")])
+        env2 = await a2.encrypt(b"same", [AgentId("bob")])
+        assert env1 == env2
+
+
+class TestSelectiveDisclosure:
+    async def test_revealed_fields_verify(self) -> None:
+        alice = _mk("alice")
+        statement, witness, _ = _credential()
+        proof = await alice.prove(statement, witness)
+        assert await alice.verify_proof(statement, proof)
+
+    async def test_undisclosed_field_absent_from_proof(self) -> None:
+        alice = _mk("alice")
+        statement, witness, _ = _credential()
+        proof = await alice.prove(statement, witness)
+        # The hidden salary value must not leak into the proof bytes.
+        assert b"99999" not in proof.data
+
+    async def test_tampered_revealed_value_fails(self) -> None:
+        alice = _mk("alice")
+        statement, witness, _ = _credential()
+        proof = await alice.prove(statement, witness)
+        assert not await alice.verify_proof(statement, corrupt_proof(proof))
+
+    async def test_wrong_root_fails(self) -> None:
+        alice = _mk("alice")
+        statement, witness, _ = _credential()
+        proof = await alice.prove(statement, witness)
+        forged = Statement(
+            predicate=statement.predicate,
+            public_inputs={**statement.public_inputs, "root": "00" * 32},
+        )
+        assert not await alice.verify_proof(forged, proof)
+
+    async def test_inconsistent_witness_raises(self) -> None:
+        alice = _mk("alice")
+        statement, _, _ = _credential()
+        bad_witness = Witness(private_inputs={"age": "21", "__salts__": "{}"})
+        try:
+            await alice.prove(statement, bad_witness)
+        except ValueError:
+            return
+        raise AssertionError("inconsistent witness unexpectedly proved")  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# 2. Adversarial discrimination — validators pass vs hybrid, fail vs noop
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorsPassAgainstHybrid:
+    async def test_eavesdropper_blocked(self) -> None:
+        alice, bob, snoop = _mk("alice"), _mk("bob"), _mk("snoop")
+        alice.register_peer(AgentId("bob"), bob.public_key)
+        secret = b"bid:1700"
+        env = await alice.encrypt(secret, [AgentId("bob")])
+        report = await check_eavesdropper_blocked(snoop, env, secret=secret)
+        assert report.passed, report.detail
+
+    async def test_replay_rejected(self) -> None:
+        alice, bob = _mk("alice"), _mk("bob")
+        alice.register_peer(AgentId("bob"), bob.public_key)
+        env = await alice.encrypt(b"once", [AgentId("bob")])
+        report = await check_replay_rejected(bob, env)
+        assert report.passed, report.detail
+
+    async def test_field_injection_rejected(self) -> None:
+        alice = _mk("alice")
+        statement, witness, _ = _credential()
+        good = await alice.prove(statement, witness)
+        report = await check_field_injection_rejected(alice, statement, good, corrupt_proof(good))
+        assert report.passed, report.detail
+
+    async def test_stale_revocation_blocked(self) -> None:
+        sender, carol = _mk("sender"), _mk("carol")
+        sender.register_peer(AgentId("carol"), carol.public_key)
+        pre = await sender.encrypt(b"pre", [AgentId("carol")])
+        sender.revoke(AgentId("carol"))
+        post = await sender.encrypt(b"post", [AgentId("carol")])
+        report = await check_stale_revocation_blocked(carol, pre, post)
+        assert report.passed, report.detail
+
+
+class TestValidatorsFailAgainstNoop:
+    """The same validators must be unsatisfiable by the passthrough reference."""
+
+    async def test_eavesdropper_leaks(self) -> None:
+        noop = NoopPrivacy()
+        secret = b"bid:1700"
+        env = await noop.encrypt(secret, [AgentId("bob")])
+        report = await check_eavesdropper_blocked(noop, env, secret=secret)
+        assert not report.passed
+
+    async def test_replay_accepted(self) -> None:
+        noop = NoopPrivacy()
+        env = await noop.encrypt(b"once", [AgentId("bob")])
+        report = await check_replay_rejected(noop, env)
+        assert not report.passed
+
+    async def test_field_injection_accepted(self) -> None:
+        noop = NoopPrivacy()
+        statement, witness, _ = _credential()
+        good = await noop.prove(statement, witness)
+        report = await check_field_injection_rejected(noop, statement, good, corrupt_proof(good))
+        assert not report.passed
+
+    async def test_revocation_not_enforced(self) -> None:
+        noop = NoopPrivacy()
+        pre = await noop.encrypt(b"pre", [AgentId("carol")])
+        post = await noop.encrypt(b"post", [AgentId("carol")])
+        report = await check_stale_revocation_blocked(noop, pre, post)
+        assert not report.passed
+
+
+# ---------------------------------------------------------------------------
+# 3. Sealed-bid-with-privacy scenario (runnable form of the YAML)
+# ---------------------------------------------------------------------------
+
+
+class TestSealedBidWithPrivacy:
+    async def test_bids_sealed_on_wire_but_auctioneer_resolves_winner(self) -> None:
+        auctioneer = _mk("auctioneer")
+        bids = {"bidder-0": 1200, "bidder-1": 1750, "bidder-2": 900, "bidder-3": 1500}
+        bidders = {name: _mk(name) for name in bids}
+        for plugin in bidders.values():
+            plugin.register_peer(AgentId("auctioneer"), auctioneer.public_key)
+
+        # Each bidder seals its bid to the auctioneer only.
+        envelopes: dict[str, bytes] = {}
+        for name, plugin in bidders.items():
+            secret = f"bid:{bids[name]}".encode()
+            envelopes[name] = await plugin.encrypt(secret, [AgentId("auctioneer")])
+
+        # An eavesdropper watching the wire learns nothing about any bid.
+        snoop = _mk("snoop")
+        for name, env in envelopes.items():
+            report = await check_eavesdropper_blocked(
+                snoop, env, secret=f"bid:{bids[name]}".encode()
+            )
+            assert report.passed, report.detail
+            assert str(bids[name]).encode() not in env
+
+        # The auctioneer alone decrypts every bid and resolves a second-price win.
+        decoded = {
+            name: int((await auctioneer.decrypt(env)).split(b":")[1])
+            for name, env in envelopes.items()
+        }
+        assert decoded == bids
+        winner = max(decoded, key=lambda n: decoded[n])
+        clearing_price = sorted(decoded.values())[-2]
+        assert winner == "bidder-1"
+        assert clearing_price == 1500
+
+
+def test_replay_error_is_distinct_from_audience_error() -> None:
+    """Sanity anchor: the two decrypt failure modes are distinct exception types."""
+    assert issubclass(ReplayError, Exception)
+    assert issubclass(NotInAudienceError, Exception)
+    assert ReplayError is not NotInAudienceError

--- a/packages/nest-plugins-reference/tests/test_hybrid_x25519.py
+++ b/packages/nest-plugins-reference/tests/test_hybrid_x25519.py
@@ -166,6 +166,21 @@ class TestSelectiveDisclosure:
             return
         raise AssertionError("inconsistent witness unexpectedly proved")  # pragma: no cover
 
+    async def test_random_salts_by_default_are_unlinkable_but_verify(self) -> None:
+        """With no salt_seed the salts are random: two commitments of the same
+        fields differ (unlinkable), yet each still proves and verifies."""
+        alice = _mk("alice")
+        fields = {"age": "21", "country": "NG"}
+        root1, salts1 = commit_credential(fields)
+        root2, _ = commit_credential(fields)
+        assert root1 != root2
+        statement = Statement(
+            predicate="selective_disclosure", public_inputs={"root": root1, "reveal": "age"}
+        )
+        witness = Witness(private_inputs={**fields, "__salts__": _dumps(salts1)})
+        proof = await alice.prove(statement, witness)
+        assert await alice.verify_proof(statement, proof)
+
 
 # ---------------------------------------------------------------------------
 # 2. Adversarial discrimination — validators pass vs hybrid, fail vs noop

--- a/packages/nest-plugins-reference/tests/test_hybrid_x25519_properties.py
+++ b/packages/nest-plugins-reference/tests/test_hybrid_x25519_properties.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hypothesis property-based tests for the ``hybrid_x25519`` privacy plugin.
+
+Each invariant is checked over generated payloads, seeds, audiences, credential
+field sets, and reveal subsets — so the guarantees hold for *all* inputs, not
+just the hand-picked cases in ``test_hybrid_x25519.py``:
+
+1. **Round-trip.** Every member of the audience recovers the exact plaintext.
+2. **Audience confidentiality.** A non-audience agent never recovers the
+   plaintext (decrypt always fails).
+3. **Determinism.** In deterministic mode, the same ``(seed, agent, payload,
+   audience, call order)`` yields byte-identical envelopes (Tier-1 replay).
+4. **Tamper-evidence.** Corrupting the ciphertext always breaks authentication.
+5. **Replay.** The second presentation of any envelope is always rejected.
+6. **Revocation monotonicity.** After revocation a member is blocked from
+   *future* messages while non-revoked members still read them.
+7. **Selective-disclosure completeness & soundness.** An honest proof over any
+   field set and any non-empty reveal subset verifies; tampering any revealed
+   field always makes it fail.
+
+The plugin's ``encrypt``/``decrypt``/``prove``/``verify_proof`` are ``async`` by
+the ``Privacy`` protocol, so each property drives them through ``asyncio.run``
+inside an otherwise-synchronous Hypothesis test.
+
+Example::
+
+    pytest packages/nest-plugins-reference/tests/test_hybrid_x25519_properties.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Coroutine
+from typing import Any
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Statement, Witness
+from nest_plugins_reference.privacy.hybrid_x25519 import (
+    HybridX25519Privacy,
+    commit_credential,
+)
+from nest_plugins_reference.validators import corrupt_proof
+
+# Letters g-z only: never collide with hex (0-9a-f) and never a JSON metachar,
+# so generated values stay distinctive without tripping substring heuristics.
+_letters = "ghijklmnopqrstuvwxyz"
+_payloads = st.binary(min_size=0, max_size=128)
+_seeds = st.binary(min_size=0, max_size=32)
+_names = st.text(alphabet=_letters, min_size=1, max_size=6)
+_values = st.text(alphabet=_letters, min_size=1, max_size=8)
+_field_sets = st.dictionaries(_names, _values, min_size=1, max_size=5)
+
+
+def _run(coro: Coroutine[Any, Any, None]) -> None:
+    asyncio.run(coro)
+
+
+def _sender(seed: bytes, *, deterministic: bool = False) -> HybridX25519Privacy:
+    return HybridX25519Privacy(AgentId("sender"), seed=seed, deterministic=deterministic)
+
+
+def _recipient(index: int, seed: bytes, *, deterministic: bool = False) -> HybridX25519Privacy:
+    return HybridX25519Privacy(
+        AgentId(f"r{index}"), seed=seed + bytes([index % 256]), deterministic=deterministic
+    )
+
+
+async def _failed(coro: Coroutine[Any, Any, bytes]) -> bool:
+    """Return ``True`` iff awaiting *coro* raises (i.e. the decrypt was blocked)."""
+    try:
+        await coro
+    except Exception:  # noqa: BLE001 - any failure counts as "blocked"
+        return True
+    return False
+
+
+class TestEncryptionInvariants:
+    @settings(max_examples=40, deadline=None)
+    @given(payload=_payloads, k=st.integers(min_value=1, max_value=4), seed=_seeds)
+    def test_all_audience_members_recover_plaintext(
+        self, payload: bytes, k: int, seed: bytes
+    ) -> None:
+        async def go() -> None:
+            sender = _sender(seed)
+            recipients = [_recipient(i, seed) for i in range(k)]
+            ids = [AgentId(f"r{i}") for i in range(k)]
+            for rid, plugin in zip(ids, recipients, strict=True):
+                sender.register_peer(rid, plugin.public_key)
+            env = await sender.encrypt(payload, ids)
+            for plugin in recipients:
+                assert await plugin.decrypt(env) == payload
+
+        _run(go())
+
+    @settings(max_examples=40, deadline=None)
+    @given(payload=_payloads, seed=_seeds)
+    def test_outsider_never_recovers_plaintext(self, payload: bytes, seed: bytes) -> None:
+        async def go() -> None:
+            sender = _sender(seed)
+            bob = _recipient(0, seed)
+            outsider = _recipient(99, seed)
+            sender.register_peer(AgentId("r0"), bob.public_key)
+            env = await sender.encrypt(payload, [AgentId("r0")])
+            assert await _failed(outsider.decrypt(env))
+
+        _run(go())
+
+    @settings(max_examples=30, deadline=None)
+    @given(payload=_payloads, seed=_seeds)
+    def test_deterministic_mode_is_byte_reproducible(self, payload: bytes, seed: bytes) -> None:
+        async def go() -> None:
+            def build() -> tuple[HybridX25519Privacy, list[AgentId]]:
+                sender = _sender(seed, deterministic=True)
+                bob = _recipient(0, seed, deterministic=True)
+                sender.register_peer(AgentId("r0"), bob.public_key)
+                return sender, [AgentId("r0")]
+
+            s1, ids1 = build()
+            s2, ids2 = build()
+            assert await s1.encrypt(payload, ids1) == await s2.encrypt(payload, ids2)
+
+        _run(go())
+
+    @settings(max_examples=40, deadline=None)
+    @given(payload=st.binary(min_size=1, max_size=128), seed=_seeds)
+    def test_ciphertext_tamper_always_detected(self, payload: bytes, seed: bytes) -> None:
+        async def go() -> None:
+            sender = _sender(seed)
+            bob = _recipient(0, seed)
+            sender.register_peer(AgentId("r0"), bob.public_key)
+            env = bytearray(await sender.encrypt(payload, [AgentId("r0")]))
+            # Flip the first ciphertext char (always encodes a significant bit,
+            # so the decoded ciphertext byte 0 always changes -> AEAD rejects).
+            start = env.index(b'"ct":"') + len(b'"ct":"')
+            env[start] = ord("B") if env[start] == ord("A") else ord("A")
+            assert await _failed(bob.decrypt(bytes(env)))
+
+        _run(go())
+
+    @settings(max_examples=40, deadline=None)
+    @given(payload=_payloads, seed=_seeds)
+    def test_replay_always_rejected(self, payload: bytes, seed: bytes) -> None:
+        async def go() -> None:
+            sender = _sender(seed)
+            bob = _recipient(0, seed)
+            sender.register_peer(AgentId("r0"), bob.public_key)
+            env = await sender.encrypt(payload, [AgentId("r0")])
+            assert await bob.decrypt(env) == payload
+            assert await _failed(bob.decrypt(env))
+
+        _run(go())
+
+    @settings(max_examples=30, deadline=None)
+    @given(payload=_payloads, seed=_seeds)
+    def test_revocation_blocks_future_only(self, payload: bytes, seed: bytes) -> None:
+        async def go() -> None:
+            sender = _sender(seed)
+            keep = _recipient(0, seed)
+            victim = _recipient(1, seed)
+            ids = [AgentId("r0"), AgentId("r1")]
+            sender.register_peer(AgentId("r0"), keep.public_key)
+            sender.register_peer(AgentId("r1"), victim.public_key)
+            pre = await sender.encrypt(payload, ids)
+            assert await victim.decrypt(pre) == payload  # had access before
+            sender.revoke(AgentId("r1"))
+            post = await sender.encrypt(payload, ids)
+            assert await keep.decrypt(post) == payload  # non-revoked still reads
+            assert await _failed(victim.decrypt(post))  # revoked is blocked
+
+        _run(go())
+
+
+class TestSelectiveDisclosureInvariants:
+    @settings(max_examples=40, deadline=None)
+    @given(fields=_field_sets, seed=_seeds, data=st.data())
+    def test_completeness_and_soundness(
+        self, fields: dict[str, str], seed: bytes, data: st.DataObject
+    ) -> None:
+        async def go() -> None:
+            names = sorted(fields)
+            reveal = data.draw(
+                st.lists(st.sampled_from(names), min_size=1, max_size=len(names), unique=True)
+            )
+            root, salts = commit_credential(fields, salt_seed=seed)
+            statement = Statement(
+                predicate="selective_disclosure",
+                public_inputs={"root": root, "reveal": ",".join(sorted(set(reveal)))},
+            )
+            witness = Witness(
+                private_inputs={**fields, "__salts__": json.dumps(salts, sort_keys=True)}
+            )
+            priv = _sender(seed)
+            proof = await priv.prove(statement, witness)
+            # Completeness: an honest proof over any reveal subset verifies.
+            assert await priv.verify_proof(statement, proof)
+            # Soundness: tampering any revealed field is always rejected.
+            assert not await priv.verify_proof(statement, corrupt_proof(proof))
+
+        _run(go())

--- a/packages/nest-plugins-reference/tests/test_hybrid_x25519_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_hybrid_x25519_scenario.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Full-simulator integration for the ``hybrid_x25519`` privacy layer.
+
+Boots ``scenarios/sealed_bid_with_privacy.yaml`` through the real
+:class:`~nest_core.runner.ScenarioRunner` to prove the plugin integrates into an
+end-to-end run without breaking the simulator, and that the run stays
+deterministic under replay (Tier-1). The sealed-bid *mechanics* are exercised
+directly in ``test_hybrid_x25519.py::TestSealedBidWithPrivacy``; here we verify
+the plugin is discoverable and simulator-safe.
+
+Example::
+
+    pytest packages/nest-plugins-reference/tests/test_hybrid_x25519_scenario.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_plugins_reference.privacy.hybrid_x25519 import HybridX25519Privacy
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "sealed_bid_with_privacy.yaml"
+
+
+def test_privacy_layer_resolves_to_hybrid_plugin() -> None:
+    """The registry discovers ``hybrid_x25519`` via the built-in map / entry point."""
+    cls = PluginRegistry().resolve("privacy", "hybrid_x25519")
+    assert cls is HybridX25519Privacy
+
+
+@pytest.mark.parametrize("seed", [42, 7])
+def test_scenario_boots_and_runs(seed: int) -> None:
+    """The scenario wiring the hybrid privacy layer runs to completion."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    assert config.layers.privacy == "hybrid_x25519"
+    config = config.model_copy(update={"seed": seed})
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"sealed_{seed}.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        result = asyncio.run(runner.run())
+        assert result.exists()
+        assert result.stat().st_size > 0
+
+
+def test_scenario_is_deterministic_under_replay() -> None:
+    """Two seed-42 runs produce byte-identical traces (Tier-1 reproducibility)."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+
+    def run_once() -> bytes:
+        config = ScenarioConfig.from_yaml(str(SCENARIO_PATH)).model_copy(update={"seed": 42})
+        with tempfile.TemporaryDirectory() as tmp:
+            trace_path = Path(tmp) / "sealed_replay.jsonl"
+            config = config.model_copy(
+                update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+            )
+            runner = ScenarioRunner(config, registry=PluginRegistry())
+            result = asyncio.run(runner.run())
+            return result.read_bytes()
+
+    assert run_once() == run_once()

--- a/scenarios/sealed_bid_with_privacy.yaml
+++ b/scenarios/sealed_bid_with_privacy.yaml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Sealed-bid auction with a REAL privacy layer.
+#
+# Identical to the `auction` scenario except the privacy layer is the
+# `hybrid_x25519` plugin instead of `noop`. Where `noop` leaves every bid
+# readable on the wire, `hybrid_x25519` gives agents real hybrid encryption
+# (X25519 + ChaCha20-Poly1305) so a bid encrypted to the auctioneer is
+# unreadable to eavesdroppers and other bidders.
+#
+# This file wires the capability into a full simulator run (see
+# `tests/test_hybrid_x25519_scenario.py`, which boots it and asserts the layer
+# resolves to `HybridX25519Privacy` and the run is deterministic). The
+# sealed-bid *mechanics* — bidders sealing bids the auctioneer alone opens to
+# resolve a second-price winner — are demonstrated end-to-end in
+# `tests/test_hybrid_x25519.py::TestSealedBidWithPrivacy`.
+name: sealed_bid_with_privacy
+description: "1 auctioneer and 7 bidders; bids sealed via the hybrid_x25519 privacy layer."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 8
+  brain: state-machine
+  roles:
+    - name: auctioneer
+      count: 1
+    - name: bidder
+      count: 7
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: hybrid_x25519
+  datafacts: datafacts_v1
+
+task:
+  type: auction
+  config:
+    rounds: 3
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/sealed_bid_with_privacy.jsonl


### PR DESCRIPTION
## Problem 09 — Privacy: hybrid encryption with selective disclosure and broadcast revocation

**Persona:** applied-cryptography / security engineer. The code is
threat-model-first, adversarial-test-driven, and *honest about what it does not
provide* (see the forward-secrecy disclosure below) — that posture is meant to
be legible in the diff itself, not just this description.

### Motivation

The default privacy plugin (`noop`) is 60 lines of passthrough: `encrypt` returns
its input, `verify_proof` is an unconditional `True`. Every Nanda Town scenario
that simulates a sensitive workflow therefore leaks everything to every observer,
and the trace can't even tell you it would have leaked in production. This PR
ships a real privacy layer so any scenario can opt into a believable
confidentiality story by changing one line (`privacy: hybrid_x25519`).

### What this ships

- **`privacy/hybrid_x25519.py`** — HPKE-shaped hybrid encryption: one
  ChaCha20-Poly1305 content-key encryption of the payload, wrapped once per
  recipient via X25519 ephemeral-static ECDH + HKDF-SHA256 (the broadcast/
  group-key shape — N cheap key-wraps, not N re-encryptions). Plus salted-Merkle
  **selective disclosure** (`prove`/`verify_proof`) and **epoch-based broadcast
  revocation** (`revoke`).
- **`validators/privacy_validators.py`** — four adversarial checks (eavesdropper,
  replay, field-injection, stale-revocation) on the `Privacy` protocol surface.
  Each **passes against `hybrid_x25519` and fails against `noop`** — the charter's
  bar for "adversarial."
- **32 tests** across unit, adversarial-discrimination, **Hypothesis property**,
  and full-**ScenarioRunner** integration.
- **`scenarios/sealed_bid_with_privacy.yaml`** wiring the layer into a real run.
- Doc update at `docs/layers/privacy.md`.

### Design & the four attacks

| Attack | Defense |
|---|---|
| **Eavesdropper** | A non-audience agent holds no wrap entry keyed to its pubkey → `decrypt` raises `NotInAudienceError`; the plaintext never appears in the envelope bytes. |
| **Replay** | A unique `msg_id` (`sender:epoch:seq`) is bound into the AEAD AAD; a re-presented envelope raises `ReplayError`; a redirected one fails to authenticate. |
| **Field-injection** | Selective-disclosure leaves are salted, length-prefixed Merkle commitments. Tampering any revealed value/salt/path node changes the reconstructed root ≠ the issuer-anchored root → `verify_proof` returns `False`. |
| **Stale-revocation** | A member revoked at epoch *E* is excluded from the wrap set of every message at epoch ≥ *E* → `decrypt` raises `NotInAudienceError`. |

The sender, epoch, msg_id and the **sorted recipient key-ids** are all bound into
the AEAD associated data, so audience-set edits and redirection break
authentication, not just payload edits.

### Two non-obvious decisions

1. **Deterministic mode for Tier-1 traces.** Hybrid encryption is randomized
   (fresh ephemeral + nonces), which would make traces non-reproducible.
   `deterministic=True` derives the ephemeral scalar and every nonce from
   `HKDF(seed, msg_id)`, so identical inputs yield byte-identical envelopes — and
   this is sound *only because* `msg_id` is unique per `(sender, epoch)` via a
   monotonic counter (the `(key, nonce)`-reuse guard). The scenario determinism
   test asserts byte-identical traces across replays.
2. **Honest forward-secrecy disclosure.** Revocation is **future-only**: it
   guarantees a revoked member can't read messages issued at/after their epoch,
   but makes **no** claim about earlier messages they already received. True
   forward secrecy would need per-epoch content re-keying with key deletion,
   which would change the broadcast cost model — so I document the boundary
   rather than imply a stronger property. The module docstring states this
   explicitly.

### Selective disclosure

A credential is committed as a salted Merkle root (issued by an authority, carried
in `Statement.public_inputs['root']`). The holder reveals a subset of fields plus
their authentication paths; undisclosed field values never appear in the proof
(test: the hidden `salary` value is absent from `proof.data`). No SNARK required —
a hash tree is sufficient and reproducible.

### How to verify

```bash
uv sync
# the four-attack discrimination + property + scenario tests:
uv run pytest packages/nest-plugins-reference/tests/test_hybrid_x25519.py \
              packages/nest-plugins-reference/tests/test_hybrid_x25519_properties.py \
              packages/nest-plugins-reference/tests/test_hybrid_x25519_scenario.py -v
# full CI gate (all green):
uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -q
```

Minimal round-trip + eavesdropper:

```python
import asyncio
from nest_core.types import AgentId
from nest_plugins_reference.privacy.hybrid_x25519 import HybridX25519Privacy, NotInAudienceError

async def main():
    alice, bob, snoop = (HybridX25519Privacy(AgentId(n), seed=n.encode()) for n in ("a", "b", "c"))
    alice.register_peer(AgentId("b"), bob.public_key)
    env = await alice.encrypt(b"sealed-bid:1700", [AgentId("b")])
    assert await bob.decrypt(env) == b"sealed-bid:1700"     # audience reads it
    assert b"1700" not in env                                 # not on the wire
    try:
        await snoop.decrypt(env)                              # outsider blocked
    except NotInAudienceError:
        print("eavesdropper blocked; bob read the bid")

asyncio.run(main())
```

### API fit

Implements the `Privacy` protocol exactly; registered as `("privacy",
"hybrid_x25519")` in `nest_core/plugins.py` and as a `nest.plugins.privacy` entry
point. SPDX headers, `from __future__ import annotations`, docstrings with
`Example::` blocks throughout. `cryptography>=42` is already a hard dependency of
`nest-plugins-reference` and is documented in the `[plugins]` extra. Whole-repo
`ruff check`, `ruff format --check`, `pyright` (strict), and `pytest`
(573 passed) are green.

### Scope / limitations

- Selective disclosure is a hash-tree commitment, not a SNARK (per the brief's
  "a Merkle approach is acceptable").
- Forward secrecy is future-only (documented above).
- The reference `auction` task doesn't yet route bids through the privacy layer,
  so the scenario YAML wires the capability and the integration test proves it
  runs/replays deterministically, while the sealed-bid *mechanics* (bidders seal,
  auctioneer alone opens, second-price resolution, eavesdropper learns nothing)
  are demonstrated end-to-end in `TestSealedBidWithPrivacy`.
