### PR TITLE
[Hackathon] swamx: Partition-tolerant BFT coordination with HotStuff

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -30,6 +30,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
     ("coordination", "contract_net"): f"{_REF}.coordination.contract_net:ContractNet",
+    ("coordination", "hotstuff"): f"{_REF}.coordination.hotstuff:HotStuff",
     ("negotiation", "alternating_offers"): (
         f"{_REF}.negotiation.alternating_offers:AlternatingOffers"
     ),

--- a/packages/nest-core/nest_core/runner.py
+++ b/packages/nest-core/nest_core/runner.py
@@ -165,6 +165,7 @@ class ScenarioRunner:
             message_drop_rate=failures.message_drop,
             byzantine_fraction=failures.byzantine_agents,
             partition_groups=partition_groups,
+            partition_heal_at=failures.partition_heal_at_tick,
             plugins=plugins,
         )
 

--- a/packages/nest-core/nest_core/scenario.py
+++ b/packages/nest-core/nest_core/scenario.py
@@ -107,6 +107,7 @@ class FailureConfig(BaseModel):
     message_drop: float = 0.0
     byzantine_agents: float = 0.0
     network_partition: dict[str, Any] | None = None
+    partition_heal_at_tick: int | None = None
 
     @field_validator("message_drop", "byzantine_agents")
     @classmethod

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -109,3 +109,7 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("provenance_supply_chain", provenance_supply_chain_factory)
+    elif name == "bft_hotstuff":
+        from nest_core.scenarios_builtin.bft_hotstuff import bft_hotstuff_factory
+
+        register_scenario("bft_hotstuff", bft_hotstuff_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/bft_hotstuff.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/bft_hotstuff.py
@@ -1,0 +1,384 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Partition-tolerant BFT consensus -- linear 2-phase HotStuff.
+
+Every replica runs the same state machine (``ReplicaAgent``): it can
+propose, vote, form Quorum Certificates, and become leader after a
+view-change, since round-robin leader rotation means any replica may be
+asked to lead a future view. This differs deliberately from
+``nest_core.scenarios_builtin.consensus``'s fixed ``LeaderAgent``/
+``FollowerAgent`` split, which never rotates leadership.
+
+Protocol shape (2-phase, not the original 3-phase HotStuff): PREPARE then
+COMMIT, each gathering its own 2f+1-vote Quorum Certificate out of 3f+1
+total replicas. Safety across view-changes comes from the standard
+locked-QC rule (never vote prepare for a view below what you've already
+locked), not from the phase count -- the third phase in the original paper
+buys cross-view pipelining/throughput, which is out of scope here.
+
+The ``Coordination``-protocol-shaped plugin (``nest_plugins_reference.
+coordination.hotstuff.HotStuff``) is a separate, non-networked conformance
+wrapper -- it is not used by this factory, matching the precedent set by
+``contract_net``/``consensus.py``. The real wire protocol lives entirely in
+this module.
+
+Example::
+
+    agents = bft_hotstuff_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from nest_plugins_reference.coordination import hotstuff_wire
+from nest_plugins_reference.coordination.hotstuff_wire import QuorumCert, VoteRecord
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Signature
+
+
+class ReplicaAgent(StateMachineAgent):
+    """Honest HotStuff replica: proposes (when leader), votes, forms QCs.
+
+    Example::
+
+        replica = ReplicaAgent(AgentId("replica-0"), replica_ids, f=2)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        replica_ids: Sequence[AgentId],
+        f: int,
+        view_timeout_ticks: int = 40,
+    ) -> None:
+        self._agent_id = agent_id
+        self._replica_ids = sorted(replica_ids)
+        self._f = f
+        self._quorum = 2 * f + 1
+        self._view_timeout_ticks = view_timeout_ticks
+        self._current_view = 0
+        self._locked_qc: QuorumCert | None = None
+        self._voted_prepare: dict[int, str] = {}
+        self._voted_commit: dict[int, str] = {}
+        self._prepare_votes: dict[tuple[int, str], dict[str, str]] = {}
+        self._commit_votes: dict[tuple[int, str], dict[str, str]] = {}
+        self._prepare_qc_formed: set[tuple[int, str]] = set()
+        self._commit_qc_formed: set[tuple[int, str]] = set()
+        self._new_view_msgs: dict[int, dict[str, QuorumCert | None]] = {}
+        self._proposed_for_view: set[int] = set()
+        self._committed: dict[int, tuple[str, int, int]] = {}
+        self._current_value_for_view: dict[int, str] = {}
+
+    def _leader_for_view(self, view: int) -> AgentId:
+        return self._replica_ids[view % len(self._replica_ids)]
+
+    def _is_leader(self, view: int) -> bool:
+        return self._leader_for_view(view) == self._agent_id
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Schedule the view-0 timeout and propose if leading view 0.
+
+        Example::
+
+            await replica.on_start(ctx)
+        """
+        await ctx.schedule(self._view_timeout_ticks, f"view-timeout:{self._current_view}".encode())
+        if self._is_leader(self._current_view):
+            await self._propose(ctx, self._current_view, justify_qc=None)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Dispatch an incoming wire message or self-scheduled timeout.
+
+        Malformed or byzantine-garbled payloads are silently dropped --
+        never raises.
+
+        Example::
+
+            await replica.on_message(ctx, AgentId("replica-1"), b"vote:prepare:1:abcd|sig:..")
+        """
+        text = payload.decode("utf-8", errors="replace")
+        if text.startswith("view-timeout:"):
+            await self._handle_timeout(ctx, text)
+            return
+        body, sig = hotstuff_wire.split_signature(text)
+        if body.startswith("prepare:"):
+            await self._handle_prepare(ctx, sender, body, sig)
+        elif body.startswith("vote:"):
+            await self._handle_vote(ctx, sender, body, sig)
+        elif body.startswith("qc:"):
+            await self._handle_qc(ctx, sender, body, sig)
+        elif body.startswith("new-view:"):
+            await self._handle_new_view(ctx, sender, body, sig)
+
+    async def _propose(self, ctx: AgentContext, view: int, justify_qc: QuorumCert | None) -> None:
+        if view in self._proposed_for_view:
+            return
+        self._proposed_for_view.add(view)
+        value = str(ctx.rng.randint(1, 100))
+        self._current_value_for_view[view] = value
+        body = hotstuff_wire.encode_prepare(view, value, justify_qc)
+        await self._send_signed(ctx, body, self._replica_ids)
+
+    async def _send_signed(
+        self, ctx: AgentContext, body: bytes, recipients: Sequence[AgentId]
+    ) -> None:
+        identity = ctx.plugins.get("identity")
+        sig_hex = identity.sign(body).value.hex() if identity is not None else ""
+        wire = hotstuff_wire.with_signature(body, sig_hex)
+        for rid in recipients:
+            await ctx.send(rid, wire)
+
+    def _verify(
+        self, ctx: AgentContext, claimed_signer: AgentId, body: str, sig: bytes | None
+    ) -> bool:
+        if sig is None:
+            return False
+        identity = ctx.plugins.get("identity")
+        if identity is None:
+            return False
+        signature = Signature(signer=claimed_signer, value=sig, algorithm="sim-rsa-sha256")
+        return bool(identity.verify(body.encode(), signature, claimed_signer))
+
+    def _qc_is_valid(self, ctx: AgentContext, qc: QuorumCert) -> bool:
+        required = 2 * self._f + 1
+        seen: set[str] = set()
+        valid = 0
+        payload = hotstuff_wire.encode_vote(qc.phase, qc.view, qc.block_hash).decode()
+        for vote in qc.votes:
+            if vote.voter in seen:
+                continue
+            seen.add(vote.voter)
+            try:
+                sig_bytes = bytes.fromhex(vote.signature_hex)
+            except ValueError:
+                continue
+            if self._verify(ctx, AgentId(vote.voter), payload, sig_bytes):
+                valid += 1
+        return valid >= required
+
+    async def _handle_timeout(self, ctx: AgentContext, text: str) -> None:
+        try:
+            view = int(text.split(":", 1)[1])
+        except (IndexError, ValueError):
+            return
+        if view != self._current_view or view in self._committed:
+            return
+        await self._advance_view(ctx)
+
+    async def _advance_view(self, ctx: AgentContext) -> None:
+        new_view = self._current_view + 1
+        self._current_view = new_view
+        body = hotstuff_wire.encode_new_view(new_view, self._locked_qc)
+        leader = self._leader_for_view(new_view)
+        await self._send_signed(ctx, body, [leader])
+        await ctx.schedule(self._view_timeout_ticks, f"view-timeout:{new_view}".encode())
+
+    async def _handle_prepare(
+        self, ctx: AgentContext, sender: AgentId, body: str, sig: bytes | None
+    ) -> None:
+        msg = hotstuff_wire.decode_prepare(body)
+        if msg is None or not self._verify(ctx, sender, body, sig):
+            return
+        if sender != self._leader_for_view(msg.view) or msg.view < self._current_view:
+            return
+        if msg.justify_qc is not None and not self._qc_is_valid(ctx, msg.justify_qc):
+            return
+        if (
+            self._locked_qc is not None
+            and msg.justify_qc is not None
+            and msg.justify_qc.view < self._locked_qc.view
+        ):
+            return
+        if msg.view > self._current_view:
+            self._current_view = msg.view
+            await ctx.schedule(self._view_timeout_ticks, f"view-timeout:{msg.view}".encode())
+        if self._voted_prepare.get(msg.view) is not None:
+            return
+        self._voted_prepare[msg.view] = msg.block_hash
+        self._current_value_for_view[msg.view] = msg.value
+        vote_body = hotstuff_wire.encode_vote("prepare", msg.view, msg.block_hash)
+        await self._send_signed(ctx, vote_body, [sender])
+
+    async def _handle_vote(
+        self, ctx: AgentContext, sender: AgentId, body: str, sig: bytes | None
+    ) -> None:
+        msg = hotstuff_wire.decode_vote(body)
+        if msg is None or sig is None or not self._verify(ctx, sender, body, sig):
+            return
+        if not self._is_leader(msg.view):
+            return
+        key = (msg.view, msg.block_hash)
+        bucket = self._prepare_votes if msg.phase == "prepare" else self._commit_votes
+        votes = bucket.setdefault(key, {})
+        votes[str(sender)] = sig.hex()
+        if len(votes) < self._quorum:
+            return
+        formed = self._prepare_qc_formed if msg.phase == "prepare" else self._commit_qc_formed
+        if key in formed:
+            return
+        formed.add(key)
+        records = tuple(VoteRecord(voter=v, signature_hex=s) for v, s in votes.items())
+        qc_body = hotstuff_wire.encode_qc_broadcast(
+            msg.phase, msg.view, msg.block_hash, self._f, records
+        )
+        await self._send_signed(ctx, qc_body, self._replica_ids)
+
+    async def _handle_qc(
+        self, ctx: AgentContext, sender: AgentId, body: str, sig: bytes | None
+    ) -> None:
+        msg = hotstuff_wire.decode_qc_broadcast(body)
+        if msg is None or not self._verify(ctx, sender, body, sig):
+            return
+        if sender != self._leader_for_view(msg.view) or msg.f != self._f:
+            return
+        qc = QuorumCert(phase=msg.phase, view=msg.view, block_hash=msg.block_hash, votes=msg.votes)
+        if not self._qc_is_valid(ctx, qc):
+            return
+        if msg.phase == "prepare":
+            await self._on_prepare_qc_received(ctx, qc)
+        else:
+            await self._on_commit_qc_received(ctx, qc)
+
+    async def _on_prepare_qc_received(self, ctx: AgentContext, qc: QuorumCert) -> None:
+        if self._locked_qc is None or qc.view >= self._locked_qc.view:
+            self._locked_qc = qc
+        if self._voted_commit.get(qc.view) is not None:
+            return
+        self._voted_commit[qc.view] = qc.block_hash
+        vote_body = hotstuff_wire.encode_vote("commit", qc.view, qc.block_hash)
+        await self._send_signed(ctx, vote_body, [self._leader_for_view(qc.view)])
+
+    async def _on_commit_qc_received(self, ctx: AgentContext, qc: QuorumCert) -> None:
+        if qc.view not in self._committed:
+            value = self._current_value_for_view.get(qc.view, "")
+            accepts = len(qc.votes)
+            total = len(self._replica_ids)
+            self._committed[qc.view] = (value, accepts, total)
+            result_body = hotstuff_wire.encode_result(qc.view, qc.block_hash, accepts, total, value)
+            await self._send_signed(ctx, result_body, self._replica_ids)
+        next_view = qc.view + 1
+        if next_view > self._current_view:
+            self._current_view = next_view
+            await ctx.schedule(self._view_timeout_ticks, f"view-timeout:{next_view}".encode())
+        if self._is_leader(next_view):
+            await self._propose(ctx, next_view, justify_qc=qc)
+
+    async def _handle_new_view(
+        self, ctx: AgentContext, sender: AgentId, body: str, sig: bytes | None
+    ) -> None:
+        msg = hotstuff_wire.decode_new_view(body)
+        if msg is None or not self._verify(ctx, sender, body, sig):
+            return
+        if msg.highest_qc is not None and not self._qc_is_valid(ctx, msg.highest_qc):
+            return
+        if not self._is_leader(msg.view):
+            return
+        bucket = self._new_view_msgs.setdefault(msg.view, {})
+        bucket[str(sender)] = msg.highest_qc
+        if len(bucket) < self._quorum or msg.view in self._proposed_for_view:
+            return
+        highest: QuorumCert | None = None
+        for qc in bucket.values():
+            if qc is not None and (highest is None or qc.view > highest.view):
+                highest = qc
+        if self._current_view < msg.view:
+            self._current_view = msg.view
+            await ctx.schedule(self._view_timeout_ticks, f"view-timeout:{msg.view}".encode())
+        await self._propose(ctx, msg.view, justify_qc=highest)
+
+
+class MaliciousLeaderAgent(ReplicaAgent):
+    """A replica that equivocates only on its own leader turns.
+
+    When this replica is leader for a view, it sends two different PREPARE
+    proposals (different value, different block hash) to disjoint halves of
+    the replica set -- the literal "leader sending different proposals to
+    different followers" failure mode the hackathon's equivocation
+    validator must catch. Outside of its own leader turns it behaves like
+    an honest ``ReplicaAgent``: voting, forming QCs, and view-changing
+    normally, so the scenario exercises exactly one failure mode at a time.
+
+    Example::
+
+        leader = MaliciousLeaderAgent(AgentId("replica-1"), replica_ids, f=2)
+    """
+
+    async def _propose(self, ctx: AgentContext, view: int, justify_qc: QuorumCert | None) -> None:
+        if view in self._proposed_for_view:
+            return
+        self._proposed_for_view.add(view)
+        half = len(self._replica_ids) // 2
+        group_a = self._replica_ids[:half] or list(self._replica_ids)
+        group_b = self._replica_ids[half:] or list(self._replica_ids)
+        value_a = str(ctx.rng.randint(1, 100))
+        value_b = str(ctx.rng.randint(101, 200))
+        self._current_value_for_view[view] = value_a
+        body_a = hotstuff_wire.encode_prepare(view, value_a, justify_qc)
+        body_b = hotstuff_wire.encode_prepare(view, value_b, justify_qc)
+        await self._send_signed(ctx, body_a, group_a)
+        await self._send_signed(ctx, body_b, group_b)
+
+
+def instantiate_identity(plugins: dict[str, Any], all_ids: Sequence[AgentId]) -> None:
+    """Wire a per-agent signed ``DidKeyIdentity`` with full peer cross-registration.
+
+    Mirrors ``nest_core.scenarios_builtin.marketplace``'s identity-wiring
+    block: every replica must sign its own votes/proposals and verify every
+    peer's signatures, so each gets its own identity instance with all
+    peers registered, stored under ``plugins["_agent_plugins"]`` for the
+    runner to apply as a per-agent override.
+
+    Example::
+
+        instantiate_identity(plugins, [AgentId("replica-0"), AgentId("replica-1")])
+    """
+    identity_cls = plugins.get("identity")
+    if identity_cls is None or not isinstance(identity_cls, type):
+        return
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+    identities: dict[AgentId, Any] = {aid: identity_cls(aid, seed=b"sim-seed") for aid in all_ids}
+    for aid, ident in identities.items():
+        for peer_id, peer_ident in identities.items():
+            if peer_id != aid:
+                ident.register_peer(peer_id, peer_ident.public_key)
+    for aid, ident in identities.items():
+        agent_plugins.setdefault(aid, {})["identity"] = ident
+    plugins.pop("identity", None)
+
+
+def bft_hotstuff_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create HotStuff replica agents and wire per-agent signed identities.
+
+    Reads ``task.config.f`` (defaults to ``(count - 1) // 3``),
+    ``task.config.view_timeout_ticks`` (default 40), and
+    ``task.config.malicious_agents`` (a list of replica id strings to
+    instantiate as ``MaliciousLeaderAgent`` instead of ``ReplicaAgent``).
+
+    Example::
+
+        agents = bft_hotstuff_factory(config, plugins)
+    """
+    task_config = config.task.config
+    count = config.agents.count
+    f = int(task_config.get("f", (count - 1) // 3))
+    view_timeout_ticks = int(task_config.get("view_timeout_ticks", 40))
+    malicious_names: set[str] = set(task_config.get("malicious_agents", []))
+
+    replica_ids = [AgentId(f"replica-{i}") for i in range(count)]
+    instantiate_identity(plugins, replica_ids)
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    for rid in replica_ids:
+        if str(rid) in malicious_names:
+            agents[rid] = MaliciousLeaderAgent(
+                rid, replica_ids, f=f, view_timeout_ticks=view_timeout_ticks
+            )
+        else:
+            agents[rid] = ReplicaAgent(rid, replica_ids, f=f, view_timeout_ticks=view_timeout_ticks)
+    return agents

--- a/packages/nest-core/nest_core/sim/simulator.py
+++ b/packages/nest-core/nest_core/sim/simulator.py
@@ -149,6 +149,7 @@ class Simulator:
         message_drop_rate: float = 0.0,
         byzantine_fraction: float = 0.0,
         partition_groups: list[list[str]] | None = None,
+        partition_heal_at: int | None = None,
         plugins: dict[str, Any] | None = None,
     ) -> None:
         if not 0.0 <= message_drop_rate <= 1.0:
@@ -172,6 +173,8 @@ class Simulator:
         self._message_drop_rate = message_drop_rate
         self._byzantine_fraction = byzantine_fraction
         self._partition_groups = partition_groups
+        self._partition_heal_at = partition_heal_at
+        self._partition_healed = False
         self._byzantine_agents: set[AgentId] = set()
         self._partition_map: dict[AgentId, int] = {}
         self._failure_rng = random.Random(self._master_rng.randint(0, 2**63))
@@ -305,6 +308,22 @@ class Simulator:
 
             self._clock.advance_to(event.time)
             self._tick_count += 1
+
+            if (
+                self._partition_heal_at is not None
+                and not self._partition_healed
+                and self._tick_count >= self._partition_heal_at
+            ):
+                self._partition_map = {}
+                self._partition_healed = True
+                if self._trace:
+                    self._trace.record(
+                        {
+                            "ts": self._clock.now,
+                            "agent": "_simulator",
+                            "kind": "partition_healed",
+                        }
+                    )
 
             if event.kind == "start":
                 continue

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -2312,6 +2312,219 @@ def validate_provenance_chain_unforgeable(
 
 
 # ---------------------------------------------------------------------------
+# BFT HotStuff validators
+# ---------------------------------------------------------------------------
+
+_STUCK_VIEW_K_TICKS = 300
+
+
+def validate_bft_no_conflicting_commits(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """No two honest replicas commit conflicting values for the same view.
+
+    Reads ``result:<view>:committed:<accepts>/<total>:<block_hash>:<value>``
+    lines, each announced independently by the replica that observed the
+    commit QC (not just the leader's say-so). Conflicts are keyed on
+    ``block_hash`` -- the field that comes straight from the commit QC and
+    is therefore identical across every honest replica for a given view --
+    rather than ``value``, since a replica that only saw the commit QC (not
+    the original PREPARE, e.g. after being partitioned away) may not know
+    the plaintext value but still agrees on the hash. A trace with zero
+    commits is itself a failure -- it means no quorum-backed progress was
+    ever observed, which is also why this validator FAILS against a
+    ``contract_net``-coordinated trace (no ``result:...committed`` lines
+    exist at all).
+
+    Example::
+
+        results = validate_bft_no_conflicting_commits(events)
+    """
+    commits_by_view: dict[str, dict[str, str]] = defaultdict(dict)
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("result:"):
+            continue
+        parts = msg.split(":")
+        if len(parts) < 6 or parts[2] != "committed":
+            continue
+        view, block_hash_hex = parts[1], parts[4]
+        commits_by_view[view][str(ev.get("agent", ""))] = block_hash_hex
+
+    if not commits_by_view:
+        return [
+            ValidationResult("bft_no_conflicting_commits", False, "no commits observed in trace")
+        ]
+
+    violations: list[str] = []
+    for view, by_agent in commits_by_view.items():
+        distinct = set(by_agent.values())
+        if len(distinct) > 1:
+            violations.append(f"view {view}: conflicting commits {by_agent}")
+
+    if violations:
+        return [ValidationResult("bft_no_conflicting_commits", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "bft_no_conflicting_commits",
+            True,
+            f"checked {len(commits_by_view)} committed view(s), no conflicts",
+        )
+    ]
+
+
+def validate_bft_no_equivocation(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """No leader sends two different PREPARE proposals in the same view.
+
+    Reads ``prepare:<view>:<block_hash>:<value>:<justify_qc>`` lines, grouped
+    by ``(sender, view)``. More than one distinct ``block_hash`` from the
+    same sender in the same view means that leader equivocated.
+
+    Example::
+
+        results = validate_bft_no_equivocation(events)
+    """
+    hashes_by_leader_view: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("prepare:"):
+            continue
+        parts = msg.split(":", 4)
+        if len(parts) < 3:
+            continue
+        view, block_hash_hex = parts[1], parts[2]
+        key = (str(ev.get("agent", "")), view)
+        hashes_by_leader_view[key].add(block_hash_hex)
+
+    violations = [
+        f"leader {leader} view {view}: sent conflicting proposals {hashes}"
+        for (leader, view), hashes in hashes_by_leader_view.items()
+        if len(hashes) > 1
+    ]
+
+    if violations:
+        return [ValidationResult("bft_no_equivocation", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "bft_no_equivocation",
+            True,
+            f"checked {len(hashes_by_leader_view)} (leader, view) proposal(s), no equivocation",
+        )
+    ]
+
+
+def validate_bft_forged_quorum(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every broadcast commit QC is backed by >= 2f+1 distinct signers.
+
+    Reads ``qc:<phase>:<view>:<block_hash>:<f>:<voter1>=<sig1>,...`` lines.
+    Distinct voter tokens are counted after deduplication, so padding the
+    same signer twice to inflate the count is itself caught as a forgery.
+
+    Example::
+
+        results = validate_bft_forged_quorum(events)
+    """
+    violations: list[str] = []
+    checked = 0
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("qc:"):
+            continue
+        parts = msg.split(":", 5)
+        if len(parts) != 6:
+            continue
+        phase, view, block_hash_hex, f_str, votes_str = (
+            parts[1],
+            parts[2],
+            parts[3],
+            parts[4],
+            parts[5],
+        )
+        try:
+            f_value = int(f_str)
+        except ValueError:
+            continue
+        required = 2 * f_value + 1
+        voters = {entry.partition("=")[0] for entry in votes_str.split(",") if entry}
+        checked += 1
+        if len(voters) < required:
+            violations.append(
+                f"{phase} qc view {view} block {block_hash_hex}: "
+                f"{len(voters)} distinct signers, needed {required}"
+            )
+
+    if violations:
+        return [ValidationResult("bft_forged_quorum", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "bft_forged_quorum",
+            True,
+            f"checked {checked} broadcast QC(s), all backed by a real quorum",
+        )
+    ]
+
+
+def validate_bft_no_stuck_view(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Commit progress resumes within K ticks of the network healing.
+
+    Baseline is the simulator's ``partition_healed`` marker if present,
+    else ``ts=0`` (so the same validator also covers the byzantine scenario,
+    which has no partition). Fails if no ``result:...committed`` line
+    appears within ``_STUCK_VIEW_K_TICKS`` ticks after the baseline.
+
+    Example::
+
+        results = validate_bft_no_stuck_view(events)
+    """
+    baseline = 0.0
+    for ev in events:
+        if ev.get("kind") == "partition_healed":
+            baseline = float(ev.get("ts", 0.0))
+            break
+
+    commit_ticks: list[float] = []
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if msg.startswith("result:") and ":committed:" in msg:
+            commit_ticks.append(float(ev.get("ts", 0.0)))
+
+    if not commit_ticks:
+        return [ValidationResult("bft_no_stuck_view", False, "no commits observed in trace")]
+
+    window_end = baseline + _STUCK_VIEW_K_TICKS
+    in_window = [t for t in commit_ticks if baseline <= t <= window_end]
+    if not in_window:
+        return [
+            ValidationResult(
+                "bft_no_stuck_view",
+                False,
+                f"no commit within {_STUCK_VIEW_K_TICKS} ticks of baseline ts={baseline}",
+            )
+        ]
+    return [
+        ValidationResult(
+            "bft_no_stuck_view",
+            True,
+            f"commit progress resumed at ts={min(in_window)} (baseline ts={baseline})",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -2375,5 +2588,11 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_provenance_substitution_resistant,
         validate_provenance_freshness_unforgeable,
         validate_provenance_chain_unforgeable,
+    ],
+    "bft_hotstuff": [
+        validate_bft_no_conflicting_commits,
+        validate_bft_no_equivocation,
+        validate_bft_forged_quorum,
+        validate_bft_no_stuck_view,
     ],
 }

--- a/packages/nest-core/tests/test_bft_hotstuff_scenario.py
+++ b/packages/nest-core/tests/test_bft_hotstuff_scenario.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end tests for the bft_hotstuff scenario and its validators.
+
+The core claims under test: the partition scenario heals and resumes commit
+progress deterministically across the required seeds; the byzantine
+scenario's safety/forged-quorum/stuck-view validators pass while the
+equivocation validator correctly catches the configured malicious leaders
+(proving the malicious logic actually ran, not silently no-op'd); and the
+bft_hotstuff validator suite FAILS against a contract_net-coordinated trace
+that has no prepare:/qc:/result:committed lines at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_events, validate_trace
+
+
+def _run(yaml_path: str, out: Path, seed: int = 42) -> None:
+    cfg = ScenarioConfig.from_yaml(yaml_path)
+    cfg.seed = seed
+    cfg.output.trace = str(out)
+    asyncio.run(ScenarioRunner(cfg).run())
+
+
+class TestBftPartitionScenario:
+    def test_runs_and_passes_all_validators(self, tmp_path: Path) -> None:
+        out = tmp_path / "partition.jsonl"
+        _run("scenarios/bft_consensus_partition.yaml", out)
+        results = validate_trace(out, "bft_hotstuff")
+        assert results, "expected validators to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_deterministic_across_required_seeds(self, tmp_path: Path) -> None:
+        for seed in (42, 7, 1337, 0xDEADBEEF):
+            a, b = tmp_path / f"{seed}a.jsonl", tmp_path / f"{seed}b.jsonl"
+            _run("scenarios/bft_consensus_partition.yaml", a, seed=seed)
+            _run("scenarios/bft_consensus_partition.yaml", b, seed=seed)
+            assert a.read_bytes() == b.read_bytes(), f"seed {seed} not deterministic"
+            assert all(r.passed for r in validate_trace(a, "bft_hotstuff")), seed
+
+
+class TestBftByzantineScenario:
+    def test_safety_and_recovery_pass_but_equivocation_is_detected(self, tmp_path: Path) -> None:
+        out = tmp_path / "byzantine.jsonl"
+        _run("scenarios/bft_consensus_byzantine.yaml", out)
+        results = {r.name: r for r in validate_trace(out, "bft_hotstuff")}
+
+        assert results["bft_no_conflicting_commits"].passed is True, results[
+            "bft_no_conflicting_commits"
+        ].detail
+        assert results["bft_forged_quorum"].passed is True, results["bft_forged_quorum"].detail
+        assert results["bft_no_stuck_view"].passed is True, results["bft_no_stuck_view"].detail
+        # Sanity check: if this ever passes, the configured malicious_agents
+        # silently no-op'd instead of actually equivocating.
+        assert results["bft_no_equivocation"].passed is False
+
+
+class TestValidatorsFailAgainstNonBftTrace:
+    def test_fails_against_synthetic_contract_net_style_trace(self) -> None:
+        events = [
+            {"kind": "start", "agent": "r0"},
+            {"kind": "send", "agent": "r0", "msg": "bids:[]"},
+            {"kind": "stop", "agent": "r0"},
+        ]
+        results = validate_events(events, "bft_hotstuff")
+        assert any(not r.passed for r in results), "expected at least one validator to fail"
+
+    def test_fails_against_real_consensus_trace(self, tmp_path: Path) -> None:
+        out = tmp_path / "consensus.jsonl"
+        _run("scenarios/consensus.yaml", out)
+        results = validate_trace(out, "bft_hotstuff")
+        assert any(not r.passed for r in results), "expected at least one validator to fail"

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -756,6 +756,7 @@ class TestValidatorRegistry:
             "receipt_reputation",
             "multi_attribute_market",
             "provenance_supply_chain",
+            "bft_hotstuff",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/coordination/hotstuff.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/coordination/hotstuff.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HotStuff coordination plugin -- ``Coordination`` protocol conformance wrapper.
+
+This class satisfies the ``Coordination`` protocol's ``propose`` /
+``participate`` / ``resolve`` / ``commit`` surface for isolated,
+single-process testing: it runs one PREPARE -> COMMIT round in-memory with
+no networking, no view-change timers, and no Byzantine handling.
+
+The full networked protocol -- multi-round messaging, round-robin leader
+rotation, view-change on timeout, the locked-QC safety rule across views,
+and the deliberately-malicious leader behavior exercised by the Byzantine
+scenario -- lives in ``nest_core.scenarios_builtin.bft_hotstuff``
+(``ReplicaAgent`` / ``MaliciousLeaderAgent``), which drives the simulator's
+event loop directly. This split mirrors the existing precedent set by
+``contract_net`` and ``nest_core.scenarios_builtin.consensus``: every
+built-in scenario factory hand-rolls its wire protocol inside
+``StateMachineAgent`` subclasses rather than calling into the
+``Coordination``-shaped plugin -- that plugin class exists for API
+conformance and isolated unit testing only, it is not invoked by the
+simulator at runtime.
+
+Example::
+
+    coord = HotStuff(AgentId("r0"), f=1)
+    rnd = await coord.propose(Task(id="t1", description="agree on a value"))
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from nest_core.types import AgentId, Outcome, Round, Task, Vote
+
+
+class HotStuff:
+    """Single-process HotStuff round: propose, vote, resolve by quorum.
+
+    Example::
+
+        coord = HotStuff(AgentId("r0"), f=1)
+        rnd = await coord.propose(Task(id="t1", description="work"))
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        f: int = 1,
+        replica_ids: Sequence[AgentId] | None = None,
+    ) -> None:
+        self._agent_id = agent_id
+        self._f = f
+        self._replica_ids = list(replica_ids) if replica_ids is not None else [agent_id]
+
+    async def propose(self, task: Task) -> Round:
+        """Propose a task as a single-view HotStuff round.
+
+        Example::
+
+            rnd = await coord.propose(task)
+        """
+        round_id = str(uuid.uuid4())
+        return Round(
+            id=round_id,
+            task=task,
+            participants=[],
+            metadata={"view": 0, "votes": [], "quorum": 2 * self._f + 1},
+        )
+
+    async def participate(self, round: Round) -> Vote:
+        """Cast a prepare-phase accept vote for the round's task.
+
+        Example::
+
+            vote = await coord.participate(rnd)
+        """
+        vote = Vote(voter=self._agent_id, round_id=round.id, value="accept")
+        votes: list[dict[str, Any]] = round.metadata.setdefault("votes", [])
+        votes.append({"voter": str(vote.voter), "value": vote.value})
+        if self._agent_id not in round.participants:
+            round.participants.append(self._agent_id)
+        return vote
+
+    async def resolve(self, round: Round) -> Outcome:
+        """Resolve a round once at least 2f+1 prepare votes have accumulated.
+
+        Example::
+
+            outcome = await coord.resolve(rnd)
+        """
+        votes: list[dict[str, Any]] = round.metadata.get("votes", [])
+        accepts = sum(1 for v in votes if v.get("value") == "accept")
+        quorum = int(round.metadata.get("quorum", 2 * self._f + 1))
+        winner: AgentId | None = self._agent_id if accepts >= quorum else None
+        return Outcome(
+            round_id=round.id,
+            winner=winner,
+            task=round.task,
+            metadata={"accepts": accepts, "quorum": quorum},
+        )
+
+    async def commit(self, outcome: Outcome) -> None:
+        """Commit a resolved outcome.
+
+        This wrapper holds no externally-visible state, so commit is a
+        no-op; the networked protocol's actual commit/decide step lives in
+        ``ReplicaAgent`` in ``nest_core.scenarios_builtin.bft_hotstuff``.
+
+        Example::
+
+            await coord.commit(outcome)
+        """

--- a/packages/nest-plugins-reference/nest_plugins_reference/coordination/hotstuff_wire.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/coordination/hotstuff_wire.py
@@ -1,0 +1,349 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Wire encoding/decoding for the HotStuff BFT coordination protocol.
+
+All HotStuff messages are colon-delimited UTF-8 text ending in a
+``|sig:<hex>`` signature suffix, matching the convention already used by
+``nest_core.scenarios_builtin.marketplace`` and read by
+``nest_core.validators._message_body``. A Quorum Certificate (a set of
+signed votes) is embedded inline using a ``;``/``,``/``=`` sub-grammar so it
+nests inside the outer ``:``-delimited message without ambiguity.
+
+Every ``decode_*`` function returns ``None`` on malformed input instead of
+raising -- callers (the simulator's byzantine fault injection XOR-garbles
+payload bytes) must never crash or miscount a vote when handed garbage.
+
+Example::
+
+    body = encode_vote("prepare", view=3, block_hash_hex=block_hash(3, "42"))
+    msg = decode_vote(body.decode())
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+_PHASES = ("prepare", "commit")
+
+
+@dataclass(frozen=True)
+class VoteRecord:
+    """A single signed vote inside a Quorum Certificate.
+
+    Example::
+
+        record = VoteRecord(voter="replica-0", signature_hex="a1b2")
+    """
+
+    voter: str
+    signature_hex: str
+
+
+@dataclass(frozen=True)
+class QuorumCert:
+    """A Quorum Certificate: >=2f+1 signed votes for one (phase, view, block).
+
+    Example::
+
+        qc = QuorumCert(phase="prepare", view=3, block_hash="abcd", votes=())
+    """
+
+    phase: str
+    view: int
+    block_hash: str
+    votes: tuple[VoteRecord, ...]
+
+    def encode_inline(self) -> str:
+        """Encode this QC for embedding inside a PREPARE/NEW-VIEW message.
+
+        Example::
+
+            field = qc.encode_inline()
+        """
+        votes_str = ",".join(f"{v.voter}={v.signature_hex}" for v in self.votes)
+        return f"{self.phase};{self.view};{self.block_hash};{votes_str}"
+
+
+@dataclass(frozen=True)
+class PrepareMessage:
+    """A decoded PREPARE proposal.
+
+    Example::
+
+        msg = decode_prepare("prepare:3:abcd:42:none")
+    """
+
+    view: int
+    block_hash: str
+    value: str
+    justify_qc: QuorumCert | None
+
+
+@dataclass(frozen=True)
+class VoteMessage:
+    """A decoded VOTE.
+
+    Example::
+
+        msg = decode_vote("vote:prepare:3:abcd")
+    """
+
+    phase: str
+    view: int
+    block_hash: str
+
+
+@dataclass(frozen=True)
+class QcBroadcastMessage:
+    """A decoded QC broadcast (leader announcing a formed quorum).
+
+    Example::
+
+        msg = decode_qc_broadcast("qc:prepare:3:abcd:2:r0=ab,r2=cd,r4=ef")
+    """
+
+    phase: str
+    view: int
+    block_hash: str
+    f: int
+    votes: tuple[VoteRecord, ...]
+
+
+@dataclass(frozen=True)
+class NewViewMessage:
+    """A decoded NEW-VIEW (view-change) message.
+
+    Example::
+
+        msg = decode_new_view("new-view:4:none")
+    """
+
+    view: int
+    highest_qc: QuorumCert | None
+
+
+def block_hash(view: int, value: str) -> str:
+    """Deterministic block identity for a (view, value) pair.
+
+    Example::
+
+        h = block_hash(3, "42")
+    """
+    return hashlib.sha256(f"{view}:{value}".encode()).hexdigest()
+
+
+def with_signature(body: bytes, signature_hex: str) -> bytes:
+    """Append the ``|sig:<hex>`` suffix used by every HotStuff wire message.
+
+    Example::
+
+        wire_bytes = with_signature(b"vote:prepare:3:abcd", "a1b2")
+    """
+    return body + f"|sig:{signature_hex}".encode()
+
+
+def split_signature(text: str) -> tuple[str, bytes | None]:
+    """Split ``body|sig:<hex>`` into the signed body and decoded signature.
+
+    Returns ``(text, None)`` when the suffix is missing or not valid hex --
+    callers must treat a ``None`` signature as unverifiable.
+
+    Example::
+
+        body, sig_bytes = split_signature("vote:prepare:3:abcd|sig:a1b2")
+    """
+    body, sep, sig_hex = text.rpartition("|sig:")
+    if not sep:
+        return text, None
+    try:
+        return body, bytes.fromhex(sig_hex)
+    except ValueError:
+        return body, None
+
+
+def _decode_votes(votes_str: str) -> tuple[VoteRecord, ...] | None:
+    if not votes_str:
+        return ()
+    records: list[VoteRecord] = []
+    for entry in votes_str.split(","):
+        voter, sep, sig_hex = entry.partition("=")
+        if not sep or not voter or not sig_hex:
+            return None
+        records.append(VoteRecord(voter=voter, signature_hex=sig_hex))
+    return tuple(records)
+
+
+def decode_inline_qc(field: str) -> QuorumCert | None:
+    """Decode the ``phase;view;block_hash;voter=sig,...`` inline QC grammar.
+
+    Example::
+
+        qc = decode_inline_qc("prepare;3;abcd;r0=ab,r2=cd")
+    """
+    parts = field.split(";", 3)
+    if len(parts) != 4:
+        return None
+    phase, view_str, block_hash_hex, votes_str = parts
+    if phase not in _PHASES:
+        return None
+    try:
+        view = int(view_str)
+    except ValueError:
+        return None
+    votes = _decode_votes(votes_str)
+    if votes is None:
+        return None
+    return QuorumCert(phase=phase, view=view, block_hash=block_hash_hex, votes=votes)
+
+
+def encode_prepare(view: int, value: str, justify_qc: QuorumCert | None) -> bytes:
+    """Encode a PREPARE proposal body (without the trailing signature).
+
+    Example::
+
+        body = encode_prepare(3, "42", None)
+    """
+    h = block_hash(view, value)
+    qc_field = justify_qc.encode_inline() if justify_qc is not None else "none"
+    return f"prepare:{view}:{h}:{value}:{qc_field}".encode()
+
+
+def decode_prepare(body: str) -> PrepareMessage | None:
+    """Decode a PREPARE message body (text after stripping ``|sig:``).
+
+    Example::
+
+        msg = decode_prepare("prepare:3:abcd:42:none")
+    """
+    parts = body.split(":", 4)
+    if len(parts) != 5 or parts[0] != "prepare":
+        return None
+    try:
+        view = int(parts[1])
+    except ValueError:
+        return None
+    block_hash_hex, value, qc_field = parts[2], parts[3], parts[4]
+    justify_qc: QuorumCert | None = None
+    if qc_field != "none":
+        justify_qc = decode_inline_qc(qc_field)
+        if justify_qc is None:
+            return None
+    return PrepareMessage(view=view, block_hash=block_hash_hex, value=value, justify_qc=justify_qc)
+
+
+def encode_vote(phase: str, view: int, block_hash_hex: str) -> bytes:
+    """Encode a VOTE message body -- also the exact payload a voter signs.
+
+    Example::
+
+        body = encode_vote("prepare", 3, "abcd")
+    """
+    return f"vote:{phase}:{view}:{block_hash_hex}".encode()
+
+
+def decode_vote(body: str) -> VoteMessage | None:
+    """Decode a VOTE message body.
+
+    Example::
+
+        msg = decode_vote("vote:prepare:3:abcd")
+    """
+    parts = body.split(":")
+    if len(parts) != 4 or parts[0] != "vote":
+        return None
+    phase = parts[1]
+    if phase not in _PHASES:
+        return None
+    try:
+        view = int(parts[2])
+    except ValueError:
+        return None
+    return VoteMessage(phase=phase, view=view, block_hash=parts[3])
+
+
+def encode_qc_broadcast(
+    phase: str, view: int, block_hash_hex: str, f: int, votes: Sequence[VoteRecord]
+) -> bytes:
+    """Encode a QC broadcast body (leader -> all replicas), no trailing signature.
+
+    Example::
+
+        body = encode_qc_broadcast("prepare", 3, "abcd", 2, [])
+    """
+    votes_str = ",".join(f"{v.voter}={v.signature_hex}" for v in votes)
+    return f"qc:{phase}:{view}:{block_hash_hex}:{f}:{votes_str}".encode()
+
+
+def decode_qc_broadcast(body: str) -> QcBroadcastMessage | None:
+    """Decode a QC broadcast message body.
+
+    Example::
+
+        msg = decode_qc_broadcast("qc:prepare:3:abcd:2:r0=ab,r2=cd,r4=ef")
+    """
+    parts = body.split(":", 5)
+    if len(parts) != 6 or parts[0] != "qc":
+        return None
+    phase = parts[1]
+    if phase not in _PHASES:
+        return None
+    try:
+        view = int(parts[2])
+        f_value = int(parts[4])
+    except ValueError:
+        return None
+    votes = _decode_votes(parts[5])
+    if votes is None:
+        return None
+    return QcBroadcastMessage(phase=phase, view=view, block_hash=parts[3], f=f_value, votes=votes)
+
+
+def encode_new_view(view: int, highest_qc: QuorumCert | None) -> bytes:
+    """Encode a NEW-VIEW (view-change) body, without the trailing signature.
+
+    Example::
+
+        body = encode_new_view(4, None)
+    """
+    qc_field = highest_qc.encode_inline() if highest_qc is not None else "none"
+    return f"new-view:{view}:{qc_field}".encode()
+
+
+def decode_new_view(body: str) -> NewViewMessage | None:
+    """Decode a NEW-VIEW message body.
+
+    Example::
+
+        msg = decode_new_view("new-view:4:none")
+    """
+    parts = body.split(":", 2)
+    if len(parts) != 3 or parts[0] != "new-view":
+        return None
+    try:
+        view = int(parts[1])
+    except ValueError:
+        return None
+    qc_field = parts[2]
+    highest_qc: QuorumCert | None = None
+    if qc_field != "none":
+        highest_qc = decode_inline_qc(qc_field)
+        if highest_qc is None:
+            return None
+    return NewViewMessage(view=view, highest_qc=highest_qc)
+
+
+def encode_result(view: int, block_hash_hex: str, accepts: int, total: int, value: str) -> bytes:
+    """Encode the trace/metrics-friendly commit summary line.
+
+    ``block_hash_hex`` -- not ``value`` -- is the safety-critical field: it
+    comes straight from the commit QC, so every honest replica reports the
+    same hash for a given view regardless of whether it happens to know the
+    plaintext ``value`` locally (e.g. a replica that only saw the commit QC,
+    not the original PREPARE, after being partitioned away).
+
+    Example::
+
+        body = encode_result(3, "abcd", 5, 7, "42")
+    """
+    return f"result:{view}:committed:{accepts}/{total}:{block_hash_hex}:{value}".encode()

--- a/packages/nest-plugins-reference/tests/test_hotstuff_plugin.py
+++ b/packages/nest-plugins-reference/tests/test_hotstuff_plugin.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the HotStuff coordination plugin, wire format, and agents."""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+import pytest
+from nest_core.scenarios_builtin.bft_hotstuff import (
+    MaliciousLeaderAgent,
+    ReplicaAgent,
+    instantiate_identity,
+)
+from nest_core.types import AgentId, Task
+from nest_plugins_reference.coordination import hotstuff_wire
+from nest_plugins_reference.coordination.hotstuff import HotStuff
+from nest_plugins_reference.coordination.hotstuff_wire import QuorumCert, VoteRecord
+from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+
+class _FakeAgentContext:
+    """Minimal stand-in for the simulator's AgentContext, for direct unit tests."""
+
+    def __init__(self, agent_id: AgentId, plugins: dict[str, Any]) -> None:
+        self.agent_id = agent_id
+        self.time = 0.0
+        self.rng = random.Random(1)
+        self.plugins = plugins
+        self.sent: list[tuple[AgentId, bytes]] = []
+
+    async def send(self, to: AgentId, payload: bytes) -> None:
+        self.sent.append((to, payload))
+
+    async def broadcast(self, payload: bytes) -> None:
+        self.sent.append((AgentId("*"), payload))
+
+    async def schedule(self, delay: float, payload: bytes) -> None:
+        self.sent.append((AgentId(f"self-after-{delay}"), payload))
+
+
+def _make_identities(replica_ids: list[AgentId]) -> dict[AgentId, DidKeyIdentity]:
+    plugins: dict[str, Any] = {"identity": DidKeyIdentity}
+    instantiate_identity(plugins, replica_ids)
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.pop("_agent_plugins")
+    return {rid: agent_plugins[rid]["identity"] for rid in replica_ids}
+
+
+# ---------------------------------------------------------------------------
+# Coordination-protocol conformance wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestHotStuffCoordinationWrapper:
+    @pytest.mark.asyncio
+    async def test_propose_participate_resolve_commit(self) -> None:
+        leader = HotStuff(AgentId("r0"), f=1)
+        replica1 = HotStuff(AgentId("r1"), f=1)
+        replica2 = HotStuff(AgentId("r2"), f=1)
+
+        task = Task(id="t1", description="agree on a value")
+        rnd = await leader.propose(task)
+
+        await leader.participate(rnd)
+        await replica1.participate(rnd)
+        await replica2.participate(rnd)
+
+        outcome = await leader.resolve(rnd)
+        assert outcome.task.id == "t1"
+        assert outcome.winner == AgentId("r0")
+        await leader.commit(outcome)
+
+    @pytest.mark.asyncio
+    async def test_resolve_below_quorum_has_no_winner(self) -> None:
+        leader = HotStuff(AgentId("r0"), f=2)
+        task = Task(id="t1", description="agree")
+        rnd = await leader.propose(task)
+        await leader.participate(rnd)
+
+        outcome = await leader.resolve(rnd)
+        assert outcome.winner is None
+
+
+# ---------------------------------------------------------------------------
+# Wire format: round-trip and malformed-input handling
+# ---------------------------------------------------------------------------
+
+
+class TestHotStuffWireFormat:
+    def test_vote_round_trip(self) -> None:
+        h = hotstuff_wire.block_hash(3, "42")
+        body = hotstuff_wire.encode_vote("prepare", 3, h)
+        msg = hotstuff_wire.decode_vote(body.decode())
+        assert msg is not None
+        assert msg.phase == "prepare"
+        assert msg.view == 3
+        assert msg.block_hash == h
+
+    def test_prepare_round_trip_no_qc(self) -> None:
+        body = hotstuff_wire.encode_prepare(1, "42", None)
+        msg = hotstuff_wire.decode_prepare(body.decode())
+        assert msg is not None
+        assert msg.view == 1
+        assert msg.value == "42"
+        assert msg.justify_qc is None
+
+    def test_prepare_round_trip_with_inline_qc(self) -> None:
+        qc = QuorumCert(
+            phase="prepare",
+            view=1,
+            block_hash="abcd",
+            votes=(VoteRecord(voter="r0", signature_hex="a1b2"),),
+        )
+        body = hotstuff_wire.encode_prepare(2, "99", qc)
+        msg = hotstuff_wire.decode_prepare(body.decode())
+        assert msg is not None
+        assert msg.justify_qc is not None
+        assert msg.justify_qc.view == 1
+        assert msg.justify_qc.votes == (VoteRecord(voter="r0", signature_hex="a1b2"),)
+
+    def test_qc_broadcast_round_trip(self) -> None:
+        votes = [VoteRecord(voter=f"r{i}", signature_hex=f"sig{i}") for i in range(3)]
+        body = hotstuff_wire.encode_qc_broadcast("commit", 4, "deadbeef", 1, votes)
+        msg = hotstuff_wire.decode_qc_broadcast(body.decode())
+        assert msg is not None
+        assert msg.phase == "commit"
+        assert msg.f == 1
+        assert set(msg.votes) == set(votes)
+
+    def test_new_view_round_trip(self) -> None:
+        body = hotstuff_wire.encode_new_view(5, None)
+        msg = hotstuff_wire.decode_new_view(body.decode())
+        assert msg is not None
+        assert msg.view == 5
+        assert msg.highest_qc is None
+
+    def test_signature_split_round_trip(self) -> None:
+        wire = hotstuff_wire.with_signature(b"vote:prepare:1:abcd", "a1b2c3")
+        body, sig = hotstuff_wire.split_signature(wire.decode())
+        assert body == "vote:prepare:1:abcd"
+        assert sig == bytes.fromhex("a1b2c3")
+
+    def test_signature_split_missing_suffix(self) -> None:
+        body, sig = hotstuff_wire.split_signature("vote:prepare:1:abcd")
+        assert body == "vote:prepare:1:abcd"
+        assert sig is None
+
+    @pytest.mark.parametrize(
+        "garbage",
+        [
+            "",
+            "not-a-hotstuff-message",
+            "prepare:notanint:abcd:42:none",
+            "prepare:1:abcd:42",
+            "vote:prepare:notanint:abcd",
+            "vote:bogus-phase:1:abcd",
+            "qc:prepare:1:abcd:notanint:r0=ab",
+            "qc:prepare:1:abcd:1:r0",
+            "new-view:notanint:none",
+        ],
+    )
+    def test_decoders_never_raise_on_malformed_input(self, garbage: str) -> None:
+        assert hotstuff_wire.decode_prepare(garbage) is None
+        assert hotstuff_wire.decode_vote(garbage) is None
+        assert hotstuff_wire.decode_qc_broadcast(garbage) is None
+        assert hotstuff_wire.decode_new_view(garbage) is None
+
+
+# ---------------------------------------------------------------------------
+# ReplicaAgent: QC formation, idempotency, view-change
+# ---------------------------------------------------------------------------
+
+
+class TestReplicaAgentQcFormation:
+    @pytest.mark.asyncio
+    async def test_leader_forms_prepare_qc_at_threshold_not_before(self) -> None:
+        replica_ids = [AgentId(f"replica-{i}") for i in range(4)]  # f=1, quorum=3
+        identities = _make_identities(replica_ids)
+        leader_id = replica_ids[0]  # leader_for_view(0)
+        leader = ReplicaAgent(leader_id, replica_ids, f=1, view_timeout_ticks=1000)
+        ctx = _FakeAgentContext(leader_id, {"identity": identities[leader_id]})
+
+        await leader.on_start(ctx)
+        prepare_wire = next(payload for to, payload in ctx.sent if to == leader_id)
+        body, _sig = hotstuff_wire.split_signature(prepare_wire.decode())
+        prepare = hotstuff_wire.decode_prepare(body)
+        assert prepare is not None
+
+        def qc_count() -> int:
+            return sum(1 for _to, p in ctx.sent if p.decode().startswith("qc:prepare:"))
+
+        for i in range(2):
+            voter = replica_ids[i + 1]
+            vote_body = hotstuff_wire.encode_vote("prepare", 0, prepare.block_hash)
+            sig_hex = identities[voter].sign(vote_body).value.hex()
+            wire = hotstuff_wire.with_signature(vote_body, sig_hex)
+            await leader.on_message(ctx, voter, wire)
+
+        assert qc_count() == 0, "QC must not form below the 2f+1 threshold"
+
+        voter = replica_ids[3]
+        vote_body = hotstuff_wire.encode_vote("prepare", 0, prepare.block_hash)
+        sig_hex = identities[voter].sign(vote_body).value.hex()
+        wire = hotstuff_wire.with_signature(vote_body, sig_hex)
+        await leader.on_message(ctx, voter, wire)
+
+        count_at_threshold = qc_count()
+        assert count_at_threshold == len(replica_ids), "QC must form exactly at the 2f+1 threshold"
+
+        # A duplicate/late vote must not form a second QC (one broadcast per recipient, not two).
+        await leader.on_message(ctx, voter, wire)
+        assert qc_count() == count_at_threshold, "Re-delivering a vote must not double-form a QC"
+
+    @pytest.mark.asyncio
+    async def test_leader_rejects_unsigned_vote(self) -> None:
+        replica_ids = [AgentId(f"replica-{i}") for i in range(4)]
+        identities = _make_identities(replica_ids)
+        leader_id = replica_ids[0]
+        leader = ReplicaAgent(leader_id, replica_ids, f=1, view_timeout_ticks=1000)
+        ctx = _FakeAgentContext(leader_id, {"identity": identities[leader_id]})
+        await leader.on_start(ctx)
+
+        unsigned = hotstuff_wire.encode_vote("prepare", 0, hotstuff_wire.block_hash(0, "1"))
+        await leader.on_message(ctx, replica_ids[1], unsigned)
+
+        assert not any(p.decode().startswith("qc:") for _to, p in ctx.sent)
+
+    @pytest.mark.asyncio
+    async def test_garbled_payload_is_silently_dropped(self) -> None:
+        replica_ids = [AgentId(f"replica-{i}") for i in range(4)]
+        identities = _make_identities(replica_ids)
+        leader_id = replica_ids[0]
+        leader = ReplicaAgent(leader_id, replica_ids, f=1, view_timeout_ticks=1000)
+        ctx = _FakeAgentContext(leader_id, {"identity": identities[leader_id]})
+
+        garbage = bytes(b ^ 0xFF for b in b"prepare:0:abcd:42:none|sig:deadbeef")
+        await leader.on_message(ctx, replica_ids[1], garbage)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# MaliciousLeaderAgent: equivocation
+# ---------------------------------------------------------------------------
+
+
+class TestMaliciousLeaderEquivocates:
+    @pytest.mark.asyncio
+    async def test_sends_two_distinct_proposals_to_disjoint_groups(self) -> None:
+        replica_ids = [AgentId(f"replica-{i}") for i in range(4)]
+        identities = _make_identities(replica_ids)
+        leader_id = replica_ids[0]
+        leader = MaliciousLeaderAgent(leader_id, replica_ids, f=1, view_timeout_ticks=1000)
+        ctx = _FakeAgentContext(leader_id, {"identity": identities[leader_id]})
+
+        await leader.on_start(ctx)
+
+        prepares = [
+            hotstuff_wire.decode_prepare(hotstuff_wire.split_signature(p.decode())[0])
+            for _to, p in ctx.sent
+            if p.decode().startswith("prepare:")
+        ]
+        block_hashes = {p.block_hash for p in prepares if p is not None}
+        assert len(block_hashes) == 2, "the malicious leader must equivocate on its own turn"

--- a/packages/nest-plugins-reference/tests/test_hotstuff_properties.py
+++ b/packages/nest-plugins-reference/tests/test_hotstuff_properties.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Property-based safety tests for the HotStuff BFT coordination plugin.
+
+Safety (no two honest replicas commit conflicting values for the same
+view) must hold under any randomized partition schedule or randomized
+malicious-leader placement -- liveness is explicitly not asserted here,
+since an adversarial partition or enough equivocation can legitimately
+stall progress without breaking safety.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.scenarios_builtin.bft_hotstuff import (
+    MaliciousLeaderAgent,
+    ReplicaAgent,
+    instantiate_identity,
+)
+from nest_core.sim.simulator import Simulator
+from nest_core.types import AgentId
+from nest_core.validators import validate_events
+from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+_N = 7
+_F = 2
+
+
+def _load_events(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    with path.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
+    return events
+
+
+def _no_conflicting_commits_detail(events: list[dict[str, Any]]) -> str:
+    results = validate_events(events, "bft_hotstuff")
+    safety = next(r for r in results if r.name == "bft_no_conflicting_commits")
+    return safety.detail
+
+
+class TestSafetyUnderRandomPartitions:
+    @settings(max_examples=15, deadline=None)
+    @given(
+        seed=st.integers(min_value=0, max_value=10000),
+        split=st.integers(min_value=1, max_value=_N - 1),
+        drop_rate=st.floats(min_value=0.0, max_value=0.3, allow_nan=False, allow_infinity=False),
+    )
+    @pytest.mark.asyncio
+    async def test_safety_holds_under_random_partition_and_drop_rate(
+        self, seed: int, split: int, drop_rate: float
+    ) -> None:
+        """No conflicting commits, however the network is partitioned or lossy."""
+        replica_ids = [AgentId(f"replica-{i}") for i in range(_N)]
+        groups = [
+            [str(r) for r in replica_ids[:split]],
+            [str(r) for r in replica_ids[split:]],
+        ]
+
+        plugins: dict[str, Any] = {"identity": DidKeyIdentity}
+        instantiate_identity(plugins, replica_ids)
+        agent_plugins = plugins.pop("_agent_plugins")
+
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as fh:
+            trace_path = Path(fh.name)
+        try:
+            sim = Simulator(
+                seed=seed,
+                trace_path=trace_path,
+                message_drop_rate=drop_rate,
+                partition_groups=groups,
+                plugins=plugins,
+            )
+            for rid in replica_ids:
+                sim.add_agent(rid, ReplicaAgent(rid, replica_ids, f=_F, view_timeout_ticks=40))
+            for rid, overrides in agent_plugins.items():
+                sim.set_agent_plugins(rid, overrides)
+
+            await sim.run(max_ticks=3000)
+            events = _load_events(trace_path)
+        finally:
+            trace_path.unlink(missing_ok=True)
+
+        detail = _no_conflicting_commits_detail(events)
+        assert "conflicting commits" not in detail, detail
+
+
+class TestSafetyUnderRandomByzantineLeaders:
+    @settings(max_examples=15, deadline=None)
+    @given(
+        seed=st.integers(min_value=0, max_value=10000),
+        malicious_indices=st.lists(
+            st.integers(min_value=0, max_value=_N - 1), unique=True, max_size=2
+        ),
+        byzantine_fraction=st.floats(
+            min_value=0.0, max_value=0.3, allow_nan=False, allow_infinity=False
+        ),
+    )
+    @pytest.mark.asyncio
+    async def test_safety_holds_despite_equivocation_and_byzantine_noise(
+        self, seed: int, malicious_indices: list[int], byzantine_fraction: float
+    ) -> None:
+        """No conflicting commits, however leaders equivocate or noise is injected.
+
+        Equivocation IS expected to be detected by ``bft_no_equivocation`` when
+        a malicious leader actually gets a turn -- that validator is not
+        asserted here. The property under test is narrower: safety survives
+        equivocation, it does not prevent it.
+        """
+        replica_ids = [AgentId(f"replica-{i}") for i in range(_N)]
+        malicious = {str(replica_ids[i]) for i in malicious_indices}
+
+        plugins: dict[str, Any] = {"identity": DidKeyIdentity}
+        instantiate_identity(plugins, replica_ids)
+        agent_plugins = plugins.pop("_agent_plugins")
+
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as fh:
+            trace_path = Path(fh.name)
+        try:
+            sim = Simulator(
+                seed=seed,
+                trace_path=trace_path,
+                byzantine_fraction=byzantine_fraction,
+                plugins=plugins,
+            )
+            for rid in replica_ids:
+                cls = MaliciousLeaderAgent if str(rid) in malicious else ReplicaAgent
+                sim.add_agent(rid, cls(rid, replica_ids, f=_F, view_timeout_ticks=40))
+            for rid, overrides in agent_plugins.items():
+                sim.set_agent_plugins(rid, overrides)
+
+            await sim.run(max_ticks=3000)
+            events = _load_events(trace_path)
+        finally:
+            trace_path.unlink(missing_ok=True)
+
+        detail = _no_conflicting_commits_detail(events)
+        assert "conflicting commits" not in detail, detail

--- a/scenarios/bft_consensus_byzantine.yaml
+++ b/scenarios/bft_consensus_byzantine.yaml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# BFT consensus scenario: 7-replica HotStuff with 2 deliberately-equivocating
+# leaders plus generic transport-level byzantine noise.
+name: bft_consensus_byzantine
+description: "7 HotStuff replicas (f=2); 2 equivocate when leader, plus 28% byzantine noise."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 7
+  brain: state-machine
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: hotstuff
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: bft_hotstuff
+  config:
+    f: 2
+    view_timeout_ticks: 40
+    malicious_agents:
+      - "replica-1"
+      - "replica-4"
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.28
+
+duration: "ticks: 4000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/bft_consensus_byzantine.jsonl

--- a/scenarios/bft_consensus_partition.yaml
+++ b/scenarios/bft_consensus_partition.yaml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# BFT consensus scenario: 7-replica HotStuff under a healing network partition.
+name: bft_consensus_partition
+description: "7 HotStuff replicas (f=2); a 4/3 partition for the first 30% of the run, then heals."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 7
+  brain: state-machine
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: hotstuff
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: bft_hotstuff
+  config:
+    f: 2
+    view_timeout_ticks: 40
+
+failures:
+  message_drop: 0.0
+  network_partition:
+    groups:
+      - ["replica-0", "replica-1", "replica-2", "replica-3"]
+      - ["replica-4", "replica-5", "replica-6"]
+  partition_heal_at_tick: 1800
+
+duration: "ticks: 6000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/bft_consensus_partition.jsonl


### PR DESCRIPTION
[Hackathon] swamx: Partition-tolerant BFT coordination with HotStuff view-change

Implements problem #10 (docs/hackathon/problems/10-coordination-bft-partition-tolerant.md):
a linear 2-phase HotStuff coordination plugin (PREPARE -> COMMIT, 2f+1 quorums
out of 3f+1) with round-robin leader rotation, timeout-driven view-change, and
the standard locked-QC safety rule across views. contract_net has no quorum
concept at all, so this is the first coordination plugin that can actually
survive a leader failure or a lying leader without losing agreement.

- nest_plugins_reference.coordination.hotstuff{,_wire}: Coordination-protocol
  conformance wrapper + wire encode/decode (signed PREPARE/VOTE/QC/NEW-VIEW)
- nest_core.scenarios_builtin.bft_hotstuff: the real networked protocol
  (ReplicaAgent) plus a MaliciousLeaderAgent that equivocates on its own
  leader turns, for the byzantine scenario
- nest_core.sim.simulator: add partition_heal_at_tick so a configured network
  partition can heal mid-run (additive, default None, no behavior change for
  existing scenarios)
- nest_core.validators: four adversarial validators (conflicting commits,
  equivocation, forged quorum, stuck view
- scenarios/bft_consensus_{partition,byzantine}.yaml: 7 replicas (f=2), a
  4/3 partition that heals at 30%, and 2 deliberately-equivocating leaders
  plus 28% byzantine transport noise

Unit tests, two Hypothesis property suites (randomized partition schedules,
randomized malicious-leader placement), and end-to-end scenario tests all
pass; the partition scenario is byte-identical across reruns for seeds
42/7/1337/0xdeadbeef. make ci-local is green.

Note: Written using Claude AI.