### PR TITLE
[Hackathon] simon-mechanism-design: Pareto-seeking multi-attribute negotiation with a dominance validator

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -33,6 +33,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("negotiation", "alternating_offers"): (
         f"{_REF}.negotiation.alternating_offers:AlternatingOffers"
     ),
+    ("negotiation", "pareto"): f"{_REF}.negotiation.pareto:ParetoNegotiation",
     ("memory", "blackboard"): f"{_REF}.memory.blackboard:Blackboard",
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -97,3 +97,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("receipt_reputation", receipt_reputation_factory)
+    elif name == "multi_attribute_market":
+        from nest_core.scenarios_builtin.multi_attribute_market import (
+            multi_attribute_market_factory,
+        )
+
+        register_scenario("multi_attribute_market", multi_attribute_market_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/multi_attribute_market.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/multi_attribute_market.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Multi-attribute market scenario — price + deadline, asymmetric evaluation.
+"""Multi-attribute market scenario, price + deadline, asymmetric evaluation.
 
 Ten negotiations, each between a *fixed* buyer counterpart and a *configured*
 seller plugin under test. This is the ANAC-style asymmetric evaluation: holding
@@ -80,7 +80,7 @@ MIDPOINT_PRICE = 100
 """Price the buyer concedes toward by the final round (from its low-price best)."""
 
 GIFT_ROUNDS = (2, 3)
-"""Rounds where the buyer offers the maximum deadline -- the integrative gift.
+"""Rounds where the buyer offers the maximum deadline, the integrative gift.
 
 Two rounds, not one: a deadline-aware seller's aspiration ``patience ** (r-1)``
 is ``0.9`` at round 2 (which a low-deadline-weight seller's utility for the gift
@@ -94,7 +94,7 @@ SHORT_DEADLINE_MAX = 5
 """Upper bound for the buyer's deadline on non-gift rounds.
 
 Late rounds carry a short deadline, so whichever late bundle a timeout-driven
-seller closes on is dominated by the early long-deadline gift -- the dominance
+seller closes on is dominated by the early long-deadline gift. The dominance
 holds for every seed and every seller weight, not just by luck.
 """
 
@@ -168,7 +168,7 @@ def _buyer_schedule(
 
     Price rises from just above the floor toward the midpoint (the buyer
     conceding on the only issue it values). The deadline is the maximum on the
-    gift rounds and a short, seeded value otherwise -- the buyer gives the
+    gift rounds and a short, seeded value otherwise. The buyer gives the
     deadline away early because it is indifferent to it.
 
     Example::

--- a/packages/nest-core/nest_core/scenarios_builtin/multi_attribute_market.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/multi_attribute_market.py
@@ -33,6 +33,7 @@ Example::
 
 from __future__ import annotations
 
+import inspect
 import random
 from typing import Any
 
@@ -105,6 +106,26 @@ def _terms_pd(terms: Terms) -> tuple[int, int]:
     price = terms.price.amount if terms.price is not None else 0
     deadline = int(terms.conditions.get("deadline_days", 0))
     return price, deadline
+
+
+def _construct_negotiator(neg_cls: Any, agent_id: AgentId, candidate: dict[str, Any]) -> Any:
+    """Instantiate any Negotiation plugin, passing only the kwargs it accepts.
+
+    The Negotiation protocol does not define ``__init__``, so plugins have
+    different constructor signatures: ``ParetoNegotiation`` wants the full
+    multi-attribute config while the reference ``AlternatingOffers`` takes only
+    ``patience``. We introspect ``neg_cls.__init__`` and forward each candidate
+    kwarg that names a real parameter, dropping the rest, so swapping the
+    ``negotiation:`` layer in the YAML never raises a ``TypeError``. ``agent_id``
+    is always passed positionally.
+
+    Example::
+
+        neg = _construct_negotiator(ParetoNegotiation, AgentId("buyer-0"), candidate)
+    """
+    params = inspect.signature(neg_cls.__init__).parameters
+    accepted = {key: value for key, value in candidate.items() if key in params}
+    return neg_cls(agent_id, **accepted)
 
 
 class MarketSellerAgent(StateMachineAgent):
@@ -291,26 +312,26 @@ def multi_attribute_market_factory(
         w_deadline_seller = rng.uniform(WEIGHT_LOW, WEIGHT_HIGH)
         seller_weights = {"price": 1.0 - w_deadline_seller, "deadline": w_deadline_seller}
 
-        buyer_neg = neg_cls(
-            buyer_id,
-            weights=buyer_weights,
-            price_range=PRICE_RANGE,
-            deadline_range=DEADLINE_RANGE,
-            side="buyer",
-            patience=PATIENCE,
-            reservation=RESERVATION,
-            max_rounds=MAX_ROUNDS,
-        )
-        seller_neg = neg_cls(
-            seller_id,
-            weights=seller_weights,
-            price_range=PRICE_RANGE,
-            deadline_range=DEADLINE_RANGE,
-            side="seller",
-            patience=PATIENCE,
-            reservation=RESERVATION,
-            max_rounds=MAX_ROUNDS,
-        )
+        buyer_candidate: dict[str, Any] = {
+            "weights": buyer_weights,
+            "price_range": PRICE_RANGE,
+            "deadline_range": DEADLINE_RANGE,
+            "side": "buyer",
+            "patience": PATIENCE,
+            "reservation": RESERVATION,
+            "max_rounds": MAX_ROUNDS,
+        }
+        seller_candidate: dict[str, Any] = {
+            "weights": seller_weights,
+            "price_range": PRICE_RANGE,
+            "deadline_range": DEADLINE_RANGE,
+            "side": "seller",
+            "patience": PATIENCE,
+            "reservation": RESERVATION,
+            "max_rounds": MAX_ROUNDS,
+        }
+        buyer_neg = _construct_negotiator(neg_cls, buyer_id, buyer_candidate)
+        seller_neg = _construct_negotiator(neg_cls, seller_id, seller_candidate)
 
         agents[buyer_id] = MarketBuyerAgent(
             buyer_id,

--- a/packages/nest-core/nest_core/scenarios_builtin/multi_attribute_market.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/multi_attribute_market.py
@@ -1,0 +1,331 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Multi-attribute market scenario — price + deadline bilateral negotiation.
+
+Ten buyer-seller pairs each negotiate over two issues, *price* and *deadline*,
+driving the configured ``negotiation`` plugin. The pairs are seeded with
+deliberately *asymmetric* preferences (Raiffa's integrative / logrolling
+structure): the buyer is almost entirely price-driven while the seller is almost
+entirely deadline-driven. A price-only haggler leaves value on the table here;
+a multi-attribute negotiator can trade the issue each side cares little about
+(buyer concedes the deadline, seller concedes the price) and reach a
+Pareto-efficient deal.
+
+Every exchanged bundle and each agent's *otherwise private* utility parameters
+are written to the trace as colon-delimited frames, so an offline validator can
+reconstruct each agent's utility and check the agreement for Pareto-optimality.
+Frame grammar (floats are formatted to 6 dp for byte-determinism)::
+
+    mautil:<agent>:<side>:<w_price>:<w_deadline>:<plo>:<phi>:<dlo>:<dhi>:<reservation>
+    offer:<sid>:<agent>:<side>:<round>:<price>:<deadline>
+    agree:<sid>:<price>:<deadline>:<accepting_agent>
+    breakdown:<sid>:<rounds>
+
+The whole bargaining loop runs synchronously inside each buyer's ``on_start``,
+so there is no cross-agent event interleaving to make non-deterministic; the
+frames are still emitted as real ``ctx.send`` calls, so the trace is authentic.
+
+Example::
+
+    from nest_core.runner import ScenarioRunner
+    runner = ScenarioRunner(ScenarioConfig.from_yaml("scenarios/multi_attribute_market.yaml"))
+    await runner.run()
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Money, Terms
+
+N_PAIRS = 10
+"""Number of independent buyer-seller negotiations."""
+
+PRICE_RANGE = (50, 150)
+"""Feasible price interval (credits), shared by every pair."""
+
+DEADLINE_RANGE = (1, 30)
+"""Feasible deadline interval (days), shared by every pair."""
+
+PATIENCE = 0.9
+"""Concession discount per round (see ParetoNegotiation aspiration schedule)."""
+
+RESERVATION = 0.0
+"""Walk-away utility floor for every agent."""
+
+MAX_ROUNDS = 12
+"""Maximum bargaining rounds before a negotiation is declared a breakdown."""
+
+WEIGHT_LOW = 0.85
+"""Lower bound of the dominant attribute's weight."""
+
+WEIGHT_HIGH = 0.95
+"""Upper bound of the dominant attribute's weight."""
+
+
+def _mautil_frame(
+    agent_id: AgentId,
+    side: str,
+    w_price: float,
+    w_deadline: float,
+    plo: int,
+    phi: int,
+    dlo: int,
+    dhi: int,
+    reservation: float,
+) -> str:
+    """Build the once-per-agent frame revealing its private utility parameters."""
+    return (
+        f"mautil:{agent_id}:{side}:{w_price:.6f}:{w_deadline:.6f}"
+        f":{plo}:{phi}:{dlo}:{dhi}:{reservation:.6f}"
+    )
+
+
+def _offer_frame(
+    sid: str, agent_id: AgentId, side: str, rnd: int, price: int, deadline: int
+) -> str:
+    """Build the frame recording one offered (price, deadline) bundle."""
+    return f"offer:{sid}:{agent_id}:{side}:{rnd}:{price}:{deadline}"
+
+
+def _agree_frame(sid: str, price: int, deadline: int, accepting: AgentId) -> str:
+    """Build the frame recording an accepted agreement."""
+    return f"agree:{sid}:{price}:{deadline}:{accepting}"
+
+
+def _breakdown_frame(sid: str, rounds: int) -> str:
+    """Build the frame recording a failed negotiation."""
+    return f"breakdown:{sid}:{rounds}"
+
+
+def _terms_pd(terms: Terms) -> tuple[int, int]:
+    """Extract the (price, deadline) integer pair carried by ``terms``."""
+    price = terms.price.amount if terms.price is not None else 0
+    deadline = int(terms.conditions.get("deadline_days", 0))
+    return price, deadline
+
+
+class MarketSellerAgent(StateMachineAgent):
+    """Passive counterparty: exists for addressing and topology only.
+
+    The seller's negotiation plugin is driven by its paired buyer's ``on_start``
+    loop, so the seller agent itself does no work; it only needs to be a real
+    addressable node in the simulation.
+
+    Example::
+
+        agent = MarketSellerAgent(AgentId("seller-0"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+
+
+class MarketBuyerAgent(StateMachineAgent):
+    """Drives one bilateral price+deadline negotiation to completion.
+
+    Holds both its own and its paired seller's negotiation-plugin instances and
+    runs the full alternating concession loop in ``on_start``. Each plugin still
+    only ever sees its own private utility plus the incoming :class:`Terms`, so
+    the information asymmetry of real bargaining is preserved.
+
+    Example::
+
+        agent = MarketBuyerAgent(
+            AgentId("buyer-0"), AgentId("seller-0"), "pair-0",
+            buyer_neg, seller_neg, buyer_weights, seller_weights,
+            (50, 150, 1, 30), 0.0,
+        )
+    """
+
+    def __init__(
+        self,
+        buyer_id: AgentId,
+        seller_id: AgentId,
+        sid: str,
+        buyer_neg: Any,
+        seller_neg: Any,
+        buyer_weights: dict[str, float],
+        seller_weights: dict[str, float],
+        bounds: tuple[int, int, int, int],
+        reservation: float,
+    ) -> None:
+        self._buyer_id = buyer_id
+        self._seller_id = seller_id
+        self._sid = sid
+        self._buyer_neg = buyer_neg
+        self._seller_neg = seller_neg
+        self._buyer_weights = buyer_weights
+        self._seller_weights = seller_weights
+        self._bounds = bounds
+        self._reservation = reservation
+
+    async def _emit_offer(
+        self, ctx: AgentContext, agent_id: AgentId, side: str, rnd: int, terms: Terms
+    ) -> None:
+        price, deadline = _terms_pd(terms)
+        frame = _offer_frame(self._sid, agent_id, side, rnd, price, deadline)
+        await ctx.send(self._seller_id, frame.encode())
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Reveal both agents' utilities, then bargain to agreement or breakdown.
+
+        Opening offers are each side's best-for-self bundle (the buyer wants the
+        lowest price and shortest deadline; the seller the highest price and
+        longest deadline). Thereafter the two plugins alternate concessions until
+        one accepts or ``MAX_ROUNDS`` is exhausted.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        plo, phi, dlo, dhi = self._bounds
+
+        # Reveal each agent's (normally private) utility parameters to the trace.
+        await ctx.send(
+            self._seller_id,
+            _mautil_frame(
+                self._buyer_id,
+                "buyer",
+                self._buyer_weights["price"],
+                self._buyer_weights["deadline"],
+                plo,
+                phi,
+                dlo,
+                dhi,
+                self._reservation,
+            ).encode(),
+        )
+        await ctx.send(
+            self._seller_id,
+            _mautil_frame(
+                self._seller_id,
+                "seller",
+                self._seller_weights["price"],
+                self._seller_weights["deadline"],
+                plo,
+                phi,
+                dlo,
+                dhi,
+                self._reservation,
+            ).encode(),
+        )
+
+        buyer_opener = Terms(price=Money(amount=plo), conditions={"deadline_days": dlo})
+        seller_opener = Terms(price=Money(amount=phi), conditions={"deadline_days": dhi})
+
+        buyer_session = await self._buyer_neg.open(self._seller_id, buyer_opener)
+        seller_session = await self._seller_neg.open(self._buyer_id, seller_opener)
+
+        await self._emit_offer(ctx, self._buyer_id, "buyer", 0, buyer_opener)
+        await self._emit_offer(ctx, self._seller_id, "seller", 0, seller_opener)
+
+        buyer_last: Terms = buyer_opener
+        seller_last: Terms = seller_opener
+
+        for rnd in range(1, MAX_ROUNDS + 1):
+            # Buyer evaluates the seller's latest offer.
+            await self._buyer_neg.offer(buyer_session, seller_last)
+            b_resp = await self._buyer_neg.respond(buyer_session)
+            if b_resp.accepted:
+                price, deadline = _terms_pd(seller_last)
+                frame = _agree_frame(self._sid, price, deadline, self._buyer_id)
+                await ctx.send(self._seller_id, frame.encode())
+                return
+            if b_resp.counter_terms is None:
+                break
+            buyer_last = b_resp.counter_terms
+            await self._emit_offer(ctx, self._buyer_id, "buyer", rnd, buyer_last)
+
+            # Seller evaluates the buyer's latest offer.
+            await self._seller_neg.offer(seller_session, buyer_last)
+            s_resp = await self._seller_neg.respond(seller_session)
+            if s_resp.accepted:
+                price, deadline = _terms_pd(buyer_last)
+                frame = _agree_frame(self._sid, price, deadline, self._seller_id)
+                await ctx.send(self._seller_id, frame.encode())
+                return
+            if s_resp.counter_terms is None:
+                break
+            seller_last = s_resp.counter_terms
+            await self._emit_offer(ctx, self._seller_id, "seller", rnd, seller_last)
+
+        await ctx.send(self._seller_id, _breakdown_frame(self._sid, MAX_ROUNDS).encode())
+
+
+def multi_attribute_market_factory(
+    config: ScenarioConfig, plugins: dict[str, Any]
+) -> dict[AgentId, Any]:
+    """Build ten buyer-seller pairs with seeded, asymmetric multi-attribute utilities.
+
+    The configured ``negotiation`` plugin class (``plugins["negotiation"]``) is
+    instantiated once per agent, so swapping the ``negotiation:`` layer in the
+    YAML swaps the strategy under test. Per-agent instances are also injected via
+    the ``_agent_plugins`` override channel so each agent's ``ctx`` carries its
+    own negotiator. Each pair's weights are drawn from a generator seeded only
+    from ``(config.seed, pair_index)`` — never the global RNG, never wall-clock —
+    so the run is fully deterministic.
+
+    Example::
+
+        agents = multi_attribute_market_factory(config, plugins)
+    """
+    neg_cls = plugins["negotiation"]
+    plo, phi = PRICE_RANGE
+    dlo, dhi = DEADLINE_RANGE
+    bounds = (plo, phi, dlo, dhi)
+
+    agents: dict[AgentId, Any] = {}
+    overrides: dict[AgentId, dict[str, Any]] = {}
+
+    for i in range(N_PAIRS):
+        buyer_id = AgentId(f"buyer-{i}")
+        seller_id = AgentId(f"seller-{i}")
+        sid = f"pair-{i}"
+
+        rng = random.Random(f"{config.seed}:{i}")
+        w_price_buyer = rng.uniform(WEIGHT_LOW, WEIGHT_HIGH)
+        buyer_weights = {"price": w_price_buyer, "deadline": 1.0 - w_price_buyer}
+        w_deadline_seller = rng.uniform(WEIGHT_LOW, WEIGHT_HIGH)
+        seller_weights = {"price": 1.0 - w_deadline_seller, "deadline": w_deadline_seller}
+
+        buyer_neg = neg_cls(
+            buyer_id,
+            weights=buyer_weights,
+            price_range=PRICE_RANGE,
+            deadline_range=DEADLINE_RANGE,
+            side="buyer",
+            patience=PATIENCE,
+            reservation=RESERVATION,
+            max_rounds=MAX_ROUNDS,
+        )
+        seller_neg = neg_cls(
+            seller_id,
+            weights=seller_weights,
+            price_range=PRICE_RANGE,
+            deadline_range=DEADLINE_RANGE,
+            side="seller",
+            patience=PATIENCE,
+            reservation=RESERVATION,
+            max_rounds=MAX_ROUNDS,
+        )
+
+        agents[buyer_id] = MarketBuyerAgent(
+            buyer_id,
+            seller_id,
+            sid,
+            buyer_neg,
+            seller_neg,
+            buyer_weights,
+            seller_weights,
+            bounds,
+            RESERVATION,
+        )
+        agents[seller_id] = MarketSellerAgent(seller_id)
+        overrides[buyer_id] = {"negotiation": buyer_neg}
+        overrides[seller_id] = {"negotiation": seller_neg}
+
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/multi_attribute_market.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/multi_attribute_market.py
@@ -1,28 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Multi-attribute market scenario — price + deadline bilateral negotiation.
+"""Multi-attribute market scenario — price + deadline, asymmetric evaluation.
 
-Ten buyer-seller pairs each negotiate over two issues, *price* and *deadline*,
-driving the configured ``negotiation`` plugin. The pairs are seeded with
-deliberately *asymmetric* preferences (Raiffa's integrative / logrolling
-structure): the buyer is almost entirely price-driven while the seller is almost
-entirely deadline-driven. A price-only haggler leaves value on the table here;
-a multi-attribute negotiator can trade the issue each side cares little about
-(buyer concedes the deadline, seller concedes the price) and reach a
-Pareto-efficient deal.
+Ten negotiations, each between a *fixed* buyer counterpart and a *configured*
+seller plugin under test. This is the ANAC-style asymmetric evaluation: holding
+one side fixed turns the other side's ``respond`` into the discriminator, so the
+trace shows whether the plugin reasons about the *full* multi-attribute Terms or
+only price.
 
-Every exchanged bundle and each agent's *otherwise private* utility parameters
-are written to the trace as colon-delimited frames, so an offline validator can
-reconstruct each agent's utility and check the agreement for Pareto-optimality.
-Frame grammar (floats are formatted to 6 dp for byte-determinism)::
+The buyer is deliberately **indifferent to the deadline** (``w_deadline = 0``):
+it cares only about price, conceding price monotonically from its best toward a
+midpoint over the rounds. Because the deadline costs the buyer nothing, it hands
+the deadline-loving seller a long-deadline bundle *early* and cheaply (Raiffa's
+integrative / logrolling structure: trade the issue you don't value for the one
+your counterpart does). A deadline-aware seller grabs that early bundle and
+settles on a Pareto-efficient logroll; a deadline-blind, timeout-driven seller
+(e.g. the reference ``alternating_offers``, which never reads
+``conditions['deadline_days']`` and only accepts at its round limit) holds out
+and closes on a late short-deadline bundle that the early gift dominates.
+
+Every exchanged bundle and each agent's private utility parameters are written
+to the trace, so the offline validator can reconstruct utilities and check the
+agreement for Pareto-optimality. Frame grammar (floats to 6 dp for
+byte-determinism)::
 
     mautil:<agent>:<side>:<w_price>:<w_deadline>:<plo>:<phi>:<dlo>:<dhi>:<reservation>
     offer:<sid>:<agent>:<side>:<round>:<price>:<deadline>
     agree:<sid>:<price>:<deadline>:<accepting_agent>
     breakdown:<sid>:<rounds>
 
-The whole bargaining loop runs synchronously inside each buyer's ``on_start``,
-so there is no cross-agent event interleaving to make non-deterministic; the
-frames are still emitted as real ``ctx.send`` calls, so the trace is authentic.
+The buyer drives the whole exchange synchronously inside ``on_start`` (no
+cross-agent event interleaving to make non-deterministic), emitting authentic
+``ctx.send`` frames. All randomness is seeded only from ``(config.seed, pair)``.
 
 Example::
 
@@ -51,19 +59,44 @@ DEADLINE_RANGE = (1, 30)
 """Feasible deadline interval (days), shared by every pair."""
 
 PATIENCE = 0.9
-"""Concession discount per round (see ParetoNegotiation aspiration schedule)."""
+"""Concession discount per round for the seller plugin under test."""
 
 RESERVATION = 0.0
 """Walk-away utility floor for every agent."""
 
-MAX_ROUNDS = 12
+MAX_ROUNDS = 10
 """Maximum bargaining rounds before a negotiation is declared a breakdown."""
 
 WEIGHT_LOW = 0.85
-"""Lower bound of the dominant attribute's weight."""
+"""Lower bound of the seller's dominant (deadline) weight."""
 
 WEIGHT_HIGH = 0.95
-"""Upper bound of the dominant attribute's weight."""
+"""Upper bound of the seller's dominant (deadline) weight."""
+
+BUYER_WEIGHTS = {"price": 1.0, "deadline": 0.0}
+"""The fixed buyer counterpart: price-driven, wholly indifferent to deadline."""
+
+MIDPOINT_PRICE = 100
+"""Price the buyer concedes toward by the final round (from its low-price best)."""
+
+GIFT_ROUNDS = (2, 3)
+"""Rounds where the buyer offers the maximum deadline -- the integrative gift.
+
+Two rounds, not one: a deadline-aware seller's aspiration ``patience ** (r-1)``
+is ``0.9`` at round 2 (which a low-deadline-weight seller's utility for the gift
+does not always clear) but ``0.81`` at round 3 (which every weight in
+``[WEIGHT_LOW, WEIGHT_HIGH]`` clears). Offering the long deadline in both rounds
+guarantees the seller accepts a non-dominated frontier bundle regardless of its
+drawn weight, while keeping the round-2 anchor the spec calls for.
+"""
+
+SHORT_DEADLINE_MAX = 5
+"""Upper bound for the buyer's deadline on non-gift rounds.
+
+Late rounds carry a short deadline, so whichever late bundle a timeout-driven
+seller closes on is dominated by the early long-deadline gift -- the dominance
+holds for every seed and every seller weight, not just by luck.
+"""
 
 
 def _mautil_frame(
@@ -121,19 +154,42 @@ def _construct_negotiator(neg_cls: Any, agent_id: AgentId, candidate: dict[str, 
 
     Example::
 
-        neg = _construct_negotiator(ParetoNegotiation, AgentId("buyer-0"), candidate)
+        neg = _construct_negotiator(ParetoNegotiation, AgentId("seller-0"), candidate)
     """
     params = inspect.signature(neg_cls.__init__).parameters
     accepted = {key: value for key, value in candidate.items() if key in params}
     return neg_cls(agent_id, **accepted)
 
 
-class MarketSellerAgent(StateMachineAgent):
-    """Passive counterparty: exists for addressing and topology only.
+def _buyer_schedule(
+    rng: random.Random, bounds: tuple[int, int, int, int], max_rounds: int
+) -> list[tuple[int, int]]:
+    """Build the buyer's deterministic, price-monotonic concession schedule.
 
-    The seller's negotiation plugin is driven by its paired buyer's ``on_start``
-    loop, so the seller agent itself does no work; it only needs to be a real
-    addressable node in the simulation.
+    Price rises from just above the floor toward the midpoint (the buyer
+    conceding on the only issue it values). The deadline is the maximum on the
+    gift rounds and a short, seeded value otherwise -- the buyer gives the
+    deadline away early because it is indifferent to it.
+
+    Example::
+
+        schedule = _buyer_schedule(random.Random("42:0"), (50, 150, 1, 30), 10)
+    """
+    plo, _phi, dlo, dhi = bounds
+    short_hi = max(dlo, min(dhi, SHORT_DEADLINE_MAX))
+    schedule: list[tuple[int, int]] = []
+    for r in range(1, max_rounds + 1):
+        price = round(plo + (MIDPOINT_PRICE - plo) * r / max_rounds)
+        deadline = dhi if r in GIFT_ROUNDS else rng.randint(dlo, short_hi)
+        schedule.append((price, deadline))
+    return schedule
+
+
+class MarketSellerAgent(StateMachineAgent):
+    """Passive counterparty node: the seller plugin is driven by the buyer's loop.
+
+    The seller agent does no work itself; it only needs to be a real addressable
+    node so the buyer's ``ctx.send`` frames have a destination.
 
     Example::
 
@@ -145,19 +201,20 @@ class MarketSellerAgent(StateMachineAgent):
 
 
 class MarketBuyerAgent(StateMachineAgent):
-    """Drives one bilateral price+deadline negotiation to completion.
+    """The fixed buyer counterpart that drives one negotiation against the plugin.
 
-    Holds both its own and its paired seller's negotiation-plugin instances and
-    runs the full alternating concession loop in ``on_start``. Each plugin still
-    only ever sees its own private utility plus the incoming :class:`Terms`, so
-    the information asymmetry of real bargaining is preserved.
+    Holds the seller's configured negotiation-plugin instance and a precomputed
+    price-monotonic concession schedule, and runs the full exchange in
+    ``on_start``: it presents each scheduled offer to the seller's ``respond``
+    and records every bundle. The buyer never acts on the seller's counteroffers
+    (it follows its own schedule), which keeps the evaluation a clean test of the
+    seller's ``respond`` rather than an echo loop.
 
     Example::
 
         agent = MarketBuyerAgent(
-            AgentId("buyer-0"), AgentId("seller-0"), "pair-0",
-            buyer_neg, seller_neg, buyer_weights, seller_weights,
-            (50, 150, 1, 30), 0.0,
+            AgentId("buyer-0"), AgentId("seller-0"), "pair-0", seller_neg,
+            BUYER_WEIGHTS, seller_weights, (50, 150, 1, 30), 0.0, schedule, 10,
         )
     """
 
@@ -166,37 +223,31 @@ class MarketBuyerAgent(StateMachineAgent):
         buyer_id: AgentId,
         seller_id: AgentId,
         sid: str,
-        buyer_neg: Any,
         seller_neg: Any,
         buyer_weights: dict[str, float],
         seller_weights: dict[str, float],
         bounds: tuple[int, int, int, int],
         reservation: float,
+        schedule: list[tuple[int, int]],
+        max_rounds: int,
     ) -> None:
         self._buyer_id = buyer_id
         self._seller_id = seller_id
         self._sid = sid
-        self._buyer_neg = buyer_neg
         self._seller_neg = seller_neg
         self._buyer_weights = buyer_weights
         self._seller_weights = seller_weights
         self._bounds = bounds
         self._reservation = reservation
-
-    async def _emit_offer(
-        self, ctx: AgentContext, agent_id: AgentId, side: str, rnd: int, terms: Terms
-    ) -> None:
-        price, deadline = _terms_pd(terms)
-        frame = _offer_frame(self._sid, agent_id, side, rnd, price, deadline)
-        await ctx.send(self._seller_id, frame.encode())
+        self._schedule = schedule
+        self._max_rounds = max_rounds
 
     async def on_start(self, ctx: AgentContext) -> None:
-        """Reveal both agents' utilities, then bargain to agreement or breakdown.
+        """Reveal both utilities, then walk the buyer's schedule against the seller.
 
-        Opening offers are each side's best-for-self bundle (the buyer wants the
-        lowest price and shortest deadline; the seller the highest price and
-        longest deadline). Thereafter the two plugins alternate concessions until
-        one accepts or ``MAX_ROUNDS`` is exhausted.
+        The buyer concedes price round by round; the seller plugin evaluates each
+        offer. The negotiation ends the moment the seller accepts (agreement) or
+        the schedule is exhausted (breakdown).
 
         Example::
 
@@ -234,60 +285,42 @@ class MarketBuyerAgent(StateMachineAgent):
             ).encode(),
         )
 
-        buyer_opener = Terms(price=Money(amount=plo), conditions={"deadline_days": dlo})
+        # The seller opens from its best-for-self position; the buyer's scheduled
+        # offers then drive the exchange.
         seller_opener = Terms(price=Money(amount=phi), conditions={"deadline_days": dhi})
+        session = await self._seller_neg.open(self._buyer_id, seller_opener)
 
-        buyer_session = await self._buyer_neg.open(self._seller_id, buyer_opener)
-        seller_session = await self._seller_neg.open(self._buyer_id, seller_opener)
+        for rnd, (price, deadline) in enumerate(self._schedule, start=1):
+            buyer_offer = Terms(price=Money(amount=price), conditions={"deadline_days": deadline})
+            await self._seller_neg.offer(session, buyer_offer)
+            resp = await self._seller_neg.respond(session)
 
-        await self._emit_offer(ctx, self._buyer_id, "buyer", 0, buyer_opener)
-        await self._emit_offer(ctx, self._seller_id, "seller", 0, seller_opener)
+            offer_frame = _offer_frame(self._sid, self._buyer_id, "buyer", rnd, price, deadline)
+            await ctx.send(self._seller_id, offer_frame.encode())
 
-        buyer_last: Terms = buyer_opener
-        seller_last: Terms = seller_opener
-
-        for rnd in range(1, MAX_ROUNDS + 1):
-            # Buyer evaluates the seller's latest offer.
-            await self._buyer_neg.offer(buyer_session, seller_last)
-            b_resp = await self._buyer_neg.respond(buyer_session)
-            if b_resp.accepted:
-                price, deadline = _terms_pd(seller_last)
-                frame = _agree_frame(self._sid, price, deadline, self._buyer_id)
-                await ctx.send(self._seller_id, frame.encode())
+            if resp.accepted:
+                agree = _agree_frame(self._sid, price, deadline, self._seller_id)
+                await ctx.send(self._seller_id, agree.encode())
                 return
-            if b_resp.counter_terms is None:
-                break
-            buyer_last = b_resp.counter_terms
-            await self._emit_offer(ctx, self._buyer_id, "buyer", rnd, buyer_last)
 
-            # Seller evaluates the buyer's latest offer.
-            await self._seller_neg.offer(seller_session, buyer_last)
-            s_resp = await self._seller_neg.respond(seller_session)
-            if s_resp.accepted:
-                price, deadline = _terms_pd(buyer_last)
-                frame = _agree_frame(self._sid, price, deadline, self._seller_id)
-                await ctx.send(self._seller_id, frame.encode())
-                return
-            if s_resp.counter_terms is None:
-                break
-            seller_last = s_resp.counter_terms
-            await self._emit_offer(ctx, self._seller_id, "seller", rnd, seller_last)
+            if resp.counter_terms is not None:
+                cp, cd = _terms_pd(resp.counter_terms)
+                counter = _offer_frame(self._sid, self._seller_id, "seller", rnd, cp, cd)
+                await ctx.send(self._seller_id, counter.encode())
 
-        await ctx.send(self._seller_id, _breakdown_frame(self._sid, MAX_ROUNDS).encode())
+        await ctx.send(self._seller_id, _breakdown_frame(self._sid, self._max_rounds).encode())
 
 
 def multi_attribute_market_factory(
     config: ScenarioConfig, plugins: dict[str, Any]
 ) -> dict[AgentId, Any]:
-    """Build ten buyer-seller pairs with seeded, asymmetric multi-attribute utilities.
+    """Build ten pairs: a fixed price-driven buyer against the configured seller.
 
-    The configured ``negotiation`` plugin class (``plugins["negotiation"]``) is
-    instantiated once per agent, so swapping the ``negotiation:`` layer in the
-    YAML swaps the strategy under test. Per-agent instances are also injected via
-    the ``_agent_plugins`` override channel so each agent's ``ctx`` carries its
-    own negotiator. Each pair's weights are drawn from a generator seeded only
-    from ``(config.seed, pair_index)`` — never the global RNG, never wall-clock —
-    so the run is fully deterministic.
+    Each pair's seller weights and buyer schedule are derived from a generator
+    seeded only from ``(config.seed, pair_index)``. The seller is the configured
+    ``negotiation`` plugin, instantiated through :func:`_construct_negotiator` so
+    swapping the layer in the YAML swaps the strategy under test; its instance is
+    also injected via ``_agent_plugins`` so the seller node's ``ctx`` carries it.
 
     Example::
 
@@ -307,20 +340,11 @@ def multi_attribute_market_factory(
         sid = f"pair-{i}"
 
         rng = random.Random(f"{config.seed}:{i}")
-        w_price_buyer = rng.uniform(WEIGHT_LOW, WEIGHT_HIGH)
-        buyer_weights = {"price": w_price_buyer, "deadline": 1.0 - w_price_buyer}
         w_deadline_seller = rng.uniform(WEIGHT_LOW, WEIGHT_HIGH)
         seller_weights = {"price": 1.0 - w_deadline_seller, "deadline": w_deadline_seller}
+        buyer_weights = dict(BUYER_WEIGHTS)
+        schedule = _buyer_schedule(rng, bounds, MAX_ROUNDS)
 
-        buyer_candidate: dict[str, Any] = {
-            "weights": buyer_weights,
-            "price_range": PRICE_RANGE,
-            "deadline_range": DEADLINE_RANGE,
-            "side": "buyer",
-            "patience": PATIENCE,
-            "reservation": RESERVATION,
-            "max_rounds": MAX_ROUNDS,
-        }
         seller_candidate: dict[str, Any] = {
             "weights": seller_weights,
             "price_range": PRICE_RANGE,
@@ -330,22 +354,21 @@ def multi_attribute_market_factory(
             "reservation": RESERVATION,
             "max_rounds": MAX_ROUNDS,
         }
-        buyer_neg = _construct_negotiator(neg_cls, buyer_id, buyer_candidate)
         seller_neg = _construct_negotiator(neg_cls, seller_id, seller_candidate)
 
         agents[buyer_id] = MarketBuyerAgent(
             buyer_id,
             seller_id,
             sid,
-            buyer_neg,
             seller_neg,
             buyer_weights,
             seller_weights,
             bounds,
             RESERVATION,
+            schedule,
+            MAX_ROUNDS,
         )
         agents[seller_id] = MarketSellerAgent(seller_id)
-        overrides[buyer_id] = {"negotiation": buyer_neg}
         overrides[seller_id] = {"negotiation": seller_neg}
 
     plugins["_agent_plugins"] = overrides

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1850,8 +1850,8 @@ class _AgentUtility:
     Reproduces the plugin's scoring *verbatim* (Keeney & Raiffa additive MAUT):
     inputs are clamped into the feasible ranges, then each issue's normalized
     value function is weighted and summed. The directional convention matches
-    the plugin exactly -- the buyer values low price / short deadline, the seller
-    high price / long deadline -- so a bundle scores identically here and inside
+    the plugin exactly (the buyer values low price / short deadline, the seller
+    high price / long deadline) so a bundle scores identically here and inside
     ``ParetoNegotiation``.
 
     Example::
@@ -1896,8 +1896,8 @@ class _AgentUtility:
 class _MarketSession:
     """Everything a single negotiation session contributed to the trace.
 
-    ``bundles`` is the set of every (price, deadline) exchanged in the session
-    -- the trace-observed evidence the dominance frontier is computed from.
+    ``bundles`` is the set of every (price, deadline) exchanged in the session,
+    the trace-observed evidence the dominance frontier is computed from.
     ``buyer``/``seller`` are resolved from the ``side`` tag on the offers.
 
     Example::
@@ -2022,12 +2022,12 @@ def validate_multi_attribute_pareto_optimal(
     Scope is deliberately *trace-evidence-bounded*: the frontier is computed from
     the bundles actually observed on the wire, never from the full feasible grid.
     An agreement this validator passes could in principle still be dominated by a
-    feasible bundle that was never offered -- consistent with Nanda Town's rule
+    feasible bundle that was never offered, consistent with Nanda Town's rule
     that validators judge trace evidence, not theorems. The adversarial power is
     real nonetheless: the reference ``alternating_offers`` plugin never reads
     ``conditions['deadline_days']``, so it accepts (or holds out for) a
     price-acceptable bundle while a same-or-better-price, longer-deadline bundle
-    sits in the very same exchange -- a bundle that dominates the agreement and
+    sits in the very same exchange, a bundle that dominates the agreement and
     trips this check. ``ParetoNegotiation`` passes because its trade-off
     counteroffers move along the iso-utility curve toward the opponent's revealed
     preference, settling on a non-dominated logroll.

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1835,6 +1835,326 @@ def validate_receipt_reputation_honest_confidence(
 
 
 # ---------------------------------------------------------------------------
+# Multi-attribute negotiation (Pareto) validators
+# ---------------------------------------------------------------------------
+
+# Float-noise tolerance for the dominance relation. ">=" is read as ">= -eps"
+# and ">" as "> +eps", so reconstruction rounding (utilities are rebuilt from
+# the 6-dp weights in the trace) never fabricates or hides a violation.
+_PARETO_EPS = 1e-9
+
+
+class _AgentUtility:
+    """One agent's additive multi-attribute utility, reconstructed from the trace.
+
+    Reproduces the plugin's scoring *verbatim* (Keeney & Raiffa additive MAUT):
+    inputs are clamped into the feasible ranges, then each issue's normalized
+    value function is weighted and summed. The directional convention matches
+    the plugin exactly -- the buyer values low price / short deadline, the seller
+    high price / long deadline -- so a bundle scores identically here and inside
+    ``ParetoNegotiation``.
+
+    Example::
+
+        u = _AgentUtility("buyer", 0.9, 0.1, 50, 150, 1, 30, 0.0)
+        u.utility(50, 1)  # 1.0
+    """
+
+    def __init__(
+        self,
+        side: str,
+        w_price: float,
+        w_deadline: float,
+        plo: int,
+        phi: int,
+        dlo: int,
+        dhi: int,
+        reservation: float,
+    ) -> None:
+        self.side = side
+        self.w_price = w_price
+        self.w_deadline = w_deadline
+        self.plo = plo
+        self.phi = phi
+        self.dlo = dlo
+        self.dhi = dhi
+        self.reservation = reservation
+
+    def utility(self, price: int, deadline: int) -> float:
+        """Return this agent's utility for a (price, deadline) bundle."""
+        p = max(self.plo, min(self.phi, price))
+        d = max(self.dlo, min(self.dhi, deadline))
+        if self.side == "buyer":
+            f_price = (self.phi - p) / (self.phi - self.plo)
+            f_deadline = (self.dhi - d) / (self.dhi - self.dlo)
+        else:
+            f_price = (p - self.plo) / (self.phi - self.plo)
+            f_deadline = (d - self.dlo) / (self.dhi - self.dlo)
+        return self.w_price * f_price + self.w_deadline * f_deadline
+
+
+class _MarketSession:
+    """Everything a single negotiation session contributed to the trace.
+
+    ``bundles`` is the set of every (price, deadline) exchanged in the session
+    -- the trace-observed evidence the dominance frontier is computed from.
+    ``buyer``/``seller`` are resolved from the ``side`` tag on the offers.
+
+    Example::
+
+        sess = _MarketSession()
+        sess.bundles.add((55, 30))
+    """
+
+    def __init__(self) -> None:
+        self.bundles: set[tuple[int, int]] = set()
+        self.buyer: str | None = None
+        self.seller: str | None = None
+        self.agreement: tuple[int, int, str] | None = None
+        self.breakdown: bool = False
+
+
+def _collect_agent_utilities(events: list[dict[str, Any]]) -> dict[str, _AgentUtility]:
+    """Parse ``mautil:`` frames into per-agent utility reconstructors.
+
+    Frames are ``mautil:<agent>:<side>:<w_price>:<w_deadline>:<plo>:<phi>:<dlo>:
+    <dhi>:<reservation>``. Malformed frames (short split, non-numeric fields,
+    unknown side, or a degenerate range that would divide by zero) are skipped.
+
+    Example::
+
+        utils = _collect_agent_utilities(events)
+    """
+    utils: dict[str, _AgentUtility] = {}
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("mautil:"):
+            continue
+        parts = msg.split(":")
+        if len(parts) < 10:
+            continue
+        agent, side = parts[1], parts[2]
+        if side not in ("buyer", "seller"):
+            continue
+        try:
+            w_price = float(parts[3])
+            w_deadline = float(parts[4])
+            plo, phi, dlo, dhi = int(parts[5]), int(parts[6]), int(parts[7]), int(parts[8])
+            reservation = float(parts[9])
+        except ValueError:
+            continue
+        if phi <= plo or dhi <= dlo:
+            continue
+        utils[agent] = _AgentUtility(side, w_price, w_deadline, plo, phi, dlo, dhi, reservation)
+    return utils
+
+
+def _collect_market_sessions(events: list[dict[str, Any]]) -> dict[str, _MarketSession]:
+    """Group ``offer:``/``agree:``/``breakdown:`` frames by session id.
+
+    Example::
+
+        sessions = _collect_market_sessions(events)
+    """
+    sessions: dict[str, _MarketSession] = defaultdict(_MarketSession)
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        parts = msg.split(":")
+        if msg.startswith("offer:") and len(parts) >= 7:
+            sid, agent, side = parts[1], parts[2], parts[3]
+            try:
+                price, deadline = int(parts[5]), int(parts[6])
+            except ValueError:
+                continue
+            sess = sessions[sid]
+            sess.bundles.add((price, deadline))
+            if side == "buyer":
+                sess.buyer = agent
+            elif side == "seller":
+                sess.seller = agent
+        elif msg.startswith("agree:") and len(parts) >= 5:
+            sid, accepting = parts[1], parts[4]
+            try:
+                price, deadline = int(parts[2]), int(parts[3])
+            except ValueError:
+                continue
+            sess = sessions[sid]
+            sess.agreement = (price, deadline, accepting)
+            sess.bundles.add((price, deadline))
+        elif msg.startswith("breakdown:") and len(parts) >= 3:
+            sessions[parts[1]].breakdown = True
+    return dict(sessions)
+
+
+def _pareto_dominates(ub_x: float, us_x: float, ub_y: float, us_y: float) -> bool:
+    """Return whether bundle X Pareto-dominates bundle Y (Zlotkin & Rosenschein Eq.4).
+
+    X dominates Y iff X is no worse for *either* party and strictly better for at
+    least one (Zlotkin & Rosenschein 1996; Royal Holloway negotiation notes,
+    Eq. 4). The ``>=`` comparisons are relaxed by ``_PARETO_EPS`` and the ``>``
+    comparisons tightened by it, so float reconstruction noise cannot manufacture
+    or mask a violation.
+
+    Example::
+
+        assert _pareto_dominates(0.9, 0.9, 0.9, 0.8)
+    """
+    no_worse = ub_x >= ub_y - _PARETO_EPS and us_x >= us_y - _PARETO_EPS
+    strictly_better = ub_x > ub_y + _PARETO_EPS or us_x > us_y + _PARETO_EPS
+    return no_worse and strictly_better
+
+
+def validate_multi_attribute_pareto_optimal(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """No concluded agreement is Pareto-dominated by another bundle it exchanged.
+
+    For every session that reached an ``agree:`` outcome, this reconstructs both
+    parties' utilities (from their ``mautil:`` frames) and FAILS if any *other*
+    bundle exchanged in the same session dominates the agreement under
+    :func:`_pareto_dominates`. A ``breakdown:`` session is **not** a failure: a
+    bilateral negotiation can legitimately reach no deal.
+
+    Scope is deliberately *trace-evidence-bounded*: the frontier is computed from
+    the bundles actually observed on the wire, never from the full feasible grid.
+    An agreement this validator passes could in principle still be dominated by a
+    feasible bundle that was never offered -- consistent with Nanda Town's rule
+    that validators judge trace evidence, not theorems. The adversarial power is
+    real nonetheless: the reference ``alternating_offers`` plugin never reads
+    ``conditions['deadline_days']``, so it accepts (or holds out for) a
+    price-acceptable bundle while a same-or-better-price, longer-deadline bundle
+    sits in the very same exchange -- a bundle that dominates the agreement and
+    trips this check. ``ParetoNegotiation`` passes because its trade-off
+    counteroffers move along the iso-utility curve toward the opponent's revealed
+    preference, settling on a non-dominated logroll.
+
+    Guards against a vacuous pass: if no agreement was scorable, it FAILS with
+    ``"scenario exercised no negotiation"`` (mirrors the receipt-reputation guard).
+
+    Example::
+
+        results = validate_multi_attribute_pareto_optimal(events)
+    """
+    utils = _collect_agent_utilities(events)
+    sessions = _collect_market_sessions(events)
+
+    scored = 0
+    violations: list[str] = []
+    for sid in sorted(sessions):
+        sess = sessions[sid]
+        if sess.agreement is None or sess.buyer is None or sess.seller is None:
+            continue
+        buyer_u = utils.get(sess.buyer)
+        seller_u = utils.get(sess.seller)
+        if buyer_u is None or seller_u is None:
+            continue
+
+        scored += 1
+        a_price, a_deadline, _accepting = sess.agreement
+        ub_star = buyer_u.utility(a_price, a_deadline)
+        us_star = seller_u.utility(a_price, a_deadline)
+
+        for xp, xd in sorted(sess.bundles):
+            if (xp, xd) == (a_price, a_deadline):
+                continue
+            ub_x = buyer_u.utility(xp, xd)
+            us_x = seller_u.utility(xp, xd)
+            if _pareto_dominates(ub_x, us_x, ub_star, us_star):
+                violations.append(
+                    f"session {sid}: agreement ({a_price},{a_deadline}) "
+                    f"u_buyer={ub_star:.6f} u_seller={us_star:.6f} dominated by "
+                    f"({xp},{xd}) u_buyer={ub_x:.6f} u_seller={us_x:.6f}"
+                )
+                break
+
+    if scored == 0:
+        return [
+            ValidationResult(
+                "multi_attribute_pareto_optimal",
+                False,
+                "scenario exercised no negotiation",
+            )
+        ]
+    if violations:
+        return [ValidationResult("multi_attribute_pareto_optimal", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "multi_attribute_pareto_optimal",
+            True,
+            f"{scored} agreement(s) non-dominated by any exchanged bundle",
+        )
+    ]
+
+
+def validate_multi_attribute_individually_rational(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every agreement clears both parties' reservation utility.
+
+    Reconstructs each party's utility for the agreed bundle and FAILS if either
+    falls below its declared reservation (within ``_PARETO_EPS``). This catches a
+    degenerate "agree to anything" plugin that closes a deal one side strictly
+    prefers to walk away from. Like the Pareto check it guards against a vacuous
+    pass: if no agreement was scorable it FAILS with
+    ``"scenario exercised no negotiation"``.
+
+    Example::
+
+        results = validate_multi_attribute_individually_rational(events)
+    """
+    utils = _collect_agent_utilities(events)
+    sessions = _collect_market_sessions(events)
+
+    scored = 0
+    offenders: list[str] = []
+    for sid in sorted(sessions):
+        sess = sessions[sid]
+        if sess.agreement is None or sess.buyer is None or sess.seller is None:
+            continue
+        buyer_u = utils.get(sess.buyer)
+        seller_u = utils.get(sess.seller)
+        if buyer_u is None or seller_u is None:
+            continue
+
+        scored += 1
+        a_price, a_deadline, _accepting = sess.agreement
+        ub = buyer_u.utility(a_price, a_deadline)
+        us = seller_u.utility(a_price, a_deadline)
+        if ub < buyer_u.reservation - _PARETO_EPS:
+            offenders.append(
+                f"session {sid}: buyer u={ub:.6f} < reservation {buyer_u.reservation:.6f}"
+            )
+        if us < seller_u.reservation - _PARETO_EPS:
+            offenders.append(
+                f"session {sid}: seller u={us:.6f} < reservation {seller_u.reservation:.6f}"
+            )
+
+    if scored == 0:
+        return [
+            ValidationResult(
+                "multi_attribute_individually_rational",
+                False,
+                "scenario exercised no negotiation",
+            )
+        ]
+    if offenders:
+        return [
+            ValidationResult("multi_attribute_individually_rational", False, "; ".join(offenders))
+        ]
+    return [
+        ValidationResult(
+            "multi_attribute_individually_rational",
+            True,
+            f"{scored} agreement(s) individually rational for both parties",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -1888,5 +2208,9 @@ VALIDATORS: dict[str, list[Any]] = {
     "receipt_reputation": [
         validate_receipt_reputation_ring_severed,
         validate_receipt_reputation_honest_confidence,
+    ],
+    "multi_attribute_market": [
+        validate_multi_attribute_pareto_optimal,
+        validate_multi_attribute_individually_rational,
     ],
 }

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -754,6 +754,7 @@ class TestValidatorRegistry:
             "streaming_payments",
             "comms_versioning",
             "receipt_reputation",
+            "multi_attribute_market",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/negotiation/pareto.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/negotiation/pareto.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pareto-seeking multi-attribute negotiation plugin.
+
+Bilateral bargaining over *price* and *deadline* using additive multi-attribute
+utility and similarity-based trade-off (iso-utility) concessions, so the two
+parties move toward Pareto-efficient agreements instead of fighting over price
+alone.
+
+Example::
+
+    neg = ParetoNegotiation(
+        AgentId("buyer"),
+        weights={"price": 0.6, "deadline": 0.4},
+        price_range=(10, 100),
+        deadline_range=(1, 30),
+        side="buyer",
+    )
+    session = await neg.open(AgentId("seller"), Terms(price=Money(amount=10)))
+"""
+
+from __future__ import annotations
+
+from nest_core.types import (
+    AgentId,
+    Agreement,
+    Money,
+    NegotiationResponse,
+    NegotiationSession,
+    NegotiationStatus,
+    Terms,
+)
+
+
+class ParetoNegotiation:
+    """Multi-attribute, Pareto-seeking bilateral negotiation.
+
+    Each agent knows only its *own* private utility configuration (weights,
+    feasible ranges, reservation level) and negotiates over two issues — price
+    and deadline — that ride in ``terms.price`` and ``terms.conditions``.
+
+    The strategy combines three classical results:
+
+    - Keeney & Raiffa additive multi-attribute utility: a bundle's worth is the
+      weighted sum of per-issue value functions, each normalized to ``[0, 1]``.
+    - Rosenschein & Zlotkin 1994 Monotonic Concession Protocol (Zeuthen): the
+      agent's own-utility aspiration is non-increasing across rounds, which
+      guarantees the bargaining either converges or terminates.
+    - Faratin, Sierra & Jennings 2002 similarity-based trade-off: when the
+      opponent's offer is below aspiration, the agent counters with the bundle
+      on its current iso-utility set that is *closest* to the opponent's offer,
+      yielding integrative ("logrolling") moves that are Pareto-improving.
+
+    The plugin is Tier-1 deterministic: no wall-clock and no RNG. Session ids
+    come from a per-instance counter and all scoring is pure integer arithmetic.
+
+    Example::
+
+        neg = ParetoNegotiation(
+            AgentId("seller"),
+            weights={"price": 0.5, "deadline": 0.5},
+            price_range=(10, 100),
+            deadline_range=(1, 30),
+            side="seller",
+        )
+        session = await neg.open(AgentId("buyer"), Terms(price=Money(amount=100)))
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        weights: dict[str, float],
+        price_range: tuple[int, int],
+        deadline_range: tuple[int, int],
+        side: str,
+        patience: float = 0.9,
+        reservation: float = 0.0,
+        max_rounds: int = 12,
+    ) -> None:
+        self._agent_id = agent_id
+        self._weights = weights
+        self._price_range = price_range
+        self._deadline_range = deadline_range
+        self._side = side
+        self._patience = patience
+        self._reservation = reservation
+        self._max_rounds = max_rounds
+        self._rounds: dict[str, int] = {}
+        self._session_counter = 0
+
+    async def open(self, partner: AgentId, terms: Terms) -> NegotiationSession:
+        """Open a negotiation with initial terms and a deterministic session id.
+
+        Example::
+
+            session = await neg.open(AgentId("seller"), Terms(price=Money(amount=10)))
+        """
+        self._session_counter += 1
+        return NegotiationSession(
+            id=f"pareto-{self._agent_id}-{self._session_counter}",
+            initiator=self._agent_id,
+            partner=partner,
+            status=NegotiationStatus.OPEN,
+            current_terms=terms,
+            history=[terms],
+        )
+
+    async def offer(self, session: NegotiationSession, terms: Terms) -> None:
+        """Record an offer as the current terms and append it to history.
+
+        Example::
+
+            await neg.offer(session, Terms(price=Money(amount=80), conditions={"deadline_days": 7}))
+        """
+        session.current_terms = terms
+        session.history.append(terms)
+
+    async def respond(self, session: NegotiationSession) -> NegotiationResponse:
+        """Accept if the opponent's offer clears aspiration, else trade off.
+
+        Reads the opponent's latest offer from ``session.current_terms``. If its
+        own-utility is at least this round's aspiration ``alpha(t)`` the offer is
+        accepted; otherwise the agent returns the aspiration-satisfying grid
+        bundle nearest (in normalized issue space) to the opponent's offer — a
+        Faratin–Sierra–Jennings trade-off move along the iso-utility curve. When
+        aspiration exceeds the agent's reachable maximum it counters with its
+        single most-preferred bundle.
+
+        Example::
+
+            resp = await neg.respond(session)
+        """
+        opponent = session.current_terms
+        if opponent is None or opponent.price is None:
+            return NegotiationResponse(accepted=True)
+
+        round_index = self._rounds.get(session.id, 0)
+        self._rounds[session.id] = round_index + 1
+        alpha = self._aspiration(round_index)
+
+        if self.utility(opponent) >= alpha:
+            return NegotiationResponse(accepted=True)
+
+        plo, phi = self._price_range
+        dlo, dhi = self._deadline_range
+        p_span = phi - plo
+        d_span = dhi - dlo
+        p_opp, d_opp = self._clamp(*self._extract(opponent))
+
+        grid = self._grid()
+        acceptable = [(p, d) for (p, d) in grid if self._score(p, d) >= alpha]
+        if acceptable:
+            p_b, d_b = min(
+                acceptable,
+                key=lambda b: (
+                    ((b[0] - p_opp) / p_span) ** 2 + ((b[1] - d_opp) / d_span) ** 2,
+                    b[0],
+                    b[1],
+                ),
+            )
+        else:
+            # Aspiration above our reachable maximum: offer our most-preferred bundle.
+            p_b, d_b = min(grid, key=lambda b: (-self._score(b[0], b[1]), b[0], b[1]))
+
+        counter = Terms(price=Money(amount=p_b), conditions={"deadline_days": d_b})
+        return NegotiationResponse(accepted=False, counter_terms=counter)
+
+    async def close(self, session: NegotiationSession) -> Agreement | None:
+        """Return an agreement if the session was agreed, else mark it rejected.
+
+        Example::
+
+            agreement = await neg.close(session)
+        """
+        if session.status == NegotiationStatus.AGREED:
+            return Agreement(
+                session_id=session.id,
+                terms=session.current_terms or Terms(),
+                parties=[session.initiator, session.partner],
+            )
+        session.status = NegotiationStatus.REJECTED
+        return None
+
+    def utility(self, terms: Terms) -> float:
+        """Return this agent's additive multi-attribute utility for ``terms``.
+
+        Combines the price and deadline value functions (each normalized to
+        ``[0, 1]`` per the agent's directional convention) weighted by
+        ``weights``. Inputs are clamped into the feasible ranges before scoring.
+
+        Example::
+
+            neg = ParetoNegotiation(
+                AgentId("buyer"),
+                weights={"price": 0.5, "deadline": 0.5},
+                price_range=(10, 20),
+                deadline_range=(1, 5),
+                side="buyer",
+            )
+            neg.utility(Terms(price=Money(amount=10), conditions={"deadline_days": 1}))  # 1.0
+        """
+        return self._score(*self._extract(terms))
+
+    def _aspiration(self, round_index: int) -> float:
+        """Non-increasing own-utility floor for a round (Zeuthen/MCP schedule).
+
+        ``alpha(t) = reservation + (1 - reservation) * patience ** t``, with ``t``
+        capped at ``max_rounds`` so the floor settles at the agent's deadline
+        horizon while staying monotonically non-increasing.
+        """
+        t = min(round_index, self._max_rounds)
+        return self._reservation + (1.0 - self._reservation) * (self._patience**t)
+
+    def _grid(self) -> list[tuple[int, int]]:
+        """Deterministic enumeration of every feasible (price, deadline) bundle."""
+        plo, phi = self._price_range
+        dlo, dhi = self._deadline_range
+        return [(p, d) for p in range(plo, phi + 1) for d in range(dlo, dhi + 1)]
+
+    def _extract(self, terms: Terms) -> tuple[int, int]:
+        """Pull the raw (price, deadline) pair out of ``terms`` as ints."""
+        plo, _ = self._price_range
+        dlo, _ = self._deadline_range
+        price = terms.price.amount if terms.price is not None else plo
+        deadline = int(terms.conditions.get("deadline_days", dlo))
+        return price, deadline
+
+    def _clamp(self, price: int, deadline: int) -> tuple[int, int]:
+        """Clamp a (price, deadline) pair into the feasible ranges."""
+        plo, phi = self._price_range
+        dlo, dhi = self._deadline_range
+        return max(plo, min(phi, price)), max(dlo, min(dhi, deadline))
+
+    def _score(self, price: int, deadline: int) -> float:
+        """Additive MAUT score for a (price, deadline) pair after clamping."""
+        plo, phi = self._price_range
+        dlo, dhi = self._deadline_range
+        p, d = self._clamp(price, deadline)
+        if self._side == "buyer":
+            # Buyer prefers a low price and a short deadline.
+            f_price = (phi - p) / (phi - plo)
+            f_deadline = (dhi - d) / (dhi - dlo)
+        else:
+            # Seller prefers a high price and a long deadline.
+            f_price = (p - plo) / (phi - plo)
+            f_deadline = (d - dlo) / (dhi - dlo)
+        return self._weights["price"] * f_price + self._weights["deadline"] * f_deadline

--- a/packages/nest-plugins-reference/nest_plugins_reference/negotiation/pareto.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/negotiation/pareto.py
@@ -35,8 +35,8 @@ class ParetoNegotiation:
     """Multi-attribute, Pareto-seeking bilateral negotiation.
 
     Each agent knows only its *own* private utility configuration (weights,
-    feasible ranges, reservation level) and negotiates over two issues — price
-    and deadline — that ride in ``terms.price`` and ``terms.conditions``.
+    feasible ranges, reservation level) and negotiates over two issues (price
+    and deadline) that ride in ``terms.price`` and ``terms.conditions``.
 
     The strategy combines three classical results:
 
@@ -121,7 +121,7 @@ class ParetoNegotiation:
         Reads the opponent's latest offer from ``session.current_terms``. If its
         own-utility is at least this round's aspiration ``alpha(t)`` the offer is
         accepted; otherwise the agent returns the aspiration-satisfying grid
-        bundle nearest (in normalized issue space) to the opponent's offer — a
+        bundle nearest (in normalized issue space) to the opponent's offer, a
         Faratin–Sierra–Jennings trade-off move along the iso-utility curve. When
         aspiration exceeds the agent's reachable maximum it counters with its
         single most-preferred bundle.

--- a/packages/nest-plugins-reference/tests/test_multi_attribute_market.py
+++ b/packages/nest-plugins-reference/tests/test_multi_attribute_market.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validator unit tests and the end-to-end discrimination gate for the market.
+
+Two layers:
+
+1. **Validator direct-call** — hand-built event lists drive each branch of
+   ``validate_multi_attribute_pareto_optimal`` (dominated agreement fails, a
+   clean frontier passes, a breakdown is not a dominance failure) and of
+   ``validate_multi_attribute_individually_rational`` (a sub-reservation
+   agreement fails).
+2. **End-to-end discrimination** (the core deliverable) — boot the real
+   ``multi_attribute_market`` scenario through ``ScenarioRunner`` under seeds
+   42, 7, 1337. With ``negotiation: pareto`` every validator PASSES; with
+   ``negotiation: alternating_offers`` (a deadline-blind, timeout-driven plugin)
+   ``validate_multi_attribute_pareto_optimal`` FAILS on at least one agreement
+   dominated by an exchanged bundle. The layer is overridden in-test; the shipped
+   YAML is untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import (
+    ValidationResult,
+    validate_multi_attribute_individually_rational,
+    validate_multi_attribute_pareto_optimal,
+    validate_trace,
+)
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "multi_attribute_market.yaml"
+
+
+def _send(msg: str) -> dict[str, Any]:
+    """A minimal send event carrying a colon-delimited market frame."""
+    return {"kind": "send", "msg": msg, "agent": "driver", "to": "peer"}
+
+
+# ---------------------------------------------------------------------------
+# Validator direct-call tests
+# ---------------------------------------------------------------------------
+
+
+def test_pareto_validator_flags_dominated_agreement() -> None:
+    """An agreement dominated by another exchanged bundle is caught and named."""
+    events = [
+        _send("mautil:buyer-0:buyer:1.000000:0.000000:50:150:1:30:0.000000"),
+        _send("mautil:seller-0:seller:0.100000:0.900000:50:150:1:30:0.000000"),
+        _send("offer:pair-0:buyer-0:buyer:2:60:30"),  # the logroll: cheap + long deadline
+        _send("offer:pair-0:seller-0:seller:2:150:30"),  # resolves the seller side of the pair
+        _send("offer:pair-0:buyer-0:buyer:9:95:3"),  # late, deadline-suboptimal
+        _send("agree:pair-0:95:3:seller-0"),  # ... and it is what gets agreed
+    ]
+    result = validate_multi_attribute_pareto_optimal(events)[0]
+    assert not result.passed
+    assert "dominated by" in result.detail
+    assert "(60,30)" in result.detail
+
+
+def test_pareto_validator_passes_clean_frontier() -> None:
+    """A session whose agreement is the frontier bundle passes."""
+    events = [
+        _send("mautil:buyer-1:buyer:1.000000:0.000000:50:150:1:30:0.000000"),
+        _send("mautil:seller-1:seller:0.100000:0.900000:50:150:1:30:0.000000"),
+        _send("offer:pair-1:buyer-1:buyer:2:60:30"),
+        _send("offer:pair-1:seller-1:seller:2:150:30"),
+        _send("agree:pair-1:60:30:seller-1"),
+    ]
+    result = validate_multi_attribute_pareto_optimal(events)[0]
+    assert result.passed, result.detail
+
+
+def test_pareto_validator_ignores_breakdown_sessions() -> None:
+    """A breakdown is a legitimate no-deal, not a dominance failure."""
+    events = [
+        # A clean agreement so the guard ("no negotiation") does not trip.
+        _send("mautil:buyer-1:buyer:1.000000:0.000000:50:150:1:30:0.000000"),
+        _send("mautil:seller-1:seller:0.100000:0.900000:50:150:1:30:0.000000"),
+        _send("offer:pair-1:buyer-1:buyer:2:60:30"),
+        _send("offer:pair-1:seller-1:seller:2:150:30"),
+        _send("agree:pair-1:60:30:seller-1"),
+        # A second session that simply broke down.
+        _send("mautil:buyer-2:buyer:1.000000:0.000000:50:150:1:30:0.000000"),
+        _send("mautil:seller-2:seller:0.100000:0.900000:50:150:1:30:0.000000"),
+        _send("offer:pair-2:buyer-2:buyer:1:55:5"),
+        _send("offer:pair-2:seller-2:seller:1:150:30"),
+        _send("breakdown:pair-2:10"),
+    ]
+    result = validate_multi_attribute_pareto_optimal(events)[0]
+    assert result.passed, result.detail
+    assert "pair-2" not in result.detail
+
+
+def test_individual_rationality_flags_below_reservation() -> None:
+    """An agreement below a party's reservation utility is flagged."""
+    events = [
+        # Buyer reservation 0.95, but the agreed bundle (150,30) gives it utility 0.
+        _send("mautil:buyer-3:buyer:1.000000:0.000000:50:150:1:30:0.950000"),
+        _send("mautil:seller-3:seller:0.100000:0.900000:50:150:1:30:0.000000"),
+        _send("offer:pair-3:buyer-3:buyer:1:150:30"),
+        _send("offer:pair-3:seller-3:seller:1:150:30"),
+        _send("agree:pair-3:150:30:seller-3"),
+    ]
+    result = validate_multi_attribute_individually_rational(events)[0]
+    assert not result.passed
+    assert "buyer" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# End-to-end discrimination gate
+# ---------------------------------------------------------------------------
+
+
+def _run_scenario(seed: int, negotiation: str) -> list[ValidationResult]:
+    """Run the market scenario with a chosen negotiation layer; validate its trace."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    config.seed = seed
+    config.layers.negotiation = negotiation
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"mam_{negotiation}_{seed}.jsonl"
+        config.output.trace = str(trace_path)
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        asyncio.run(runner.run())
+        return validate_trace(trace_path, "multi_attribute_market")
+
+
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_pareto_passes_all_validators(seed: int) -> None:
+    """The plugin under test (pareto) reaches only non-dominated, rational deals."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    results = _run_scenario(seed, "pareto")
+    assert results, "expected validators to run"
+    assert all(r.passed for r in results), [(r.name, r.detail) for r in results]
+
+
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_alternating_offers_fails_pareto_validator(seed: int) -> None:
+    """The deadline-blind reference plugin is caught: at least one dominated deal."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    results = _run_scenario(seed, "alternating_offers")
+    pareto = next(r for r in results if r.name == "multi_attribute_pareto_optimal")
+    assert not pareto.passed, f"seed={seed}: alternating_offers should be caught"
+    assert "dominated by" in pareto.detail

--- a/packages/nest-plugins-reference/tests/test_multi_attribute_market.py
+++ b/packages/nest-plugins-reference/tests/test_multi_attribute_market.py
@@ -3,12 +3,12 @@
 
 Two layers:
 
-1. **Validator direct-call** — hand-built event lists drive each branch of
+1. **Validator direct-call**, hand-built event lists drive each branch of
    ``validate_multi_attribute_pareto_optimal`` (dominated agreement fails, a
    clean frontier passes, a breakdown is not a dominance failure) and of
    ``validate_multi_attribute_individually_rational`` (a sub-reservation
    agreement fails).
-2. **End-to-end discrimination** (the core deliverable) — boot the real
+2. **End-to-end discrimination** (the core deliverable), boot the real
    ``multi_attribute_market`` scenario through ``ScenarioRunner`` under seeds
    42, 7, 1337. With ``negotiation: pareto`` every validator PASSES; with
    ``negotiation: alternating_offers`` (a deadline-blind, timeout-driven plugin)
@@ -43,9 +43,7 @@ def _send(msg: str) -> dict[str, Any]:
     return {"kind": "send", "msg": msg, "agent": "driver", "to": "peer"}
 
 
-# ---------------------------------------------------------------------------
 # Validator direct-call tests
-# ---------------------------------------------------------------------------
 
 
 def test_pareto_validator_flags_dominated_agreement() -> None:
@@ -113,9 +111,7 @@ def test_individual_rationality_flags_below_reservation() -> None:
     assert "buyer" in result.detail
 
 
-# ---------------------------------------------------------------------------
 # End-to-end discrimination gate
-# ---------------------------------------------------------------------------
 
 
 def _run_scenario(seed: int, negotiation: str) -> list[ValidationResult]:

--- a/packages/nest-plugins-reference/tests/test_pareto_negotiation.py
+++ b/packages/nest-plugins-reference/tests/test_pareto_negotiation.py
@@ -3,12 +3,12 @@
 
 Three property families (Hypothesis):
 
-* **Determinism** — identical construction + identical offer sequence yields an
+* **Determinism**, identical construction + identical offer sequence yields an
   identical run (no wall-clock, no RNG).
-* **Monotonic concession** — a single agent's own counter-offer utilities are
+* **Monotonic concession**, a single agent's own counter-offer utilities are
   non-increasing across rounds (Rosenschein & Zlotkin's Monotonic Concession
   Protocol / Zeuthen).
-* **No dominated self-play** — two ParetoNegotiation agents with asymmetric
+* **No dominated self-play**, two ParetoNegotiation agents with asymmetric
   weights never settle on an agreement Pareto-dominated by a bundle they
   exchanged.
 """
@@ -43,9 +43,7 @@ def _dominates(ub_x: float, us_x: float, ub_y: float, us_y: float) -> bool:
     return no_worse and strictly_better
 
 
-# ---------------------------------------------------------------------------
 # Unit tests
-# ---------------------------------------------------------------------------
 
 
 def test_utility_directional_buyer() -> None:
@@ -146,9 +144,7 @@ def test_respond_counter_then_accept() -> None:
     assert result[2][0] is True  # utility 0.85 >= aspiration 0.81
 
 
-# ---------------------------------------------------------------------------
 # Property tests (Hypothesis)
-# ---------------------------------------------------------------------------
 
 
 class _Cfg(NamedTuple):
@@ -307,8 +303,8 @@ def test_selfplay_agreement_individually_rational(cfg: _Cfg) -> None:
     An agent only accepts (and only counters with) bundles whose own utility
     meets its aspiration ``reservation + (1 - reservation) * patience ** t``,
     which is bounded below by ``reservation``. So neither side ever agrees to a
-    bundle it strictly prefers walking away from -- individual rationality, the
-    invariant the FSJ trade-off mechanism *does* guarantee.
+    bundle it strictly prefers walking away from (individual rationality, the
+    invariant the FSJ trade-off mechanism *does* guarantee).
     """
     buyer = _make_buyer(cfg, max_rounds=25)
     seller = _make_seller(cfg, max_rounds=25)
@@ -345,13 +341,13 @@ def test_fsj_tradeoff_does_not_guarantee_pareto_optimality() -> None:
     joint gains and *approach* the Pareto frontier, but do not *guarantee* it
     under incomplete information: a Pareto-improving bundle offered early can be
     rejected (the recipient's aspiration is still above it) and gone by the time
-    aspiration falls enough to accept -- the bundle is ephemeral. A hard guarantee
+    aspiration falls enough to accept. The bundle is ephemeral. A hard guarantee
     would require the MCP/Zeuthen optimal-deal search (exponential in the issue
     grid per round); ParetoNegotiation deliberately trades that guarantee for
     tractable, deterministic concession.
 
     This test pins the configuration Hypothesis found and asserts the agreement
-    IS dominated by a bundle exchanged earlier in the same session -- documenting
+    IS dominated by a bundle exchanged earlier in the same session, documenting
     the limit as an intentional design boundary, not a bug. (The end-to-end
     asymmetric gate asserts Pareto-efficiency where the design *does* secure it.)
     """

--- a/packages/nest-plugins-reference/tests/test_pareto_negotiation.py
+++ b/packages/nest-plugins-reference/tests/test_pareto_negotiation.py
@@ -1,0 +1,379 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit and property tests for the ParetoNegotiation plugin.
+
+Three property families (Hypothesis):
+
+* **Determinism** — identical construction + identical offer sequence yields an
+  identical run (no wall-clock, no RNG).
+* **Monotonic concession** — a single agent's own counter-offer utilities are
+  non-increasing across rounds (Rosenschein & Zlotkin's Monotonic Concession
+  Protocol / Zeuthen).
+* **No dominated self-play** — two ParetoNegotiation agents with asymmetric
+  weights never settle on an agreement Pareto-dominated by a bundle they
+  exchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import NamedTuple
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.strategies import DrawFn
+from nest_core.types import AgentId, Money, Terms
+from nest_plugins_reference.negotiation.pareto import ParetoNegotiation
+
+_EPS = 1e-9
+
+
+def _terms(price: int, deadline: int) -> Terms:
+    return Terms(price=Money(amount=price), conditions={"deadline_days": deadline})
+
+
+def _pd(terms: Terms) -> tuple[int, int]:
+    price = terms.price.amount if terms.price is not None else 0
+    return price, int(terms.conditions.get("deadline_days", 0))
+
+
+def _dominates(ub_x: float, us_x: float, ub_y: float, us_y: float) -> bool:
+    """X dominates Y: no worse for either party, strictly better for one (eps-guarded)."""
+    no_worse = ub_x >= ub_y - _EPS and us_x >= us_y - _EPS
+    strictly_better = ub_x > ub_y + _EPS or us_x > us_y + _EPS
+    return no_worse and strictly_better
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_utility_directional_buyer() -> None:
+    """The buyer prefers lower price and shorter deadline."""
+    buyer = ParetoNegotiation(
+        AgentId("b"),
+        weights={"price": 0.5, "deadline": 0.5},
+        price_range=(50, 150),
+        deadline_range=(1, 30),
+        side="buyer",
+    )
+    assert buyer.utility(_terms(60, 5)) > buyer.utility(_terms(120, 5))
+    assert buyer.utility(_terms(60, 5)) > buyer.utility(_terms(60, 25))
+
+
+def test_utility_directional_seller() -> None:
+    """The seller prefers higher price and longer deadline."""
+    seller = ParetoNegotiation(
+        AgentId("s"),
+        weights={"price": 0.5, "deadline": 0.5},
+        price_range=(50, 150),
+        deadline_range=(1, 30),
+        side="seller",
+    )
+    assert seller.utility(_terms(120, 25)) > seller.utility(_terms(60, 25))
+    assert seller.utility(_terms(120, 25)) > seller.utility(_terms(120, 5))
+
+
+def test_best_for_self_has_utility_one() -> None:
+    """Each side's ideal bundle scores exactly 1.0."""
+    buyer = ParetoNegotiation(
+        AgentId("b"),
+        weights={"price": 0.7, "deadline": 0.3},
+        price_range=(50, 150),
+        deadline_range=(1, 30),
+        side="buyer",
+    )
+    seller = ParetoNegotiation(
+        AgentId("s"),
+        weights={"price": 0.2, "deadline": 0.8},
+        price_range=(50, 150),
+        deadline_range=(1, 30),
+        side="seller",
+    )
+    assert buyer.utility(_terms(50, 1)) == 1.0
+    assert seller.utility(_terms(150, 30)) == 1.0
+
+
+def test_respond_accepts_best_immediately() -> None:
+    """An offer that equals the agent's ideal clears even the round-0 aspiration (1.0)."""
+    buyer = ParetoNegotiation(
+        AgentId("b"),
+        weights={"price": 0.5, "deadline": 0.5},
+        price_range=(0, 10),
+        deadline_range=(0, 10),
+        side="buyer",
+    )
+
+    async def go() -> bool:
+        session = await buyer.open(AgentId("opp"), _terms(0, 0))
+        await buyer.offer(session, _terms(0, 0))  # buyer's ideal -> utility 1.0
+        resp = await buyer.respond(session)
+        return resp.accepted
+
+    assert asyncio.run(go()) is True
+
+
+def test_respond_counter_then_accept() -> None:
+    """Counters meet the (falling) aspiration and minimize distance; then it accepts.
+
+    Range 0..10 on both issues, equal weights, patience 0.9, reservation 0:
+    aspiration is 1.0, 0.9, 0.81 on rounds 0, 1, 2. Against the buyer's worst
+    offer (10, 10) the only utility>=1.0 bundle is (0, 0); the closest utility>=0.9
+    bundle is (1, 1); finally an offer worth 0.85 clears the round-2 floor of 0.81.
+    """
+    buyer = ParetoNegotiation(
+        AgentId("b"),
+        weights={"price": 0.5, "deadline": 0.5},
+        price_range=(0, 10),
+        deadline_range=(0, 10),
+        side="buyer",
+        patience=0.9,
+    )
+
+    async def go() -> list[tuple[bool, tuple[int, int] | None]]:
+        session = await buyer.open(AgentId("opp"), _terms(0, 0))
+        out: list[tuple[bool, tuple[int, int] | None]] = []
+        for offer in (_terms(10, 10), _terms(10, 10), _terms(1, 2)):
+            await buyer.offer(session, offer)
+            resp = await buyer.respond(session)
+            counter = _pd(resp.counter_terms) if resp.counter_terms is not None else None
+            out.append((resp.accepted, counter))
+        return out
+
+    result = asyncio.run(go())
+    assert result[0] == (False, (0, 0))
+    assert result[1] == (False, (1, 1))
+    assert result[2][0] is True  # utility 0.85 >= aspiration 0.81
+
+
+# ---------------------------------------------------------------------------
+# Property tests (Hypothesis)
+# ---------------------------------------------------------------------------
+
+
+class _Cfg(NamedTuple):
+    plo: int
+    phi: int
+    dlo: int
+    dhi: int
+    patience: float
+    buyer_wp: float
+    seller_wd: float
+    reservation: float
+
+
+@st.composite
+def _cfgs(draw: DrawFn) -> _Cfg:
+    plo = draw(st.integers(10, 50))
+    phi = plo + draw(st.integers(20, 40))
+    dlo = draw(st.integers(1, 5))
+    dhi = dlo + draw(st.integers(8, 15))
+    patience = draw(st.floats(0.7, 0.95, allow_nan=False, allow_infinity=False))
+    buyer_wp = draw(st.floats(0.6, 0.95, allow_nan=False, allow_infinity=False))
+    seller_wd = draw(st.floats(0.6, 0.95, allow_nan=False, allow_infinity=False))
+    reservation = draw(st.floats(0.0, 0.3, allow_nan=False, allow_infinity=False))
+    return _Cfg(plo, phi, dlo, dhi, patience, buyer_wp, seller_wd, reservation)
+
+
+@st.composite
+def _cfg_and_offers(draw: DrawFn) -> tuple[_Cfg, list[tuple[int, int]]]:
+    cfg = draw(_cfgs())
+    offers = draw(
+        st.lists(
+            st.tuples(st.integers(cfg.plo, cfg.phi), st.integers(cfg.dlo, cfg.dhi)),
+            min_size=1,
+            max_size=8,
+        )
+    )
+    return cfg, offers
+
+
+def _make_seller(cfg: _Cfg, max_rounds: int = 12) -> ParetoNegotiation:
+    return ParetoNegotiation(
+        AgentId("s"),
+        weights={"price": 1.0 - cfg.seller_wd, "deadline": cfg.seller_wd},
+        price_range=(cfg.plo, cfg.phi),
+        deadline_range=(cfg.dlo, cfg.dhi),
+        side="seller",
+        patience=cfg.patience,
+        reservation=cfg.reservation,
+        max_rounds=max_rounds,
+    )
+
+
+def _make_buyer(cfg: _Cfg, max_rounds: int = 12) -> ParetoNegotiation:
+    return ParetoNegotiation(
+        AgentId("b"),
+        weights={"price": cfg.buyer_wp, "deadline": 1.0 - cfg.buyer_wp},
+        price_range=(cfg.plo, cfg.phi),
+        deadline_range=(cfg.dlo, cfg.dhi),
+        side="buyer",
+        patience=cfg.patience,
+        reservation=cfg.reservation,
+        max_rounds=max_rounds,
+    )
+
+
+async def _self_play(
+    buyer: ParetoNegotiation, seller: ParetoNegotiation, bounds: tuple[int, int, int, int]
+) -> tuple[tuple[int, int] | None, list[tuple[int, int]]]:
+    """Run two agents to settlement; return the agreement (if any) and exchanged bundles.
+
+    Each side opens from its best-for-self position, then alternately responds to
+    the other's latest offer. An agent either accepts (the offer becomes the
+    agreement) or returns a trade-off counter that is recorded and forwarded.
+    """
+    plo, phi, dlo, dhi = bounds
+    buyer_open = _terms(plo, dlo)
+    seller_open = _terms(phi, dhi)
+    bs = await buyer.open(AgentId("s"), buyer_open)
+    ss = await seller.open(AgentId("b"), seller_open)
+    exchanged: list[tuple[int, int]] = [(plo, dlo), (phi, dhi)]
+    buyer_last, seller_last = buyer_open, seller_open
+    for _ in range(30):
+        await buyer.offer(bs, seller_last)
+        br = await buyer.respond(bs)
+        if br.accepted:
+            return _pd(seller_last), exchanged
+        if br.counter_terms is None:
+            return None, exchanged
+        buyer_last = br.counter_terms
+        exchanged.append(_pd(buyer_last))
+
+        await seller.offer(ss, buyer_last)
+        sr = await seller.respond(ss)
+        if sr.accepted:
+            return _pd(buyer_last), exchanged
+        if sr.counter_terms is None:
+            return None, exchanged
+        seller_last = sr.counter_terms
+        exchanged.append(_pd(seller_last))
+    return None, exchanged
+
+
+@given(payload=_cfg_and_offers())
+@settings(max_examples=200)
+def test_determinism(payload: tuple[_Cfg, list[tuple[int, int]]]) -> None:
+    """Two identically-built agents fed the same offers produce identical responses."""
+    cfg, offers = payload
+
+    async def drive(agent: ParetoNegotiation) -> list[tuple[bool, tuple[int, int] | None]]:
+        session = await agent.open(AgentId("opp"), _terms(cfg.plo, cfg.dlo))
+        out: list[tuple[bool, tuple[int, int] | None]] = []
+        for price, deadline in offers:
+            await agent.offer(session, _terms(price, deadline))
+            resp = await agent.respond(session)
+            counter = _pd(resp.counter_terms) if resp.counter_terms is not None else None
+            out.append((resp.accepted, counter))
+        return out
+
+    assert asyncio.run(drive(_make_seller(cfg))) == asyncio.run(drive(_make_seller(cfg)))
+
+
+@given(cfg=_cfgs())
+@settings(max_examples=200)
+def test_monotonic_concession(cfg: _Cfg) -> None:
+    """A seller's own counter-offer utilities are non-increasing (MCP / Zeuthen).
+
+    Fed its worst bundle (lowest price, shortest deadline) repeatedly, the seller
+    never accepts (its utility for that bundle is 0 < aspiration), so it keeps
+    countering; each counter sits on a non-increasing aspiration floor.
+    """
+    seller = _make_seller(cfg)
+    worst_for_seller = _terms(cfg.plo, cfg.dlo)
+
+    async def collect() -> list[float]:
+        session = await seller.open(AgentId("opp"), worst_for_seller)
+        utils: list[float] = []
+        for _ in range(15):
+            await seller.offer(session, worst_for_seller)
+            resp = await seller.respond(session)
+            if resp.accepted or resp.counter_terms is None:
+                break
+            utils.append(seller.utility(resp.counter_terms))
+        return utils
+
+    utils = asyncio.run(collect())
+    assert len(utils) >= 2
+    for earlier, later in zip(utils, utils[1:], strict=False):
+        assert later <= earlier + _EPS, f"concession not monotonic: {utils}"
+
+
+@given(cfg=_cfgs())
+@settings(max_examples=100, deadline=None)
+def test_selfplay_agreement_individually_rational(cfg: _Cfg) -> None:
+    """Every settled self-play agreement clears both parties' reservation utility.
+
+    An agent only accepts (and only counters with) bundles whose own utility
+    meets its aspiration ``reservation + (1 - reservation) * patience ** t``,
+    which is bounded below by ``reservation``. So neither side ever agrees to a
+    bundle it strictly prefers walking away from -- individual rationality, the
+    invariant the FSJ trade-off mechanism *does* guarantee.
+    """
+    buyer = _make_buyer(cfg, max_rounds=25)
+    seller = _make_seller(cfg, max_rounds=25)
+    agreement, _exchanged = asyncio.run(
+        _self_play(buyer, seller, (cfg.plo, cfg.phi, cfg.dlo, cfg.dhi))
+    )
+    if agreement is None:
+        return  # no settlement reached: individual rationality is vacuous
+
+    ap, ad = agreement
+    assert buyer.utility(_terms(ap, ad)) >= cfg.reservation - _EPS
+    assert seller.utility(_terms(ap, ad)) >= cfg.reservation - _EPS
+
+
+# The exact configuration Hypothesis surfaced as a counterexample to the (false)
+# "self-play is always Pareto-efficient" conjecture. Pinned so the boundary
+# reproduces deterministically.
+_FSJ_SUBOPTIMAL = _Cfg(
+    plo=10,
+    phi=30,
+    dlo=1,
+    dhi=9,
+    patience=0.890625,
+    buyer_wp=0.75,
+    seller_wd=0.90625,
+    reservation=0.0,
+)
+
+
+def test_fsj_tradeoff_does_not_guarantee_pareto_optimality() -> None:
+    """Characterize the boundary: trade-off concession approaches but does not reach Pareto.
+
+    Faratin, Sierra & Jennings 2002 show similarity-based trade-off moves raise
+    joint gains and *approach* the Pareto frontier, but do not *guarantee* it
+    under incomplete information: a Pareto-improving bundle offered early can be
+    rejected (the recipient's aspiration is still above it) and gone by the time
+    aspiration falls enough to accept -- the bundle is ephemeral. A hard guarantee
+    would require the MCP/Zeuthen optimal-deal search (exponential in the issue
+    grid per round); ParetoNegotiation deliberately trades that guarantee for
+    tractable, deterministic concession.
+
+    This test pins the configuration Hypothesis found and asserts the agreement
+    IS dominated by a bundle exchanged earlier in the same session -- documenting
+    the limit as an intentional design boundary, not a bug. (The end-to-end
+    asymmetric gate asserts Pareto-efficiency where the design *does* secure it.)
+    """
+    cfg = _FSJ_SUBOPTIMAL
+    buyer = _make_buyer(cfg, max_rounds=25)
+    seller = _make_seller(cfg, max_rounds=25)
+    agreement, exchanged = asyncio.run(
+        _self_play(buyer, seller, (cfg.plo, cfg.phi, cfg.dlo, cfg.dhi))
+    )
+    assert agreement is not None, "expected this configuration to settle"
+
+    ap, ad = agreement
+    ub_star = buyer.utility(_terms(ap, ad))
+    us_star = seller.utility(_terms(ap, ad))
+
+    def _dominates_agreement(bundle: tuple[int, int]) -> bool:
+        xp, xd = bundle
+        ub_x = buyer.utility(_terms(xp, xd))
+        us_x = seller.utility(_terms(xp, xd))
+        return _dominates(ub_x, us_x, ub_star, us_star)
+
+    dominators = [b for b in exchanged if b != (ap, ad) and _dominates_agreement(b)]
+    assert dominators, (
+        f"expected an ephemeral dominating bundle; agreement={agreement}, exchanged={exchanged}"
+    )

--- a/scenarios/multi_attribute_market.yaml
+++ b/scenarios/multi_attribute_market.yaml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Multi-attribute market scenario.
+#
+# 10 buyer-seller pairs negotiate over BOTH price and deadline. Each pair is
+# seeded with asymmetric preferences (buyer ~price-driven, seller
+# ~deadline-driven), creating Raiffa-style integrative potential: trading the
+# issue each side cares little about reaches a Pareto-efficient deal that a
+# price-only haggler cannot.
+#
+# Every exchanged bundle and each agent's private utility parameters are written
+# to the trace (mautil/offer/agree/breakdown frames) so an offline validator can
+# reconstruct utilities and check Pareto-optimality.
+#
+# Deterministic: per-pair weights are drawn from a generator seeded only from
+# (seed, pair_index); the bargaining loop runs synchronously in each buyer's
+# on_start, so the same seed yields a byte-identical trace.
+name: multi_attribute_market
+description: "10 buyer-seller pairs negotiating price + deadline toward Pareto efficiency."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 20
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 10
+    - name: seller
+      count: 10
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: pareto
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: multi_attribute_market
+
+duration: "ticks: 10000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/multi_attribute_market.jsonl


### PR DESCRIPTION
## Motivation

The reference `alternating_offers` plugin collapses multi-attribute bargaining into a one-dimensional price fight: its `respond` only looks at `terms.price` and never reads `conditions['deadline_days']`. Problem 07 asks for a negotiator that reasons over more than one issue and reaches Pareto-efficient deals. Separately, the negotiation layer was previously exercised and traced by **no** scenario in the repo, so there was no way to observe or validate negotiation behavior at all. This adds the first scenario that drives the negotiation layer and writes it to a trace, plus a plugin and an adversarial validator.

## Design

- **Additive multi-attribute utility** over price and `conditions['deadline_days']`, each normalized to `[0,1]` and weighted (Keeney & Raiffa additive MAUT). The buyer values low price / short deadline; the seller the opposite.
- **Monotonic-concession aspiration schedule** `alpha(t) = reservation + (1 - reservation) * patience ** t`, non-increasing in `t` (Rosenschein & Zlotkin 1994 Monotonic Concession Protocol / Zeuthen).
- **Similarity-based trade-off counteroffers** (Faratin, Sierra & Jennings 2002): when an offer is below aspiration, the plugin counters with the grid bundle whose own utility still clears the aspiration floor and whose normalized distance to the opponent's offer is minimal — moving along the iso-utility curve toward the opponent's revealed preference.
- **Polymorphic plugin construction**: the scenario builds the configured negotiator through an `inspect.signature` kwargs filter, forwarding only the parameters a given `__init__` accepts. The Negotiation protocol does not define `__init__`, so this lets the YAML `negotiation:` layer be swapped to *any* Negotiation plugin (Pareto gets its full config; `alternating_offers` gets only `patience`) without a `TypeError`.
- **Evaluation follows ANAC fixed-counterpart methodology**: the plugin under test plays the **seller** against a fixed, deterministic, price-driven **buyer** that is indifferent to the deadline. Because the deadline costs the buyer nothing, it hands the deadline-loving seller a generous long-deadline bundle early and cheaply (Raiffa integrative logrolling). Holding one side fixed makes the seller's `respond` — does it reason about the full multi-attribute Terms? — the discriminator.

## Honesty / tradeoffs

- The plugin is **Pareto-SEEKING, not Pareto-guaranteeing**. The FSJ trade-off *approaches* but does not *guarantee* the frontier under incomplete information; a hard guarantee would require the exponential MCP/Zeuthen optimal-deal search per round, which the plugin deliberately trades away for tractable, deterministic concession.
- Agreements are **individually rational** (proven property) and **empirically non-dominated on the shipped scenario** (the asymmetric gate). The validator is the independent, strict check — it is not the plugin grading itself.
- The validator computes the frontier **from observed bids only**, so it is **trace-evidence-bounded**: an agreement it passes could still be dominated by a feasible bundle nobody offered. This matches NANDA Town's "validators check trace evidence, not proofs" stance.
- The buyer counterpart's early long-deadline offer is **honest integrative bargaining, not a hidden trap** — the buyer is genuinely indifferent to the deadline, so giving it away costs it nothing and reflects real logrolling.

## Adversarial result

`validate_multi_attribute_pareto_optimal`:
- **FAILS** on `negotiation: alternating_offers` — its deadline-blind `respond` never concedes and only accepts at its round-limit timeout, closing on a short-deadline `(95, …)` bundle that the early `(60,30)` gift dominates (better price for the buyer, far longer deadline for the deadline-loving seller).
- **PASSES** on `negotiation: pareto` — the trade-off counters settle on the non-dominated logroll.

Both hold **deterministically under seeds 42, 7, and 1337**. A separate characterization test documents the FSJ heuristic's boundary with a pinned counterexample (a Pareto-improving bundle offered early, rejected while aspiration is still high, and gone by the time aspiration falls — so the self-play agreement is dominated by an ephemeral exchanged bundle).

## Test rigor (19 tests)

- **Directional-utility units**: buyer/seller conventions; best-for-self bundle scores 1.0; `respond` accepts at aspiration and otherwise returns a minimal-distance counter that meets its own aspiration.
- **Property tests (Hypothesis)**: determinism (same construction + offer sequence → identical run), MCP monotonic concession (own counter utilities non-increasing), self-play individual rationality (both sides clear reservation).
- **Cited FSJ characterization**: pinned counterexample asserting the not-always-Pareto boundary, green and intentional.
- **Validator direct-call**: dominated agreement FAILS, clean frontier PASSES, breakdown not flagged as a dominance failure, sub-reservation agreement flagged by the IR validator.
- **End-to-end FAIL/PASS gate**: the scenario booted through `ScenarioRunner` with each plugin under seeds 42/7/1337.

## Runnable verification

```bash
# 1. Run the scenario (deterministic; writes ./traces/multi_attribute_market.jsonl)
uv run nest run multi_attribute_market

# 2. Validate the trace (both validators PASS on pareto)
uv run python - <<'PY'
from pathlib import Path
from nest_core.validators import validate_trace
for r in validate_trace(Path("traces/multi_attribute_market.jsonl"), "multi_attribute_market"):
    print(("PASS" if r.passed else "FAIL"), r.name, "-", r.detail)
PY

# 3. The discrimination + characterization tests
uv run pytest -v \
  packages/nest-plugins-reference/tests/test_multi_attribute_market.py \
  packages/nest-plugins-reference/tests/test_pareto_negotiation.py
```

## Determinism

No wall-clock and no unseeded RNG anywhere: session ids come from a per-instance counter (not `uuid4`), all scoring is pure integer/float arithmetic, and the scenario draws every per-pair parameter from `random.Random(f"{seed}:{i}")`. The same seed yields a **byte-identical** trace.

## Files added / changed

- `packages/nest-plugins-reference/nest_plugins_reference/negotiation/pareto.py` — the `ParetoNegotiation` plugin (new).
- `packages/nest-core/nest_core/plugins.py` — one line registering `("negotiation", "pareto")` in `_BUILTINS`.
- `packages/nest-core/nest_core/scenarios_builtin/multi_attribute_market.py` — the scenario driver (new).
- `packages/nest-core/nest_core/scenarios.py` — the lazy registration branch for the scenario.
- `scenarios/multi_attribute_market.yaml` — the scenario config (new).
- `packages/nest-core/nest_core/validators.py` — the two validators + `VALIDATORS["multi_attribute_market"]`.
- `packages/nest-plugins-reference/tests/test_pareto_negotiation.py`, `packages/nest-plugins-reference/tests/test_multi_attribute_market.py` — the test suite (new).
- `packages/nest-core/tests/test_validators.py` — **one line**: adds `"multi_attribute_market"` to the registry-completeness test's expected set (the only edit to a pre-existing test, required because that test enumerates every validated scenario type).

Nothing outside the negotiation layer plus its scenario, validators, and tests was modified. No changes to the rubric, seed bank, `docs/hackathon/scores.json`, `scripts/judge/*`, or any other submission.

`make ci-local` (uv sync; ruff check; ruff format --check; pyright; pytest) is green: **560 passed, 1 skipped**.
