### PR TITLE
[Hackathon] provenance-engineer: content-addressed datafacts with provenance chains & signed freshness proofs

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -37,6 +37,9 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
     ("datafacts", "datafacts_v1"): f"{_REF}.datafacts.datafacts_v1:DataFactsV1",
+    ("datafacts", "content_addressed"): (
+        f"{_REF}.datafacts.content_addressed:ContentAddressedDataFacts"
+    ),
 }
 
 

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -97,3 +97,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("receipt_reputation", receipt_reputation_factory)
+    elif name == "provenance_supply_chain":
+        from nest_core.scenarios_builtin.provenance_supply_chain import (
+            provenance_supply_chain_factory,
+        )
+
+        register_scenario("provenance_supply_chain", provenance_supply_chain_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain.py
@@ -1,0 +1,475 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Content-addressed supply-chain provenance scenario with byzantine forgers.
+
+Persona: ``provenance-engineer``. This is the supply-chain scenario re-cast as a
+*provenance* test. Four honest hops (supplier -> manufacturer -> distributor ->
+retailer) each publish a content-addressed dataset derived from the previous
+hop's, building an end-to-end provenance DAG that the retailer verifies. A
+fraction of byzantine agents attempt the three attacks the
+``content_addressed`` plugin is built to defeat:
+
+* **substitution** — publish *different* content while trying to occupy an
+  existing dataset's address;
+* **stale-freshness** — claim a dataset is current without re-issuing a signed
+  freshness proof;
+* **broken provenance** — publish a derived dataset whose ancestry references a
+  hash nobody ever published.
+
+Every publish, freshness attestation, verification, and attack is emitted into
+the trace in a ``:``-delimited line protocol that the ``provenance_supply_chain``
+validators parse (see
+``nest_core.validators.validate_datafacts_*``). Behaviour is *capability-gated*
+via ``hasattr``: run the same scenario with ``datafacts: datafacts_v1`` and the
+hops fall back to name-addressed publishes with no signed proofs and no
+provenance checks — the validators then fail, which is the honest demonstration
+that ``datafacts_v1`` cannot catch any of the three attacks. Under
+``datafacts: content_addressed`` the same scenario passes.
+
+Trace line protocol (carried in message bodies to the auditor):
+
+* ``publish:<agent>:<url>:<parents>:<tick>`` — a publish; ``parents`` is a
+  ``|``-joined list of parent URLs or ``-``.
+* ``freshness:<agent>:<url>:<proof_tick>:<observed_tick>:<verdict>`` — a
+  freshness attestation; ``proof_tick`` is the tick the proof was signed at (or
+  ``none`` for an unsigned/keyless plugin); ``verdict`` is ``ok`` (current) or
+  ``stale`` (a deliberately non-current claim).
+* ``verify:<agent>:<url>:<verdict>`` — the retailer's end-to-end provenance
+  check; ``ok``, ``broken``, or ``unverifiable`` (plugin can't verify).
+* ``attack:substitution:<agent>:<url1>:<url2>`` — two publishes of *different*
+  content; ``url1 == url2`` means substitution succeeded.
+* ``attack:broken:<agent>:<ghost_url>:<verdict>`` — a derived publish anchored
+  to a never-published parent; ``rejected`` or ``accepted``.
+
+Example::
+
+    agents = provenance_supply_chain_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
+
+
+def _datafacts_of(ctx: AgentContext) -> Any:
+    """Return the per-agent datafacts instance from the agent's context.
+
+    Example::
+
+        df = _datafacts_of(ctx)
+    """
+    return ctx.plugins.get("datafacts")
+
+
+def _is_content_addressed(df: Any) -> bool:
+    """Return whether ``df`` exposes the content-addressed capability surface.
+
+    Example::
+
+        ok = _is_content_addressed(ctx.plugins.get("datafacts"))
+    """
+    return hasattr(df, "content_id") and hasattr(df, "issue_freshness_proof")
+
+
+def _tok(url: str) -> str:
+    """Render a DataFacts URL as a colon-free trace token (scheme stripped).
+
+    The ``:``-delimited line protocol cannot carry the ``df://`` scheme (it
+    contains a colon), so trace tokens use the bare content id — ``sha256-<hex>``
+    for the content-addressed plugin, or the bare name for ``datafacts_v1``. The
+    presence or absence of the ``sha256-`` prefix is exactly what the
+    content-addressing validator keys on.
+
+    Example::
+
+        assert _tok("df://sha256-abc") == "sha256-abc"
+    """
+    return url.removeprefix("df://")
+
+
+def _parents_token(parents: list[DataFactsUrl]) -> str:
+    """Render a parent-URL list as ``|``-joined colon-free tokens (``-`` when empty).
+
+    Example::
+
+        token = _parents_token([DataFactsUrl("df://sha256-a")])  # "sha256-a"
+    """
+    return "|".join(_tok(p) for p in parents) if parents else "-"
+
+
+async def _publish(
+    df: Any,
+    ctx: AgentContext,
+    name: str,
+    parents: list[DataFactsUrl],
+) -> DataFactsUrl:
+    """Publish a dataset at the current tick and return its URL.
+
+    Sets the plugin clock to ``ctx.time`` first so signed proofs bind to the
+    simulator's logical tick (Tier 1 determinism).
+
+    Example::
+
+        url = await _publish(df, ctx, "good-0", [])
+    """
+    if hasattr(df, "set_clock"):
+        df.set_clock(ctx.time)
+    meta = DatasetMetadata(name=name, owner=ctx.agent_id, parents=list(parents))
+    return await df.publish(meta)
+
+
+class ChainHop(StateMachineAgent):
+    """An honest supply-chain hop: publishes a derived dataset and re-attests it.
+
+    The first hop (``is_origin``) publishes a root dataset on start and forwards
+    its URL downstream. Each subsequent hop publishes a dataset whose ``parents``
+    is the predecessor's URL, extending the provenance DAG, and forwards. On every
+    auditor ``tick:`` pulse a hop re-issues a *current* signed freshness proof for
+    its own dataset, so honest freshness is always backed by a proof at the
+    observed tick. The final hop (``is_terminal``) additionally verifies the full
+    provenance chain end-to-end and emits a ``verify:`` line.
+
+    Example::
+
+        hop = ChainHop(AgentId("supplier-0"), AgentId("manufacturer-0"),
+                       AgentId("auditor-0"), is_origin=True)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        next_stage: AgentId | None,
+        auditor: AgentId,
+        is_origin: bool = False,
+        is_terminal: bool = False,
+    ) -> None:
+        self._id = agent_id
+        self._next = next_stage
+        self._auditor = auditor
+        self._is_origin = is_origin
+        self._is_terminal = is_terminal
+        self._url: DataFactsUrl | None = None
+
+    async def _emit_publish(self, ctx: AgentContext, parents: list[DataFactsUrl]) -> None:
+        df = _datafacts_of(ctx)
+        if df is None:  # pragma: no cover - scenario always configures datafacts
+            return
+        url = await _publish(df, ctx, f"dataset-{self._id}", parents)
+        self._url = url
+        await ctx.send(
+            self._auditor,
+            f"publish:{self._id}:{_tok(url)}:{_parents_token(parents)}:{ctx.time}".encode(),
+        )
+        await self._emit_freshness(ctx)
+        if self._next is not None:
+            await ctx.send(self._next, f"derive:{url}".encode())
+        if self._is_terminal:
+            await self._emit_verify(ctx, url)
+
+    async def _emit_freshness(self, ctx: AgentContext) -> None:
+        df = _datafacts_of(ctx)
+        if df is None or self._url is None:
+            return
+        if _is_content_addressed(df):
+            df.set_clock(ctx.time)
+            proof = df.issue_freshness_proof(self._url)
+            proof_tick: str = str(proof.tick)
+        else:
+            proof_tick = "none"
+        await ctx.send(
+            self._auditor,
+            f"freshness:{self._id}:{_tok(self._url)}:{proof_tick}:{ctx.time}:ok".encode(),
+        )
+
+    async def _emit_verify(self, ctx: AgentContext, url: DataFactsUrl) -> None:
+        df = _datafacts_of(ctx)
+        if df is None:
+            return
+        if hasattr(df, "verify_provenance"):
+            verdict = "ok" if df.verify_provenance(url) else "broken"
+        else:
+            verdict = "unverifiable"
+        await ctx.send(self._auditor, f"verify:{self._id}:{_tok(url)}:{verdict}".encode())
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Origin hop seeds the chain; other hops wait for an upstream URL.
+
+        Example::
+
+            await hop.on_start(ctx)
+        """
+        if self._is_origin:
+            await self._emit_publish(ctx, parents=[])
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Publish on an upstream ``derive:`` URL; re-attest on auditor ``tick:``.
+
+        Example::
+
+            await hop.on_message(ctx, AgentId("supplier-0"), b"derive:df://sha256-a")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if msg.startswith("derive:"):
+            parent = DataFactsUrl(msg.split(":", 1)[1])
+            await self._emit_publish(ctx, parents=[parent])
+        elif msg.startswith("tick:"):
+            await self._emit_freshness(ctx)
+
+
+class ProvenanceByzantine(StateMachineAgent):
+    """A byzantine agent that attempts substitution, stale-freshness, and forgery.
+
+    Each attack is self-contained and deterministic. Against ``content_addressed``
+    all three are deflected (substitution yields a *different* address, stale
+    claims carry a non-current proof tick, broken-provenance publishes raise); the
+    emitted lines record the deflection so the validators can confirm it. Against
+    ``datafacts_v1`` the same attacks succeed, and the validators fail — which is
+    the point.
+
+    Example::
+
+        byz = ProvenanceByzantine(AgentId("byz-0"), AgentId("auditor-0"))
+    """
+
+    def __init__(self, agent_id: AgentId, auditor: AgentId) -> None:
+        self._id = agent_id
+        self._auditor = auditor
+        self._url: DataFactsUrl | None = None
+        self._published_tick: float = 0.0
+
+    async def _attack_substitution(self, ctx: AgentContext) -> None:
+        df = _datafacts_of(ctx)
+        if df is None:
+            return
+        if hasattr(df, "set_clock"):
+            df.set_clock(ctx.time)
+        # Publish two datasets that share a *name* but differ in content. A
+        # content-addressed store gives them different URLs (substitution
+        # impossible); a name-addressed store collapses them (substitution).
+        url1 = await df.publish(DatasetMetadata(name=f"victim-{self._id}", owner=self._id))
+        url2 = await df.publish(
+            DatasetMetadata(name=f"victim-{self._id}", owner=self._id, description="tampered")
+        )
+        self._url = url1
+        self._published_tick = ctx.time
+        await ctx.send(
+            self._auditor,
+            f"publish:{self._id}:{_tok(url1)}:-:{ctx.time}".encode(),
+        )
+        await ctx.send(
+            self._auditor,
+            f"attack:substitution:{self._id}:{_tok(url1)}:{_tok(url2)}".encode(),
+        )
+
+    async def _attack_stale(self, ctx: AgentContext) -> None:
+        if self._url is None:
+            return
+        df = _datafacts_of(ctx)
+        if df is None:
+            return
+        # Claim freshness at the *current* observed tick while pointing at the
+        # ORIGINAL proof tick — i.e. no re-issued signature. Content-addressed:
+        # proof_tick < observed, detectable. Name-addressed: no proof at all.
+        if _is_content_addressed(df):
+            proof_tick: str = str(self._published_tick)
+        else:
+            proof_tick = "none"
+        await ctx.send(
+            self._auditor,
+            f"freshness:{self._id}:{_tok(self._url)}:{proof_tick}:{ctx.time}:stale".encode(),
+        )
+
+    async def _attack_broken(self, ctx: AgentContext) -> None:
+        df = _datafacts_of(ctx)
+        if df is None:
+            return
+        if hasattr(df, "set_clock"):
+            df.set_clock(ctx.time)
+        ghost = DataFactsUrl("df://sha256-" + "0" * 64)
+        meta = DatasetMetadata(name=f"forged-{self._id}", owner=self._id, parents=[ghost])
+        verdict = "accepted"
+        try:
+            url = await df.publish(meta)
+        except Exception:  # noqa: BLE001 - any rejection (BrokenProvenanceError) deflects the attack
+            verdict = "rejected"
+        else:
+            # The publish was accepted; record the orphan so the validator sees it.
+            await ctx.send(
+                self._auditor,
+                f"publish:{self._id}:{_tok(url)}:{_tok(ghost)}:{ctx.time}".encode(),
+            )
+        await ctx.send(
+            self._auditor,
+            f"attack:broken:{self._id}:{_tok(ghost)}:{verdict}".encode(),
+        )
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Launch the substitution attack and publish the byzantine's dataset.
+
+        Example::
+
+            await byz.on_start(ctx)
+        """
+        await self._attack_substitution(ctx)
+        await self._attack_broken(ctx)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """On each auditor ``tick:`` pulse, attempt the stale-freshness attack.
+
+        Example::
+
+            await byz.on_message(ctx, AgentId("auditor-0"), b"tick:2")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if msg.startswith("tick:"):
+            await self._attack_stale(ctx)
+
+
+class AuditorAgent(StateMachineAgent):
+    """Drives rounds; the trace is the audit log.
+
+    Pulses every hop and byzantine agent once per round (``tick:`` messages) at a
+    strictly increasing logical tick, so the observed tick the validators anchor
+    freshness to advances deterministically. All verification happens offline in
+    the ``provenance_supply_chain`` validators against the emitted trace.
+
+    Example::
+
+        auditor = AuditorAgent(AgentId("auditor-0"), members, rounds=4)
+    """
+
+    def __init__(self, agent_id: AgentId, members: list[AgentId], rounds: int = 4) -> None:
+        self._id = agent_id
+        self._members = members
+        self._rounds = rounds
+        self._round = 1
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Schedule the first round pulse one tick ahead so the clock advances.
+
+        Example::
+
+            await auditor.on_start(ctx)
+        """
+        await self._schedule_next(ctx)
+
+    async def _schedule_next(self, ctx: AgentContext) -> None:
+        if self._round >= self._rounds:
+            return
+        await ctx.schedule(1.0, b"pulse:")
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Advance one round on each self-scheduled ``pulse:`` tick.
+
+        Example::
+
+            await auditor.on_message(ctx, AgentId("auditor-0"), b"pulse:")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("pulse:"):
+            return
+        self._round += 1
+        for member in self._members:
+            await ctx.send(member, f"tick:{self._round}".encode())
+        await self._schedule_next(ctx)
+
+
+def _provision_datafacts(plugins: dict[str, Any], hop_ids: list[AgentId]) -> None:
+    """Give each agent a datafacts instance, sharing one content-addressed store.
+
+    Mirrors ``identity_rotation``'s identity provisioning: resolve the class at
+    ``plugins["datafacts"]``, build per-agent instances over a *shared* store
+    (so substitution resistance spans the whole swarm), each signing with its own
+    deterministic ``did_key`` identity, and stash them under
+    ``plugins["_agent_plugins"]``. Capability-gated: a plugin whose constructor
+    does not accept ``store`` (e.g. ``datafacts_v1``) is instantiated once and
+    shared by reference, so the scenario still runs and the validators expose its
+    weaker guarantees.
+
+    Example::
+
+        _provision_datafacts(plugins, [AgentId("supplier-0"), AgentId("byz-0")])
+    """
+    df_cls = plugins.get("datafacts")
+    if not isinstance(df_cls, type):
+        return
+
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+    params = inspect.signature(df_cls.__init__).parameters
+
+    if "store" in params and "identity" in params:
+        from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+        shared_store: dict[Any, Any] = {}
+        identities = {
+            aid: DidKeyIdentity(aid, seed=b"provenance:" + str(aid).encode()) for aid in hop_ids
+        }
+        for aid, ident in identities.items():
+            for peer_id, peer_ident in identities.items():
+                if peer_id != aid:
+                    ident.register_peer(peer_id, peer_ident.public_key)
+        for aid in hop_ids:
+            inst = df_cls(identity=identities[aid], store=shared_store)
+            agent_plugins.setdefault(aid, {})["datafacts"] = inst
+    else:
+        shared = df_cls()
+        for aid in hop_ids:
+            agent_plugins.setdefault(aid, {})["datafacts"] = shared
+
+    plugins.pop("datafacts", None)
+
+
+def provenance_supply_chain_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create the honest 4-hop chain, byzantine attackers, and one auditor.
+
+    The byzantine count comes from ``failures.byzantine_agents`` (default 0.20)
+    or an explicit ``byzantine`` role. Every agent shares one content-addressed
+    store provisioned from the configured datafacts plugin, so swapping
+    ``datafacts: datafacts_v1`` in the YAML genuinely changes behaviour and the
+    validators can tell the plugins apart.
+
+    Example::
+
+        agents = provenance_supply_chain_factory(config, plugins)
+    """
+    task_config = config.task.config
+    rounds = int(task_config.get("rounds", 4))
+    byzantine_fraction = config.failures.byzantine_agents or task_config.get(
+        "byzantine_fraction", 0.20
+    )
+
+    byzantine_count = max(1, int(4 * byzantine_fraction))
+    if config.agents.roles:
+        for role in config.agents.roles:
+            if role.name == "byzantine":
+                byzantine_count = role.count
+
+    auditor_id = AgentId("auditor-0")
+    supplier_id = AgentId("supplier-0")
+    manufacturer_id = AgentId("manufacturer-0")
+    distributor_id = AgentId("distributor-0")
+    retailer_id = AgentId("retailer-0")
+    byzantine_ids = [AgentId(f"byz-{i}") for i in range(byzantine_count)]
+
+    chain_ids = [supplier_id, manufacturer_id, distributor_id, retailer_id]
+    members = chain_ids + byzantine_ids
+    _provision_datafacts(plugins, members)
+
+    agents: dict[AgentId, StateMachineAgent] = {
+        supplier_id: ChainHop(supplier_id, manufacturer_id, auditor_id, is_origin=True),
+        manufacturer_id: ChainHop(manufacturer_id, distributor_id, auditor_id),
+        distributor_id: ChainHop(distributor_id, retailer_id, auditor_id),
+        retailer_id: ChainHop(retailer_id, None, auditor_id, is_terminal=True),
+    }
+    for aid in byzantine_ids:
+        agents[aid] = ProvenanceByzantine(aid, auditor_id)
+
+    agents[auditor_id] = AuditorAgent(auditor_id, members=members, rounds=rounds)
+    return agents

--- a/packages/nest-core/nest_core/types.py
+++ b/packages/nest-core/nest_core/types.py
@@ -515,9 +515,21 @@ class Proof(BaseModel):
 class DatasetMetadata(BaseModel):
     """Metadata about a dataset published via DataFacts.
 
+    ``parents`` records the content-addressed provenance DAG: the hashes of
+    every dataset this one was derived from. It defaults to an empty list, so
+    existing callers (e.g. ``datafacts_v1``) and the 12-layer reference
+    scenarios keep working unchanged. Content-addressed plugins such as
+    ``nest_plugins_reference.datafacts.content_addressed`` fold ``parents`` into
+    the dataset's content hash, making the provenance trail tamper-evident: a
+    forged or substituted ancestor changes every descendant's URL.
+
     Example::
 
-        meta = DatasetMetadata(name="weather-2024", owner=AgentId("a1"), schema_version="1.0")
+        raw = DatasetMetadata(name="weather-2024", owner=AgentId("a1"), schema_version="1.0")
+        derived = DatasetMetadata(
+            name="weather-clean", owner=AgentId("a2"),
+            parents=[DataFactsUrl("df://sha256-abc123")],
+        )
     """
 
     name: str
@@ -530,6 +542,7 @@ class DatasetMetadata(BaseModel):
     size_bytes: int | None = None
     checksum: str | None = None
     access_tier: str = "public"
+    parents: list[DataFactsUrl] = Field(default_factory=lambda: list[DataFactsUrl]())
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1835,6 +1835,179 @@ def validate_receipt_reputation_honest_confidence(
 
 
 # ---------------------------------------------------------------------------
+# DataFacts provenance validators (provenance_supply_chain scenario)
+# ---------------------------------------------------------------------------
+#
+# These parse the `:`-delimited line protocol emitted by
+# `nest_core.scenarios_builtin.provenance_supply_chain`. URL tokens are
+# scheme-stripped content ids (`sha256-<hex>` for the content-addressed plugin,
+# or a bare name for `datafacts_v1`), so they are colon-free and split cleanly.
+
+
+def _provenance_sends(events: list[dict[str, Any]], prefix: str) -> list[list[str]]:
+    """Return ``:``-split fields for every ``send`` whose body starts with ``prefix``.
+
+    Example::
+
+        rows = _provenance_sends(events, "publish:")
+    """
+    rows: list[list[str]] = []
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        body = _message_body(ev)
+        if body.startswith(prefix):
+            rows.append(body.split(":"))
+    return rows
+
+
+def validate_datafacts_content_addressing(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every dataset is addressed by its content hash, and substitution is impossible.
+
+    Catches the *substitution* attack: ``datafacts_v1`` addresses by
+    publisher-chosen name (``df://<name>``), so republishing different bytes under
+    the same name silently overwrites — the validator sees a non-``sha256-`` URL
+    and a substitution attempt landing at the *same* address. ``content_addressed``
+    derives the URL from the content, so different bytes get a different address;
+    the attack lands at a distinct URL and is deflected.
+
+    Example::
+
+        results = validate_datafacts_content_addressing(events)
+    """
+    violations: list[str] = []
+    publishes = 0
+    deflected = 0
+    for f in _provenance_sends(events, "publish:"):
+        if len(f) < 5:
+            continue
+        publishes += 1
+        agent, url = f[1], f[2]
+        if not url.startswith("sha256-"):
+            violations.append(f"{agent} published non-content-addressed url {url!r}")
+    for f in _provenance_sends(events, "attack:substitution:"):
+        if len(f) < 5:
+            continue
+        agent, url1, url2 = f[2], f[3], f[4]
+        if url1 == url2:
+            violations.append(f"{agent} substituted different content at same address {url1!r}")
+        else:
+            deflected += 1
+    if violations:
+        return [ValidationResult("datafacts_content_addressing", False, "; ".join(violations))]
+    detail = (
+        f"{publishes} publish(es) content-addressed; {deflected} substitution attempt(s) deflected"
+    )
+    return [ValidationResult("datafacts_content_addressing", True, detail)]
+
+
+def validate_datafacts_freshness_proofs(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every freshness claim is backed by a current signed proof; stale claims are detectable.
+
+    Catches the *stale-freshness* attack: ``datafacts_v1`` "proves" freshness with
+    a bare wall-clock comparison, so a publisher re-touching a timestamp without
+    re-publishing looks fresh (no proof tick at all — ``none``).
+    ``content_addressed`` requires a signature binding *(content-hash, tick,
+    signer)*, so an honest ``ok`` claim carries a proof minted at the observed
+    tick, and a stale claim's proof tick lags the observed tick and is caught.
+
+    Example::
+
+        results = validate_datafacts_freshness_proofs(events)
+    """
+    violations: list[str] = []
+    fresh_ok = 0
+    stale_detected = 0
+    for f in _provenance_sends(events, "freshness:"):
+        if len(f) < 6:
+            continue
+        agent, url, proof_tick, observed, verdict = f[1], f[2], f[3], f[4], f[5]
+        if verdict == "ok":
+            fresh_ok += 1
+            if proof_tick == "none":
+                violations.append(f"{agent} claimed freshness for {url} with no signed proof")
+            elif proof_tick != observed:
+                violations.append(
+                    f"{agent} claimed current freshness for {url} but proof tick "
+                    f"{proof_tick} != observed {observed}"
+                )
+        elif verdict == "stale":
+            if proof_tick != "none" and proof_tick == observed:
+                violations.append(
+                    f"{agent} stale claim for {url} is indistinguishable from current"
+                )
+            else:
+                stale_detected += 1
+    if violations:
+        return [ValidationResult("datafacts_freshness_proofs", False, "; ".join(violations))]
+    detail = (
+        f"{fresh_ok} fresh claim(s) backed by current signed proofs; "
+        f"{stale_detected} stale claim(s) detected"
+    )
+    return [ValidationResult("datafacts_freshness_proofs", True, detail)]
+
+
+def validate_datafacts_provenance_chain(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every derived dataset's ancestry resolves to published hashes; orphans are rejected.
+
+    Catches the *broken-provenance* attack: a derived dataset whose ``parents``
+    reference a hash nobody published. ``content_addressed`` folds parents into the
+    child hash and rejects a publish with a dangling parent (the attack is
+    ``rejected``); ``datafacts_v1`` ignores provenance entirely, so the orphan
+    publish lands (``accepted``) and dangles. Also confirms the retailer's
+    end-to-end verification of the honest chain succeeds.
+
+    Example::
+
+        results = validate_datafacts_provenance_chain(events)
+    """
+    violations: list[str] = []
+    published: set[str] = set()
+    chain_links = 0
+    for f in _provenance_sends(events, "publish:"):
+        if len(f) < 5:
+            continue
+        agent, url, parents_tok = f[1], f[2], f[3]
+        parents = [] if parents_tok == "-" else parents_tok.split("|")
+        for parent in parents:
+            chain_links += 1
+            if parent not in published:
+                violations.append(f"{agent}: dataset {url} references unpublished parent {parent}")
+        published.add(url)
+    rejected = 0
+    for f in _provenance_sends(events, "attack:broken:"):
+        if len(f) < 5:
+            continue
+        agent, ghost, verdict = f[2], f[3], f[4]
+        if verdict != "rejected":
+            violations.append(f"{agent}: broken-provenance publish accepted (ghost parent {ghost})")
+        else:
+            rejected += 1
+    verified = 0
+    for f in _provenance_sends(events, "verify:"):
+        if len(f) < 4:
+            continue
+        agent, url, verdict = f[1], f[2], f[3]
+        if verdict != "ok":
+            violations.append(f"{agent}: end-to-end provenance verification returned {verdict!r}")
+        else:
+            verified += 1
+    if violations:
+        return [ValidationResult("datafacts_provenance_chain", False, "; ".join(violations))]
+    detail = (
+        f"{chain_links} provenance link(s) anchored across {len(published)} dataset(s); "
+        f"{rejected} broken-provenance attempt(s) rejected; {verified} end-to-end verify(s) ok"
+    )
+    return [ValidationResult("datafacts_provenance_chain", True, detail)]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -1888,5 +2061,10 @@ VALIDATORS: dict[str, list[Any]] = {
     "receipt_reputation": [
         validate_receipt_reputation_ring_severed,
         validate_receipt_reputation_honest_confidence,
+    ],
+    "provenance_supply_chain": [
+        validate_datafacts_content_addressing,
+        validate_datafacts_freshness_proofs,
+        validate_datafacts_provenance_chain,
     ],
 }

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -754,6 +754,7 @@ class TestValidatorRegistry:
             "streaming_payments",
             "comms_versioning",
             "receipt_reputation",
+            "provenance_supply_chain",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/content_addressed.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/content_addressed.py
@@ -1,0 +1,415 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Content-addressed DataFacts plugin with provenance chains and signed freshness proofs.
+
+Persona: ``provenance-engineer``. This plugin replaces the default
+``datafacts_v1`` registry — which addresses datasets by *publisher-chosen name*
+(``df://<name>``), grants access to anyone, and "proves" freshness with a bare
+``time.time()`` comparison — with a design where **the address is the content**
+and **every freshness claim is a signature, not a timestamp**.
+
+Three classes of provenance attack that are silently undetectable under
+``datafacts_v1`` become *impossible by construction* or *cryptographically
+caught* here:
+
+* **Substitution** — republishing different bytes under an existing address.
+  Impossible: the URL is ``df://sha256-<hex>`` derived from the canonical
+  content, so different content is a different URL. You cannot overwrite.
+* **Stale-freshness** — claiming a dataset is current by re-touching a clock
+  without re-publishing. Caught: freshness is a :class:`FreshnessProof` signed
+  by the publisher's identity-layer key binding *(content-hash, tick, signer)*.
+  A publisher who issues no fresh signature has no valid proof.
+* **Broken provenance** — a derived dataset whose ancestry references a hash
+  that was never published. Caught: ``parents`` are folded into the child's
+  content hash (a Merkle-DAG), and :meth:`verify_provenance` rejects any
+  dangling parent.
+
+The plugin implements the :class:`~nest_core.layers.datafacts.DataFacts`
+protocol exactly (``publish`` / ``fetch`` / ``request_access`` /
+``verify_freshness``). The signed-proof machinery is exposed through *additional*
+methods (:meth:`issue_freshness_proof`, :meth:`verify_freshness_proof`,
+:meth:`content_id`, :meth:`verify_provenance`) so the base protocol surface is
+unchanged and drop-in compatible.
+
+Determinism: content hashing is pure ``sha256`` over canonical JSON, and the
+logical "now" is the simulator tick set via :meth:`set_clock` — never wall
+time — so the same seed yields byte-identical URLs and proofs.
+
+Example::
+
+    from nest_plugins_reference.identity.did_key import DidKeyIdentity
+    from nest_core.types import AgentId, DatasetMetadata
+
+    ident = DidKeyIdentity(AgentId("a1"), seed=b"seed")
+    df = ContentAddressedDataFacts(identity=ident)
+    url = await df.publish(DatasetMetadata(name="weather", owner=AgentId("a1")))
+    assert url.startswith("df://sha256-")
+    assert await df.verify_freshness(url)  # a signed proof was issued on publish
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Protocol, runtime_checkable
+
+from nest_core.types import (
+    AccessGrant,
+    AgentId,
+    DataFactsUrl,
+    DatasetMetadata,
+    Signature,
+)
+from pydantic import BaseModel
+
+# Fields excluded from the content hash. ``created_at`` / ``updated_at`` are
+# wall-clock-ish and would break the "same content -> same address" invariant;
+# ``parents`` is hashed separately (see ``_content_digest``) so the Merkle
+# structure is explicit rather than buried in a dict ordering.
+_VOLATILE_FIELDS = frozenset({"created_at", "updated_at"})
+
+_HASH_PREFIX = "sha256-"
+_URL_SCHEME = "df://"
+
+
+@runtime_checkable
+class SigningIdentity(Protocol):
+    """Structural type for the identity-layer instance the plugin signs with.
+
+    Any object exposing the reference identity surface (``did_key``,
+    ``ed25519_rotating``) satisfies this without an explicit import, so the
+    datafacts plugin stays decoupled from a concrete identity implementation.
+
+    Example::
+
+        ident: SigningIdentity = DidKeyIdentity(AgentId("a1"))
+    """
+
+    def sign(self, payload: bytes) -> Signature:
+        """Sign ``payload`` and return a :class:`~nest_core.types.Signature`.
+
+        Example::
+
+            sig = ident.sign(b"content")
+        """
+        ...
+
+    def verify(self, payload: bytes, sig: Signature, agent: AgentId) -> bool:
+        """Verify ``sig`` over ``payload`` was produced by ``agent``.
+
+        Example::
+
+            ok = ident.verify(b"content", sig, AgentId("a1"))
+        """
+        ...
+
+
+class FreshnessProof(BaseModel):
+    """A publisher's signed attestation that a content hash was current at a tick.
+
+    The proof binds three things the verifier cares about — the content address
+    (``cid``), the logical ``tick`` the publisher attested at, and the
+    ``signer`` — under a single signature. A verifier validates it *without*
+    trusting any wall clock: the signature either covers exactly
+    ``<cid>|<tick>|<signer>`` or it does not. ``signature`` is ``None`` only when
+    the plugin was constructed without an identity (freshness then cannot be
+    proven, which the validators treat as a stale claim).
+
+    Example::
+
+        proof = df.issue_freshness_proof(url)
+        assert df.verify_freshness_proof(proof)
+    """
+
+    url: DataFactsUrl
+    cid: str
+    tick: float
+    signer: AgentId
+    signature: Signature | None = None
+
+    def signed_bytes(self) -> bytes:
+        """Return the canonical payload the signature is computed over.
+
+        Example::
+
+            payload = proof.signed_bytes()
+        """
+        return _canonical_bytes({"cid": self.cid, "tick": self.tick, "signer": str(self.signer)})
+
+
+class _Record(BaseModel):
+    """Internal store entry: the immutable content plus its provenance and proofs."""
+
+    cid: str
+    metadata: DatasetMetadata
+    content_digest: str
+    parents: list[DataFactsUrl]
+    published_tick: float
+    publisher: AgentId
+    proofs: list[FreshnessProof]
+
+
+def _canonical_bytes(obj: object) -> bytes:
+    """Serialize ``obj`` to canonical (sorted-key, tight) JSON bytes.
+
+    Example::
+
+        raw = _canonical_bytes({"b": 1, "a": 2})  # b'{"a":2,"b":1}'
+    """
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+
+
+class ContentAddressedDataFacts:
+    """Content-addressed dataset registry with provenance DAG and signed freshness.
+
+    Instances may share a ``store`` dict so a whole swarm publishes into one
+    content-addressed namespace (substitution resistance is only meaningful when
+    the namespace is shared), while each instance signs freshness proofs with its
+    own ``identity``. Pass ``store`` to join an existing namespace; omit it for an
+    isolated one.
+
+    Example::
+
+        shared: dict[DataFactsUrl, object] = {}
+        a = ContentAddressedDataFacts(identity=id_a, store=shared)
+        b = ContentAddressedDataFacts(identity=id_b, store=shared)
+        url = await a.publish(meta)
+        meta_back = await b.fetch(url)  # b sees a's publish through the shared store
+    """
+
+    def __init__(
+        self,
+        identity: SigningIdentity | None = None,
+        store: dict[DataFactsUrl, _Record] | None = None,
+    ) -> None:
+        self._identity = identity
+        self._store: dict[DataFactsUrl, _Record] = store if store is not None else {}
+        self._grants: dict[DataFactsUrl, list[AccessGrant]] = {}
+        self._clock: float = 0.0
+
+    # -- determinism -------------------------------------------------------
+
+    def set_clock(self, tick: float) -> None:
+        """Set the logical "now" used to stamp freshness proofs.
+
+        Mirrors ``ed25519_rotating.set_clock``: scenarios call this with
+        ``ctx.time`` so proofs bind to the simulator's logical tick, never wall
+        time, keeping Tier 1 byte-deterministic.
+
+        Example::
+
+            df.set_clock(7.0)
+        """
+        self._clock = tick
+
+    # -- content addressing ------------------------------------------------
+
+    def _content_digest(self, dataset: DatasetMetadata) -> str:
+        """Hash the canonical, volatile-free content view *including* parents.
+
+        Folding ``parents`` in makes this a Merkle-DAG node: tampering with any
+        ancestor's bytes changes its hash, which changes this child's hash, which
+        propagates to every descendant.
+
+        Example::
+
+            digest = df._content_digest(DatasetMetadata(name="x", owner=AgentId("a1")))
+        """
+        view = dataset.model_dump(mode="json", exclude=set(_VOLATILE_FIELDS))
+        return hashlib.sha256(_canonical_bytes(view)).hexdigest()
+
+    def content_id(self, dataset: DatasetMetadata) -> str:
+        """Return the content identifier (``sha256-<hex>``) for ``dataset``.
+
+        Pure and deterministic: identical content always yields the identical id,
+        and any change to any content-bearing field yields a different one.
+
+        Example::
+
+            cid = df.content_id(DatasetMetadata(name="x", owner=AgentId("a1")))
+            assert cid.startswith("sha256-")
+        """
+        return f"{_HASH_PREFIX}{self._content_digest(dataset)}"
+
+    def url_for(self, dataset: DatasetMetadata) -> DataFactsUrl:
+        """Return the content-addressed URL (``df://sha256-<hex>``) for ``dataset``.
+
+        Example::
+
+            url = df.url_for(DatasetMetadata(name="x", owner=AgentId("a1")))
+        """
+        return DataFactsUrl(f"{_URL_SCHEME}{self.content_id(dataset)}")
+
+    # -- DataFacts protocol ------------------------------------------------
+
+    async def publish(self, dataset: DatasetMetadata) -> DataFactsUrl:
+        """Publish ``dataset`` at its content address and issue a freshness proof.
+
+        Republishing identical content is idempotent (same URL, refreshed proof).
+        Every ``parents`` entry must already exist in the store, or
+        :class:`BrokenProvenanceError` is raised — you cannot anchor provenance to
+        a hash nobody published.
+
+        Example::
+
+            url = await df.publish(DatasetMetadata(name="weather", owner=AgentId("a1")))
+        """
+        for parent in dataset.parents:
+            if parent not in self._store:
+                msg = f"parent not found in content store: {parent}"
+                raise BrokenProvenanceError(msg)
+
+        url = self.url_for(dataset)
+        digest = self._content_digest(dataset)
+        record = self._store.get(url)
+        if record is None:
+            record = _Record(
+                cid=self.content_id(dataset),
+                metadata=dataset,
+                content_digest=digest,
+                parents=list(dataset.parents),
+                published_tick=self._clock,
+                publisher=dataset.owner,
+                proofs=[],
+            )
+            self._store[url] = record
+        # Whether new or idempotent re-publish, attest freshness *now*.
+        record.proofs.append(self._make_proof(url, record.cid, dataset.owner))
+        return url
+
+    async def fetch(self, url: DataFactsUrl) -> DatasetMetadata:
+        """Fetch metadata for a content-addressed URL.
+
+        Example::
+
+            meta = await df.fetch(DataFactsUrl("df://sha256-abc123"))
+        """
+        record = self._store.get(url)
+        if record is None:
+            msg = f"Dataset not found: {url}"
+            raise KeyError(msg)
+        return record.metadata
+
+    async def request_access(self, url: DataFactsUrl, requester: AgentId) -> AccessGrant:
+        """Grant access, keyed by the *content hash* and the dataset's access tier.
+
+        Unlike ``datafacts_v1`` (which grants unconditionally), a non-public
+        dataset only grants to its owner. The grant is recorded against the
+        content address, so it cannot be transferred to a substituted dataset.
+
+        Example::
+
+            grant = await df.request_access(url, AgentId("a2"))
+        """
+        record = self._store.get(url)
+        if record is None:
+            msg = f"Dataset not found: {url}"
+            raise KeyError(msg)
+        if record.metadata.access_tier != "public" and requester != record.publisher:
+            msg = f"access denied for {requester} on {url}"
+            raise PermissionError(msg)
+        grant = AccessGrant(url=url, grantee=requester, tier="read")
+        self._grants.setdefault(url, []).append(grant)
+        return grant
+
+    async def verify_freshness(self, url: DataFactsUrl) -> bool:
+        """Return whether ``url`` has a cryptographically valid freshness proof.
+
+        Protocol-exact (``-> bool``). True iff the most recent proof for ``url``
+        is signed and verifies against the publisher's key and binds the stored
+        content hash. Returns False for unsigned/keyless plugins — which is why
+        ``datafacts_v1`` (no proofs at all) fails the freshness validator. The
+        *staleness-by-tick* judgment is left to the validator, which anchors it to
+        externally observed trace ticks rather than publisher-claimed ones.
+
+        Example::
+
+            fresh = await df.verify_freshness(url)
+        """
+        record = self._store.get(url)
+        if record is None or not record.proofs:
+            return False
+        return self.verify_freshness_proof(record.proofs[-1])
+
+    # -- signed freshness proofs ------------------------------------------
+
+    def _make_proof(self, url: DataFactsUrl, cid: str, signer: AgentId) -> FreshnessProof:
+        payload = _canonical_bytes({"cid": cid, "tick": self._clock, "signer": str(signer)})
+        signature = self._identity.sign(payload) if self._identity is not None else None
+        return FreshnessProof(
+            url=url, cid=cid, tick=self._clock, signer=signer, signature=signature
+        )
+
+    def issue_freshness_proof(self, url: DataFactsUrl) -> FreshnessProof:
+        """Issue (and store) a fresh signed proof for an already-published ``url``.
+
+        This is how an honest publisher *re-attests* currency at a later tick.
+        A stale publisher who skips this keeps only its old proof — exactly the
+        signal the freshness validator looks for.
+
+        Example::
+
+            df.set_clock(9.0)
+            proof = df.issue_freshness_proof(url)
+        """
+        record = self._store.get(url)
+        if record is None:
+            msg = f"Dataset not found: {url}"
+            raise KeyError(msg)
+        proof = self._make_proof(url, record.cid, record.publisher)
+        record.proofs.append(proof)
+        return proof
+
+    def verify_freshness_proof(self, proof: FreshnessProof) -> bool:
+        """Verify a freshness proof's signature and content binding.
+
+        Fails if the proof is unsigned, if the signature does not verify against
+        the claimed signer's key, or if the bound ``cid`` does not match the
+        content actually stored at ``proof.url`` (a tampered/forged proof).
+
+        Example::
+
+            ok = df.verify_freshness_proof(proof)
+        """
+        if proof.signature is None or self._identity is None:
+            return False
+        record = self._store.get(proof.url)
+        if record is None or record.cid != proof.cid:
+            return False
+        return self._identity.verify(proof.signed_bytes(), proof.signature, proof.signer)
+
+    # -- provenance --------------------------------------------------------
+
+    def verify_provenance(self, url: DataFactsUrl) -> bool:
+        """Return whether every ancestor of ``url`` is present in the store.
+
+        Walks the transitive ``parents`` DAG; any dangling reference (a parent
+        hash nobody published) makes the chain unverifiable and returns False.
+
+        Example::
+
+            ok = df.verify_provenance(url)
+        """
+        seen: set[DataFactsUrl] = set()
+        frontier: list[DataFactsUrl] = [url]
+        while frontier:
+            current = frontier.pop()
+            if current in seen:
+                continue
+            seen.add(current)
+            record = self._store.get(current)
+            if record is None:
+                return False
+            frontier.extend(record.parents)
+        return True
+
+
+class BrokenProvenanceError(ValueError):
+    """Raised when a publish references a parent hash absent from the store.
+
+    Example::
+
+        try:
+            await df.publish(DatasetMetadata(name="x", owner=a, parents=[ghost]))
+        except BrokenProvenanceError:
+            ...
+    """

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -36,6 +36,9 @@ Repository = "https://github.com/projnanda/nandatown"
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
 
+[project.entry-points."nest.plugins.datafacts"]
+content_addressed = "nest_plugins_reference.datafacts.content_addressed:ContentAddressedDataFacts"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/nest-plugins-reference/tests/test_content_addressed.py
+++ b/packages/nest-plugins-reference/tests/test_content_addressed.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the content-addressed DataFacts plugin.
+
+Covers the protocol contract and the three provenance-integrity guarantees the
+``provenance-engineer`` persona cares about: content addressing (substitution
+resistance), signed freshness proofs, and a tamper-evident provenance DAG.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.layers.datafacts import DataFacts
+from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
+from nest_plugins_reference.datafacts.content_addressed import (
+    BrokenProvenanceError,
+    ContentAddressedDataFacts,
+    FreshnessProof,
+)
+from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+
+def _plugin(
+    store: dict[DataFactsUrl, object] | None = None,
+    agent: str = "pub-0",
+) -> tuple[AgentId, ContentAddressedDataFacts]:
+    aid = AgentId(agent)
+    ident = DidKeyIdentity(aid, seed=b"test:" + agent.encode())
+    return aid, ContentAddressedDataFacts(identity=ident, store=store)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_implements_datafacts_protocol() -> None:
+    _aid, df = _plugin()
+    assert isinstance(df, DataFacts)
+
+
+async def test_fetch_missing_raises_keyerror() -> None:
+    _aid, df = _plugin()
+    with pytest.raises(KeyError):
+        await df.fetch(DataFactsUrl("df://sha256-deadbeef"))
+
+
+# ---------------------------------------------------------------------------
+# Content addressing — substitution resistance
+# ---------------------------------------------------------------------------
+
+
+async def test_url_is_content_addressed() -> None:
+    aid, df = _plugin()
+    url = await df.publish(DatasetMetadata(name="weather", owner=aid))
+    assert url.startswith("df://sha256-")
+
+
+async def test_identical_content_yields_same_url() -> None:
+    aid, df = _plugin()
+    u1 = await df.publish(DatasetMetadata(name="weather", owner=aid))
+    u2 = await df.publish(DatasetMetadata(name="weather", owner=aid))
+    assert u1 == u2
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        {"description": "changed"},
+        {"schema_version": "2.0"},
+        {"tags": ["x"]},
+        {"size_bytes": 99},
+        {"checksum": "abc"},
+        {"access_tier": "private"},
+        {"metadata": {"payload_hex": "ff"}},
+    ],
+)
+async def test_any_content_change_changes_url(mutate: dict[str, object]) -> None:
+    aid, df = _plugin()
+    base = DatasetMetadata(name="weather", owner=aid)
+    tampered = base.model_copy(update=mutate)
+    assert df.url_for(base) != df.url_for(tampered)
+
+
+async def test_substitution_is_impossible() -> None:
+    """Different content under the same name cannot occupy the same address."""
+    aid, df = _plugin()
+    original = await df.publish(DatasetMetadata(name="prices", owner=aid))
+    substitute = await df.publish(DatasetMetadata(name="prices", owner=aid, description="forged"))
+    assert original != substitute
+    # The original is still intact at its address — not overwritten.
+    assert (await df.fetch(original)).description == ""
+
+
+# ---------------------------------------------------------------------------
+# Signed freshness proofs
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_issues_verifiable_freshness_proof() -> None:
+    aid, df = _plugin()
+    url = await df.publish(DatasetMetadata(name="weather", owner=aid))
+    assert await df.verify_freshness(url) is True
+
+
+async def test_freshness_proof_binds_content_hash() -> None:
+    aid, df = _plugin()
+    url = await df.publish(DatasetMetadata(name="weather", owner=aid))
+    proof = df.issue_freshness_proof(url)
+    forged = proof.model_copy(update={"cid": "sha256-forged"})
+    assert df.verify_freshness_proof(forged) is False
+
+
+async def test_freshness_proof_tick_advances_with_clock() -> None:
+    aid, df = _plugin()
+    df.set_clock(0.0)
+    url = await df.publish(DatasetMetadata(name="weather", owner=aid))
+    df.set_clock(5.0)
+    proof = df.issue_freshness_proof(url)
+    assert proof.tick == 5.0
+    assert df.verify_freshness_proof(proof) is True
+
+
+async def test_keyless_plugin_cannot_prove_freshness() -> None:
+    """Without an identity there is no signature, so freshness cannot be proven."""
+    df = ContentAddressedDataFacts()  # no identity
+    url = await df.publish(DatasetMetadata(name="weather", owner=AgentId("a1")))
+    assert await df.verify_freshness(url) is False
+
+
+def test_unsigned_proof_rejected() -> None:
+    df = ContentAddressedDataFacts()
+    proof = FreshnessProof(
+        url=DataFactsUrl("df://sha256-x"), cid="sha256-x", tick=0.0, signer=AgentId("a1")
+    )
+    assert df.verify_freshness_proof(proof) is False
+
+
+# ---------------------------------------------------------------------------
+# Provenance DAG
+# ---------------------------------------------------------------------------
+
+
+async def test_parents_fold_into_child_hash() -> None:
+    """A child's address depends on its parent's content (Merkle-DAG property)."""
+    aid, df = _plugin()
+    p1 = await df.publish(DatasetMetadata(name="raw", owner=aid))
+    p2 = await df.publish(DatasetMetadata(name="raw", owner=aid, description="different"))
+    child_of_p1 = df.url_for(DatasetMetadata(name="clean", owner=aid, parents=[p1]))
+    child_of_p2 = df.url_for(DatasetMetadata(name="clean", owner=aid, parents=[p2]))
+    assert child_of_p1 != child_of_p2
+
+
+async def test_broken_provenance_is_rejected() -> None:
+    aid, df = _plugin()
+    ghost = DataFactsUrl("df://sha256-" + "0" * 64)
+    with pytest.raises(BrokenProvenanceError):
+        await df.publish(DatasetMetadata(name="forged", owner=aid, parents=[ghost]))
+
+
+async def test_verify_provenance_walks_full_chain() -> None:
+    aid, df = _plugin()
+    p0 = await df.publish(DatasetMetadata(name="d0", owner=aid))
+    p1 = await df.publish(DatasetMetadata(name="d1", owner=aid, parents=[p0]))
+    p2 = await df.publish(DatasetMetadata(name="d2", owner=aid, parents=[p1]))
+    assert df.verify_provenance(p2) is True
+
+
+async def test_verify_provenance_fails_on_unresolvable_url() -> None:
+    """A URL whose record is absent (forged or never published) does not resolve."""
+    _aid, df = _plugin()
+    assert df.verify_provenance(DataFactsUrl("df://sha256-" + "0" * 64)) is False
+
+
+# ---------------------------------------------------------------------------
+# Access control + shared store
+# ---------------------------------------------------------------------------
+
+
+async def test_public_access_granted_to_anyone() -> None:
+    aid, df = _plugin()
+    url = await df.publish(DatasetMetadata(name="open", owner=aid, access_tier="public"))
+    grant = await df.request_access(url, AgentId("stranger"))
+    assert grant.tier == "read"
+
+
+async def test_private_access_denied_to_non_owner() -> None:
+    aid, df = _plugin()
+    url = await df.publish(DatasetMetadata(name="secret", owner=aid, access_tier="private"))
+    with pytest.raises(PermissionError):
+        await df.request_access(url, AgentId("stranger"))
+
+
+async def test_shared_store_is_visible_across_instances() -> None:
+    store: dict[DataFactsUrl, object] = {}
+    a_id, a = _plugin(store=store, agent="a")
+    _b_id, b = _plugin(store=store, agent="b")
+    url = await a.publish(DatasetMetadata(name="shared", owner=a_id))
+    # b sees a's publish through the shared content-addressed namespace.
+    assert (await b.fetch(url)).name == "shared"

--- a/packages/nest-plugins-reference/tests/test_content_addressed_properties.py
+++ b/packages/nest-plugins-reference/tests/test_content_addressed_properties.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Property-based tests for the content-addressed DataFacts plugin.
+
+Hypothesis drives the invariants the persona stakes the design on:
+
+* content addressing is a deterministic, injective function of *content*;
+* volatile timestamps are excluded, so re-publishing identical content is stable;
+* canonical serialization is order-independent;
+* parents fold into the child hash (Merkle-DAG);
+* freshness signatures bind to exactly their payload (no cross-payload forgery).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
+from nest_plugins_reference.datafacts.content_addressed import ContentAddressedDataFacts
+from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+_text = st.text(min_size=0, max_size=24)
+_df = ContentAddressedDataFacts()  # content_id is identity-independent and pure
+# Build the signing identity once: deriving the simulation RSA keypair (Miller-Rabin
+# primality) is expensive, so doing it per Hypothesis example would trip the deadline.
+_SIGNER = AgentId("signer-0")
+_signer_ident = DidKeyIdentity(_SIGNER, seed=b"prop")
+
+
+@given(name=_text, desc=_text)
+def test_content_id_is_deterministic(name: str, desc: str) -> None:
+    meta = DatasetMetadata(name=name, owner=AgentId("a1"), description=desc)
+    other = ContentAddressedDataFacts()
+    assert _df.content_id(meta) == other.content_id(meta)
+    assert _df.content_id(meta).startswith("sha256-")
+
+
+@given(name1=_text, name2=_text)
+def test_distinct_names_yield_distinct_addresses(name1: str, name2: str) -> None:
+    a = DatasetMetadata(name=name1, owner=AgentId("a1"))
+    b = DatasetMetadata(name=name2, owner=AgentId("a1"))
+    assert (_df.content_id(a) == _df.content_id(b)) == (name1 == name2)
+
+
+@given(t1=st.datetimes(), t2=st.datetimes(), name=_text)
+def test_volatile_timestamps_excluded_from_address(t1: datetime, t2: datetime, name: str) -> None:
+    """Re-publishing identical content with a new timestamp is the same address."""
+    a = DatasetMetadata(name=name, owner=AgentId("a1"), created_at=t1, updated_at=t1)
+    b = DatasetMetadata(name=name, owner=AgentId("a1"), created_at=t2, updated_at=t2)
+    assert _df.content_id(a) == _df.content_id(b)
+
+
+@given(
+    items=st.dictionaries(
+        st.text(min_size=1, max_size=8), st.text(max_size=8), min_size=0, max_size=5
+    )
+)
+def test_metadata_dict_order_irrelevant(items: dict[str, str]) -> None:
+    forward = DatasetMetadata(name="x", owner=AgentId("a1"), metadata=dict(items))
+    reversed_items = dict(reversed(list(items.items())))
+    backward = DatasetMetadata(name="x", owner=AgentId("a1"), metadata=reversed_items)
+    assert _df.content_id(forward) == _df.content_id(backward)
+
+
+@given(p1=_text, p2=_text)
+def test_parents_fold_into_child_address(p1: str, p2: str) -> None:
+    parent_a = DataFactsUrl(f"df://sha256-{p1}")
+    parent_b = DataFactsUrl(f"df://sha256-{p2}")
+    child_a = DatasetMetadata(name="c", owner=AgentId("a1"), parents=[parent_a])
+    child_b = DatasetMetadata(name="c", owner=AgentId("a1"), parents=[parent_b])
+    assert (_df.content_id(child_a) == _df.content_id(child_b)) == (p1 == p2)
+
+
+@settings(deadline=None)
+@given(payload=st.binary(max_size=64), other=st.binary(max_size=64))
+def test_signature_binds_to_its_payload(payload: bytes, other: bytes) -> None:
+    """A freshness signature verifies its own payload and rejects any other."""
+    sig = _signer_ident.sign(payload)
+    assert _signer_ident.verify(payload, sig, _SIGNER) is True
+    assert _signer_ident.verify(other, sig, _SIGNER) == (other == payload)

--- a/packages/nest-plugins-reference/tests/test_provenance_validators_and_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_provenance_validators_and_scenario.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validator + end-to-end scenario tests for the content-addressed datafacts plugin.
+
+Three layers of coverage:
+
+1. **Validator unit tests** — hand-built trace lines exercising the pass and
+   fail paths of each of the three provenance validators.
+2. **Adversarial discrimination** — the *same* ``provenance_supply_chain``
+   scenario run through the default ``datafacts_v1`` plugin MUST FAIL all three
+   validators (it is name-addressed, unsigned, provenance-blind), and through
+   ``content_addressed`` MUST PASS them. This is the charter's bar for "a
+   validator that catches a class of attacks the default reference plugin would
+   miss."
+3. **Determinism** — same seed yields a byte-identical trace, and the validators
+   pass under seeds 42, 7, and 1337.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import (
+    ValidationResult,
+    validate_datafacts_content_addressing,
+    validate_datafacts_freshness_proofs,
+    validate_datafacts_provenance_chain,
+    validate_events,
+)
+
+
+def _send(agent: str, msg: str) -> dict[str, Any]:
+    return {"kind": "send", "agent": agent, "to": "auditor-0", "msg": msg}
+
+
+def _only(results: list[ValidationResult]) -> ValidationResult:
+    assert len(results) == 1
+    return results[0]
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests — content addressing
+# ---------------------------------------------------------------------------
+
+
+def test_content_addressing_passes_on_hashed_urls_and_deflected_substitution() -> None:
+    events = [
+        _send("supplier-0", "publish:supplier-0:sha256-aaa:-:0.0"),
+        _send("byz-0", "attack:substitution:byz-0:sha256-bbb:sha256-ccc"),
+    ]
+    assert _only(validate_datafacts_content_addressing(events)).passed
+
+
+def test_content_addressing_fails_on_name_addressed_url() -> None:
+    events = [_send("supplier-0", "publish:supplier-0:dataset-supplier-0:-:0.0")]
+    result = _only(validate_datafacts_content_addressing(events))
+    assert not result.passed
+    assert "non-content-addressed" in result.detail
+
+
+def test_content_addressing_fails_when_substitution_lands_same_address() -> None:
+    events = [_send("byz-0", "attack:substitution:byz-0:victim:victim")]
+    assert not _only(validate_datafacts_content_addressing(events)).passed
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests — freshness proofs
+# ---------------------------------------------------------------------------
+
+
+def test_freshness_passes_on_current_signed_proof() -> None:
+    events = [_send("supplier-0", "freshness:supplier-0:sha256-aaa:3.0:3.0:ok")]
+    assert _only(validate_datafacts_freshness_proofs(events)).passed
+
+
+def test_freshness_fails_on_unsigned_claim() -> None:
+    events = [_send("supplier-0", "freshness:supplier-0:dataset-x:none:3.0:ok")]
+    result = _only(validate_datafacts_freshness_proofs(events))
+    assert not result.passed
+    assert "no signed proof" in result.detail
+
+
+def test_freshness_fails_on_non_current_ok_claim() -> None:
+    events = [_send("byz-0", "freshness:byz-0:sha256-aaa:1.0:3.0:ok")]
+    assert not _only(validate_datafacts_freshness_proofs(events)).passed
+
+
+def test_freshness_accepts_detectable_stale_claim() -> None:
+    events = [_send("byz-0", "freshness:byz-0:sha256-aaa:1.0:3.0:stale")]
+    assert _only(validate_datafacts_freshness_proofs(events)).passed
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests — provenance chain
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_passes_on_anchored_chain() -> None:
+    events = [
+        _send("supplier-0", "publish:supplier-0:sha256-a:-:0.0"),
+        _send("manufacturer-0", "publish:manufacturer-0:sha256-b:sha256-a:0.0"),
+        _send("byz-0", "attack:broken:byz-0:sha256-ghost:rejected"),
+        _send("retailer-0", "verify:retailer-0:sha256-b:ok"),
+    ]
+    assert _only(validate_datafacts_provenance_chain(events)).passed
+
+
+def test_provenance_fails_on_dangling_parent() -> None:
+    events = [_send("byz-0", "publish:byz-0:sha256-b:sha256-ghost:0.0")]
+    result = _only(validate_datafacts_provenance_chain(events))
+    assert not result.passed
+    assert "unpublished parent" in result.detail
+
+
+def test_provenance_fails_when_broken_attack_accepted() -> None:
+    events = [_send("byz-0", "attack:broken:byz-0:sha256-ghost:accepted")]
+    assert not _only(validate_datafacts_provenance_chain(events)).passed
+
+
+def test_provenance_fails_when_end_to_end_verify_not_ok() -> None:
+    events = [_send("retailer-0", "verify:retailer-0:dataset-x:unverifiable")]
+    assert not _only(validate_datafacts_provenance_chain(events)).passed
+
+
+# ---------------------------------------------------------------------------
+# Full simulator integration — adversarial discrimination + determinism
+# ---------------------------------------------------------------------------
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "provenance_supply_chain.yaml"
+
+
+def _run_scenario(seed: int, datafacts: str | None = None) -> tuple[bytes, list[dict[str, Any]]]:
+    """Run the scenario; return (raw trace bytes, parsed events)."""
+    import json
+
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    config = config.model_copy(update={"seed": seed})
+    if datafacts is not None:
+        config = config.model_copy(
+            update={"layers": config.layers.model_copy(update={"datafacts": datafacts})}
+        )
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"prov_{seed}.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        asyncio.run(runner.run())
+        raw = trace_path.read_bytes()
+    events = [json.loads(line) for line in raw.decode().splitlines() if line.strip()]
+    return raw, events
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason="scenario yaml not found")
+def test_content_addressed_passes_all_validators() -> None:
+    _raw, events = _run_scenario(42)
+    results = validate_events(events, "provenance_supply_chain")
+    assert len(results) == 3
+    assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason="scenario yaml not found")
+def test_datafacts_v1_fails_all_validators() -> None:
+    """The same scenario on the default plugin fails every provenance validator."""
+    _raw, events = _run_scenario(42, datafacts="datafacts_v1")
+    results = validate_events(events, "provenance_supply_chain")
+    assert len(results) == 3
+    assert all(not r.passed for r in results), [r.name for r in results if r.passed]
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason="scenario yaml not found")
+def test_trace_is_byte_identical_under_replay() -> None:
+    first, _ = _run_scenario(42)
+    second, _ = _run_scenario(42)
+    assert first == second
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason="scenario yaml not found")
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_validators_pass_under_seed_bank(seed: int) -> None:
+    _raw, events = _run_scenario(seed)
+    results = validate_events(events, "provenance_supply_chain")
+    assert all(r.passed for r in results), [r.detail for r in results if not r.passed]

--- a/scenarios/provenance_supply_chain.yaml
+++ b/scenarios/provenance_supply_chain.yaml
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Content-addressed provenance supply chain.
+#
+# Four honest hops (supplier -> manufacturer -> distributor -> retailer) publish
+# content-addressed datasets that form an end-to-end provenance DAG; the retailer
+# verifies the whole chain. Two byzantine agents attempt substitution,
+# stale-freshness, and broken-provenance attacks. Under `datafacts: content_addressed`
+# all three are deflected and the `provenance_supply_chain` validators pass; swap in
+# `datafacts: datafacts_v1` and the same validators fail (it cannot catch any of them).
+#
+# Verify::
+#
+#     nest run provenance_supply_chain.yaml -o ./traces/prov.jsonl
+#     python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
+#       [print('PASS' if r.passed else 'FAIL', r.name) \
+#        for r in validate_trace(Path('traces/prov.jsonl'), 'provenance_supply_chain')]"
+name: provenance_supply_chain
+description: "4-hop content-addressed provenance chain; 2 byzantine agents attempt substitution, stale-freshness, and broken-provenance attacks."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 7
+  brain: state-machine
+  roles:
+    - name: supplier
+      count: 1
+    - name: manufacturer
+      count: 1
+    - name: distributor
+      count: 1
+    - name: retailer
+      count: 1
+    - name: byzantine
+      count: 2
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: content_addressed
+
+task:
+  type: provenance_supply_chain
+  config:
+    rounds: 4
+    byzantine_fraction: 0.50
+
+# The honest provenance chain is driven by message passing; dropping a `derive:`
+# message would legitimately break a hop's provenance, so the chain runs without
+# message loss. Adversarial coverage comes from the byzantine agents, not the wire.
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/provenance_supply_chain.jsonl


### PR DESCRIPTION
## Problem

Problem 08 (datafacts). The default `datafacts_v1` plugin addresses datasets by **publisher-chosen name** (`df://<name>`), grants access unconditionally, and "proves" freshness with a bare `time.time()` check. That makes three classes of provenance attack silently undetectable in any trace:

- **Substitution** — republish *different* bytes under an existing name.
- **Stale-freshness** — claim a dataset is current by re-touching a timestamp without re-publishing.
- **Broken provenance** — a derived dataset whose ancestry references a hash nobody ever published.

## Design

A new `content_addressed` datafacts plugin where **the address is the content** and **freshness is a signature, not a timestamp**:

- `publish()` returns `df://sha256-<hex>` over the canonical content (volatile timestamps excluded so re-publishing identical content is idempotent). Different bytes ⇒ different address ⇒ **substitution is impossible by construction** — you cannot overwrite.
- `DatasetMetadata.parents` (new **optional** field, explicitly permitted by the problem) is folded into the child's content hash → a **Merkle-DAG**: a forged ancestor changes every descendant's address. `verify_provenance()` walks the DAG and rejects dangling parents; `publish()` raises `BrokenProvenanceError` on an unpublished parent.
- A `FreshnessProof` binds *(content-hash, tick, signer)* under a signature from the identity layer (`did_key`, taken via constructor — the same pattern as the EigenTrust PRs). A verifier validates it **without trusting wall-clock time**.

## API fit & tradeoffs

- Implements the `DataFacts` protocol **exactly** (`isinstance(plugin, DataFacts)` passes). The signed-proof machinery is added through **new** methods (`issue_freshness_proof`, `verify_freshness_proof`, `content_id`, `verify_provenance`) so `verify_freshness() -> bool` keeps the reference return type. The "proof object" the brief mentions is the new method, deliberately, so the plugin stays drop-in.
- Per-agent instances share one content-addressed **store** (substitution resistance is only meaningful swarm-wide) but each signs with its **own** identity — mirroring the merged `identity_rotation` provisioning pattern. Capability-gated so the same scenario degrades honestly under `datafacts_v1`.

## Adversarial validators (the charter's bar)

Three validators for scenario type `provenance_supply_chain`, each catching one attack class. From the **same** scenario YAML they **FAIL against `datafacts_v1`** and **PASS against `content_addressed`**:

| Validator | Catches |
|---|---|
| `validate_datafacts_content_addressing` | substitution / name-addressing |
| `validate_datafacts_freshness_proofs` | stale, unsigned freshness claims |
| `validate_datafacts_provenance_chain` | dangling ancestry, unverified chains |

## Verify

```bash
uv sync && uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -v
# Adversarial discrimination — same YAML, two plugins:
uv run nest run scenarios/provenance_supply_chain.yaml -o ./traces/prov.jsonl
uv run python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
  [print('PASS' if r.passed else 'FAIL', r.name, '—', r.detail) \
   for r in validate_trace(Path('traces/prov.jsonl'),'provenance_supply_chain')]"
# -> 3x PASS on content_addressed; flip the YAML to `datafacts: datafacts_v1` -> 3x FAIL
```

## Persona — `provenance-engineer`

The persona is in the code, not the label: content addressing as substitution resistance, parents folded into the hash to make the provenance DAG tamper-evident, a freshness proof that binds the content hash under a signature, and a validator that anchors freshness to *externally observed* ticks rather than attacker-claimed ones.

## Determinism & secrets

Pure-Python (`hashlib` / `json` + simulation-crypto `did_key`), **no new dependencies, no secrets/API keys**. Logical-tick clock, seeded only — `test_trace_is_byte_identical_under_replay` asserts byte-identical traces, and the validators pass under seeds 42 / 7 / 1337. Tier 1 fully deterministic.

**Local CI:** all five gates green — `ruff check`, `ruff format --check`, `pyright` (0 errors), `pytest` (588 passed, 1 skipped).
