### PR TITLE
[Hackathon] data-engineer: content-addressed datafacts with provenance and signed freshness

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -39,6 +39,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
     ("privacy", "hybrid_x25519"): f"{_REF}.privacy.hybrid_x25519:HybridX25519Privacy",
     ("datafacts", "datafacts_v1"): f"{_REF}.datafacts.datafacts_v1:DataFactsV1",
+    ("datafacts", "cid_facts"): f"{_REF}.datafacts.cid_facts:CidFacts",
 }
 
 

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -103,3 +103,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("multi_attribute_market", multi_attribute_market_factory)
+    elif name == "provenance_supply_chain":
+        from nest_core.scenarios_builtin.provenance_supply_chain import (
+            provenance_supply_chain_factory,
+        )
+
+        register_scenario("provenance_supply_chain", provenance_supply_chain_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Content-addressed provenance scenario: a data pipeline, then three attacks.
+
+A 4-stage pipeline mirrors the existing ``supply_chain`` scenario, except each
+hop publishes a *dataset* (not a physical good) through ``plugins["datafacts"]``
+and the next hop's dataset declares the upstream one as its provenance
+parent: ``source -> refine -> aggregate -> verify``.
+
+The final stage plays two roles:
+
+1. **Verifier** — walks the parent chain back to the source via ``fetch``,
+   checks the final dataset's freshness, and reports both.
+2. **Attacker** — using its own identity (never the source's), attempts the
+   three attacks the datafacts problem brief calls out:
+
+   * *Substitution*: publish different content under the source's exact
+     ``name`` and see whether it lands on the source's URL.
+   * *Forged freshness*: publish identical content claiming the source's
+     ``owner`` and see whether the source's freshness now reads as valid
+     under someone else's signature.
+   * *Broken provenance*: publish a dataset whose declared parent was never
+     published, and see whether that is rejected.
+
+Every step is reported as a ``|``-delimited trace message (``:`` collides
+with the ``df://`` URL scheme, so this scenario does not use it as a
+delimiter the way other validators do). ``validate_trace(..., "provenance_supply_chain")``
+reads exactly these messages, so the same scenario YAML demonstrates both
+directions: point ``layers.datafacts`` at ``cid_facts`` and every adversarial
+validator passes; point it at ``datafacts_v1`` and they fail, because that
+reference plugin has no content-addressing, no signed freshness, and no
+provenance concept at all.
+
+Example::
+
+    agents = provenance_supply_chain_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, DatasetMetadata
+
+_PHANTOM_PARENT = "df://sha256-" + "0" * 64
+
+
+class SourceAgent(StateMachineAgent):
+    """Publishes the root dataset (no provenance parents) and hands off its URL."""
+
+    def __init__(self, agent_id: AgentId, next_stage: AgentId, name: str, description: str) -> None:
+        self._id = agent_id
+        self._next = next_stage
+        self._name = name
+        self._description = description
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        facts = ctx.plugins.get("datafacts")
+        if facts is None:
+            return
+        dataset = DatasetMetadata(name=self._name, owner=self._id, description=self._description)
+        url = await facts.publish(dataset)
+        await ctx.send(self._next, f"lineage|{url}|{self._id}".encode())
+
+
+class RefineAgent(StateMachineAgent):
+    """Publishes a derived dataset whose provenance parent is the upstream URL."""
+
+    def __init__(self, agent_id: AgentId, next_stage: AgentId, name: str) -> None:
+        self._id = agent_id
+        self._next = next_stage
+        self._name = name
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("lineage|"):
+            return
+        _, parent_url, _parent_owner = msg.split("|", 2)
+        facts = ctx.plugins.get("datafacts")
+        if facts is None:
+            return
+        dataset = DatasetMetadata(
+            name=self._name,
+            owner=self._id,
+            metadata={"parents": [parent_url]},
+        )
+        url = await facts.publish(dataset)
+        await ctx.send(self._next, f"lineage|{url}|{self._id}".encode())
+
+
+class VerifyAndAttackAgent(StateMachineAgent):
+    """Verifies the happy-path chain, then attempts three attacks as an outsider."""
+
+    def __init__(self, agent_id: AgentId, source_id: AgentId, source_name: str) -> None:
+        self._id = agent_id
+        self._source_id = source_id
+        self._source_name = source_name
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("lineage|"):
+            return
+        _, final_url, _final_owner = msg.split("|", 2)
+        facts = ctx.plugins.get("datafacts")
+        if facts is None:
+            return
+
+        root_url = await self._verify_chain(ctx, facts, final_url)
+        await self._verify_freshness(ctx, facts, final_url)
+        if root_url is not None:
+            await self._attack_substitution(ctx, facts, root_url)
+            await self._attack_forged_freshness(ctx, facts)
+        await self._attack_provenance(ctx, facts)
+
+    async def _verify_chain(self, ctx: AgentContext, facts: Any, final_url: str) -> str | None:
+        """Walk the parent chain back to the root and report depth.
+
+        Returns the root dataset's own URL (the source's published URL), or
+        ``None`` if the chain was broken, so the caller can target the
+        substitution attack at the *actual* source address rather than the
+        terminal (derived) one.
+        """
+        depth = 0
+        url: str = final_url
+        try:
+            while True:
+                meta: DatasetMetadata = await facts.fetch(url)
+                depth += 1
+                parents: list[str] = meta.metadata.get("parents", [])
+                if not parents:
+                    break
+                url = parents[0]
+        except KeyError:
+            await ctx.send(self._id, f"chain_broken|{final_url}|{url}".encode())
+            return None
+        await ctx.send(self._id, f"chain_ok|{final_url}|{depth}".encode())
+        return url
+
+    async def _verify_freshness(self, ctx: AgentContext, facts: Any, final_url: str) -> None:
+        fresh = await facts.verify_freshness(final_url)
+        await ctx.send(self._id, f"freshness|{final_url}|{int(fresh)}".encode())
+
+    async def _attack_substitution(self, ctx: AgentContext, facts: Any, source_url: str) -> None:
+        """Try to republish different content under the source's exact name."""
+        forged = DatasetMetadata(
+            name=self._source_name,
+            owner=self._source_id,
+            description="tampered-by-attacker",
+        )
+        attacker_url = await facts.publish(forged)
+        collided = int(str(attacker_url) == str(source_url))
+        await ctx.send(
+            self._id, f"attack_substitution|{source_url}|{attacker_url}|{collided}".encode()
+        )
+
+    async def _attack_forged_freshness(self, ctx: AgentContext, facts: Any) -> None:
+        """Republish the source's exact content, signed by the attacker, then re-check freshness."""
+        forged = DatasetMetadata(name=self._source_name, owner=self._source_id)
+        forged_url = await facts.publish(forged)
+        fresh = await facts.verify_freshness(forged_url)
+        await ctx.send(self._id, f"attack_forged_freshness|{forged_url}|{int(fresh)}".encode())
+
+    async def _attack_provenance(self, ctx: AgentContext, facts: Any) -> None:
+        """Try to publish a dataset whose declared parent was never published."""
+        phantom = DatasetMetadata(
+            name="laundered",
+            owner=self._source_id,
+            metadata={"parents": [_PHANTOM_PARENT]},
+        )
+        try:
+            await facts.publish(phantom)
+            rejected = 0
+        except ValueError:
+            rejected = 1
+        await ctx.send(self._id, f"attack_provenance|{_PHANTOM_PARENT}|{rejected}".encode())
+
+
+def _build_datafacts_handles(
+    datafacts_cls: type[Any],
+    identities: dict[AgentId, Any],
+    all_ids: list[AgentId],
+) -> dict[AgentId, Any]:
+    """Instantiate one datafacts handle per agent, sharing state where possible.
+
+    Plugins that take an ``Identity`` and ``datasets``/``proofs``/``clock``
+    keyword arguments (e.g. ``cid_facts``) get one handle per agent, all
+    backed by the same shared dicts and logical clock -- mirroring how the
+    reference ``prepaid_credits`` payments plugin gives every agent its own
+    handle over one shared ledger. Plugins with a no-argument constructor
+    (e.g. ``datafacts_v1``) get a single shared instance for every agent,
+    which is already correct for them since their internal storage is a
+    single dict.
+
+    Example::
+
+        handles = _build_datafacts_handles(CidFacts, identities, all_ids)
+    """
+    shared_datasets: dict[Any, Any] = {}
+    shared_proofs: dict[Any, Any] = {}
+    shared_clock: Any = None
+    shared_instance: Any = None
+    handles: dict[AgentId, Any] = {}
+
+    for aid in all_ids:
+        try:
+            kwargs: dict[str, Any] = {"datasets": shared_datasets, "proofs": shared_proofs}
+            if shared_clock is not None:
+                kwargs["clock"] = shared_clock
+            handle = datafacts_cls(identities[aid], **kwargs)
+            shared_clock = getattr(handle, "clock", shared_clock)
+            handles[aid] = handle
+        except TypeError:
+            if shared_instance is None:
+                shared_instance = datafacts_cls()
+            handles[aid] = shared_instance
+    return handles
+
+
+def provenance_supply_chain_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create the source/refine/aggregate/verify pipeline.
+
+    Instantiates per-agent identity instances (so each hop signs as itself)
+    and wires the resolved ``datafacts`` plugin class into per-agent handles
+    via :func:`_build_datafacts_handles`.
+
+    Example::
+
+        agents = provenance_supply_chain_factory(config, plugins)
+    """
+    source_id = AgentId("source-0")
+    refine_id = AgentId("refine-0")
+    aggregate_id = AgentId("aggregate-0")
+    verify_id = AgentId("verify-0")
+    all_ids = [source_id, refine_id, aggregate_id, verify_id]
+
+    identity_cls = plugins.get("identity")
+    identities: dict[AgentId, Any] = {}
+    if identity_cls is not None and isinstance(identity_cls, type):
+        for aid in all_ids:
+            identities[aid] = identity_cls(aid, seed=b"sim-seed")
+        for aid, ident in identities.items():
+            for peer_id, peer_ident in identities.items():
+                if peer_id != aid:
+                    ident.register_peer(peer_id, peer_ident.public_key)
+
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+    datafacts_cls = plugins.get("datafacts")
+    if datafacts_cls is not None and isinstance(datafacts_cls, type) and identities:
+        handles = _build_datafacts_handles(datafacts_cls, identities, all_ids)
+        for aid, handle in handles.items():
+            agent_plugins.setdefault(aid, {})["datafacts"] = handle
+    plugins.pop("datafacts", None)
+    plugins.pop("identity", None)
+
+    source_name = "raw_sensor_readings"
+    return {
+        source_id: SourceAgent(source_id, refine_id, source_name, description="batch-A"),
+        refine_id: RefineAgent(refine_id, aggregate_id, "cleaned_sensor_readings"),
+        aggregate_id: RefineAgent(aggregate_id, verify_id, "aggregated_report"),
+        verify_id: VerifyAndAttackAgent(verify_id, source_id, source_name),
+    }

--- a/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain.py
@@ -47,7 +47,13 @@ _PHANTOM_PARENT = "df://sha256-" + "0" * 64
 
 
 class SourceAgent(StateMachineAgent):
-    """Publishes the root dataset (no provenance parents) and hands off its URL."""
+    """Publishes the root dataset (no provenance parents) and hands off its URL.
+
+    Example::
+
+        source = SourceAgent(AgentId("source-0"), next_stage=AgentId("refine-0"),
+                              name="raw_sensor_readings", description="batch-A")
+    """
 
     def __init__(self, agent_id: AgentId, next_stage: AgentId, name: str, description: str) -> None:
         self._id = agent_id
@@ -56,6 +62,12 @@ class SourceAgent(StateMachineAgent):
         self._description = description
 
     async def on_start(self, ctx: AgentContext) -> None:
+        """Publish the root dataset and hand its URL to the next stage.
+
+        Example::
+
+            await source.on_start(ctx)
+        """
         facts = ctx.plugins.get("datafacts")
         if facts is None:
             return
@@ -65,7 +77,13 @@ class SourceAgent(StateMachineAgent):
 
 
 class RefineAgent(StateMachineAgent):
-    """Publishes a derived dataset whose provenance parent is the upstream URL."""
+    """Publishes a derived dataset whose provenance parent is the upstream URL.
+
+    Example::
+
+        refine = RefineAgent(AgentId("refine-0"), next_stage=AgentId("aggregate-0"),
+                              name="cleaned_sensor_readings")
+    """
 
     def __init__(self, agent_id: AgentId, next_stage: AgentId, name: str) -> None:
         self._id = agent_id
@@ -73,6 +91,12 @@ class RefineAgent(StateMachineAgent):
         self._name = name
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Publish a derived dataset parented on the lineage URL just received.
+
+        Example::
+
+            await refine.on_message(ctx, AgentId("source-0"), b"lineage|df://sha256-x|source-0")
+        """
         msg = payload.decode("utf-8", errors="replace")
         if not msg.startswith("lineage|"):
             return
@@ -90,7 +114,13 @@ class RefineAgent(StateMachineAgent):
 
 
 class VerifyAndAttackAgent(StateMachineAgent):
-    """Verifies the happy-path chain, then attempts three attacks as an outsider."""
+    """Verifies the happy-path chain, then attempts three attacks as an outsider.
+
+    Example::
+
+        verify = VerifyAndAttackAgent(AgentId("verify-0"), source_id=AgentId("source-0"),
+                                       source_name="raw_sensor_readings")
+    """
 
     def __init__(self, agent_id: AgentId, source_id: AgentId, source_name: str) -> None:
         self._id = agent_id
@@ -98,6 +128,12 @@ class VerifyAndAttackAgent(StateMachineAgent):
         self._source_name = source_name
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Verify the received chain's integrity and freshness, then run the three attacks.
+
+        Example::
+
+            await verify.on_message(ctx, AgentId("aggregate-0"), b"lineage|df://sha256-x|aggregate-0")
+        """
         msg = payload.decode("utf-8", errors="replace")
         if not msg.startswith("lineage|"):
             return

--- a/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain.py
@@ -1,30 +1,40 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Content-addressed provenance scenario: a data pipeline, then three attacks.
+"""Content-addressed provenance scenario: a diamond data pipeline, then attacks.
 
-A 4-stage pipeline mirrors the existing ``supply_chain`` scenario, except each
-hop publishes a *dataset* (not a physical good) through ``plugins["datafacts"]``
-and the next hop's dataset declares the upstream one as its provenance
-parent: ``source -> refine -> aggregate -> verify``.
+The pipeline is a **diamond**, not a line -- the canonical data-lineage shape::
 
-The final stage plays two roles:
+                 source-0
+                /        \\
+          refine-a      refine-b
+                \\        /
+               aggregate-0   (join: parents = [refine-a, refine-b])
+                    |
+                 verify-0
 
-1. **Verifier** — walks the parent chain back to the source via ``fetch``,
-   checks the final dataset's freshness, and reports both.
-2. **Attacker** — using its own identity (never the source's), attempts the
-   three attacks the datafacts problem brief calls out:
+Each hop publishes a *dataset* through ``plugins["datafacts"]`` and declares its
+upstream input(s) as provenance parents. ``aggregate-0`` is a join: it waits for
+both refiners and lists both as parents, so the final report's lineage fans back
+out to a single shared root. A verifier that only followed the first parent would
+silently miss half the graph; the walk here is a full breadth-first traversal.
 
-   * *Substitution*: publish different content under the source's exact
-     ``name`` and see whether it lands on the source's URL.
-   * *Forged freshness*: publish identical content claiming the source's
-     ``owner`` and see whether the source's freshness now reads as valid
-     under someone else's signature.
+``verify-0`` plays two roles:
+
+1. **Verifier** -- walks the whole provenance DAG back to the root and reports
+   how many distinct datasets it found.
+2. **Attacker** -- using its own identity (never the source's), it runs three
+   attacks:
+
+   * *Substitution*: republish different content under the source's exact
+     ``name``; does it land on the source's URL?
+   * *Forged freshness*: republish identical content claiming the source's
+     ``owner``; does the source then read as freshly attested under an
+     outsider's signature?
    * *Broken provenance*: publish a dataset whose declared parent was never
-     published, and see whether that is rejected.
+     published; is it rejected?
 
-Every step is reported as a ``|``-delimited trace message (``:`` collides
-with the ``df://`` URL scheme, so this scenario does not use it as a
-delimiter the way other validators do). ``validate_trace(..., "provenance_supply_chain")``
-reads exactly these messages, so the same scenario YAML demonstrates both
+Every step is reported as a ``|``-delimited trace message (``:`` collides with
+the ``df://`` URL scheme). ``validate_trace(..., "provenance_supply_chain")``
+reads exactly these messages, so the one scenario YAML demonstrates both
 directions: point ``layers.datafacts`` at ``cid_facts`` and every adversarial
 validator passes; point it at ``datafacts_v1`` and they fail, because that
 reference plugin has no content-addressing, no signed freshness, and no
@@ -37,7 +47,7 @@ Example::
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from nest_core.scenario import ScenarioConfig
 from nest_core.sim.agent import AgentContext, StateMachineAgent
@@ -46,23 +56,39 @@ from nest_core.types import AgentId, DatasetMetadata
 _PHANTOM_PARENT = "df://sha256-" + "0" * 64
 
 
-class SourceAgent(StateMachineAgent):
-    """Publishes the root dataset (no provenance parents) and hands off its URL.
+def _parents_of(meta: DatasetMetadata) -> list[str]:
+    """Read declared provenance parents off a dataset as a plain list of URL strings.
 
     Example::
 
-        source = SourceAgent(AgentId("source-0"), next_stage=AgentId("refine-0"),
-                              name="raw_sensor_readings", description="batch-A")
+        parents = _parents_of(meta)
+    """
+    raw: object = meta.metadata.get("parents", [])
+    if not isinstance(raw, list):
+        return []
+    return [str(p) for p in cast("list[Any]", raw)]
+
+
+class SourceAgent(StateMachineAgent):
+    """Publishes the root dataset (no parents) and fans it out to both refiners.
+
+    Example::
+
+        source = SourceAgent(AgentId("source-0"),
+                             refiners=[AgentId("refine-a"), AgentId("refine-b")],
+                             name="raw_sensor_readings", description="batch-A")
     """
 
-    def __init__(self, agent_id: AgentId, next_stage: AgentId, name: str, description: str) -> None:
+    def __init__(
+        self, agent_id: AgentId, refiners: list[AgentId], name: str, description: str
+    ) -> None:
         self._id = agent_id
-        self._next = next_stage
+        self._refiners = refiners
         self._name = name
         self._description = description
 
     async def on_start(self, ctx: AgentContext) -> None:
-        """Publish the root dataset and hand its URL to the next stage.
+        """Publish the root dataset and send its URL to every refiner.
 
         Example::
 
@@ -73,25 +99,26 @@ class SourceAgent(StateMachineAgent):
             return
         dataset = DatasetMetadata(name=self._name, owner=self._id, description=self._description)
         url = await facts.publish(dataset)
-        await ctx.send(self._next, f"lineage|{url}|{self._id}".encode())
+        for refiner in self._refiners:
+            await ctx.send(refiner, f"lineage|{url}|{self._id}".encode())
 
 
 class RefineAgent(StateMachineAgent):
-    """Publishes a derived dataset whose provenance parent is the upstream URL.
+    """Publishes a derived dataset parented on the source, forwards to the aggregator.
 
     Example::
 
-        refine = RefineAgent(AgentId("refine-0"), next_stage=AgentId("aggregate-0"),
-                              name="cleaned_sensor_readings")
+        refine = RefineAgent(AgentId("refine-a"), aggregator=AgentId("aggregate-0"),
+                             name="cleaned_a")
     """
 
-    def __init__(self, agent_id: AgentId, next_stage: AgentId, name: str) -> None:
+    def __init__(self, agent_id: AgentId, aggregator: AgentId, name: str) -> None:
         self._id = agent_id
-        self._next = next_stage
+        self._aggregator = aggregator
         self._name = name
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
-        """Publish a derived dataset parented on the lineage URL just received.
+        """Publish a dataset parented on the source URL and forward it to the aggregator.
 
         Example::
 
@@ -100,26 +127,69 @@ class RefineAgent(StateMachineAgent):
         msg = payload.decode("utf-8", errors="replace")
         if not msg.startswith("lineage|"):
             return
-        _, parent_url, _parent_owner = msg.split("|", 2)
+        _, parent_url, _owner = msg.split("|", 2)
         facts = ctx.plugins.get("datafacts")
         if facts is None:
             return
         dataset = DatasetMetadata(
-            name=self._name,
-            owner=self._id,
-            metadata={"parents": [parent_url]},
+            name=self._name, owner=self._id, metadata={"parents": [parent_url]}
         )
         url = await facts.publish(dataset)
-        await ctx.send(self._next, f"lineage|{url}|{self._id}".encode())
+        await ctx.send(self._aggregator, f"lineage|{url}|{self._id}".encode())
+
+
+class AggregateAgent(StateMachineAgent):
+    """Joins both refiners into one dataset -- the diamond's closure -- and forwards it.
+
+    A join lists *both* upstream datasets as parents, so the report's lineage
+    fans back out to the shared root. This is what forces a verifier to walk
+    every parent rather than a single spine.
+
+    Example::
+
+        agg = AggregateAgent(AgentId("aggregate-0"), downstream=AgentId("verify-0"),
+                             name="aggregated_report", expected_parents=2)
+    """
+
+    def __init__(
+        self, agent_id: AgentId, downstream: AgentId, name: str, expected_parents: int
+    ) -> None:
+        self._id = agent_id
+        self._downstream = downstream
+        self._name = name
+        self._expected = expected_parents
+        self._parents: list[str] = []
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Collect refiner inputs and, once both arrive, publish + forward the join.
+
+        Example::
+
+            await agg.on_message(ctx, AgentId("refine-a"), b"lineage|df://sha256-a|refine-a")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("lineage|"):
+            return
+        facts = ctx.plugins.get("datafacts")
+        if facts is None:
+            return
+        _, parent_url, _owner = msg.split("|", 2)
+        self._parents.append(parent_url)
+        if len(self._parents) == self._expected:
+            dataset = DatasetMetadata(
+                name=self._name, owner=self._id, metadata={"parents": list(self._parents)}
+            )
+            url = await facts.publish(dataset)
+            await ctx.send(self._downstream, f"lineage|{url}|{self._id}".encode())
 
 
 class VerifyAndAttackAgent(StateMachineAgent):
-    """Verifies the happy-path chain, then attempts three attacks as an outsider.
+    """Walks the provenance DAG, then runs three attacks as an outsider.
 
     Example::
 
         verify = VerifyAndAttackAgent(AgentId("verify-0"), source_id=AgentId("source-0"),
-                                       source_name="raw_sensor_readings")
+                                      source_name="raw_sensor_readings")
     """
 
     def __init__(self, agent_id: AgentId, source_id: AgentId, source_name: str) -> None:
@@ -128,7 +198,7 @@ class VerifyAndAttackAgent(StateMachineAgent):
         self._source_name = source_name
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
-        """Verify the received chain's integrity and freshness, then run the three attacks.
+        """Walk the lineage from the received leaf, then attempt the three attacks.
 
         Example::
 
@@ -137,52 +207,50 @@ class VerifyAndAttackAgent(StateMachineAgent):
         msg = payload.decode("utf-8", errors="replace")
         if not msg.startswith("lineage|"):
             return
-        _, final_url, _final_owner = msg.split("|", 2)
         facts = ctx.plugins.get("datafacts")
         if facts is None:
             return
-
-        root_url = await self._verify_chain(ctx, facts, final_url)
-        await self._verify_freshness(ctx, facts, final_url)
+        _, leaf_url, _owner = msg.split("|", 2)
+        root_url = await self._verify_chain(ctx, facts, leaf_url)
         if root_url is not None:
             await self._attack_substitution(ctx, facts, root_url)
             await self._attack_forged_freshness(ctx, facts)
         await self._attack_provenance(ctx, facts)
 
-    async def _verify_chain(self, ctx: AgentContext, facts: Any, final_url: str) -> str | None:
-        """Walk the parent chain back to the root and report depth.
+    async def _verify_chain(self, ctx: AgentContext, facts: Any, leaf_url: str) -> str | None:
+        """Full breadth-first walk of the provenance DAG from the leaf to its root.
 
-        Returns the root dataset's own URL (the source's published URL), or
-        ``None`` if the chain was broken, so the caller can target the
-        substitution attack at the *actual* source address rather than the
-        terminal (derived) one.
+        Visits *every* parent of every node (not just ``parents[0]``), de-dupes
+        shared ancestors so a diamond is counted once, reports the number of
+        distinct datasets in the lineage, and returns the single root (a node
+        with no parents) so the substitution attack can target the true source.
+        A parent that does not resolve is a broken chain.
         """
-        depth = 0
-        url: str = final_url
-        try:
-            while True:
+        seen: set[str] = set()
+        roots: list[str] = []
+        stack: list[str] = [leaf_url]
+        while stack:
+            url = stack.pop()
+            if url in seen:
+                continue
+            seen.add(url)
+            try:
                 meta: DatasetMetadata = await facts.fetch(url)
-                depth += 1
-                parents: list[str] = meta.metadata.get("parents", [])
-                if not parents:
-                    break
-                url = parents[0]
-        except KeyError:
-            await ctx.send(self._id, f"chain_broken|{final_url}|{url}".encode())
-            return None
-        await ctx.send(self._id, f"chain_ok|{final_url}|{depth}".encode())
-        return url
-
-    async def _verify_freshness(self, ctx: AgentContext, facts: Any, final_url: str) -> None:
-        fresh = await facts.verify_freshness(final_url)
-        await ctx.send(self._id, f"freshness|{final_url}|{int(fresh)}".encode())
+            except KeyError:
+                await ctx.send(self._id, f"chain_broken|{leaf_url}|{url}".encode())
+                return None
+            parents = _parents_of(meta)
+            if parents:
+                stack.extend(parents)
+            else:
+                roots.append(url)
+        await ctx.send(self._id, f"chain_ok|{leaf_url}|{len(seen)}".encode())
+        return sorted(roots)[0] if roots else None
 
     async def _attack_substitution(self, ctx: AgentContext, facts: Any, source_url: str) -> None:
         """Try to republish different content under the source's exact name."""
         forged = DatasetMetadata(
-            name=self._source_name,
-            owner=self._source_id,
-            description="tampered-by-attacker",
+            name=self._source_name, owner=self._source_id, description="tampered-by-attacker"
         )
         attacker_url = await facts.publish(forged)
         collided = int(str(attacker_url) == str(source_url))
@@ -191,7 +259,7 @@ class VerifyAndAttackAgent(StateMachineAgent):
         )
 
     async def _attack_forged_freshness(self, ctx: AgentContext, facts: Any) -> None:
-        """Republish the source's exact content, signed by the attacker, then re-check freshness."""
+        """Republish the source's content signed by the attacker, then re-check freshness."""
         forged = DatasetMetadata(name=self._source_name, owner=self._source_id)
         forged_url = await facts.publish(forged)
         fresh = await facts.verify_freshness(forged_url)
@@ -200,9 +268,7 @@ class VerifyAndAttackAgent(StateMachineAgent):
     async def _attack_provenance(self, ctx: AgentContext, facts: Any) -> None:
         """Try to publish a dataset whose declared parent was never published."""
         phantom = DatasetMetadata(
-            name="laundered",
-            owner=self._source_id,
-            metadata={"parents": [_PHANTOM_PARENT]},
+            name="laundered", owner=self._source_id, metadata={"parents": [_PHANTOM_PARENT]}
         )
         try:
             await facts.publish(phantom)
@@ -219,14 +285,13 @@ def _build_datafacts_handles(
 ) -> dict[AgentId, Any]:
     """Instantiate one datafacts handle per agent, sharing state where possible.
 
-    Plugins that take an ``Identity`` and ``datasets``/``proofs``/``clock``
-    keyword arguments (e.g. ``cid_facts``) get one handle per agent, all
-    backed by the same shared dicts and logical clock -- mirroring how the
-    reference ``prepaid_credits`` payments plugin gives every agent its own
-    handle over one shared ledger. Plugins with a no-argument constructor
-    (e.g. ``datafacts_v1``) get a single shared instance for every agent,
-    which is already correct for them since their internal storage is a
-    single dict.
+    Plugins that take an ``Identity`` plus ``datasets``/``proofs``/``clock``
+    keyword arguments (e.g. ``cid_facts``) get one handle per agent over the
+    same shared dicts and logical clock -- mirroring how the reference
+    ``prepaid_credits`` payments plugin gives every agent its own handle over
+    one shared ledger. Plugins with a no-argument constructor (e.g.
+    ``datafacts_v1``) get a single shared instance, already correct for them
+    since their storage is one dict.
 
     Example::
 
@@ -257,21 +322,22 @@ def provenance_supply_chain_factory(
     config: ScenarioConfig,
     plugins: dict[str, Any],
 ) -> dict[AgentId, StateMachineAgent]:
-    """Create the source/refine/aggregate/verify pipeline.
+    """Create the diamond pipeline: source -> {refine-a, refine-b} -> aggregate -> verify.
 
-    Instantiates per-agent identity instances (so each hop signs as itself)
-    and wires the resolved ``datafacts`` plugin class into per-agent handles
-    via :func:`_build_datafacts_handles`.
+    Instantiates per-agent identity instances (so each hop signs as itself) and
+    wires the resolved ``datafacts`` plugin class into per-agent handles via
+    :func:`_build_datafacts_handles`.
 
     Example::
 
         agents = provenance_supply_chain_factory(config, plugins)
     """
     source_id = AgentId("source-0")
-    refine_id = AgentId("refine-0")
+    refine_a = AgentId("refine-a")
+    refine_b = AgentId("refine-b")
     aggregate_id = AgentId("aggregate-0")
     verify_id = AgentId("verify-0")
-    all_ids = [source_id, refine_id, aggregate_id, verify_id]
+    all_ids = [source_id, refine_a, refine_b, aggregate_id, verify_id]
 
     identity_cls = plugins.get("identity")
     identities: dict[AgentId, Any] = {}
@@ -294,8 +360,13 @@ def provenance_supply_chain_factory(
 
     source_name = "raw_sensor_readings"
     return {
-        source_id: SourceAgent(source_id, refine_id, source_name, description="batch-A"),
-        refine_id: RefineAgent(refine_id, aggregate_id, "cleaned_sensor_readings"),
-        aggregate_id: RefineAgent(aggregate_id, verify_id, "aggregated_report"),
-        verify_id: VerifyAndAttackAgent(verify_id, source_id, source_name),
+        source_id: SourceAgent(
+            source_id, refiners=[refine_a, refine_b], name=source_name, description="batch-A"
+        ),
+        refine_a: RefineAgent(refine_a, aggregator=aggregate_id, name="cleaned_a"),
+        refine_b: RefineAgent(refine_b, aggregator=aggregate_id, name="cleaned_b"),
+        aggregate_id: AggregateAgent(
+            aggregate_id, downstream=verify_id, name="aggregated_report", expected_parents=2
+        ),
+        verify_id: VerifyAndAttackAgent(verify_id, source_id=source_id, source_name=source_name),
     }

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -2090,6 +2090,58 @@ def validate_multi_attribute_pareto_optimal(
     ]
 
 
+# ---------------------------------------------------------------------------
+# Provenance supply-chain validators
+# ---------------------------------------------------------------------------
+
+
+def _provenance_field_msg(events: list[dict[str, Any]], prefix: str) -> list[list[str]]:
+    """Collect ``|``-delimited fields from every send carrying ``prefix``.
+
+    The ``provenance_supply_chain`` scenario uses ``|`` (not ``:``) as its
+    field delimiter, since its payloads are ``df://sha256-<hex>`` URLs that
+    already contain a colon.
+
+    Example::
+
+        rows = _provenance_field_msg(events, "chain_ok|")
+    """
+    rows: list[list[str]] = []
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = str(ev.get("msg", ""))
+        if msg.startswith(prefix):
+            rows.append(msg.split("|"))
+    return rows
+
+
+def validate_provenance_chain_integrity(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """The verifier walks the full parent chain back to the source without a break.
+
+    Example::
+
+        results = validate_provenance_chain_integrity(events)
+    """
+    broken = _provenance_field_msg(events, "chain_broken|")
+    if broken:
+        detail = "; ".join(f"{row[1]} could not resolve parent {row[2]}" for row in broken)
+        return [ValidationResult("provenance_chain_integrity", False, detail)]
+    ok = _provenance_field_msg(events, "chain_ok|")
+    if not ok:
+        return [ValidationResult("provenance_chain_integrity", False, "no chain_ok recorded")]
+    depth = ok[0][2]
+    return [
+        ValidationResult(
+            "provenance_chain_integrity",
+            True,
+            f"chain resolved to depth {depth}",
+        )
+    ]
+
+
 def validate_multi_attribute_individually_rational(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
@@ -2154,6 +2206,111 @@ def validate_multi_attribute_individually_rational(
     ]
 
 
+def validate_provenance_substitution_resistant(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """An outsider republishing different content must not land on the source's URL.
+
+    Catches the *substitution* attack: a name-addressed registry
+    (``datafacts_v1``) lets anyone overwrite ``df://<name>`` with new bytes;
+    a content-addressed one (``cid_facts``) cannot alias two different
+    contents onto the same URL.
+
+    Example::
+
+        results = validate_provenance_substitution_resistant(events)
+    """
+    rows = _provenance_field_msg(events, "attack_substitution|")
+    if not rows:
+        return [ValidationResult("provenance_substitution_resistant", False, "no attack recorded")]
+    source_url, attacker_url, collided = rows[0][1], rows[0][2], rows[0][3]
+    if collided != "0":
+        return [
+            ValidationResult(
+                "provenance_substitution_resistant",
+                False,
+                f"attacker's republish landed on the source URL {source_url} "
+                f"(attacker url {attacker_url})",
+            )
+        ]
+    return [
+        ValidationResult(
+            "provenance_substitution_resistant",
+            True,
+            f"attacker's differing content resolved to a distinct URL ({attacker_url})",
+        )
+    ]
+
+
+def validate_provenance_freshness_unforgeable(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """A freshness claim signed by someone other than the owner must be rejected.
+
+    Catches the *stale-claim* attack: an unauthenticated wall-clock check
+    (``datafacts_v1``) treats any recent republish as proof of freshness,
+    regardless of who did it; a signature-backed check (``cid_facts``) only
+    accepts a proof whose signer is the dataset's declared owner.
+
+    Example::
+
+        results = validate_provenance_freshness_unforgeable(events)
+    """
+    rows = _provenance_field_msg(events, "attack_forged_freshness|")
+    if not rows:
+        return [ValidationResult("provenance_freshness_unforgeable", False, "no attack recorded")]
+    url, fresh = rows[0][1], rows[0][2]
+    if fresh != "0":
+        return [
+            ValidationResult(
+                "provenance_freshness_unforgeable",
+                False,
+                f"forged freshness claim for {url} was accepted",
+            )
+        ]
+    return [
+        ValidationResult(
+            "provenance_freshness_unforgeable",
+            True,
+            f"forged freshness claim for {url} was correctly rejected",
+        )
+    ]
+
+
+def validate_provenance_chain_unforgeable(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """A dataset declaring a never-published parent must be rejected at publish time.
+
+    Catches *provenance washing*: a registry with no lineage concept
+    (``datafacts_v1``) accepts a "derived" dataset whose claimed parent does
+    not exist anywhere in the trace; ``cid_facts`` refuses to publish it.
+
+    Example::
+
+        results = validate_provenance_chain_unforgeable(events)
+    """
+    rows = _provenance_field_msg(events, "attack_provenance|")
+    if not rows:
+        return [ValidationResult("provenance_chain_unforgeable", False, "no attack recorded")]
+    phantom_parent, rejected = rows[0][1], rows[0][2]
+    if rejected != "1":
+        return [
+            ValidationResult(
+                "provenance_chain_unforgeable",
+                False,
+                f"publish with phantom parent {phantom_parent} was not rejected",
+            )
+        ]
+    return [
+        ValidationResult(
+            "provenance_chain_unforgeable",
+            True,
+            f"publish with phantom parent {phantom_parent} was correctly rejected",
+        )
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
@@ -2212,5 +2369,11 @@ VALIDATORS: dict[str, list[Any]] = {
     "multi_attribute_market": [
         validate_multi_attribute_pareto_optimal,
         validate_multi_attribute_individually_rational,
+    ],
+    "provenance_supply_chain": [
+        validate_provenance_chain_integrity,
+        validate_provenance_substitution_resistant,
+        validate_provenance_freshness_unforgeable,
+        validate_provenance_chain_unforgeable,
     ],
 }

--- a/packages/nest-core/tests/test_provenance_supply_chain.py
+++ b/packages/nest-core/tests/test_provenance_supply_chain.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the provenance_supply_chain adversarial validators and scenario.
+
+The core claim under test: the three adversarial validators FAIL against the
+default ``datafacts_v1`` layer (name-addressed, unauthenticated freshness, no
+provenance concept) and PASS against ``cid_facts`` -- driven both from
+synthetic traces and from a real simulator run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import (
+    validate_provenance_chain_integrity,
+    validate_provenance_chain_unforgeable,
+    validate_provenance_freshness_unforgeable,
+    validate_provenance_substitution_resistant,
+    validate_trace,
+)
+
+type Event = dict[str, Any]
+
+
+def _send(msg: str) -> Event:
+    return {"ts": 0.0, "agent": "verify-0", "kind": "send", "to": "verify-0", "msg": msg}
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests (synthetic traces)
+# ---------------------------------------------------------------------------
+
+
+class TestChainIntegrity:
+    def test_pass_when_chain_resolves(self) -> None:
+        events = [_send("chain_ok|df://sha256-final|3")]
+        results = validate_provenance_chain_integrity(events)
+        assert results[0].passed is True
+
+    def test_fail_when_chain_broken(self) -> None:
+        events = [_send("chain_broken|df://sha256-final|df://sha256-missing")]
+        results = validate_provenance_chain_integrity(events)
+        assert results[0].passed is False
+
+    def test_fail_when_nothing_recorded(self) -> None:
+        results = validate_provenance_chain_integrity([])
+        assert results[0].passed is False
+
+
+class TestSubstitutionResistant:
+    def test_pass_when_attacker_lands_on_distinct_url(self) -> None:
+        events = [_send("attack_substitution|df://sha256-root|df://sha256-attacker|0")]
+        results = validate_provenance_substitution_resistant(events)
+        assert results[0].passed is True
+
+    def test_fail_when_attacker_collides_with_source(self) -> None:
+        # datafacts_v1 behaviour: name-addressed, so the attacker's republish
+        # overwrites the exact same URL as the source.
+        events = [_send("attack_substitution|df://raw|df://raw|1")]
+        results = validate_provenance_substitution_resistant(events)
+        assert results[0].passed is False
+
+    def test_fail_when_no_attack_recorded(self) -> None:
+        results = validate_provenance_substitution_resistant([])
+        assert results[0].passed is False
+
+
+class TestFreshnessUnforgeable:
+    def test_pass_when_forged_claim_rejected(self) -> None:
+        events = [_send("attack_forged_freshness|df://sha256-x|0")]
+        results = validate_provenance_freshness_unforgeable(events)
+        assert results[0].passed is True
+
+    def test_fail_when_forged_claim_accepted(self) -> None:
+        # datafacts_v1 behaviour: wall-clock freshness trusts any republish.
+        events = [_send("attack_forged_freshness|df://raw|1")]
+        results = validate_provenance_freshness_unforgeable(events)
+        assert results[0].passed is False
+
+
+class TestChainUnforgeable:
+    def test_pass_when_phantom_parent_rejected(self) -> None:
+        events = [_send("attack_provenance|df://sha256-phantom|1")]
+        results = validate_provenance_chain_unforgeable(events)
+        assert results[0].passed is True
+
+    def test_fail_when_phantom_parent_accepted(self) -> None:
+        # datafacts_v1 behaviour: no provenance concept, publish always succeeds.
+        events = [_send("attack_provenance|df://sha256-phantom|0")]
+        results = validate_provenance_chain_unforgeable(events)
+        assert results[0].passed is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real simulator run
+# ---------------------------------------------------------------------------
+
+
+def _run(datafacts: str, out: Path, seed: int = 42) -> None:
+    cfg = ScenarioConfig.from_yaml("scenarios/provenance_supply_chain.yaml")
+    cfg.layers.datafacts = datafacts
+    cfg.seed = seed
+    cfg.output.trace = str(out)
+    asyncio.run(ScenarioRunner(cfg).run())
+
+
+class TestScenarioEndToEnd:
+    def test_cid_facts_passes_all(self, tmp_path: Path) -> None:
+        out = tmp_path / "cid_facts.jsonl"
+        _run("cid_facts", out)
+        results = validate_trace(out, "provenance_supply_chain")
+        assert results, "expected validators to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_datafacts_v1_fails_all_adversarial_checks(self, tmp_path: Path) -> None:
+        out = tmp_path / "v1.jsonl"
+        _run("datafacts_v1", out)
+        results = {r.name: r.passed for r in validate_trace(out, "provenance_supply_chain")}
+        # The happy-path lineage walk still works -- v1 stores parents in its
+        # metadata dict even though it never validates them.
+        assert results["provenance_chain_integrity"] is True
+        assert results["provenance_substitution_resistant"] is False
+        assert results["provenance_freshness_unforgeable"] is False
+        assert results["provenance_chain_unforgeable"] is False
+
+    def test_deterministic_across_required_seeds(self, tmp_path: Path) -> None:
+        for seed in (42, 7, 1337):
+            a, b = tmp_path / f"{seed}a.jsonl", tmp_path / f"{seed}b.jsonl"
+            _run("cid_facts", a, seed=seed)
+            _run("cid_facts", b, seed=seed)
+            assert a.read_bytes() == b.read_bytes(), f"seed {seed} not deterministic"
+            assert all(r.passed for r in validate_trace(a, "provenance_supply_chain"))

--- a/packages/nest-core/tests/test_provenance_supply_chain.py
+++ b/packages/nest-core/tests/test_provenance_supply_chain.py
@@ -3,13 +3,14 @@
 
 The core claim under test: the three adversarial validators FAIL against the
 default ``datafacts_v1`` layer (name-addressed, unauthenticated freshness, no
-provenance concept) and PASS against ``cid_facts`` -- driven both from
-synthetic traces and from a real simulator run.
+provenance) and PASS against ``cid_facts`` -- driven both from synthetic traces
+and from a real simulator run over a diamond DAG.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from typing import Any
 
@@ -115,6 +116,19 @@ class TestScenarioEndToEnd:
         results = validate_trace(out, "provenance_supply_chain")
         assert results, "expected validators to run"
         assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_diamond_walk_visits_all_four_nodes(self, tmp_path: Path) -> None:
+        """The full DAG walk must count both refiner branches, not just one spine."""
+        out = tmp_path / "cid_facts.jsonl"
+        _run("cid_facts", out)
+        chain_ok = [
+            msg
+            for line in out.read_text().splitlines()
+            if (msg := str(json.loads(line).get("msg", ""))).startswith("chain_ok|")
+        ]
+        assert chain_ok, "no chain_ok recorded"
+        # source + refine-a + refine-b + aggregate = 4 distinct lineage nodes.
+        assert chain_ok[0].rsplit("|", 1)[-1] == "4"
 
     def test_datafacts_v1_fails_all_adversarial_checks(self, tmp_path: Path) -> None:
         out = tmp_path / "v1.jsonl"

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -755,6 +755,7 @@ class TestValidatorRegistry:
             "comms_versioning",
             "receipt_reputation",
             "multi_attribute_market",
+            "provenance_supply_chain",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
@@ -278,6 +278,33 @@ class CidFacts:
             return False
         return (self._clock.tick - proof.tick) <= self._freshness_window
 
+    def ancestors(self, url: DataFactsUrl) -> set[DataFactsUrl]:
+        """Return every transitive provenance ancestor of ``url`` (excluding itself).
+
+        Walks all parents, not just the first, so it is correct on a diamond
+        (``A -> B``, ``A -> C``, ``{B, C} -> D``): ``D``'s ancestors are
+        ``{A, B, C}`` with ``A`` counted once. Unknown parents are simply not
+        expanded (an unpublishable dataset never reached this registry).
+
+        Example::
+
+            assert facts.ancestors(report_url) == {raw_url, cleaned_url}
+        """
+        seen: set[DataFactsUrl] = set()
+        stack: list[DataFactsUrl] = []
+        root_meta = self._datasets.get(url)
+        if root_meta is not None:
+            stack.extend(parents_of(root_meta))
+        while stack:
+            current = stack.pop()
+            if current in seen:
+                continue
+            seen.add(current)
+            meta = self._datasets.get(current)
+            if meta is not None:
+                stack.extend(parents_of(meta))
+        return seen
+
     def freshness_proof(self, url: DataFactsUrl) -> FreshnessProof | None:
         """Return the raw freshness proof for ``url``, for tests/validators.
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
@@ -49,17 +49,15 @@ if TYPE_CHECKING:
     from nest_core.layers.identity import Identity
 
 
-class ContentSubstitutionError(ValueError):
-    """Raised if a publish would bind a hash to content that disagrees with it.
-
-    Cannot happen through normal use (the hash *is* derived from the content),
-    but guards against a caller mutating a ``DatasetMetadata`` in place after
-    publishing it under the URL the old content produced.
-    """
-
-
 class ProvenanceError(ValueError):
-    """Raised when a dataset declares a parent URL this registry never published."""
+    """Raised when a dataset declares a parent URL this registry never published.
+
+    Example::
+
+        with pytest.raises(ProvenanceError):
+            await facts.publish(DatasetMetadata(name="x", owner=AgentId("a1"),
+                                                 metadata={"parents": ["df://sha256-deadbeef"]}))
+    """
 
 
 class SharedClock:

--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Content-addressed DataFacts plugin with provenance and signed freshness.
+
+The reference plugin (:class:`~nest_plugins_reference.datafacts.datafacts_v1.DataFactsV1`)
+addresses datasets by the publisher's *chosen name* and checks freshness with an
+unauthenticated wall-clock read. Both are silently exploitable:
+
+* **Substitution** — republish different content under the same name; nothing
+  rejects it, every existing holder of the URL is now pointed at new bytes.
+* **Stale-claim** — "freshness" only means *some* publish touched this name
+  recently, by anyone, with no proof the content was actually re-validated.
+* **Provenance washing** — there is no field linking a derived dataset back to
+  the dataset(s) it was built from, so a contamination trail vanishes at the
+  first hop.
+
+This plugin fixes all three by construction:
+
+* The URL **is** ``df://sha256-<hex>``, a hash of the dataset's content-bearing
+  fields. Two different contents cannot collide on one URL; the same content
+  always resolves to the same URL (republishing is idempotent).
+* A derived dataset lists its lineage in ``dataset.metadata["parents"]`` (a
+  list of parent URLs); :meth:`CidFacts.publish` rejects any parent hash it has
+  not itself seen published.
+* Every successful publish issues a :class:`FreshnessProof`: the publisher's
+  identity-layer key signs ``(url, tick)`` over a logical tick counter (never
+  ``time.time()``, so Tier 1 stays deterministic). :meth:`verify_freshness`
+  only accepts a proof whose signature both verifies *and* was produced by the
+  dataset's declared owner — an outsider re-publishing identical bytes under
+  someone else's name cannot manufacture a valid freshness claim for them.
+
+Example::
+
+    identity = DidKeyIdentity(AgentId("supplier-0"), seed=b"sim-seed")
+    facts = CidFacts(identity)
+    url = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("supplier-0")))
+    assert await facts.verify_freshness(url) is True
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any, cast
+
+from nest_core.types import AccessGrant, AgentId, DataFactsUrl, DatasetMetadata, Signature
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from nest_core.layers.identity import Identity
+
+
+class ContentSubstitutionError(ValueError):
+    """Raised if a publish would bind a hash to content that disagrees with it.
+
+    Cannot happen through normal use (the hash *is* derived from the content),
+    but guards against a caller mutating a ``DatasetMetadata`` in place after
+    publishing it under the URL the old content produced.
+    """
+
+
+class ProvenanceError(ValueError):
+    """Raised when a dataset declares a parent URL this registry never published."""
+
+
+class SharedClock:
+    """A monotonic logical tick shared by every per-agent :class:`CidFacts` handle.
+
+    Tier 1 must stay deterministic, so freshness is measured in "ticks since
+    this clock was created" rather than wall-clock time. Pass one instance to
+    every per-agent plugin handle in a scenario so they share one notion of
+    "now" (mirrors how the ``prepaid_credits`` payments plugin shares one
+    ``balances`` dict across per-agent handles).
+
+    Example::
+
+        clock = SharedClock()
+        facts_a = CidFacts(identity_a, clock=clock)
+        facts_b = CidFacts(identity_b, clock=clock)
+    """
+
+    def __init__(self) -> None:
+        self.tick: float = 0.0
+
+    def advance(self) -> float:
+        """Advance the clock by one tick and return the new value.
+
+        Example::
+
+            now = clock.advance()
+        """
+        self.tick += 1.0
+        return self.tick
+
+
+class FreshnessProof(BaseModel):
+    """A publisher-signed attestation that ``url`` was (re)published at ``tick``.
+
+    The signed payload is ``canonical_json({"url": url, "tick": tick})`` --
+    binding the proof to the content hash itself (not just to a name), per the
+    anti-pattern warning that a freshness proof must bind to *content*.
+
+    Example::
+
+        proof = FreshnessProof(url=url, tick=3.0, signature=sig)
+    """
+
+    url: DataFactsUrl
+    tick: float
+    signature: Signature
+
+
+def _freshness_payload(url: DataFactsUrl, tick: float) -> bytes:
+    return json.dumps(
+        {"url": str(url), "tick": tick}, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def content_hash(dataset: DatasetMetadata) -> str:
+    """Compute the content-address (hex sha256) of a dataset's content fields.
+
+    Excludes ``name`` (a label, not content) and the wall-clock timestamps
+    ``created_at``/``updated_at`` (so republishing byte-identical content
+    later does not change its address). Includes ``metadata`` -- which is
+    where lineage (``parents``) and any payload digest the caller wants to
+    bind in (e.g. ``checksum``) live -- so two datasets with the same name and
+    description but different parents necessarily hash differently.
+
+    Example::
+
+        h = content_hash(DatasetMetadata(name="raw", owner=AgentId("a1")))
+    """
+    content: dict[str, Any] = {
+        "owner": str(dataset.owner),
+        "description": dataset.description,
+        "schema_version": dataset.schema_version,
+        "tags": sorted(dataset.tags),
+        "size_bytes": dataset.size_bytes,
+        "checksum": dataset.checksum,
+        "access_tier": dataset.access_tier,
+        "metadata": dataset.metadata,
+    }
+    canonical = json.dumps(content, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def parents_of(dataset: DatasetMetadata) -> list[DataFactsUrl]:
+    """Read the declared provenance parents out of ``dataset.metadata``.
+
+    Example::
+
+        parents = parents_of(derived_dataset)
+    """
+    raw: object = dataset.metadata.get("parents", [])
+    if not isinstance(raw, list):
+        return []
+    return [DataFactsUrl(str(p)) for p in cast("list[Any]", raw)]
+
+
+class CidFacts:
+    """Content-addressed DataFacts registry with provenance and signed freshness.
+
+    Example::
+
+        facts = CidFacts(DidKeyIdentity(AgentId("a1"), seed=b"s"))
+        url = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+        meta = await facts.fetch(url)
+    """
+
+    def __init__(
+        self,
+        identity: Identity,
+        *,
+        datasets: dict[DataFactsUrl, DatasetMetadata] | None = None,
+        proofs: dict[DataFactsUrl, FreshnessProof] | None = None,
+        clock: SharedClock | None = None,
+        freshness_window: float = 1.0,
+    ) -> None:
+        self._identity = identity
+        self._datasets: dict[DataFactsUrl, DatasetMetadata] = (
+            datasets if datasets is not None else {}
+        )
+        self._proofs: dict[DataFactsUrl, FreshnessProof] = proofs if proofs is not None else {}
+        self._grants: dict[DataFactsUrl, list[AccessGrant]] = {}
+        self._clock = clock if clock is not None else SharedClock()
+        self._freshness_window = freshness_window
+
+    async def publish(self, dataset: DatasetMetadata) -> DataFactsUrl:
+        """Publish dataset metadata and return its content-addressed URL.
+
+        Republishing identical content is idempotent (same URL) but still
+        issues a fresh signed proof -- that is the only legitimate way to
+        extend a dataset's freshness window. Raises :class:`ProvenanceError`
+        if ``dataset.metadata["parents"]`` names a URL this registry has not
+        itself published.
+
+        Example::
+
+            url = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+        """
+        for parent in parents_of(dataset):
+            if parent not in self._datasets:
+                msg = f"unknown provenance parent {parent!r} for dataset {dataset.name!r}"
+                raise ProvenanceError(msg)
+
+        digest = content_hash(dataset)
+        url = DataFactsUrl(f"df://sha256-{digest}")
+        self._datasets[url] = dataset
+
+        tick = self._clock.advance()
+        signature = self._identity.sign(_freshness_payload(url, tick))
+        self._proofs[url] = FreshnessProof(url=url, tick=tick, signature=signature)
+        return url
+
+    async def fetch(self, url: DataFactsUrl) -> DatasetMetadata:
+        """Fetch metadata for a published dataset.
+
+        Example::
+
+            meta = await facts.fetch(url)
+        """
+        meta = self._datasets.get(url)
+        if meta is None:
+            msg = f"Dataset not found: {url}"
+            raise KeyError(msg)
+        return meta
+
+    async def request_access(self, url: DataFactsUrl, requester: AgentId) -> AccessGrant:
+        """Request access to a dataset; ACL is keyed by content hash, not name.
+
+        ``access_tier == "public"`` grants any requester read access; anything
+        else is only granted to the dataset's own owner.
+
+        Example::
+
+            grant = await facts.request_access(url, AgentId("a2"))
+        """
+        meta = await self.fetch(url)
+        if meta.access_tier != "public" and requester != meta.owner:
+            msg = f"{requester} is not authorized to read {url} (tier={meta.access_tier!r})"
+            raise PermissionError(msg)
+        grant = AccessGrant(url=url, grantee=requester, tier="read")
+        self._grants.setdefault(url, []).append(grant)
+        return grant
+
+    async def verify_freshness(self, url: DataFactsUrl) -> bool:
+        """Check whether ``url`` has a valid, recent, owner-signed freshness proof.
+
+        Fails closed: no proof, an unverifiable signature, a signature from
+        someone other than the dataset's declared owner, or a proof older
+        than the freshness window are all treated as *not fresh*. This is
+        what makes a forged claim ("I attest your dataset is fresh" from an
+        agent that isn't the owner) unable to pass, unlike the wall-clock
+        ``datafacts_v1`` check which trusts whoever last touched the name.
+
+        Example::
+
+            fresh = await facts.verify_freshness(url)
+        """
+        meta = self._datasets.get(url)
+        proof = self._proofs.get(url)
+        if meta is None or proof is None:
+            return False
+        if proof.signature.signer != meta.owner:
+            return False
+        if not self._identity.verify(
+            _freshness_payload(url, proof.tick), proof.signature, meta.owner
+        ):
+            return False
+        return (self._clock.tick - proof.tick) <= self._freshness_window
+
+    def freshness_proof(self, url: DataFactsUrl) -> FreshnessProof | None:
+        """Return the raw freshness proof for ``url``, for tests/validators.
+
+        Example::
+
+            proof = facts.freshness_proof(url)
+        """
+        return self._proofs.get(url)
+
+    def known_urls(self) -> list[DataFactsUrl]:
+        """List every URL this registry instance has published.
+
+        Example::
+
+            urls = facts.known_urls()
+        """
+        return list(self._datasets)
+
+    @property
+    def clock(self) -> SharedClock:
+        """This instance's logical clock, so callers can share it with peers.
+
+        Scenario factories that don't import ``cid_facts`` directly can still
+        wire up a shared clock with ``getattr(handle, "clock", None)`` --
+        duck typing, the same way the rest of Nanda Town treats layers as
+        structural ``Protocol``\\ s.
+
+        Example::
+
+            clock = facts.clock
+            peer = CidFacts(peer_identity, clock=clock)
+        """
+        return self._clock

--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
@@ -193,14 +193,26 @@ class CidFacts:
         if ``dataset.metadata["parents"]`` names a URL this registry has not
         itself published.
 
+        Provenance is a DAG, not a tree -- a dataset can declare more than
+        one parent (e.g. a join of two upstream datasets). Parent order is
+        not semantically meaningful, so it is normalized (sorted) before
+        hashing and storing: declaring the same two parents in either order
+        produces the same address.
+
         Example::
 
             url = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
         """
-        for parent in parents_of(dataset):
+        parents = parents_of(dataset)
+        for parent in parents:
             if parent not in self._datasets:
                 msg = f"unknown provenance parent {parent!r} for dataset {dataset.name!r}"
                 raise ProvenanceError(msg)
+
+        if parents:
+            normalized_metadata = dict(dataset.metadata)
+            normalized_metadata["parents"] = sorted(str(p) for p in parents)
+            dataset = dataset.model_copy(update={"metadata": normalized_metadata})
 
         digest = content_hash(dataset)
         url = DataFactsUrl(f"df://sha256-{digest}")

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -39,6 +39,9 @@ lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
 [project.entry-points."nest.plugins.privacy"]
 hybrid_x25519 = "nest_plugins_reference.privacy.hybrid_x25519:HybridX25519Privacy"
 
+[project.entry-points."nest.plugins.datafacts"]
+cid_facts = "nest_plugins_reference.datafacts.cid_facts:CidFacts"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/nest-plugins-reference/tests/test_cid_facts.py
+++ b/packages/nest-plugins-reference/tests/test_cid_facts.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the content-addressed DataFacts plugin.
+
+Covers protocol conformance, content-addressing (idempotent republish,
+distinct content -> distinct URL), provenance-parent enforcement, signed
+freshness (happy path and the forged-claim rejection), ACL enforcement, and
+registry wiring.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.layers.datafacts import DataFacts
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
+from nest_plugins_reference.datafacts.cid_facts import (
+    CidFacts,
+    FreshnessProof,
+    ProvenanceError,
+    SharedClock,
+    content_hash,
+)
+from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+
+def _peered_identities(*agent_ids: str) -> dict[str, DidKeyIdentity]:
+    idents = {aid: DidKeyIdentity(AgentId(aid), seed=f"seed-{aid}".encode()) for aid in agent_ids}
+    for aid, ident in idents.items():
+        for peer_id, peer_ident in idents.items():
+            if peer_id != aid:
+                ident.register_peer(AgentId(peer_id), peer_ident.public_key)
+    return idents
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance and content addressing
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_isinstance_datafacts(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        assert isinstance(CidFacts(ident), DataFacts)
+
+    @pytest.mark.asyncio
+    async def test_publish_returns_content_addressed_url(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        dataset = DatasetMetadata(name="raw", owner=AgentId("a1"))
+        url = await facts.publish(dataset)
+        assert str(url) == f"df://sha256-{content_hash(dataset)}"
+
+    @pytest.mark.asyncio
+    async def test_republish_identical_content_is_idempotent(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        dataset = DatasetMetadata(name="raw", owner=AgentId("a1"))
+        url1 = await facts.publish(dataset)
+        url2 = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+        assert url1 == url2
+
+    @pytest.mark.asyncio
+    async def test_different_content_same_name_gets_different_url(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        url1 = await facts.publish(
+            DatasetMetadata(name="raw", owner=AgentId("a1"), description="A")
+        )
+        url2 = await facts.publish(
+            DatasetMetadata(name="raw", owner=AgentId("a1"), description="B")
+        )
+        assert url1 != url2
+
+    @pytest.mark.asyncio
+    async def test_fetch_roundtrip(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        dataset = DatasetMetadata(name="raw", owner=AgentId("a1"), description="x")
+        url = await facts.publish(dataset)
+        fetched = await facts.fetch(url)
+        assert fetched == dataset
+
+    @pytest.mark.asyncio
+    async def test_fetch_missing_raises_keyerror(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        with pytest.raises(KeyError):
+            await facts.fetch("df://sha256-doesnotexist")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Provenance
+# ---------------------------------------------------------------------------
+
+
+class TestProvenance:
+    @pytest.mark.asyncio
+    async def test_publish_with_unknown_parent_raises(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        derived = DatasetMetadata(
+            name="derived",
+            owner=AgentId("a1"),
+            metadata={"parents": ["df://sha256-" + "0" * 64]},
+        )
+        with pytest.raises(ProvenanceError):
+            await facts.publish(derived)
+
+    @pytest.mark.asyncio
+    async def test_publish_with_known_parent_succeeds(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        parent_url = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+        derived = DatasetMetadata(
+            name="derived", owner=AgentId("a1"), metadata={"parents": [str(parent_url)]}
+        )
+        url = await facts.publish(derived)
+        fetched = await facts.fetch(url)
+        assert fetched.metadata["parents"] == [str(parent_url)]
+
+    @pytest.mark.asyncio
+    async def test_multi_hop_chain_walkable(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        root = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+        mid = await facts.publish(
+            DatasetMetadata(name="cleaned", owner=AgentId("a1"), metadata={"parents": [str(root)]})
+        )
+        leaf = await facts.publish(
+            DatasetMetadata(name="report", owner=AgentId("a1"), metadata={"parents": [str(mid)]})
+        )
+        url = leaf
+        depth = 0
+        while True:
+            meta = await facts.fetch(url)
+            depth += 1
+            parents = meta.metadata.get("parents", [])
+            if not parents:
+                break
+            url = parents[0]
+        assert depth == 3
+        assert url == root
+
+
+# ---------------------------------------------------------------------------
+# Signed freshness, including the forged-claim rejection
+# ---------------------------------------------------------------------------
+
+
+class TestFreshness:
+    @pytest.mark.asyncio
+    async def test_fresh_immediately_after_publish(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        url = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+        assert await facts.verify_freshness(url) is True
+
+    @pytest.mark.asyncio
+    async def test_unpublished_url_is_not_fresh(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        assert await facts.verify_freshness("df://sha256-" + "0" * 64) is False  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_stale_after_window_elapses(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident, freshness_window=0.0)
+        url = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+        # A second, genuinely different publish (distinct content -> distinct
+        # URL) advances the shared clock past the window for the first URL.
+        await facts.publish(
+            DatasetMetadata(name="other", owner=AgentId("a1"), description="distinct")
+        )
+        assert await facts.verify_freshness(url) is False
+
+    @pytest.mark.asyncio
+    async def test_forged_freshness_claim_is_rejected(self) -> None:
+        """Republishing the owner's exact content cannot pass off as a genuine freshness claim."""
+        idents = _peered_identities("owner", "attacker")
+        clock = SharedClock()
+        shared_datasets: dict[DataFactsUrl, DatasetMetadata] = {}
+        shared_proofs: dict[DataFactsUrl, FreshnessProof] = {}
+        owner_facts = CidFacts(
+            idents["owner"], datasets=shared_datasets, proofs=shared_proofs, clock=clock
+        )
+        attacker_facts = CidFacts(
+            idents["attacker"], datasets=shared_datasets, proofs=shared_proofs, clock=clock
+        )
+
+        dataset = DatasetMetadata(name="weather", owner=AgentId("owner"))
+        url = await owner_facts.publish(dataset)
+        assert await owner_facts.verify_freshness(url) is True
+
+        forged = DatasetMetadata(name="weather", owner=AgentId("owner"))
+        forged_url = await attacker_facts.publish(forged)
+        assert forged_url == url
+        assert await owner_facts.verify_freshness(url) is False
+
+    @pytest.mark.asyncio
+    async def test_genuine_republish_by_owner_stays_fresh(self) -> None:
+        idents = _peered_identities("owner", "other")
+        clock = SharedClock()
+        shared_datasets: dict[DataFactsUrl, DatasetMetadata] = {}
+        shared_proofs: dict[DataFactsUrl, FreshnessProof] = {}
+        owner_facts = CidFacts(
+            idents["owner"], datasets=shared_datasets, proofs=shared_proofs, clock=clock
+        )
+        url = await owner_facts.publish(DatasetMetadata(name="weather", owner=AgentId("owner")))
+        # Owner re-affirms by republishing the identical content again.
+        url2 = await owner_facts.publish(DatasetMetadata(name="weather", owner=AgentId("owner")))
+        assert url == url2
+        assert await owner_facts.verify_freshness(url) is True
+
+
+# ---------------------------------------------------------------------------
+# Access control
+# ---------------------------------------------------------------------------
+
+
+class TestAccessControl:
+    @pytest.mark.asyncio
+    async def test_public_dataset_grants_anyone(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        url = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+        grant = await facts.request_access(url, AgentId("anyone"))
+        assert grant.tier == "read"
+
+    @pytest.mark.asyncio
+    async def test_private_dataset_denies_non_owner(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        url = await facts.publish(
+            DatasetMetadata(name="secret", owner=AgentId("a1"), access_tier="private")
+        )
+        with pytest.raises(PermissionError):
+            await facts.request_access(url, AgentId("intruder"))
+
+    @pytest.mark.asyncio
+    async def test_private_dataset_grants_owner(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        url = await facts.publish(
+            DatasetMetadata(name="secret", owner=AgentId("a1"), access_tier="private")
+        )
+        grant = await facts.request_access(url, AgentId("a1"))
+        assert grant.tier == "read"
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_builtin_resolves(self) -> None:
+        cls = PluginRegistry().resolve("datafacts", "cid_facts")
+        assert cls is CidFacts
+
+    def test_listed_for_datafacts_layer(self) -> None:
+        assert ("datafacts", "cid_facts") in PluginRegistry().list_plugins("datafacts")

--- a/packages/nest-plugins-reference/tests/test_cid_facts.py
+++ b/packages/nest-plugins-reference/tests/test_cid_facts.py
@@ -10,6 +10,8 @@ registry wiring.
 from __future__ import annotations
 
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from nest_core.layers.datafacts import DataFacts
 from nest_core.plugins import PluginRegistry
 from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
@@ -141,6 +143,66 @@ class TestProvenance:
         assert depth == 3
         assert url == root
 
+    @pytest.mark.asyncio
+    async def test_join_of_two_parents_succeeds(self) -> None:
+        """Provenance is a DAG: a dataset may declare more than one parent."""
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        left = await facts.publish(DatasetMetadata(name="orders", owner=AgentId("a1")))
+        right = await facts.publish(
+            DatasetMetadata(name="customers", owner=AgentId("a1"), description="x")
+        )
+        joined = DatasetMetadata(
+            name="orders_with_customers",
+            owner=AgentId("a1"),
+            metadata={"parents": [str(left), str(right)]},
+        )
+        url = await facts.publish(joined)
+        fetched = await facts.fetch(url)
+        assert set(fetched.metadata["parents"]) == {str(left), str(right)}
+
+    @pytest.mark.asyncio
+    async def test_join_is_rejected_if_either_parent_is_unknown(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        known = await facts.publish(DatasetMetadata(name="orders", owner=AgentId("a1")))
+        phantom = "df://sha256-" + "f" * 64
+        joined = DatasetMetadata(
+            name="orders_with_customers",
+            owner=AgentId("a1"),
+            metadata={"parents": [str(known), phantom]},
+        )
+        with pytest.raises(ProvenanceError):
+            await facts.publish(joined)
+        # The rejected join must not have been partially registered.
+        assert phantom not in [str(u) for u in facts.known_urls()]
+
+    @pytest.mark.asyncio
+    async def test_join_address_is_independent_of_parent_declaration_order(self) -> None:
+        """The same join declared as [A, B] or [B, A] must resolve to one URL.
+
+        Parent order is an artifact of how the publishing agent happened to
+        build the list, not part of the dataset's identity -- two joins over
+        the same inputs should be the same address regardless of which side
+        was listed first.
+        """
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        left = await facts.publish(DatasetMetadata(name="orders", owner=AgentId("a1")))
+        right = await facts.publish(
+            DatasetMetadata(name="customers", owner=AgentId("a1"), description="x")
+        )
+
+        forward = DatasetMetadata(
+            name="joined", owner=AgentId("a1"), metadata={"parents": [str(left), str(right)]}
+        )
+        backward = DatasetMetadata(
+            name="joined", owner=AgentId("a1"), metadata={"parents": [str(right), str(left)]}
+        )
+        url_forward = await facts.publish(forward)
+        url_backward = await facts.publish(backward)
+        assert url_forward == url_backward
+
 
 # ---------------------------------------------------------------------------
 # Signed freshness, including the forged-claim rejection
@@ -245,6 +307,55 @@ class TestAccessControl:
         )
         grant = await facts.request_access(url, AgentId("a1"))
         assert grant.tier == "read"
+
+
+# ---------------------------------------------------------------------------
+# content_hash properties (the substitution defense rests on these holding)
+# ---------------------------------------------------------------------------
+
+_descriptions = st.text(max_size=20)
+_owners = st.sampled_from(["a1", "a2", "owner", "attacker"])
+_schema_versions = st.sampled_from(["1.0", "1.1", "2.0"])
+
+
+class TestContentHashProperties:
+    @settings(max_examples=50)
+    @given(owner=_owners, description=_descriptions, schema_version=_schema_versions)
+    def test_deterministic_for_identical_fields(
+        self, owner: str, description: str, schema_version: str
+    ) -> None:
+        """Same content fields, hashed twice, must agree -- republishing depends on this."""
+        a = DatasetMetadata(
+            name="raw", owner=AgentId(owner), description=description, schema_version=schema_version
+        )
+        b = DatasetMetadata(
+            name="raw", owner=AgentId(owner), description=description, schema_version=schema_version
+        )
+        assert content_hash(a) == content_hash(b)
+
+    @settings(max_examples=50)
+    @given(owner=_owners, description=_descriptions)
+    def test_name_does_not_affect_address(self, owner: str, description: str) -> None:
+        """The label is not content -- renaming a dataset must not change its address."""
+        a = DatasetMetadata(name="raw", owner=AgentId(owner), description=description)
+        b = DatasetMetadata(name="renamed", owner=AgentId(owner), description=description)
+        assert content_hash(a) == content_hash(b)
+
+    @settings(max_examples=50)
+    @given(schema_version=_schema_versions)
+    def test_schema_version_bump_changes_address(self, schema_version: str) -> None:
+        """A schema bump changes content; pinned consumers must not silently see new data."""
+        baseline = DatasetMetadata(name="raw", owner=AgentId("a1"), schema_version="1.0")
+        if schema_version == "1.0":
+            return
+        bumped = DatasetMetadata(name="raw", owner=AgentId("a1"), schema_version=schema_version)
+        assert content_hash(baseline) != content_hash(bumped)
+
+    def test_owner_change_changes_address(self) -> None:
+        """Re-attributing the same bytes to a new owner is a different claim -- new address."""
+        a = DatasetMetadata(name="raw", owner=AgentId("a1"))
+        b = DatasetMetadata(name="raw", owner=AgentId("a2"))
+        assert content_hash(a) != content_hash(b)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nest-plugins-reference/tests/test_cid_facts.py
+++ b/packages/nest-plugins-reference/tests/test_cid_facts.py
@@ -205,6 +205,86 @@ class TestProvenance:
 
 
 # ---------------------------------------------------------------------------
+# DAG shape: diamond ancestry, acyclicity, and Merkle tamper-evidence
+# ---------------------------------------------------------------------------
+
+
+class TestDagProperties:
+    @pytest.mark.asyncio
+    async def test_diamond_ancestor_set_counts_shared_root_once(self) -> None:
+        """A -> B, A -> C, {B, C} -> D: D's ancestors are {A, B, C}, A once."""
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        a = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+        b = await facts.publish(
+            DatasetMetadata(name="b", owner=AgentId("a1"), metadata={"parents": [str(a)]})
+        )
+        c = await facts.publish(
+            DatasetMetadata(name="c", owner=AgentId("a1"), metadata={"parents": [str(a)]})
+        )
+        d = await facts.publish(
+            DatasetMetadata(name="d", owner=AgentId("a1"), metadata={"parents": [str(b), str(c)]})
+        )
+        assert facts.ancestors(d) == {a, b, c}
+
+    @pytest.mark.asyncio
+    async def test_self_reference_is_impossible(self) -> None:
+        """A dataset cannot list its own (future) URL as a parent.
+
+        Its URL is the hash of its content *including* parents, so the URL
+        isn't known until after the parents are fixed -- you can't close the
+        loop. Listing the URL a no-parent version would have produces a
+        *different* (and unpublished) URL, so publish rejects it.
+        """
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        would_be = content_hash(DatasetMetadata(name="x", owner=AgentId("a1")))
+        self_ref = DatasetMetadata(
+            name="x", owner=AgentId("a1"), metadata={"parents": [f"df://sha256-{would_be}"]}
+        )
+        with pytest.raises(ProvenanceError):
+            await facts.publish(self_ref)
+
+    @pytest.mark.asyncio
+    async def test_no_cycle_can_be_formed(self) -> None:
+        """B parents on A; a new A' parenting on B is a *different* node, so A<->B is no cycle."""
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        a = await facts.publish(DatasetMetadata(name="a", owner=AgentId("a1")))
+        b = await facts.publish(
+            DatasetMetadata(name="b", owner=AgentId("a1"), metadata={"parents": [str(a)]})
+        )
+        a_prime = await facts.publish(
+            DatasetMetadata(name="a", owner=AgentId("a1"), metadata={"parents": [str(b)]})
+        )
+        # a_prime is a distinct address; the original a does not point back at b.
+        assert a_prime != a
+        assert facts.ancestors(a) == set()
+        assert b not in facts.ancestors(a)
+
+    @pytest.mark.asyncio
+    async def test_altering_an_ancestor_re_addresses_every_descendant(self) -> None:
+        """Merkle property: tamper with deep history and all downstream URLs change."""
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+        root = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+        child = await facts.publish(
+            DatasetMetadata(name="c", owner=AgentId("a1"), metadata={"parents": [str(root)]})
+        )
+
+        tampered_root = await facts.publish(
+            DatasetMetadata(name="raw", owner=AgentId("a1"), description="tampered")
+        )
+        tampered_child = await facts.publish(
+            DatasetMetadata(
+                name="c", owner=AgentId("a1"), metadata={"parents": [str(tampered_root)]}
+            )
+        )
+        assert tampered_root != root
+        assert tampered_child != child
+
+
+# ---------------------------------------------------------------------------
 # Signed freshness, including the forged-claim rejection
 # ---------------------------------------------------------------------------
 

--- a/scenarios/provenance_supply_chain.yaml
+++ b/scenarios/provenance_supply_chain.yaml
@@ -1,10 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-# Provenance supply-chain scenario: a 4-hop dataset pipeline, then 3 attacks.
+# Provenance scenario: a diamond dataset pipeline, then four attacks.
 #
-# source-0 -> refine-0 -> aggregate-0 -> verify-0, each hop publishing a
-# dataset that declares the upstream one as its provenance parent. verify-0
-# walks the chain back, checks freshness, then attempts substitution, forged
-# freshness, and broken-provenance attacks as an outsider.
+#                source-0
+#               /        \
+#          refine-a      refine-b
+#               \        /
+#              aggregate-0   (join: parents = [refine-a, refine-b])
+#                   |
+#                verify-0
+#
+# Each hop publishes a dataset declaring its upstream input(s) as provenance
+# parents. verify-0 walks the whole DAG back to the root, then runs
+# substitution, forged-freshness, and broken-provenance attacks as an outsider.
 #
 # Verify::
 #
@@ -17,19 +24,19 @@
 # flip to FAIL -- that plugin has no content-addressing, signed freshness, or
 # provenance concept at all.
 name: provenance_supply_chain
-description: "4-hop dataset pipeline with provenance; an outsider then attempts substitution, forged-freshness, and broken-provenance attacks."
+description: "Diamond dataset pipeline with provenance; an outsider then attempts substitution, forged-freshness, and broken-provenance attacks."
 
 tier: 1
 seed: 42
 
 agents:
-  count: 4
+  count: 5
   brain: state-machine
   roles:
     - name: source
       count: 1
     - name: refine
-      count: 1
+      count: 2
     - name: aggregate
       count: 1
     - name: verify

--- a/scenarios/provenance_supply_chain.yaml
+++ b/scenarios/provenance_supply_chain.yaml
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# Provenance supply-chain scenario: a 4-hop dataset pipeline, then 3 attacks.
+#
+# source-0 -> refine-0 -> aggregate-0 -> verify-0, each hop publishing a
+# dataset that declares the upstream one as its provenance parent. verify-0
+# walks the chain back, checks freshness, then attempts substitution, forged
+# freshness, and broken-provenance attacks as an outsider.
+#
+# Verify::
+#
+#     nest run scenarios/provenance_supply_chain.yaml
+#     python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
+#         [print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail) \
+#          for r in validate_trace(Path('traces/provenance_supply_chain.jsonl'), 'provenance_supply_chain')]"
+#
+# Swap `layers.datafacts` to `datafacts_v1` to see the adversarial validators
+# flip to FAIL -- that plugin has no content-addressing, signed freshness, or
+# provenance concept at all.
+name: provenance_supply_chain
+description: "4-hop dataset pipeline with provenance; an outsider then attempts substitution, forged-freshness, and broken-provenance attacks."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 4
+  brain: state-machine
+  roles:
+    - name: source
+      count: 1
+    - name: refine
+      count: 1
+    - name: aggregate
+      count: 1
+    - name: verify
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: cid_facts
+
+task:
+  type: provenance_supply_chain
+  config: {}
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 1000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/provenance_supply_chain.jsonl


### PR DESCRIPTION
## Problem

[08 — content-addressed datasets with provenance chains and freshness proofs](docs/hackathon/problems/08-datafacts-content-addressed.md).

`datafacts_v1` addresses datasets by the publisher's chosen *name*, so a republish under the same name silently overwrites whatever was there; "freshness" is `time.time() - timestamp < 3600` with no idea who touched it; and there's no lineage field at all.

## What this adds

`cid_facts` (`packages/nest-plugins-reference/.../datafacts/cid_facts.py`):

- **URL = `sha256` of the dataset's content fields** (owner, description, schema_version, tags, checksum, size_bytes, access_tier, metadata — not the `name` label, not timestamps). Same content → same address; different content can't collide on one. Republishing is idempotent.
- **Provenance via `metadata["parents"]`** — a list of parent URLs; `publish()` rejects any parent it hasn't itself seen. It's a DAG, not a chain: a dataset can declare multiple parents (a join), and parent order is normalized before hashing so `[A,B]` and `[B,A]` resolve to one address.
- **Freshness is a signed proof, not a clock read** — each publish signs `(url, tick)` with the identity layer's key over a logical tick (no wall-clock, so Tier 1 stays deterministic). `verify_freshness` only accepts a proof signed by the dataset's declared owner.

## The three attacks, and why a diamond

The brief calls out three holes — substitution, stale-claim, broken-provenance — and also that *"provenance is a DAG, not a tree."* So the scenario is a real **diamond**: `source → {refine-a, refine-b} → aggregate(join) → verify`. That fork is what gives the work its teeth:

- `aggregate-0` is a join — it lists *both* refiners as parents, so the report's lineage fans back out to a single shared root.
- `verify-0` walks the lineage with a full breadth-first traversal over *every* parent, not just `parents[0]`. A first-parent-only walk would silently miss half the graph; the diamond makes that walk load-bearing rather than decorative.
- Content-addressing makes the DAG **acyclic and tamper-evident for free**: a self-parent or cycle is impossible by construction (a node's address isn't known until its parents are fixed), and altering any ancestor re-addresses every descendant. These are proven in tests, not just asserted.

## Scenario & validators

`scenarios/provenance_supply_chain.yaml` runs the diamond, then `verify-0` (as an outsider, never the source) runs the three attacks. Four validators read the trace: `provenance_chain_integrity` (happy path) plus the three adversarial ones. Flip `layers.datafacts` between `cid_facts` and `datafacts_v1` in the same YAML and all three adversarial checks flip PASS↔FAIL — same scenario, same attacker logic, only the plugin underneath changes.

## Verification

```bash
uv sync
nest run scenarios/provenance_supply_chain.yaml
python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
    [print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail) \
     for r in validate_trace(Path('traces/provenance_supply_chain.jsonl'), 'provenance_supply_chain')]"
```

All four pass on `cid_facts`; swap to `datafacts_v1` and the three adversarial ones flip to FAIL.

```bash
make ci-local   # 585 passed
```

## Tests

- `test_cid_facts.py`: content-addressing (idempotent republish, distinct-content/distinct-URL, name has no effect); provenance (unknown-parent rejection, multi-hop walk, multi-parent join with order-independent addressing and partial-failure atomicity); DAG properties (diamond ancestor set counts a shared root once, self-reference impossible, no cycle can be formed, altering an ancestor re-addresses every descendant); freshness (happy path, window expiry, forged-claim rejection, owner re-sign stays fresh); ACL; registry wiring; a hypothesis property suite over `content_hash`.
- `test_provenance_supply_chain.py`: per-validator synthetic-trace unit tests, the diamond walk visiting all four nodes, end-to-end PASS/FAIL split between `cid_facts` and `datafacts_v1`, byte-identical determinism across seeds 42/7/1337.

Two real issues surfaced from these tests during development: the multi-parent join originally hashed parent order (so `[A,B]` and `[B,A]` got different addresses — fixed by sorting), and the lineage walk originally followed only the first parent (fixed to a full BFS, now exercised by the diamond).