### PR TITLE
[Hackathon] Auth: manifest-bound delegatable capability tokens

### DIFF
--- a/docs/hackathon/charan-auth-delegation-submission.md
+++ b/docs/hackathon/charan-auth-delegation-submission.md
@@ -1,0 +1,346 @@
+# Charan Auth Delegation Submission
+
+## Summary
+
+This submission targets Problem 04, **Delegatable capability tokens with
+cascading revocation**, in the Auth layer.
+
+It adds `auth: delegatable`, a small Auth-layer plugin that issues and
+verifies capability tokens constrained by signed policy manifests. A root
+token can only contain scopes allowed by the subject's manifest, and a
+delegated child token can only carry a strict subset of its parent token's
+scopes. Verification fails closed for invalid signatures, malformed payloads,
+scope widening, stale ancestors, expired tokens, and audience confusion.
+
+## Problem Solved
+
+Multi-agent workflows routinely pass capabilities down a chain:
+
+1. A coordinator receives a broad but bounded root capability.
+2. The coordinator delegates narrower capabilities to intermediary agents.
+3. Intermediaries delegate still narrower capabilities to leaf agents.
+4. A verifier must reject any child token that tries to exceed the declared
+   parent, manifest, expiry, or audience boundary.
+
+The default `jwt` Auth plugin can sign and revoke exact tokens, but it cannot
+model parent-issued delegation. A central authority can re-issue a new token,
+but that is not the same security property: it does not prove that the parent
+holder was constrained to a subset, and it does not create a delegation chain
+that can be audited or revoked transitively.
+
+This PR makes the missing Auth-layer behavior explicit:
+
+- **Manifest-bound roots.** Root issuance clamps requested scopes against a
+  signed `PolicyManifest`.
+- **Least privilege delegation.** Child scopes must be a strict subset of
+  parent scopes.
+- **Fail-closed verification.** Invalid manifests, tampered token payloads,
+  malformed payloads, unknown tokens, invalid signatures, expired tokens, and
+  invalid chains are rejected.
+- **Cascading revocation.** Revoking any token invalidates that token and all
+  descendants because descendants carry ancestor token ids.
+- **Audience binding.** A child token minted for `leaf-0-0` does not verify
+  when presented by `leaf-0-0-wrong`.
+- **Auditability.** The deterministic `delegated_auth` scenario emits trace
+  lines for honest leaf verification and each adversarial probe, and the
+  validators check those trace lines.
+
+## Why It Matters
+
+Agents often need to receive or delegate authority without inheriting every
+permission their parent has. Without manifest-bound delegation, a child agent
+can be over-privileged by accident, and a test rig cannot distinguish a real
+least-privilege protocol from central re-issuance that happens to work on the
+happy path.
+
+The security properties this PR makes testable are:
+
+- **Least privilege:** only declared scopes survive issuance and delegation.
+- **Manifest-bound authority:** an agent cannot ask for scopes beyond its
+  signed manifest, and a tampered or forged manifest fails closed when an
+  identity verifier is supplied.
+- **Scope narrowing:** delegation must strictly reduce authority, not merely
+  copy parent authority.
+- **Revocation propagation:** a stale child cannot survive ancestor revocation.
+- **Audience separation:** a valid token is not enough; the presenter must be
+  the intended audience when the caller supplies a presenter.
+- **Deterministic audit:** the scenario and validators produce stable evidence
+  for the judge panel and CI.
+
+## What Works Today
+
+### Auth Plugin
+
+`packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py`
+implements `DelegatableAuth`.
+
+Working behavior:
+
+- `issue(subject, scopes)` clamps root scopes against the signed manifest.
+- `delegate(parent_token, audience, scopes_subset, ttl)` mints a child token
+  only when:
+  - the parent verifies,
+  - the requested scopes are a strict subset of parent scopes,
+  - no requested scope is outside the parent,
+  - the child expiry does not exceed the parent expiry.
+- `verify(token, presenter=None)` checks:
+  - token wire format,
+  - JSON payload shape and field types,
+  - known-token status,
+  - stored signature,
+  - expected root or parent-anchored HMAC signature,
+  - chain shape,
+  - strict scope containment,
+  - TTL containment,
+  - expiry,
+  - transitive revocation,
+  - optional audience/presenter binding.
+- `revoke(token)` records the token id so descendants fail because their
+  `chain` contains that ancestor.
+
+### Manifest And Policy Primitives
+
+The small policy package lives under
+`packages/nest-plugins-reference/nest_plugins_reference/policy/`.
+
+Working behavior:
+
+- `manifest.py`
+  - defines `PolicyManifest`, `Budget`, and `Approval`,
+  - signs canonical JSON bytes excluding the `signature` field,
+  - verifies against the manifest's declared `agent_id`,
+  - rejects unsigned, tampered, forged, and signature-transplanted manifests,
+  - supports JSON round trips for trace/validator use.
+- `scopes.py`
+  - parses durable token scopes:
+    - `tool:<name>`
+    - `spend:<int>`
+    - `expose:<class>:<aud1,aud2,...>`
+  - returns `None` for malformed or unsupported scopes so issuance drops
+    them instead of granting ambiguous authority.
+- `decide.py`
+  - is pure and total,
+  - allows or denies tool, register, expose, and pay actions,
+  - enforces cumulative budget and approval gates,
+  - rejects malformed amounts and list-shaped inputs without raising.
+
+### Scenario And Validators
+
+The scenario is `scenarios/delegated_auth.yaml` and the built-in factory is
+`packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py`.
+
+It creates:
+
+- one coordinator,
+- three intermediaries,
+- twelve leaves,
+- one auditor sink.
+
+The coordinator builds a delegation tree and emits trace lines for:
+
+- twelve honest leaf verifications,
+- scope escalation attack,
+- stale parent attack,
+- audience confusion attack.
+
+The validators in `packages/nest-core/nest_core/validators.py` are:
+
+- `delegated_auth_scope_containment`
+- `delegated_auth_no_stale_parent`
+- `delegated_auth_audience_binding`
+
+They pass with `auth: delegatable` and fail with `auth: jwt`, which is the
+charter's required adversarial discrimination.
+
+### Registration
+
+The plugin is registered both ways reviewers expect:
+
+- Built-in registry key in `packages/nest-core/nest_core/plugins.py`:
+  `("auth", "delegatable")`
+- Package entry point in `packages/nest-plugins-reference/pyproject.toml`:
+  `[project.entry-points."nest.plugins.auth"]`
+
+## Files To Review
+
+Core Auth submission:
+
+- `packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py`
+- `packages/nest-plugins-reference/nest_plugins_reference/policy/manifest.py`
+- `packages/nest-plugins-reference/nest_plugins_reference/policy/decide.py`
+- `packages/nest-plugins-reference/nest_plugins_reference/policy/scopes.py`
+- `packages/nest-plugins-reference/nest_plugins_reference/policy/__init__.py`
+
+Wiring:
+
+- `packages/nest-core/nest_core/plugins.py`
+- `packages/nest-plugins-reference/pyproject.toml`
+- `packages/nest-core/nest_core/scenarios.py`
+
+Scenario and validators:
+
+- `scenarios/delegated_auth.yaml`
+- `packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py`
+- `packages/nest-core/nest_core/validators.py`
+
+Focused tests:
+
+- `packages/nest-plugins-reference/tests/test_manifest.py`
+- `packages/nest-plugins-reference/tests/test_decide.py`
+- `packages/nest-plugins-reference/tests/test_policy_core_properties.py`
+- `packages/nest-plugins-reference/tests/test_delegatable.py`
+- `packages/nest-plugins-reference/tests/test_delegatable_properties.py`
+- `packages/nest-core/tests/test_delegated_auth.py`
+- `packages/nest-core/tests/test_validators.py`
+
+Layer documentation:
+
+- `docs/layers/auth.md`
+- `docs/hackathon/charan-auth-delegation-submission.md`
+
+## Test Evidence
+
+Focused command:
+
+```bash
+pytest \
+  packages/nest-plugins-reference/tests/test_manifest.py \
+  packages/nest-plugins-reference/tests/test_decide.py \
+  packages/nest-plugins-reference/tests/test_policy_core_properties.py \
+  packages/nest-plugins-reference/tests/test_delegatable.py \
+  packages/nest-plugins-reference/tests/test_delegatable_properties.py \
+  packages/nest-core/tests/test_delegated_auth.py \
+  -q
+```
+
+Expected focused result after this pass:
+
+```text
+102 passed
+```
+
+What that proves:
+
+- signed manifest accepted,
+- unsigned manifest rejected,
+- tampered manifest rejected,
+- forged manifest rejected,
+- signature transplant rejected,
+- manifest JSON round trip still verifies,
+- requested root scopes are clamped to manifest scopes,
+- tool, spend, and expose scopes are all clamped,
+- duplicate scopes are removed deterministically,
+- out-of-manifest scopes are removed,
+- malformed scopes are removed,
+- child delegation succeeds only for a strict subset,
+- equal-authority delegation is rejected,
+- scope escalation is rejected,
+- handcrafted broader child tokens are rejected,
+- registered forged child tokens are rechecked by verification,
+- malformed token payloads fail closed,
+- ambiguous `aud`/`sub` payloads fail closed,
+- non-finite `NaN`/infinite payload times fail closed,
+- exp-before-iat payloads fail closed,
+- invalid signatures are rejected,
+- expired tokens are rejected,
+- non-finite, zero, and negative delegation TTLs are rejected,
+- non-finite injected clocks are rejected,
+- child TTL cannot exceed parent TTL,
+- revoked parents cannot delegate,
+- expired parents cannot delegate,
+- root revocation invalidates children and grandchildren,
+- child revocation does not invalidate the root but does invalidate
+  descendants,
+- presenter/audience mismatch is rejected,
+- plugin satisfies the Auth protocol,
+- plugin resolves through the registry,
+- property tests cover strict containment, transitive revocation,
+  determinism, decision totality, decision purity, budget soundness, and
+  manifest canonicality.
+
+Scenario adversarial proof:
+
+```bash
+pytest packages/nest-core/tests/test_delegated_auth.py -q
+```
+
+Expected behavior:
+
+- `auth: delegatable` passes all three delegated-auth validators across the
+  tested seed bank.
+- `auth: jwt` fails all three validators, proving the validators catch the
+  missing delegation security property in the baseline.
+- same seed gives byte-identical traces.
+- the trace contains 17 started agents, 12 honest leaf audit messages, and
+  blocked lines for all three attacks.
+
+Direct scenario/validator smoke output:
+
+```text
+delegatable
+PASS delegated_auth_scope_containment 12 honest leaves verified; scope_escalation attack blocked
+PASS delegated_auth_no_stale_parent 12 honest leaves verified; stale_parent attack blocked
+PASS delegated_auth_audience_binding 12 honest leaves verified; audience_confusion attack blocked
+jwt
+FAIL delegated_auth_scope_containment scope_escalation attack accepted
+FAIL delegated_auth_no_stale_parent stale_parent attack accepted
+FAIL delegated_auth_audience_binding audience_confusion attack accepted
+```
+
+Full pytest result from this checkout:
+
+```text
+838 passed, 1 skipped, 1 deselected
+```
+
+Canonical full local CI command:
+
+```bash
+make ci-local
+```
+
+That runs the charter-required sequence:
+
+```bash
+uv sync
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest -v
+```
+
+Local runner note: in this macOS checkout, `make ci-local` completed
+`uv sync`, `uv run ruff check .`, `uv run ruff format --check .`, and
+`uv run pyright`, then `uv run pytest -v` exited 139 before collection
+because pytest's startup imported the local `readline` extension and the
+extension segfaulted. The full suite above was therefore run through the
+same `.venv` interpreter with `readline` pre-seeded as an empty module before
+calling `pytest.main(["-q"])`. That workaround changes only pytest startup,
+not the project code or tests.
+
+## Charter Alignment
+
+- **One problem:** Problem 04, Auth capability delegation.
+- **One layer:** Auth, with a small policy package used by the Auth plugin for
+  manifest signing, scope parsing, and issuance decisions.
+- **Layer plugin:** `auth: delegatable`.
+- **Adversarial validator:** three validators for scope containment, stale
+  ancestors, and audience binding.
+- **Scenario YAML:** `scenarios/delegated_auth.yaml`.
+- **Deterministic:** tests assert byte-identical traces for the same seed and
+  property tests assert byte-identical tokens for identical inputs and clock.
+- **Docs:** public code symbols have docstrings with examples, the Auth layer
+  doc names the plugin, and this file provides judge-facing verification
+  instructions.
+
+## PR Description Short Form
+
+This PR adds `auth: delegatable`, an Auth-layer plugin for manifest-bound
+delegatable capability tokens. Root issuance clamps requested scopes to a
+signed `PolicyManifest`; delegation can only mint a strict subset of the
+parent token's scopes; verification checks signature, chain, expiry,
+revocation ancestry, and optional presenter/audience binding. The
+`delegated_auth` scenario builds a coordinator-to-intermediary-to-leaf
+delegation tree, and its validators pass under `delegatable` while failing
+under the baseline `jwt` plugin for scope escalation, stale parent, and
+audience confusion attacks.

--- a/docs/layers/auth.md
+++ b/docs/layers/auth.md
@@ -21,6 +21,60 @@ shape (header.payload.sig), no claim validation beyond the signature.
 
 Source: [`nest_plugins_reference/auth/jwt_auth.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/jwt_auth.py).
 
+## Bundled alternative: `delegatable`
+
+`delegatable` is the Auth-layer capability-delegation plugin. It issues
+root tokens whose requested scopes are clamped to a signed
+`PolicyManifest`, then lets a token holder mint a child token for another
+agent with a strict subset of the parent's scopes and a TTL no longer than
+the parent token's remaining lifetime.
+
+The small policy package supplies the manifest and scope grammar the Auth
+layer needs:
+
+- `PolicyManifest` signs the owner-authored allowlist for tools, data
+  exposure, spend budget, and approval gates.
+- `scope_to_op()` maps durable token scopes such as `tool:buy`,
+  `spend:250`, and `expose:pii:seller-1` into policy checks.
+- `decide()` is a pure, fail-closed decision core used by issuance to drop
+  scopes that the manifest does not authorize.
+
+Delegated tokens use a parent-anchored HMAC chain. Verification recomputes
+the chain, rejects scope widening, rejects equal-authority delegation,
+checks expiry, checks revocation transitively, and optionally checks that
+the presenter matches the token audience. Revoking a parent invalidates
+all descendants because each child carries the parent token id in its
+delegation chain.
+
+Sources:
+
+- [`nest_plugins_reference/auth/delegatable.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py)
+- [`nest_plugins_reference/policy/manifest.py`](../../packages/nest-plugins-reference/nest_plugins_reference/policy/manifest.py)
+- [`nest_plugins_reference/policy/decide.py`](../../packages/nest-plugins-reference/nest_plugins_reference/policy/decide.py)
+- [`nest_plugins_reference/policy/scopes.py`](../../packages/nest-plugins-reference/nest_plugins_reference/policy/scopes.py)
+
+Scenario and validators:
+
+- [`scenarios/delegated_auth.yaml`](../../scenarios/delegated_auth.yaml)
+- `delegated_auth_scope_containment`
+- `delegated_auth_no_stale_parent`
+- `delegated_auth_audience_binding`
+
+Judge-facing submission notes:
+[`docs/hackathon/charan-auth-delegation-submission.md`](../hackathon/charan-auth-delegation-submission.md).
+
+Focused verification:
+
+```bash
+pytest \
+  packages/nest-plugins-reference/tests/test_manifest.py \
+  packages/nest-plugins-reference/tests/test_decide.py \
+  packages/nest-plugins-reference/tests/test_policy_core_properties.py \
+  packages/nest-plugins-reference/tests/test_delegatable.py \
+  packages/nest-plugins-reference/tests/test_delegatable_properties.py \
+  packages/nest-core/tests/test_delegated_auth.py
+```
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -25,6 +25,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
+    ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -97,3 +97,7 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("receipt_reputation", receipt_reputation_factory)
+    elif name == "delegated_auth":
+        from nest_core.scenarios_builtin.delegated_auth import delegated_auth_factory
+
+        register_scenario("delegated_auth", delegated_auth_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegatable auth scenario with scope, revocation, and audience attacks.
+
+One coordinator receives a manifest-bound root token and builds a delegation
+tree: 3 intermediaries, each with 4 leaves. Honest leaves verify with in-scope,
+in-audience, unrevoked tokens. Three adversarial probes then try to:
+
+* delegate a broader scope than the parent token carries,
+* use a descendant after an ancestor was revoked, and
+* present a token minted for one audience as another audience.
+
+The scenario is capability-gated. With ``auth: delegatable`` the probes are
+blocked. With the baseline ``auth: jwt`` there is no delegation surface, so the
+scenario falls back to central re-issuance; the same three probes are accepted
+and the validators fail.
+
+Trace line protocol (carried in ``send`` message bodies):
+
+* ``honest_leaf:<leaf>:<parent>:<scopes_csv>:ok`` — an honest leaf verified.
+* ``attack:<name>:blocked`` — the configured auth plugin rejected the probe.
+* ``attack:<name>:accepted`` — the baseline accepted the probe.
+
+Example::
+
+    agents = delegated_auth_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Token
+
+
+class DelegationCoordinator(StateMachineAgent):
+    """Builds the delegation tree and emits audit lines for validators.
+
+    Example::
+
+        agent = DelegationCoordinator(AgentId("coordinator-0"), AgentId("auditor-0"))
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        auditor: AgentId,
+        intermediaries: list[AgentId],
+        leaves_by_parent: dict[AgentId, list[AgentId]],
+    ) -> None:
+        self._id = agent_id
+        self._auditor = auditor
+        self._intermediaries = intermediaries
+        self._leaves_by_parent = leaves_by_parent
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Run the full auth probe suite at tick 0.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        auth = ctx.plugins.get("auth")
+        if auth is None:  # pragma: no cover - scenario always configures auth
+            return
+        if hasattr(auth, "set_clock"):
+            auth.set_clock(ctx.time)
+
+        can_delegate = hasattr(auth, "delegate")
+        root_scopes = ["tool:buy", "tool:sell", "tool:query", "tool:admin"]
+        root = await auth.issue(self._id, root_scopes)
+
+        intermediate_scopes = [
+            ["tool:buy", "tool:query"],
+            ["tool:sell", "tool:query"],
+            ["tool:buy", "tool:sell"],
+        ]
+        intermediate_tokens: dict[AgentId, Token] = {}
+        leaf_tokens: dict[AgentId, Token] = {}
+
+        for parent, scopes in zip(self._intermediaries, intermediate_scopes, strict=True):
+            if can_delegate:
+                token = await auth.delegate(root, parent, scopes, ttl=1800)
+            else:
+                token = await auth.issue(parent, scopes)
+            intermediate_tokens[parent] = token
+
+            leaf_scope = [scopes[0]]
+            for leaf in self._leaves_by_parent[parent]:
+                if can_delegate:
+                    leaf_token = await auth.delegate(token, leaf, leaf_scope, ttl=600)
+                    await auth.verify(leaf_token, presenter=leaf)
+                else:
+                    leaf_token = await auth.issue(leaf, leaf_scope)
+                    await auth.verify(leaf_token)
+                leaf_tokens[leaf] = leaf_token
+                await self._emit(
+                    ctx,
+                    f"honest_leaf:{leaf}:{parent}:{','.join(leaf_scope)}:ok",
+                )
+
+        await self._probe_scope_escalation(ctx, auth, can_delegate, intermediate_tokens)
+        await self._probe_stale_parent(ctx, auth, can_delegate, intermediate_tokens, leaf_tokens)
+        await self._probe_audience_confusion(ctx, auth, can_delegate, leaf_tokens)
+
+    async def _probe_scope_escalation(
+        self,
+        ctx: AgentContext,
+        auth: Any,
+        can_delegate: bool,
+        intermediate_tokens: dict[AgentId, Token],
+    ) -> None:
+        parent = self._intermediaries[0]
+        if can_delegate:
+            try:
+                await auth.delegate(
+                    intermediate_tokens[parent],
+                    AgentId("attack-scope"),
+                    ["tool:buy", "tool:admin"],
+                    ttl=60,
+                )
+            except ValueError:
+                await self._emit(ctx, "attack:scope_escalation:blocked")
+                return
+            await self._emit(ctx, "attack:scope_escalation:accepted")
+            return
+
+        token = await auth.issue(AgentId("attack-scope"), ["tool:buy", "tool:admin"])
+        verified = await auth.verify(token)
+        outcome = "accepted" if "tool:admin" in verified.scopes else "blocked"
+        await self._emit(ctx, f"attack:scope_escalation:{outcome}")
+
+    async def _probe_stale_parent(
+        self,
+        ctx: AgentContext,
+        auth: Any,
+        can_delegate: bool,
+        intermediate_tokens: dict[AgentId, Token],
+        leaf_tokens: dict[AgentId, Token],
+    ) -> None:
+        parent = self._intermediaries[1]
+        stale_leaf = self._leaves_by_parent[parent][0]
+        await auth.revoke(intermediate_tokens[parent])
+        try:
+            if can_delegate:
+                await auth.verify(leaf_tokens[stale_leaf], presenter=stale_leaf)
+            else:
+                await auth.verify(leaf_tokens[stale_leaf])
+        except ValueError:
+            await self._emit(ctx, "attack:stale_parent:blocked")
+            return
+        await self._emit(ctx, "attack:stale_parent:accepted")
+
+    async def _probe_audience_confusion(
+        self,
+        ctx: AgentContext,
+        auth: Any,
+        can_delegate: bool,
+        leaf_tokens: dict[AgentId, Token],
+    ) -> None:
+        leaf = self._leaves_by_parent[self._intermediaries[2]][0]
+        wrong_presenter = AgentId(f"{leaf}-wrong")
+        try:
+            if can_delegate:
+                await auth.verify(leaf_tokens[leaf], presenter=wrong_presenter)
+            else:
+                await auth.verify(leaf_tokens[leaf])
+        except ValueError:
+            await self._emit(ctx, "attack:audience_confusion:blocked")
+            return
+        await self._emit(ctx, "attack:audience_confusion:accepted")
+
+    async def _emit(self, ctx: AgentContext, line: str) -> None:
+        await ctx.send(self._auditor, line.encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """The coordinator is start-driven and ignores incoming messages.
+
+        Example::
+
+            await agent.on_message(ctx, auditor, b"noop")
+        """
+        return
+
+
+class AuditSink(StateMachineAgent):
+    """No-op receiver; the trace itself is the audit log.
+
+    Example::
+
+        sink = AuditSink()
+    """
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Accept audit lines without side effects."""
+        return
+
+
+class DelegationParticipant(StateMachineAgent):
+    """Started participant in the delegation tree.
+
+    The coordinator drives token issuance and verification centrally so the
+    trace stays deterministic; these agents make the scenario's advertised
+    intermediaries and leaves visible as real simulator participants.
+
+    Example::
+
+        participant = DelegationParticipant()
+    """
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Ignore messages; participation is represented by lifecycle events."""
+        return
+
+
+def _build_auth_instance(auth_cls: Any, coordinator: AgentId) -> Any:
+    if not isinstance(auth_cls, type):
+        return auth_cls
+
+    if auth_cls.__name__ == "DelegatableAuth":
+        from nest_plugins_reference.auth.delegatable import DelegatableAuth
+        from nest_plugins_reference.identity.ed25519_rotating import Ed25519RotatingIdentity
+        from nest_plugins_reference.policy import Budget, PolicyManifest, sign_manifest
+
+        ident = Ed25519RotatingIdentity(coordinator, seed=b"delegated-auth:coordinator")
+        manifest = PolicyManifest(
+            agent_id=coordinator,
+            tools=["buy", "sell", "query"],
+            budget=Budget(cap=1000),
+        )
+        signed = sign_manifest(ident, manifest)
+        return DelegatableAuth(
+            manifests={coordinator: signed},
+            identities={coordinator: ident},
+            clock=0.0,
+        )
+
+    try:
+        return auth_cls(clock=0.0)
+    except TypeError:
+        return auth_cls()
+
+
+def delegated_auth_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create one coordinator, three intermediaries, twelve leaves, and a sink.
+
+    Example::
+
+        agents = delegated_auth_factory(config, plugins)
+    """
+    coordinator = AgentId("coordinator-0")
+    auditor = AgentId("auditor-0")
+    intermediate_count = int(config.task.config.get("intermediaries", 3))
+    leaves_per_intermediary = int(config.task.config.get("leaves_per_intermediary", 4))
+
+    intermediaries = [AgentId(f"intermediary-{i}") for i in range(intermediate_count)]
+    leaves_by_parent = {
+        parent: [
+            AgentId(f"leaf-{parent_idx}-{leaf_idx}") for leaf_idx in range(leaves_per_intermediary)
+        ]
+        for parent_idx, parent in enumerate(intermediaries)
+    }
+
+    plugins["auth"] = _build_auth_instance(plugins.get("auth"), coordinator)
+
+    agents: dict[AgentId, StateMachineAgent] = {
+        coordinator: DelegationCoordinator(
+            coordinator,
+            auditor,
+            intermediaries=intermediaries,
+            leaves_by_parent=leaves_by_parent,
+        ),
+        auditor: AuditSink(),
+    }
+
+    for intermediary in intermediaries:
+        agents[intermediary] = DelegationParticipant()
+    for leaves in leaves_by_parent.values():
+        for leaf in leaves:
+            agents[leaf] = DelegationParticipant()
+
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1835,6 +1835,110 @@ def validate_receipt_reputation_honest_confidence(
 
 
 # ---------------------------------------------------------------------------
+# Delegatable auth validators
+# ---------------------------------------------------------------------------
+
+
+def _delegated_auth_lines(events: list[dict[str, Any]]) -> list[str]:
+    lines: list[str] = []
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if msg.startswith(("honest_leaf:", "attack:")):
+            lines.append(msg)
+    return lines
+
+
+def _delegated_auth_attack_outcomes(lines: list[str], attack: str) -> list[str]:
+    prefix = f"attack:{attack}:"
+    return [line.removeprefix(prefix) for line in lines if line.startswith(prefix)]
+
+
+def _validate_delegated_auth_attack(
+    events: list[dict[str, Any]],
+    *,
+    attack: str,
+    name: str,
+) -> list[ValidationResult]:
+    lines = _delegated_auth_lines(events)
+    honest_count = sum(
+        1 for line in lines if line.startswith("honest_leaf:") and line.endswith(":ok")
+    )
+    if honest_count < 12:
+        return [
+            ValidationResult(
+                name,
+                False,
+                f"expected 12 honest leaf verifies, saw {honest_count}",
+            )
+        ]
+
+    outcomes = _delegated_auth_attack_outcomes(lines, attack)
+    if not outcomes:
+        return [ValidationResult(name, False, f"missing {attack} attack line")]
+    if "accepted" in outcomes:
+        return [ValidationResult(name, False, f"{attack} attack accepted")]
+    if "blocked" not in outcomes:
+        return [ValidationResult(name, False, f"{attack} attack had outcomes {outcomes}")]
+    return [
+        ValidationResult(
+            name,
+            True,
+            f"{honest_count} honest leaves verified; {attack} attack blocked",
+        )
+    ]
+
+
+def validate_delegation_scope_containment(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Delegation must not broaden scopes beyond the parent token.
+
+    Example::
+
+        results = validate_delegation_scope_containment(events)
+    """
+    return _validate_delegated_auth_attack(
+        events,
+        attack="scope_escalation",
+        name="delegated_auth_scope_containment",
+    )
+
+
+def validate_no_stale_parent_verify(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """A descendant must fail verification after any ancestor is revoked.
+
+    Example::
+
+        results = validate_no_stale_parent_verify(events)
+    """
+    return _validate_delegated_auth_attack(
+        events,
+        attack="stale_parent",
+        name="delegated_auth_no_stale_parent",
+    )
+
+
+def validate_audience_binding(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """A token minted for one audience must not verify for another presenter.
+
+    Example::
+
+        results = validate_audience_binding(events)
+    """
+    return _validate_delegated_auth_attack(
+        events,
+        attack="audience_confusion",
+        name="delegated_auth_audience_binding",
+    )
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -1888,5 +1992,10 @@ VALIDATORS: dict[str, list[Any]] = {
     "receipt_reputation": [
         validate_receipt_reputation_ring_severed,
         validate_receipt_reputation_honest_confidence,
+    ],
+    "delegated_auth": [
+        validate_delegation_scope_containment,
+        validate_no_stale_parent_verify,
+        validate_audience_binding,
     ],
 }

--- a/packages/nest-core/tests/test_delegated_auth.py
+++ b/packages/nest-core/tests/test_delegated_auth.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end tests for delegated_auth scenario + validators.
+
+The headline proof is the plugin swap:
+
+* ``auth: jwt`` FAILS all three adversarial validators, because central
+  re-issuance does not preserve delegation caveats, revocation ancestry, or
+  presenter audience.
+* ``auth: delegatable`` PASSES all three, while still verifying 12 honest leaves.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+
+_SCENARIO_YAML = Path(__file__).parent.parent.parent.parent / "scenarios" / "delegated_auth.yaml"
+
+
+def _config(auth: str, trace: Path, seed: int | None = None) -> ScenarioConfig:
+    config = ScenarioConfig.from_yaml(_SCENARIO_YAML)
+    config.layers.auth = auth
+    config.output.trace = str(trace)
+    if seed is not None:
+        config.seed = seed
+    return config
+
+
+def _results(trace: Path) -> dict[str, bool]:
+    return {r.name: r.passed for r in validate_trace(trace, "delegated_auth")}
+
+
+class TestAdversarialProof:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("seed", [1, 7, 42, 123, 9999])
+    async def test_validators_pass_under_delegatable(self, tmp_path: Path, seed: int) -> None:
+        trace = tmp_path / f"delegatable-{seed}.jsonl"
+        await ScenarioRunner(_config("delegatable", trace, seed=seed)).run()
+        results = _results(trace)
+        assert results["delegated_auth_scope_containment"] is True
+        assert results["delegated_auth_no_stale_parent"] is True
+        assert results["delegated_auth_audience_binding"] is True
+
+    @pytest.mark.asyncio
+    async def test_validators_fail_under_jwt(self, tmp_path: Path) -> None:
+        trace = tmp_path / "jwt.jsonl"
+        await ScenarioRunner(_config("jwt", trace)).run()
+        results = _results(trace)
+        assert results["delegated_auth_scope_containment"] is False
+        assert results["delegated_auth_no_stale_parent"] is False
+        assert results["delegated_auth_audience_binding"] is False
+
+
+class TestDeterminism:
+    @pytest.mark.asyncio
+    async def test_same_seed_identical_trace(self, tmp_path: Path) -> None:
+        t1 = tmp_path / "run1.jsonl"
+        t2 = tmp_path / "run2.jsonl"
+        await ScenarioRunner(_config("delegatable", t1)).run()
+        await ScenarioRunner(_config("delegatable", t2)).run()
+        h1 = hashlib.sha256(t1.read_bytes()).hexdigest()
+        h2 = hashlib.sha256(t2.read_bytes()).hexdigest()
+        assert h1 == h2
+
+
+class TestScenarioShape:
+    @pytest.mark.asyncio
+    async def test_emits_honest_leaves_and_attack_lines(self, tmp_path: Path) -> None:
+        trace = tmp_path / "shape.jsonl"
+        await ScenarioRunner(_config("delegatable", trace)).run()
+        text = trace.read_text()
+        events = [json.loads(line) for line in text.splitlines()]
+        starts = [event["agent"] for event in events if event.get("kind") == "start"]
+        assert len(starts) == 17
+        assert sum(agent.startswith("intermediary-") for agent in starts) == 3
+        assert sum(agent.startswith("leaf-") for agent in starts) == 12
+        assert text.count("honest_leaf:") == 24  # send + receive for 12 audit messages
+        assert "attack:scope_escalation:blocked" in text
+        assert "attack:stale_parent:blocked" in text
+        assert "attack:audience_confusion:blocked" in text

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -754,6 +754,7 @@ class TestValidatorRegistry:
             "streaming_payments",
             "comms_versioning",
             "receipt_reputation",
+            "delegated_auth",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
@@ -49,8 +49,10 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import math
 import time
 from collections.abc import Mapping
+from typing import cast
 
 from nest_core.types import AgentId, AuthContext, Token
 
@@ -142,6 +144,97 @@ def _hmac(key: bytes, msg: str) -> str:
     return hmac.new(key, msg.encode(), hashlib.sha256).hexdigest()
 
 
+def _finite_number(value: object, name: str) -> float:
+    """Return *value* as ``float`` if it is a finite number, else raise.
+
+    ``bool`` is rejected even though it is an ``int`` subclass, because reading
+    ``True`` as one second would make time validation surprising.
+
+    Example::
+
+        ttl = _finite_number(60, "ttl")
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f"{name} must be finite"
+        raise ValueError(msg)
+    result = float(value)
+    if not math.isfinite(result):
+        msg = f"{name} must be finite"
+        raise ValueError(msg)
+    return result
+
+
+def _payload_data(payload_json: str) -> dict[str, object]:
+    """Decode and shape-check a token payload, raising ``ValueError`` on failure.
+
+    This keeps verification fail-closed for malformed JSON, missing fields, or
+    wrong field types instead of leaking incidental ``KeyError``/``TypeError``
+    exceptions from deeper checks.
+
+    Example::
+
+        data = _payload_data('{"aud":"a1","chain":[],"exp":1,"iat":0,"scopes":[],"sub":"a1"}')
+    """
+    try:
+        raw_data: object = json.loads(payload_json)
+    except json.JSONDecodeError as exc:
+        msg = "invalid token payload"
+        raise ValueError(msg) from exc
+    if not isinstance(raw_data, dict):
+        msg = "invalid token payload"
+        raise ValueError(msg)
+    data = cast("dict[str, object]", raw_data)
+
+    missing = {"aud", "chain", "exp", "iat", "scopes", "sub"} - set(data)
+    if missing:
+        msg = f"invalid token payload: missing {sorted(missing)}"
+        raise ValueError(msg)
+
+    aud = data["aud"]
+    sub = data["sub"]
+    chain = data["chain"]
+    scopes = data["scopes"]
+    exp = data["exp"]
+    iat = data["iat"]
+    if not isinstance(aud, str) or not isinstance(sub, str):
+        msg = "invalid token payload: aud/sub must be strings"
+        raise ValueError(msg)
+    if aud != sub:
+        msg = "invalid token payload: aud/sub mismatch"
+        raise ValueError(msg)
+    if not isinstance(chain, list):
+        msg = "invalid token payload: chain must be a list of token ids"
+        raise ValueError(msg)
+    chain_items = cast("list[object]", chain)
+    if not all(isinstance(item, str) for item in chain_items):
+        msg = "invalid token payload: chain must be a list of token ids"
+        raise ValueError(msg)
+    if not isinstance(scopes, list):
+        msg = "invalid token payload: scopes must be a list of strings"
+        raise ValueError(msg)
+    scope_items = cast("list[object]", scopes)
+    if not all(isinstance(item, str) for item in scope_items):
+        msg = "invalid token payload: scopes must be a list of strings"
+        raise ValueError(msg)
+    if isinstance(exp, bool) or not isinstance(exp, (int, float)):
+        msg = "invalid token payload: exp must be numeric"
+        raise ValueError(msg)
+    if isinstance(iat, bool) or not isinstance(iat, (int, float)):
+        msg = "invalid token payload: iat must be numeric"
+        raise ValueError(msg)
+    try:
+        exp_value = _finite_number(exp, "exp")
+        iat_value = _finite_number(iat, "iat")
+    except ValueError as exc:
+        msg = "invalid token payload: exp/iat must be finite"
+        raise ValueError(msg) from exc
+    if exp_value < iat_value:
+        msg = "invalid token payload: exp before iat"
+        raise ValueError(msg)
+
+    return data
+
+
 # ---------------------------------------------------------------------------
 # DelegatableAuth
 # ---------------------------------------------------------------------------
@@ -179,7 +272,9 @@ class DelegatableAuth:
         self._manifests: dict[AgentId, PolicyManifest] = dict(manifests or {})
         self._identities: dict[AgentId, ManifestSigner] = dict(identities or {})
         self._secret = secret
-        self._clock = clock
+        self._clock: float | None = None
+        if clock is not None:
+            self.set_clock(clock)
         # token-id -> hex HMAC sig (needed for chain recomputation on verify)
         self._sigs: dict[str, str] = {}
         self._payloads: dict[str, str] = {}
@@ -192,7 +287,7 @@ class DelegatableAuth:
 
             auth.set_clock(4000.0)
         """
-        self._clock = t
+        self._clock = _finite_number(t, "clock")
 
     def _now(self) -> float:
         """Return the current time (injected clock or wall clock).
@@ -259,8 +354,12 @@ class DelegatableAuth:
             raise ValueError(msg)
         payload_json, sig = parts
 
-        data = json.loads(payload_json)
-        chain: list[str] = data["chain"]
+        data = _payload_data(payload_json)
+        chain = cast("list[str]", data["chain"])
+        scopes = cast("list[str]", data["scopes"])
+        exp = cast("float", data["exp"])
+        iat = cast("float", data["iat"])
+        aud = cast("str", data["aud"])
         tid = _tid(payload_json)
         stored_sig = self._sigs.get(tid)
         if stored_sig is None:
@@ -285,20 +384,23 @@ class DelegatableAuth:
             if parent_payload_json is None:
                 msg = f"unknown parent payload {parent_tid!r}"
                 raise ValueError(msg)
-            parent_data = json.loads(parent_payload_json)
-            expected_chain = parent_data["chain"] + [parent_tid]
+            parent_data = _payload_data(parent_payload_json)
+            parent_chain = cast("list[str]", parent_data["chain"])
+            parent_scopes = cast("list[str]", parent_data["scopes"])
+            parent_exp = cast("float", parent_data["exp"])
+            expected_chain = parent_chain + [parent_tid]
             if chain != expected_chain:
                 msg = "invalid delegation chain"
                 raise ValueError(msg)
-            child_scope_set = set(data["scopes"])
-            parent_scope_set = set(parent_data["scopes"])
-            offending = [s for s in data["scopes"] if s not in parent_scope_set]
+            child_scope_set = set(scopes)
+            parent_scope_set = set(parent_scopes)
+            offending = [s for s in scopes if s not in parent_scope_set]
             if offending:
                 raise ScopeEscalationError(offending)
             if not child_scope_set < parent_scope_set:
-                raise ScopeEscalationError(list(data["scopes"]))
-            if data["exp"] > parent_data["exp"]:
-                raise TtlExceededError(child_exp=data["exp"], parent_exp=parent_data["exp"])
+                raise ScopeEscalationError(list(scopes))
+            if exp > parent_exp:
+                raise TtlExceededError(child_exp=exp, parent_exp=parent_exp)
             expected_sig = _hmac(parent_sig.encode(), payload_json)
 
         if not hmac.compare_digest(sig, expected_sig):
@@ -306,7 +408,7 @@ class DelegatableAuth:
             raise ValueError(msg)
 
         # Expiry check
-        if data["exp"] < self._now():
+        if exp < self._now():
             msg = "token expired"
             raise ValueError(msg)
 
@@ -318,14 +420,14 @@ class DelegatableAuth:
                 raise RevokedAncestorError(ancestor_tid)
 
         # Audience check
-        if presenter is not None and str(presenter) != data["aud"]:
-            raise AudienceMismatchError(expected=data["aud"], got=str(presenter))
+        if presenter is not None and str(presenter) != aud:
+            raise AudienceMismatchError(expected=aud, got=str(presenter))
 
         return AuthContext(
-            subject=AgentId(data["aud"]),
-            scopes=data["scopes"],
-            issued_at=data["iat"],
-            expires_at=data["exp"],
+            subject=AgentId(aud),
+            scopes=scopes,
+            issued_at=iat,
+            expires_at=exp,
         )
 
     async def revoke(self, token: Token) -> None:
@@ -375,16 +477,25 @@ class DelegatableAuth:
 
             child = await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=60)
         """
+        try:
+            ttl_value = _finite_number(ttl, "ttl")
+        except ValueError as exc:
+            msg = "ttl must be a finite positive number"
+            raise ValueError(msg) from exc
+        if ttl_value <= 0:
+            msg = "ttl must be a finite positive number"
+            raise ValueError(msg)
+
         # Verify the parent (propagates revocation/expiry errors)
         await self.verify(parent_token)
 
         # Parse parent
         raw = str(parent_token)
         parent_payload_json = raw.rsplit("|", 1)[0]
-        parent_data = json.loads(parent_payload_json)
-        parent_scopes: list[str] = parent_data["scopes"]
-        parent_exp: float = parent_data["exp"]
-        parent_chain: list[str] = parent_data["chain"]
+        parent_data = _payload_data(parent_payload_json)
+        parent_scopes = cast("list[str]", parent_data["scopes"])
+        parent_exp = cast("float", parent_data["exp"])
+        parent_chain = cast("list[str]", parent_data["chain"])
         parent_tid = _tid(parent_payload_json)
 
         # Scope escalation check
@@ -398,7 +509,7 @@ class DelegatableAuth:
 
         # TTL check
         now = self._now()
-        child_exp = now + ttl
+        child_exp = now + ttl_value
         if child_exp > parent_exp:
             raise TtlExceededError(child_exp=child_exp, parent_exp=parent_exp)
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
@@ -1,0 +1,478 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegatable capability-token auth plugin with cascading revocation.
+
+A :class:`DelegatableAuth` issues root tokens bound to a subject's
+:class:`~nest_plugins_reference.policy.PolicyManifest` and allows any token
+holder to *delegate* a strict subset of their scopes to a third party.
+Revocation of any node in a delegation chain automatically invalidates every
+descendant — no out-of-band notification required.
+
+Threat model: this is a reference, in-memory Auth plugin for deterministic
+Nanda Town scenarios. It protects against unsigned/tampered manifests, scope
+widening, equal-authority delegation, child TTL extension, stale descendants
+after local revocation, audience confusion, and token payload/signature
+tampering. Revocation and issued-token knowledge are process-local; distributed
+revocation/state replication are intentionally out of scope for this plugin.
+
+Token wire format: ``payload_json|sig_hex``
+
+The payload is ``json.dumps({...}, sort_keys=True)``.  The token id (``tid``)
+is ``sha256(payload_json.encode()).hexdigest()``.  Root-token signatures are
+``HMAC(secret, payload_json.encode())``.  Each delegated-child signature is
+``HMAC(parent_sig.encode(), child_payload_json.encode())``, chaining the
+signature material so revocation propagates cryptographically.
+
+Example::
+
+    from nest_core.types import AgentId
+    from nest_plugins_reference.policy import Budget, PolicyManifest
+    from nest_plugins_reference.policy.manifest import sign_manifest
+    from nest_plugins_reference.identity.ed25519_rotating import Ed25519RotatingIdentity
+    from nest_plugins_reference.auth.delegatable import DelegatableAuth
+
+    ident = Ed25519RotatingIdentity(AgentId("root"), seed=b"seed")
+    manifest = PolicyManifest(
+        agent_id=AgentId("root"), tools=["buy", "sell"], budget=Budget(cap=500),
+    )
+    signed = sign_manifest(ident, manifest)
+
+    auth = DelegatableAuth(manifests={AgentId("root"): signed}, clock=0.0)
+    import asyncio
+    root = asyncio.run(auth.issue(AgentId("root"), ["tool:buy", "tool:sell"]))
+    child = asyncio.run(auth.delegate(root, AgentId("delegatee"), ["tool:buy"], ttl=300))
+    ctx = asyncio.run(auth.verify(child, presenter=AgentId("delegatee")))
+    assert "tool:buy" in ctx.scopes
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from collections.abc import Mapping
+
+from nest_core.types import AgentId, AuthContext, Token
+
+from nest_plugins_reference.policy.decide import PolicyState, decide
+from nest_plugins_reference.policy.manifest import ManifestSigner, PolicyManifest, verify_manifest
+from nest_plugins_reference.policy.scopes import scope_to_op
+
+# ---------------------------------------------------------------------------
+# Typed errors (all subclass ValueError, matching repo convention)
+# ---------------------------------------------------------------------------
+
+
+class ScopeEscalationError(ValueError):
+    """Raised when a delegate request is not narrower than the parent token.
+
+    Example::
+
+        raise ScopeEscalationError(["tool:admin"])
+    """
+
+    def __init__(self, offending: list[str]) -> None:
+        self.offending = offending
+        super().__init__(f"scope escalation: {offending!r} not a strict subset of parent scopes")
+
+
+class TtlExceededError(ValueError):
+    """Raised when the requested child TTL would expire after the parent token.
+
+    Example::
+
+        raise TtlExceededError(child_exp=4000, parent_exp=3600)
+    """
+
+    def __init__(self, child_exp: float, parent_exp: float) -> None:
+        self.child_exp = child_exp
+        self.parent_exp = parent_exp
+        super().__init__(f"child exp {child_exp} exceeds parent exp {parent_exp}")
+
+
+class RevokedAncestorError(ValueError):
+    """Raised when verifying a token whose ancestor (or itself) was revoked.
+
+    Example::
+
+        raise RevokedAncestorError("abc123")
+    """
+
+    def __init__(self, tid: str) -> None:
+        self.tid = tid
+        super().__init__(f"token or ancestor {tid!r} has been revoked")
+
+
+class AudienceMismatchError(ValueError):
+    """Raised when the presenter does not match the token's audience.
+
+    Example::
+
+        raise AudienceMismatchError(expected="alice", got="bob")
+    """
+
+    def __init__(self, expected: str, got: str) -> None:
+        self.expected = expected
+        self.got = got
+        super().__init__(f"audience mismatch: expected {expected!r}, got {got!r}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tid(payload_json: str) -> str:
+    """Return the token id: sha256 of the UTF-8 encoded payload JSON.
+
+    Example::
+
+        tid = _tid('{"sub": "a1"}')
+    """
+    return hashlib.sha256(payload_json.encode()).hexdigest()
+
+
+def _hmac(key: bytes, msg: str) -> str:
+    """Return HMAC-SHA256 of *msg* (UTF-8 encoded) under *key* as hex.
+
+    Example::
+
+        sig = _hmac(b"secret", '{"sub": "a1"}')
+    """
+    return hmac.new(key, msg.encode(), hashlib.sha256).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# DelegatableAuth
+# ---------------------------------------------------------------------------
+
+
+class DelegatableAuth:
+    """Auth plugin implementing delegatable capability tokens with cascading revocation.
+
+    Root tokens are issued with scopes clamped to the subject's
+    :class:`~nest_plugins_reference.policy.PolicyManifest`.  Any token holder
+    may delegate a *strict subset* of their scopes to another agent, producing
+    a child token whose signature is *anchored* to the parent's.  Revoking any
+    token invalidates every descendant automatically because descendants carry
+    the ancestor ``tid`` in their ``chain`` list.
+
+    This reference implementation keeps issued token metadata and revocations
+    in memory. It is meant to make delegation invariants testable inside the
+    simulator, not to provide distributed revocation storage.
+
+    Example::
+
+        auth = DelegatableAuth(clock=0.0)
+        root = asyncio.run(auth.issue(AgentId("a1"), ["tool:buy", "tool:sell"]))
+        child = asyncio.run(auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=60))
+        ctx = asyncio.run(auth.verify(child, presenter=AgentId("a2")))
+    """
+
+    def __init__(
+        self,
+        manifests: Mapping[AgentId, PolicyManifest] | None = None,
+        identities: Mapping[AgentId, ManifestSigner] | None = None,
+        secret: bytes = b"nest-delegatable-secret",
+        clock: float | None = None,
+    ) -> None:
+        self._manifests: dict[AgentId, PolicyManifest] = dict(manifests or {})
+        self._identities: dict[AgentId, ManifestSigner] = dict(identities or {})
+        self._secret = secret
+        self._clock = clock
+        # token-id -> hex HMAC sig (needed for chain recomputation on verify)
+        self._sigs: dict[str, str] = {}
+        self._payloads: dict[str, str] = {}
+        self._revoked: set[str] = set()
+
+    def set_clock(self, t: float) -> None:
+        """Override the injected clock value (for testing time-sensitive behaviour).
+
+        Example::
+
+            auth.set_clock(4000.0)
+        """
+        self._clock = t
+
+    def _now(self) -> float:
+        """Return the current time (injected clock or wall clock).
+
+        Example::
+
+            t = auth._now()
+        """
+        if self._clock is not None:
+            return self._clock
+        return time.time()
+
+    # ------------------------------------------------------------------
+    # Auth protocol
+    # ------------------------------------------------------------------
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Issue a root token for *subject* with scopes clamped to its manifest.
+
+        Scopes not permitted by the subject's manifest are silently dropped.
+        If the subject has no manifest, an empty-scope token is issued.
+
+        Example::
+
+            token = await auth.issue(AgentId("a1"), ["tool:buy", "tool:admin"])
+        """
+        manifest = self._manifest_for(subject)
+        allowed_scopes = _clamp_scopes(scopes, manifest)
+
+        now = self._now()
+        payload = json.dumps(
+            {
+                "aud": str(subject),
+                "chain": [],
+                "exp": now + 3600,
+                "iat": now,
+                "scopes": allowed_scopes,
+                "sub": str(subject),
+            },
+            sort_keys=True,
+        )
+        sig = _hmac(self._secret, payload)
+        tid = _tid(payload)
+        self._sigs[tid] = sig
+        self._payloads[tid] = payload
+        return Token(f"{payload}|{sig}")
+
+    async def verify(self, token: Token, presenter: AgentId | None = None) -> AuthContext:
+        """Verify *token* and return its :class:`~nest_core.types.AuthContext`.
+
+        Raises :class:`ValueError` for expired or tampered tokens,
+        :class:`RevokedAncestorError` if the token or any ancestor was revoked,
+        and :class:`AudienceMismatchError` if *presenter* does not match the
+        token's audience.
+
+        Example::
+
+            ctx = await auth.verify(token, presenter=AgentId("a2"))
+        """
+        raw = str(token)
+        parts = raw.rsplit("|", 1)
+        if len(parts) != 2:
+            msg = "invalid token format"
+            raise ValueError(msg)
+        payload_json, sig = parts
+
+        data = json.loads(payload_json)
+        chain: list[str] = data["chain"]
+        tid = _tid(payload_json)
+        stored_sig = self._sigs.get(tid)
+        if stored_sig is None:
+            msg = f"unknown token {tid!r}"
+            raise ValueError(msg)
+        if not hmac.compare_digest(sig, stored_sig):
+            msg = "invalid signature"
+            raise ValueError(msg)
+
+        # Recompute expected signature and re-check the delegation caveats.
+        # The parent signature is visible in the parent token, so signature
+        # verification alone would let a holder handcraft a broader child.
+        if not chain:
+            expected_sig = _hmac(self._secret, payload_json)
+        else:
+            parent_tid = chain[-1]
+            parent_sig = self._sigs.get(parent_tid)
+            parent_payload_json = self._payloads.get(parent_tid)
+            if parent_sig is None:
+                msg = f"unknown parent token {parent_tid!r}"
+                raise ValueError(msg)
+            if parent_payload_json is None:
+                msg = f"unknown parent payload {parent_tid!r}"
+                raise ValueError(msg)
+            parent_data = json.loads(parent_payload_json)
+            expected_chain = parent_data["chain"] + [parent_tid]
+            if chain != expected_chain:
+                msg = "invalid delegation chain"
+                raise ValueError(msg)
+            child_scope_set = set(data["scopes"])
+            parent_scope_set = set(parent_data["scopes"])
+            offending = [s for s in data["scopes"] if s not in parent_scope_set]
+            if offending:
+                raise ScopeEscalationError(offending)
+            if not child_scope_set < parent_scope_set:
+                raise ScopeEscalationError(list(data["scopes"]))
+            if data["exp"] > parent_data["exp"]:
+                raise TtlExceededError(child_exp=data["exp"], parent_exp=parent_data["exp"])
+            expected_sig = _hmac(parent_sig.encode(), payload_json)
+
+        if not hmac.compare_digest(sig, expected_sig):
+            msg = "invalid signature"
+            raise ValueError(msg)
+
+        # Expiry check
+        if data["exp"] < self._now():
+            msg = "token expired"
+            raise ValueError(msg)
+
+        # Transitive revocation
+        if tid in self._revoked:
+            raise RevokedAncestorError(tid)
+        for ancestor_tid in chain:
+            if ancestor_tid in self._revoked:
+                raise RevokedAncestorError(ancestor_tid)
+
+        # Audience check
+        if presenter is not None and str(presenter) != data["aud"]:
+            raise AudienceMismatchError(expected=data["aud"], got=str(presenter))
+
+        return AuthContext(
+            subject=AgentId(data["aud"]),
+            scopes=data["scopes"],
+            issued_at=data["iat"],
+            expires_at=data["exp"],
+        )
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke *token*, invalidating it and all descendants.
+
+        Cascade is automatic: descendants carry this token's ``tid`` in their
+        ``chain`` list, so :meth:`verify` raises :class:`RevokedAncestorError`
+        for them too.
+
+        Example::
+
+            await auth.revoke(root_token)
+        """
+        raw = str(token)
+        parts = raw.rsplit("|", 1)
+        if len(parts) != 2:
+            msg = "invalid token format"
+            raise ValueError(msg)
+        payload_json = parts[0]
+        tid = _tid(payload_json)
+        self._revoked.add(tid)
+
+    # ------------------------------------------------------------------
+    # Delegation surface
+    # ------------------------------------------------------------------
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token:
+        """Mint a child token delegating *scopes_subset* to *audience*.
+
+        The child's scopes must be a strict subset of the parent's scopes; the
+        child's expiry must not exceed the parent's.  The child's HMAC key is
+        *anchored* to the parent's signature so revocation propagates automatically.
+
+        Raises:
+            Any error from :meth:`verify` if the parent is invalid/revoked/expired.
+            :class:`ScopeEscalationError` if *scopes_subset* is not a strict
+                subset of the parent.
+            :class:`TtlExceededError` if ``now + ttl > parent.exp``.
+
+        Example::
+
+            child = await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=60)
+        """
+        # Verify the parent (propagates revocation/expiry errors)
+        await self.verify(parent_token)
+
+        # Parse parent
+        raw = str(parent_token)
+        parent_payload_json = raw.rsplit("|", 1)[0]
+        parent_data = json.loads(parent_payload_json)
+        parent_scopes: list[str] = parent_data["scopes"]
+        parent_exp: float = parent_data["exp"]
+        parent_chain: list[str] = parent_data["chain"]
+        parent_tid = _tid(parent_payload_json)
+
+        # Scope escalation check
+        parent_scope_set = set(parent_scopes)
+        requested_scope_set = set(scopes_subset)
+        offending = [s for s in scopes_subset if s not in parent_scope_set]
+        if offending:
+            raise ScopeEscalationError(offending)
+        if not requested_scope_set < parent_scope_set:
+            raise ScopeEscalationError(list(scopes_subset))
+
+        # TTL check
+        now = self._now()
+        child_exp = now + ttl
+        if child_exp > parent_exp:
+            raise TtlExceededError(child_exp=child_exp, parent_exp=parent_exp)
+
+        # Build child payload (preserve input order for determinism)
+        child_payload = json.dumps(
+            {
+                "aud": str(audience),
+                "chain": parent_chain + [parent_tid],
+                "exp": child_exp,
+                "iat": now,
+                "scopes": list(scopes_subset),
+                "sub": str(audience),
+            },
+            sort_keys=True,
+        )
+
+        parent_sig = self._sigs[parent_tid]
+        child_sig = _hmac(parent_sig.encode(), child_payload)
+        child_tid = _tid(child_payload)
+        self._sigs[child_tid] = child_sig
+        self._payloads[child_tid] = child_payload
+        return Token(f"{child_payload}|{child_sig}")
+
+    def _manifest_for(self, subject: AgentId) -> PolicyManifest | None:
+        """Return a verified manifest for *subject*, or ``None`` to deny all.
+
+        If an identity verifier is supplied for the subject, the manifest's
+        signature must verify at the current logical clock. Without an identity
+        verifier, the constructor treats signed manifests as pre-verified by the
+        scenario factory and rejects unsigned manifests.
+        """
+        manifest = self._manifests.get(subject)
+        if manifest is None or manifest.signature is None:
+            return None
+        identity = self._identities.get(subject)
+        if identity is None:
+            return manifest
+        if not verify_manifest(identity, manifest, as_of=self._now()):
+            return None
+        return manifest
+
+
+# ---------------------------------------------------------------------------
+# Scope clamping helper
+# ---------------------------------------------------------------------------
+
+
+def _clamp_scopes(requested: list[str], manifest: PolicyManifest | None) -> list[str]:
+    """Return only those scopes in *requested* that the manifest permits.
+
+    If *manifest* is ``None``, returns an empty list (deny-all root).  Order is
+    preserved and duplicates are removed (first occurrence wins).
+
+    Example::
+
+        manifest = PolicyManifest(agent_id=AgentId("a1"), tools=["buy"])
+        allowed = _clamp_scopes(["tool:buy", "tool:admin", "tool:buy"], manifest)
+        assert allowed == ["tool:buy"]
+    """
+    if manifest is None:
+        return []
+
+    seen: set[str] = set()
+    result: list[str] = []
+    for scope in requested:
+        if scope in seen:
+            continue
+        parsed = scope_to_op(scope)
+        if parsed is None:
+            seen.add(scope)
+            continue
+        op, args = parsed
+        d = decide(manifest, op, args, PolicyState())
+        if d.allowed:
+            result.append(scope)
+        seen.add(scope)
+    return result

--- a/packages/nest-plugins-reference/nest_plugins_reference/policy/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/policy/__init__.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Policy primitives package — manifests, scope grammar, and decision core.
+
+Exports the full public surface of the three policy modules so callers can
+import from one place without knowing the internal file split.
+
+Example::
+
+    from nest_plugins_reference.policy import (
+        PolicyManifest, Budget, Approval, ManifestSigner,
+        sign_manifest, verify_manifest,
+        decide, Decision, PolicyState, approval_key, scope_to_op,
+    )
+    manifest = PolicyManifest(agent_id=AgentId("a1"), tools=["buy"])
+    op = scope_to_op("tool:buy")
+    d = decide(manifest, "tool", {"name": "buy"}, PolicyState())
+    assert d.allowed
+"""
+
+from __future__ import annotations
+
+from nest_plugins_reference.policy.decide import (
+    Decision,
+    PolicyState,
+    approval_key,
+    decide,
+)
+from nest_plugins_reference.policy.manifest import (
+    Approval,
+    Budget,
+    ManifestSigner,
+    PolicyManifest,
+    sign_manifest,
+    verify_manifest,
+)
+from nest_plugins_reference.policy.scopes import scope_to_op
+
+__all__ = [
+    "Approval",
+    "Budget",
+    "Decision",
+    "ManifestSigner",
+    "PolicyManifest",
+    "PolicyState",
+    "approval_key",
+    "decide",
+    "scope_to_op",
+    "sign_manifest",
+    "verify_manifest",
+]

--- a/packages/nest-plugins-reference/nest_plugins_reference/policy/decide.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/policy/decide.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The small policy decision core used to clamp manifest-bound scopes.
+
+:func:`decide` is a pure read over a
+:class:`~nest_plugins_reference.policy.manifest.PolicyManifest` and the current
+:class:`PolicyState`. It never mutates state and never raises, which lets the
+``delegatable`` Auth plugin use it safely while issuing root capability tokens.
+Callers that model runtime spend or approvals record those effects after a
+successful action, then ask again.
+
+Example::
+
+    state = PolicyState()
+    d = decide(manifest, "pay", {"amount": 100, "currency": "credits"}, state)
+    if d.allowed:
+        state.record_spend("credits", 100)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from nest_plugins_reference.policy.manifest import PolicyManifest
+
+
+def approval_key(op: str, amount: int) -> str:
+    """Return the canonical approval key for an amount-bound *op*.
+
+    The single source of the key string checked by :func:`decide`.
+
+    Example::
+
+        assert approval_key("pay", 500) == "pay:500"
+    """
+    return f"{op}:{amount}"
+
+
+@dataclass
+class Decision:
+    """Outcome of a policy check: ``allowed`` plus a ``reason`` when denied.
+
+    Example::
+
+        d = Decision(allowed=False, reason="tool not in allowlist")
+    """
+
+    allowed: bool
+    reason: str = ""
+
+
+@dataclass
+class PolicyState:
+    """Mutable per-agent runtime state the decision core reads.
+
+    Tracks cumulative spend per currency and the set of granted approval keys.
+    :func:`decide` only *reads* this; the enforcement surface mutates it after a
+    successful action.
+
+    Example::
+
+        state = PolicyState()
+        state.record_spend("credits", 100)
+        state.grant("pay:500")  # use approval_key("pay", 500)
+    """
+
+    spent: dict[str, int] = field(default_factory=lambda: dict[str, int]())
+    approvals: set[str] = field(default_factory=lambda: set[str]())
+
+    def record_spend(self, currency: str, amount: int) -> None:
+        """Add *amount* to cumulative spend for *currency*.
+
+        Example::
+
+            state.record_spend("credits", 50)
+        """
+        self.spent[currency] = self.spent.get(currency, 0) + amount
+
+    def grant(self, key: str) -> None:
+        """Record that approval *key* has been granted.
+
+        Use :func:`approval_key` to build the key, e.g.
+        ``state.grant(approval_key("pay", 500))``.
+
+        Example::
+
+            state.grant("pay:500")
+        """
+        self.approvals.add(key)
+
+
+def decide(
+    manifest: PolicyManifest,
+    op: str,
+    args: Mapping[str, Any],
+    state: PolicyState,
+) -> Decision:
+    """Decide whether *op* with *args* is permitted by *manifest* given *state*.
+
+    Covers all four governance dimensions:
+
+    - ``"tool"`` — ``args["name"]`` must be in ``manifest.tools``.
+    - ``"register"`` — every capability in ``args["capabilities"]`` must be in
+      ``manifest.tools``.
+    - ``"expose"`` — ``args["audience"]`` must be a subset of the audiences
+      declared for ``args["data_class"]`` in ``manifest.data`` (``"*"`` = any).
+    - ``"pay"`` — requires a ``manifest.budget``; cumulative spend may not
+      exceed the cap, the currency must match, and an amount over a matching
+      :class:`Approval` threshold requires a granted approval.
+
+    Returns a :class:`Decision`; never raises, never mutates *state*.
+
+    Example::
+
+        d = decide(manifest, "tool", {"name": "buy"}, PolicyState())
+    """
+    if op == "tool":
+        name = str(args.get("name", ""))
+        if name in manifest.tools:
+            return Decision(True)
+        return Decision(False, f"tool {name!r} not in allowlist")
+
+    if op == "register":
+        caps_raw = args.get("capabilities", [])
+        if not isinstance(caps_raw, list):
+            return Decision(False, "capabilities must be a list")
+        caps = [str(c) for c in cast("list[object]", caps_raw)]
+        bad = [c for c in caps if c not in manifest.tools]
+        if bad:
+            return Decision(False, f"capabilities not in allowlist: {bad}")
+        return Decision(True)
+
+    if op == "expose":
+        data_class = str(args.get("data_class", ""))
+        audience_raw = args.get("audience", [])
+        if not isinstance(audience_raw, list):
+            return Decision(False, "audience must be a list")
+        audience = [str(a) for a in cast("list[object]", audience_raw)]
+        allowed = manifest.data.get(data_class)
+        if allowed is None:
+            return Decision(False, f"data class {data_class!r} not declared")
+        if "*" in allowed:
+            return Decision(True)
+        bad = [a for a in audience if a not in allowed]
+        if bad:
+            return Decision(False, f"audience not permitted for {data_class!r}: {bad}")
+        return Decision(True)
+
+    if op == "pay":
+        if manifest.budget is None:
+            return Decision(False, "no budget declared")
+        amount = _coerce_amount(args.get("amount", 0))
+        if amount is None:
+            return Decision(False, f"invalid amount {args.get('amount')!r}")
+        currency = str(args.get("currency", manifest.budget.currency))
+        if amount < 0:
+            return Decision(False, "negative amount")
+        if currency != manifest.budget.currency:
+            return Decision(False, f"currency {currency!r} != {manifest.budget.currency!r}")
+        spent = state.spent.get(currency, 0)
+        if spent + amount > manifest.budget.cap:
+            return Decision(
+                False,
+                f"budget exceeded: {spent}+{amount} > {manifest.budget.cap}",
+            )
+        # Approval is bound to the specific amount, so one grant cannot authorise
+        # unlimited future large pays. When several rules match, the strictest
+        # (lowest threshold) wins regardless of declaration order.
+        thresholds = [a.threshold for a in manifest.approvals if a.op == "pay"]
+        if thresholds:
+            threshold = min(thresholds)
+            if amount > threshold and approval_key("pay", amount) not in state.approvals:
+                return Decision(
+                    False,
+                    f"requires authorization: amount {amount} > threshold {threshold}",
+                )
+        return Decision(True)
+
+    return Decision(False, f"unknown op {op!r}")
+
+
+def _coerce_amount(raw: Any) -> int | None:
+    """Coerce a payment amount to a non-fractional ``int``, or ``None`` if invalid.
+
+    Money is integer credits. Floats, strings, booleans, and ``None`` are
+    rejected (return ``None``) rather than silently truncated — ``int(100.9)``
+    would otherwise slip a fractional overspend past an integer cap, and
+    ``bool`` is an ``int`` subclass that must not be read as ``0``/``1``.
+
+    Example::
+
+        assert _coerce_amount(100) == 100
+        assert _coerce_amount(100.9) is None
+    """
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw
+    return None

--- a/packages/nest-plugins-reference/nest_plugins_reference/policy/manifest.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/policy/manifest.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Signed, identity-bound policy manifests for agent governance.
+
+A :class:`PolicyManifest` is the owner-authored, cryptographically-signed
+declaration of what an agent is allowed to do across four governance
+dimensions: which tools/actions it may call, what data it may expose (and to
+whom), how much it may spend, and which actions require prior authorization.
+
+The manifest is signed with the agent's own identity key (see
+``nest_plugins_reference.identity.ed25519_rotating``) so it is bound to the
+agent's cryptographic identity: only a manifest signed by the agent's key is
+honoured, and any tampering — widening the tool list, raising the spend cap —
+invalidates the signature, so :func:`verify_manifest` returns ``False``. The
+owner *authors* the policy, but the agent's own code cannot loosen it at
+runtime.
+
+Example::
+
+    from nest_core.types import AgentId
+    from nest_plugins_reference.identity.ed25519_rotating import (
+        Ed25519RotatingIdentity,
+    )
+
+    ident = Ed25519RotatingIdentity(AgentId("buyer-1"), seed=b"seed")
+    manifest = PolicyManifest(
+        agent_id=AgentId("buyer-1"), tools=["buy"], budget=Budget(cap=500),
+    )
+    signed = sign_manifest(ident, manifest)
+    assert verify_manifest(ident, signed)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Protocol, cast
+
+from nest_core.types import AgentId, Signature
+from pydantic import BaseModel, Field, field_serializer, field_validator
+
+
+class Budget(BaseModel):
+    """A spend ceiling for one currency.
+
+    Example::
+
+        budget = Budget(cap=500, currency="credits")
+    """
+
+    cap: int
+    currency: str = "credits"
+
+
+class Approval(BaseModel):
+    """A rule marking an op as requiring prior authorization above a threshold.
+
+    An action ``op`` whose amount exceeds ``threshold`` may only proceed when an
+    approval for ``op`` has been granted (recorded in policy state). A
+    ``threshold`` of ``0`` means the op always needs authorization.
+
+    Example::
+
+        approval = Approval(op="pay", threshold=200)
+    """
+
+    op: str
+    threshold: int = 0
+
+
+class PolicyManifest(BaseModel):
+    """An agent's signed, identity-bound governance policy.
+
+    ``data`` maps a data classification (e.g. ``"pii"``) to the list of agent
+    ids that classification may be exposed to (``"*"`` means any audience).
+
+    Example::
+
+        manifest = PolicyManifest(
+            agent_id=AgentId("a1"), tools=["buy"], budget=Budget(cap=500),
+        )
+    """
+
+    agent_id: AgentId
+    tools: list[str] = Field(default_factory=list)
+    data: dict[str, list[str]] = Field(default_factory=dict)
+    budget: Budget | None = None
+    approvals: list[Approval] = Field(default_factory=lambda: list[Approval]())
+    issued_at: float = 0.0
+    signature: Signature | None = None
+
+    def signing_bytes(self) -> bytes:
+        """Return the canonical, deterministic bytes the signature covers.
+
+        Excludes the ``signature`` field itself so signing and verification
+        operate over identical content regardless of insertion order.
+
+        Example::
+
+            raw = manifest.signing_bytes()
+        """
+        payload = self.model_dump(mode="json", exclude={"signature"})
+        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("ascii")
+
+    @field_serializer("signature", when_used="json")
+    def _serialize_signature(self, sig: Signature | None) -> dict[str, Any] | None:
+        """Render the signature JSON-safely (raw ``bytes`` -> hex).
+
+        Without this, ``model_dump_json`` raises on the signature's raw byte
+        ``value``. Hex keeps the *signed* manifest serialisable into a trace
+        ``manifest:`` announcement and decodable by validators, while
+        :meth:`signing_bytes` (which excludes the signature) is unaffected.
+
+        Example::
+
+            payload = signed.model_dump_json()
+        """
+        if sig is None:
+            return None
+        return {
+            "signer": str(sig.signer),
+            "value": sig.value.hex(),
+            "algorithm": sig.algorithm,
+            "key_id": sig.key_id,
+            "signed_at": sig.signed_at,
+        }
+
+    @field_validator("signature", mode="before")
+    @classmethod
+    def _decode_signature(cls, value: Any) -> Any:
+        """Decode a hex-encoded signature ``value`` back into ``bytes``.
+
+        Inverse of :meth:`_serialize_signature`, so a manifest round-trips
+        through ``model_validate_json(signed.model_dump_json())`` and still
+        verifies. Pass-through for the normal in-memory ``Signature`` path.
+
+        Example::
+
+            same = PolicyManifest.model_validate_json(signed.model_dump_json())
+        """
+        if not isinstance(value, dict):
+            return value
+        raw = cast("dict[str, Any]", value)
+        hex_value = raw.get("value")
+        if not isinstance(hex_value, str):
+            return raw
+        try:
+            decoded = bytes.fromhex(hex_value)
+        except ValueError:
+            return raw
+        return {**raw, "value": decoded}
+
+
+class ManifestSigner(Protocol):
+    """Structural identity interface used to sign and verify manifests.
+
+    Satisfied by ``nest_plugins_reference.identity.ed25519_rotating`` (and any
+    identity plugin exposing ``sign``/``verify``).
+
+    Example::
+
+        signer: ManifestSigner = Ed25519RotatingIdentity(AgentId("a1"), seed=b"s")
+    """
+
+    def sign(self, payload: bytes) -> Signature: ...
+
+    def verify(
+        self,
+        payload: bytes,
+        sig: Signature,
+        agent: AgentId,
+        as_of: float | None = None,
+    ) -> bool: ...
+
+
+def sign_manifest(identity: ManifestSigner, manifest: PolicyManifest) -> PolicyManifest:
+    """Return a copy of *manifest* signed by *identity* over its canonical bytes.
+
+    Example::
+
+        signed = sign_manifest(ident, manifest)
+        assert signed.signature is not None
+    """
+    sig = identity.sign(manifest.signing_bytes())
+    return manifest.model_copy(update={"signature": sig})
+
+
+def verify_manifest(
+    identity: ManifestSigner,
+    manifest: PolicyManifest,
+    *,
+    as_of: float | None = None,
+) -> bool:
+    """Return whether *manifest*'s signature is valid for its declared agent.
+
+    Returns ``False`` for an unsigned manifest, a tampered manifest (the
+    recomputed canonical bytes no longer match the signature), or a signature
+    made by a key the verifier does not bind to ``manifest.agent_id``.
+
+    ``as_of`` is forwarded to the identity's verification, anchoring it to an
+    externally observed tick (e.g. the trace tick at which the manifest was
+    adopted) so a manifest still verifies under key-window/rotation rules.
+    It is a *verifier-supplied* tick — never ``manifest.issued_at`` or the
+    signature's self-asserted ``signed_at`` (an attacker controls those).
+    Defaulting to ``None`` anchors to the identity's current clock, which fails
+    safe (closed) rather than open.
+
+    Example::
+
+        assert verify_manifest(ident, signed)
+        assert not verify_manifest(ident, signed.model_copy(update={"tools": ["x"]}))
+    """
+    if manifest.signature is None:
+        return False
+    return identity.verify(
+        manifest.signing_bytes(), manifest.signature, manifest.agent_id, as_of=as_of
+    )

--- a/packages/nest-plugins-reference/nest_plugins_reference/policy/scopes.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/policy/scopes.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The shared scope grammar mapping token scope strings to decision ops.
+
+A governed capability is expressed as a structured scope string. This module is
+the single source of that grammar for manifest-bound auth plugins and trace
+validators.
+
+Grammar (anything else parses to ``None`` and is treated as not-grantable):
+
+- ``tool:<name>``                    -> ("tool",   {"name": ...})
+- ``spend:<int>``                    -> ("pay",    {"amount": ...})  (per-action cap)
+- ``expose:<class>:<aud1,aud2,...>`` -> ("expose", {"data_class", "audience"})
+
+``spend`` is a per-action authorization: a single amount checked against the
+manifest cap. Cumulative spend and approval grants are stateful, so they are not
+represented by durable token scopes. ``register`` is similarly a runtime action
+and has no token-scope form by design.
+
+Example::
+
+    assert scope_to_op("tool:buy") == ("tool", {"name": "buy"})
+    assert scope_to_op("read") is None
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def scope_to_op(scope: str) -> tuple[str, dict[str, Any]] | None:
+    """Parse a structured scope string into a ``decide`` ``(op, args)`` pair.
+
+    Returns ``None`` for an ungoverned or malformed scope (including an
+    ``expose`` scope with an empty audience, which authorises nothing), which
+    callers treat as not-grantable.
+
+    Example::
+
+        assert scope_to_op("spend:100") == ("pay", {"amount": 100})
+        assert scope_to_op("expose:pii:") is None
+    """
+    parts = scope.split(":")
+    kind = parts[0]
+    if kind == "tool" and len(parts) == 2:
+        return ("tool", {"name": parts[1]})
+    if kind == "spend" and len(parts) == 2:
+        try:
+            return ("pay", {"amount": int(parts[1])})
+        except ValueError:
+            return None
+    if kind == "expose" and len(parts) == 3:
+        audience = [a for a in parts[2].split(",") if a]
+        if not audience:
+            return None
+        return ("expose", {"data_class": parts[1], "audience": audience})
+    return None

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -33,6 +33,9 @@ Repository = "https://github.com/projnanda/nandatown"
 # package. The PluginRegistry also keeps built-in defaults keyed by
 # (layer, name), but declaring the entry point here is the documented,
 # install-time discovery path described in CONTRIBUTING.md.
+[project.entry-points."nest.plugins.auth"]
+delegatable = "nest_plugins_reference.auth.delegatable:DelegatableAuth"
+
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
 

--- a/packages/nest-plugins-reference/tests/test_decide.py
+++ b/packages/nest-plugins-reference/tests/test_decide.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the single policy decision core (all four governance dimensions)."""
+
+from __future__ import annotations
+
+from nest_core.types import AgentId
+from nest_plugins_reference.policy.decide import PolicyState, decide
+from nest_plugins_reference.policy.manifest import Approval, Budget, PolicyManifest
+
+
+def _m(
+    *,
+    tools: list[str] | None = None,
+    data: dict[str, list[str]] | None = None,
+    budget: Budget | None = None,
+    approvals: list[Approval] | None = None,
+) -> PolicyManifest:
+    return PolicyManifest(
+        agent_id=AgentId("a1"),
+        tools=tools or [],
+        data=data or {},
+        budget=budget,
+        approvals=approvals or [],
+    )
+
+
+# --- tools dimension -------------------------------------------------------
+def test_tool_allowed() -> None:
+    assert decide(_m(tools=["buy"]), "tool", {"name": "buy"}, PolicyState()).allowed
+
+
+def test_tool_denied() -> None:
+    assert not decide(_m(tools=["buy"]), "tool", {"name": "sell"}, PolicyState()).allowed
+
+
+def test_register_subset_allowed() -> None:
+    d = decide(_m(tools=["buy", "sell"]), "register", {"capabilities": ["buy"]}, PolicyState())
+    assert d.allowed
+
+
+def test_register_overclaim_denied() -> None:
+    d = decide(_m(tools=["buy"]), "register", {"capabilities": ["buy", "admin"]}, PolicyState())
+    assert not d.allowed
+
+
+# --- data exposure dimension ----------------------------------------------
+def test_expose_allowed_audience() -> None:
+    m = _m(data={"pii": ["seller-1"]})
+    d = decide(m, "expose", {"data_class": "pii", "audience": ["seller-1"]}, PolicyState())
+    assert d.allowed
+
+
+def test_expose_disallowed_audience() -> None:
+    m = _m(data={"pii": ["seller-1"]})
+    d = decide(m, "expose", {"data_class": "pii", "audience": ["seller-2"]}, PolicyState())
+    assert not d.allowed
+
+
+def test_expose_wildcard_audience() -> None:
+    m = _m(data={"public": ["*"]})
+    d = decide(m, "expose", {"data_class": "public", "audience": ["anyone"]}, PolicyState())
+    assert d.allowed
+
+
+def test_expose_undeclared_class_denied() -> None:
+    d = decide(_m(), "expose", {"data_class": "secret", "audience": ["x"]}, PolicyState())
+    assert not d.allowed
+
+
+# --- spend dimension -------------------------------------------------------
+def test_pay_within_budget() -> None:
+    assert decide(_m(budget=Budget(cap=100)), "pay", {"amount": 50}, PolicyState()).allowed
+
+
+def test_pay_without_budget_denied() -> None:
+    assert not decide(_m(), "pay", {"amount": 1}, PolicyState()).allowed
+
+
+def test_pay_cumulative_exceeds_cap() -> None:
+    state = PolicyState()
+    state.record_spend("credits", 80)
+    assert not decide(_m(budget=Budget(cap=100)), "pay", {"amount": 30}, state).allowed
+
+
+def test_pay_currency_mismatch_denied() -> None:
+    m = _m(budget=Budget(cap=100, currency="credits"))
+    assert not decide(m, "pay", {"amount": 1, "currency": "usd"}, PolicyState()).allowed
+
+
+def test_pay_negative_amount_denied() -> None:
+    assert not decide(_m(budget=Budget(cap=100)), "pay", {"amount": -5}, PolicyState()).allowed
+
+
+# --- authorization-required dimension -------------------------------------
+def test_pay_over_threshold_needs_approval() -> None:
+    m = _m(budget=Budget(cap=1000), approvals=[Approval(op="pay", threshold=200)])
+    assert not decide(m, "pay", {"amount": 500}, PolicyState()).allowed
+
+
+def test_pay_over_threshold_with_grant_allowed() -> None:
+    m = _m(budget=Budget(cap=1000), approvals=[Approval(op="pay", threshold=200)])
+    state = PolicyState()
+    state.grant("pay:500")  # approval is bound to the specific amount
+    assert decide(m, "pay", {"amount": 500}, state).allowed
+
+
+def test_pay_grant_for_other_amount_does_not_authorize() -> None:
+    # A grant for 500 must NOT authorize a different large amount.
+    m = _m(budget=Budget(cap=100_000), approvals=[Approval(op="pay", threshold=200)])
+    state = PolicyState()
+    state.grant("pay:500")
+    assert not decide(m, "pay", {"amount": 50_000}, state).allowed
+
+
+def test_pay_under_threshold_no_approval_needed() -> None:
+    m = _m(budget=Budget(cap=1000), approvals=[Approval(op="pay", threshold=200)])
+    assert decide(m, "pay", {"amount": 100}, PolicyState()).allowed
+
+
+def test_pay_threshold_boundary_equal_needs_no_grant() -> None:
+    # amount == threshold does not require approval (rule is amount > threshold).
+    m = _m(budget=Budget(cap=1000), approvals=[Approval(op="pay", threshold=200)])
+    assert decide(m, "pay", {"amount": 200}, PolicyState()).allowed
+
+
+def test_pay_multiple_rules_strictest_wins() -> None:
+    # The lowest threshold applies regardless of declaration order.
+    m = _m(
+        budget=Budget(cap=10_000),
+        approvals=[Approval(op="pay", threshold=1000), Approval(op="pay", threshold=10)],
+    )
+    assert not decide(m, "pay", {"amount": 500}, PolicyState()).allowed
+
+
+# --- robustness: decide() must be total (never raise) ----------------------
+def test_pay_float_amount_rejected_no_truncation_bypass() -> None:
+    # int(100.9) == 100 must NOT slip past a cap of 100.
+    assert not decide(_m(budget=Budget(cap=100)), "pay", {"amount": 100.9}, PolicyState()).allowed
+
+
+def test_pay_bool_amount_rejected() -> None:
+    assert not decide(_m(budget=Budget(cap=100)), "pay", {"amount": True}, PolicyState()).allowed
+
+
+def test_pay_string_amount_does_not_raise() -> None:
+    assert not decide(_m(budget=Budget(cap=100)), "pay", {"amount": "abc"}, PolicyState()).allowed
+
+
+def test_pay_none_amount_does_not_raise() -> None:
+    assert not decide(_m(budget=Budget(cap=100)), "pay", {"amount": None}, PolicyState()).allowed
+
+
+def test_register_non_list_does_not_raise() -> None:
+    assert not decide(_m(tools=["buy"]), "register", {"capabilities": "buy"}, PolicyState()).allowed
+
+
+def test_expose_non_list_audience_does_not_raise() -> None:
+    m = _m(data={"pii": ["x"]})
+    assert not decide(m, "expose", {"data_class": "pii", "audience": None}, PolicyState()).allowed
+
+
+# --- purity: decide() must not mutate state --------------------------------
+def test_decide_does_not_mutate_state() -> None:
+    m = _m(budget=Budget(cap=100), approvals=[Approval(op="pay", threshold=10)])
+    state = PolicyState()
+    state.record_spend("credits", 40)
+    state.grant("pay:50")
+    spent_before = dict(state.spent)
+    approvals_before = set(state.approvals)
+    decide(m, "pay", {"amount": 50}, state)  # allowed path
+    decide(m, "pay", {"amount": 999}, state)  # denied path
+    assert state.spent == spent_before
+    assert state.approvals == approvals_before
+
+
+def test_pay_exactly_at_cap_allowed() -> None:
+    state = PolicyState()
+    state.record_spend("credits", 90)
+    assert decide(_m(budget=Budget(cap=100)), "pay", {"amount": 10}, state).allowed
+    assert not decide(_m(budget=Budget(cap=100)), "pay", {"amount": 11}, state).allowed
+
+
+def test_unknown_op_denied() -> None:
+    assert not decide(_m(), "frobnicate", {}, PolicyState()).allowed

--- a/packages/nest-plugins-reference/tests/test_delegatable.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable.py
@@ -96,6 +96,42 @@ async def test_root_issue_clamps_to_manifest() -> None:
 
 
 @pytest.mark.asyncio
+async def test_root_issue_clamps_tool_spend_and_expose_scopes() -> None:
+    """Root issuance clamps all supported scope dimensions to the signed manifest."""
+    ident = _ident("a1")
+    signed = sign_manifest(
+        ident,
+        PolicyManifest(
+            agent_id=AgentId("a1"),
+            tools=["buy"],
+            data={"pii": ["seller-1"]},
+            budget=Budget(cap=500),
+        ),
+    )
+    auth = DelegatableAuth(
+        manifests={AgentId("a1"): signed},
+        identities={AgentId("a1"): ident},
+        clock=0.0,
+    )
+    token = await auth.issue(
+        AgentId("a1"),
+        [
+            "tool:buy",
+            "tool:admin",
+            "spend:250",
+            "spend:501",
+            "expose:pii:seller-1",
+            "expose:pii:seller-2",
+            "expose:secret:seller-1",
+            "expose:pii:",
+        ],
+    )
+
+    ctx = await auth.verify(token, presenter=AgentId("a1"))
+    assert ctx.scopes == ["tool:buy", "spend:250", "expose:pii:seller-1"]
+
+
+@pytest.mark.asyncio
 async def test_root_issue_no_manifest_gives_empty_scopes() -> None:
     """Subject with no manifest receives empty scopes (deny-all root)."""
     auth = DelegatableAuth(clock=0.0)
@@ -126,6 +162,25 @@ async def test_root_issue_tampered_manifest_gives_empty_scopes_when_identity_sup
     auth = DelegatableAuth(
         manifests={AgentId("a1"): tampered},
         identities={AgentId("a1"): ident},
+        clock=0.0,
+    )
+    token = await auth.issue(AgentId("a1"), ["tool:admin"])
+    ctx = await auth.verify(token)
+    assert ctx.scopes == []
+
+
+@pytest.mark.asyncio
+async def test_root_issue_forged_manifest_gives_empty_scopes_when_identity_supplied() -> None:
+    """A manifest signed by a different key for the same agent fails closed."""
+    attacker = _ident("a1", seed=b"attacker-key")
+    honest = _ident("a1")
+    forged = sign_manifest(
+        attacker,
+        PolicyManifest(agent_id=AgentId("a1"), tools=["admin"], budget=Budget(cap=1000)),
+    )
+    auth = DelegatableAuth(
+        manifests={AgentId("a1"): forged},
+        identities={AgentId("a1"): honest},
         clock=0.0,
     )
     token = await auth.issue(AgentId("a1"), ["tool:admin"])
@@ -377,6 +432,42 @@ async def test_registered_forged_child_rechecked_by_verify(forged_scopes: list[s
         await auth.verify(forged, presenter=AgentId("a2"))
 
 
+@pytest.mark.asyncio
+async def test_invalid_token_format_rejected() -> None:
+    """A token without the payload/signature separator is malformed."""
+    auth = DelegatableAuth(clock=0.0)
+    with pytest.raises(ValueError, match="invalid token format"):
+        await auth.verify(Token("not-a-token"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw_token",
+    [
+        "not-json|sig",
+        "{}|sig",
+        "[]|sig",
+        '{"aud":"a1","chain":[],"exp":1,"iat":0,"scopes":[],"sub":"a2"}|sig',
+        '{"aud":"a1","chain":"root","exp":1,"iat":0,"scopes":[],"sub":"a1"}|sig',
+        '{"aud":"a1","chain":[],"exp":"never","iat":0,"scopes":[],"sub":"a1"}|sig',
+        '{"aud":"a1","chain":[],"exp":NaN,"iat":0,"scopes":[],"sub":"a1"}|sig',
+        '{"aud":"a1","chain":[],"exp":0,"iat":1,"scopes":[],"sub":"a1"}|sig',
+        '{"aud":"a1","chain":[],"exp":1,"iat":0,"scopes":"tool:buy","sub":"a1"}|sig',
+    ],
+)
+async def test_malformed_token_payload_rejected_fail_closed(raw_token: str) -> None:
+    """Malformed payloads raise ValueError before any authority is accepted."""
+    auth = DelegatableAuth(clock=0.0)
+    with pytest.raises(ValueError, match="invalid token payload"):
+        await auth.verify(Token(raw_token))
+
+
+def test_non_finite_injected_clock_rejected() -> None:
+    """Injected clocks must be finite so issued expiries stay meaningful."""
+    with pytest.raises(ValueError, match="clock must be finite"):
+        DelegatableAuth(clock=float("nan"))
+
+
 # ---------------------------------------------------------------------------
 # TTL enforcement
 # ---------------------------------------------------------------------------
@@ -394,6 +485,18 @@ async def test_ttl_exceeds_parent_raises() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("ttl", [0.0, -1.0, float("nan"), float("inf")])
+async def test_invalid_ttl_rejected(ttl: float) -> None:
+    """TTL must be finite and positive; NaN must not become a never-expiring token."""
+    m = _manifest("a1", tools=["buy", "sell"])
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy", "tool:sell"])
+
+    with pytest.raises(ValueError, match="ttl must be a finite positive number"):
+        await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=ttl)
+
+
+@pytest.mark.asyncio
 async def test_ttl_at_parent_boundary_allowed() -> None:
     """TTL exactly equal to parent remaining lifetime is allowed (check is strict >).
 
@@ -407,6 +510,18 @@ async def test_ttl_at_parent_boundary_allowed() -> None:
     child = await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=3600)
     ctx = await auth.verify(child, presenter=AgentId("a2"))
     assert ctx.expires_at == pytest.approx(3600.0)
+
+
+@pytest.mark.asyncio
+async def test_expired_token_rejected_on_verify() -> None:
+    """A token cannot be verified after its exp timestamp."""
+    m = _manifest("a1")
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy"])
+    auth.set_clock(3600.001)
+
+    with pytest.raises(ValueError, match="expired"):
+        await auth.verify(root, presenter=AgentId("a1"))
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nest-plugins-reference/tests/test_delegatable.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable.py
@@ -1,0 +1,458 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for DelegatableAuth — delegatable capability tokens.
+
+Covers: root-issue scope clamping, delegation subset, all three attacks
+(scope escalation, revoked ancestor, audience mismatch), token tampering,
+TTL enforcement, cascading revocation, protocol conformance, and plugin
+registry resolution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import cast
+
+import pytest
+from nest_core.layers.auth import Auth
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.delegatable import (
+    AudienceMismatchError,
+    DelegatableAuth,
+    RevokedAncestorError,
+    ScopeEscalationError,
+    TtlExceededError,
+)
+from nest_plugins_reference.identity.ed25519_rotating import Ed25519RotatingIdentity
+from nest_plugins_reference.policy import Budget, PolicyManifest, sign_manifest
+
+
+def _ident(aid: str, seed: bytes = b"seed") -> Ed25519RotatingIdentity:
+    return Ed25519RotatingIdentity(AgentId(aid), seed=seed)
+
+
+def _manifest(aid: str, tools: list[str] | None = None, cap: int = 1000) -> PolicyManifest:
+    ident = _ident(aid)
+    m = PolicyManifest(
+        agent_id=AgentId(aid),
+        tools=tools or ["buy", "sell"],
+        budget=Budget(cap=cap),
+    )
+    return sign_manifest(ident, m)
+
+
+def _tamper_token_payload(token: Token, **updates: object) -> Token:
+    payload_json, sig = str(token).rsplit("|", 1)
+    payload = json.loads(payload_json)
+    payload.update(updates)
+    return Token(f"{json.dumps(payload, sort_keys=True)}|{sig}")
+
+
+def _tamper_token_signature(token: Token) -> Token:
+    payload_json, sig = str(token).rsplit("|", 1)
+    replacement = "0" if sig[-1] != "0" else "1"
+    return Token(f"{payload_json}|{sig[:-1]}{replacement}")
+
+
+def _register_forged_child(auth: DelegatableAuth, parent: Token, scopes: list[str]) -> Token:
+    parent_payload_json, parent_sig = str(parent).rsplit("|", 1)
+    parent_data = json.loads(parent_payload_json)
+    parent_tid = hashlib.sha256(parent_payload_json.encode()).hexdigest()
+    forged_payload = json.dumps(
+        {
+            "aud": "a2",
+            "chain": parent_data["chain"] + [parent_tid],
+            "exp": parent_data["iat"] + 60.0,
+            "iat": parent_data["iat"],
+            "scopes": scopes,
+            "sub": "a2",
+        },
+        sort_keys=True,
+    )
+    forged_sig = hmac.new(parent_sig.encode(), forged_payload.encode(), hashlib.sha256).hexdigest()
+    forged_tid = hashlib.sha256(forged_payload.encode()).hexdigest()
+    sigs = cast("dict[str, str]", object.__getattribute__(auth, "_sigs"))
+    payloads = cast("dict[str, str]", object.__getattribute__(auth, "_payloads"))
+    sigs[forged_tid] = forged_sig
+    payloads[forged_tid] = forged_payload
+    return Token(f"{forged_payload}|{forged_sig}")
+
+
+# ---------------------------------------------------------------------------
+# Root issuance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_root_issue_clamps_to_manifest() -> None:
+    """Scopes not in the manifest are dropped at issuance."""
+    m = _manifest("a1", tools=["buy"])
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    token = await auth.issue(AgentId("a1"), ["tool:buy", "tool:admin", "tool:sell"])
+    ctx = await auth.verify(token)
+    assert ctx.scopes == ["tool:buy"]
+
+
+@pytest.mark.asyncio
+async def test_root_issue_no_manifest_gives_empty_scopes() -> None:
+    """Subject with no manifest receives empty scopes (deny-all root)."""
+    auth = DelegatableAuth(clock=0.0)
+    token = await auth.issue(AgentId("unknown"), ["tool:buy"])
+    ctx = await auth.verify(token)
+    assert ctx.scopes == []
+
+
+@pytest.mark.asyncio
+async def test_root_issue_unsigned_manifest_gives_empty_scopes() -> None:
+    """Unsigned manifests are deny-all, even when their content allows a tool."""
+    manifest = PolicyManifest(agent_id=AgentId("a1"), tools=["buy"], budget=Budget(cap=1000))
+    auth = DelegatableAuth(manifests={AgentId("a1"): manifest}, clock=0.0)
+    token = await auth.issue(AgentId("a1"), ["tool:buy"])
+    ctx = await auth.verify(token)
+    assert ctx.scopes == []
+
+
+@pytest.mark.asyncio
+async def test_root_issue_tampered_manifest_gives_empty_scopes_when_identity_supplied() -> None:
+    """A signed manifest widened after signing does not grant root authority."""
+    ident = _ident("a1")
+    signed = sign_manifest(
+        ident,
+        PolicyManifest(agent_id=AgentId("a1"), tools=["buy"], budget=Budget(cap=1000)),
+    )
+    tampered = signed.model_copy(update={"tools": ["buy", "admin"]})
+    auth = DelegatableAuth(
+        manifests={AgentId("a1"): tampered},
+        identities={AgentId("a1"): ident},
+        clock=0.0,
+    )
+    token = await auth.issue(AgentId("a1"), ["tool:admin"])
+    ctx = await auth.verify(token)
+    assert ctx.scopes == []
+
+
+@pytest.mark.asyncio
+async def test_root_issue_deduplicates_scopes() -> None:
+    """Duplicate scopes are removed; first occurrence is kept."""
+    m = _manifest("a1", tools=["buy"])
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    token = await auth.issue(AgentId("a1"), ["tool:buy", "tool:buy", "tool:buy"])
+    ctx = await auth.verify(token)
+    assert ctx.scopes == ["tool:buy"]
+
+
+# ---------------------------------------------------------------------------
+# Delegation — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delegate_subset_ok() -> None:
+    """Delegating a subset of parent scopes succeeds; child has only those scopes."""
+    m = _manifest("a1", tools=["buy", "sell"])
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy", "tool:sell"])
+    child = await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=300)
+    ctx = await auth.verify(child, presenter=AgentId("a2"))
+    assert ctx.scopes == ["tool:buy"]
+    assert "tool:sell" not in ctx.scopes
+
+
+@pytest.mark.asyncio
+async def test_delegate_chain_expiry_within_parent() -> None:
+    """Child expiry is correctly set to now + ttl."""
+    m = _manifest("a1")
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy", "tool:sell"])
+    child = await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=120)
+    ctx = await auth.verify(child, presenter=AgentId("a2"))
+    assert ctx.expires_at == pytest.approx(120.0)
+
+
+# ---------------------------------------------------------------------------
+# Attack 1: Scope escalation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scope_escalation_raises() -> None:
+    """Requesting scopes outside the parent raises ScopeEscalationError."""
+    m = _manifest("a1", tools=["buy"])
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy"])
+    with pytest.raises(ScopeEscalationError) as exc_info:
+        await auth.delegate(root, AgentId("a2"), ["tool:buy", "tool:admin"], ttl=60)
+    assert "tool:admin" in exc_info.value.offending
+
+
+@pytest.mark.asyncio
+async def test_equal_scope_delegation_raises() -> None:
+    """Delegation must narrow authority; equal-scope child tokens are rejected."""
+    m = _manifest("a1", tools=["buy"])
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy"])
+    with pytest.raises(ScopeEscalationError) as exc_info:
+        await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=60)
+    assert exc_info.value.offending == ["tool:buy"]
+
+
+@pytest.mark.asyncio
+async def test_handcrafted_child_token_rejected_even_with_valid_parent_hmac() -> None:
+    """A holder cannot bypass delegate() by signing a broader child payload."""
+    m = _manifest("a1", tools=["buy"])
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy"])
+    parent_payload, parent_sig = str(root).rsplit("|", 1)
+    parent_tid = hashlib.sha256(parent_payload.encode()).hexdigest()
+    forged_payload = json.dumps(
+        {
+            "aud": "a2",
+            "chain": [parent_tid],
+            "exp": 60.0,
+            "iat": 0.0,
+            "scopes": ["tool:admin"],
+            "sub": "a2",
+        },
+        sort_keys=True,
+    )
+    forged_sig = hmac.new(parent_sig.encode(), forged_payload.encode(), hashlib.sha256).hexdigest()
+    forged = Token(f"{forged_payload}|{forged_sig}")
+
+    with pytest.raises(ValueError, match="unknown token"):
+        await auth.verify(forged, presenter=AgentId("a2"))
+
+
+# ---------------------------------------------------------------------------
+# Attack 2: Cascading revocation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cascading_revocation() -> None:
+    """Revoking the root makes child and grandchild verify raise RevokedAncestorError."""
+    m = _manifest("a1", tools=["buy", "sell", "query"])
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy", "tool:sell", "tool:query"])
+    child = await auth.delegate(root, AgentId("a2"), ["tool:buy", "tool:sell"], ttl=1800)
+    grandchild = await auth.delegate(child, AgentId("a3"), ["tool:buy"], ttl=900)
+
+    await auth.revoke(root)
+
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify(child)
+
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify(grandchild)
+
+
+@pytest.mark.asyncio
+async def test_revoke_child_not_root() -> None:
+    """Revoking a child token does not affect the root, but grandchild fails."""
+    m = _manifest("a1", tools=["buy", "sell", "query"])
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy", "tool:sell", "tool:query"])
+    child = await auth.delegate(root, AgentId("a2"), ["tool:buy", "tool:sell"], ttl=1800)
+    grandchild = await auth.delegate(child, AgentId("a3"), ["tool:buy"], ttl=900)
+
+    await auth.revoke(child)
+
+    # Root still valid
+    ctx = await auth.verify(root)
+    assert "tool:buy" in ctx.scopes
+
+    # Child and grandchild fail
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify(child)
+
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify(grandchild)
+
+
+# ---------------------------------------------------------------------------
+# Attack 3: Audience mismatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audience_mismatch_raises() -> None:
+    """Verifying with the wrong presenter raises AudienceMismatchError."""
+    m = _manifest("a1")
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy", "tool:sell"])
+    child = await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=300)
+
+    with pytest.raises(AudienceMismatchError):
+        await auth.verify(child, presenter=AgentId("wrong-agent"))
+
+
+@pytest.mark.asyncio
+async def test_audience_match_ok() -> None:
+    """Verifying with the correct presenter succeeds."""
+    m = _manifest("a1")
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy", "tool:sell"])
+    child = await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=300)
+    ctx = await auth.verify(child, presenter=AgentId("a2"))
+    assert ctx.subject == AgentId("a2")
+
+
+@pytest.mark.asyncio
+async def test_verify_root_no_presenter() -> None:
+    """Omitting presenter skips the audience check."""
+    m = _manifest("a1")
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy"])
+    ctx = await auth.verify(root)
+    assert ctx.subject == AgentId("a1")
+
+
+@pytest.mark.asyncio
+async def test_root_audience_mismatch_raises() -> None:
+    """Root tokens are audience-bound when a presenter is supplied."""
+    m = _manifest("a1")
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy"])
+
+    with pytest.raises(AudienceMismatchError):
+        await auth.verify(root, presenter=AgentId("wrong-agent"))
+
+
+# ---------------------------------------------------------------------------
+# Token integrity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("aud", "a3"),
+        ("exp", 9999.0),
+        ("chain", ["unknown-parent"]),
+        ("scopes", ["tool:buy", "tool:admin"]),
+    ],
+)
+async def test_tampered_payload_rejected(field: str, value: object) -> None:
+    """Changing signed payload fields while keeping the old signature is rejected."""
+    m = _manifest("a1", tools=["buy", "sell"])
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy", "tool:sell"])
+    child = await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=300)
+
+    tampered = _tamper_token_payload(child, **{field: value})
+
+    with pytest.raises(ValueError):
+        await auth.verify(tampered, presenter=AgentId("a2"))
+
+
+@pytest.mark.asyncio
+async def test_tampered_signature_rejected() -> None:
+    """Changing only the signature on a known token is rejected."""
+    m = _manifest("a1")
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy"])
+
+    with pytest.raises(ValueError, match="invalid signature"):
+        await auth.verify(_tamper_token_signature(root), presenter=AgentId("a1"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "forged_scopes",
+    [
+        ["tool:buy", "tool:sell"],
+        ["tool:admin"],
+    ],
+)
+async def test_registered_forged_child_rechecked_by_verify(forged_scopes: list[str]) -> None:
+    """Verifier rejects registered children that violate delegation caveats."""
+    m = _manifest("a1", tools=["buy", "sell"])
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy", "tool:sell"])
+    forged = _register_forged_child(auth, root, forged_scopes)
+
+    with pytest.raises(ScopeEscalationError):
+        await auth.verify(forged, presenter=AgentId("a2"))
+
+
+# ---------------------------------------------------------------------------
+# TTL enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ttl_exceeds_parent_raises() -> None:
+    """TTL that would make child expire after parent raises TtlExceededError."""
+    m = _manifest("a1")
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy", "tool:sell"])
+    # root expires at 3600; requesting ttl=3601 exceeds it
+    with pytest.raises(TtlExceededError):
+        await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=3601)
+
+
+@pytest.mark.asyncio
+async def test_ttl_at_parent_boundary_allowed() -> None:
+    """TTL exactly equal to parent remaining lifetime is allowed (check is strict >).
+
+    child_exp = now + ttl = 0 + 3600 = 3600 == parent_exp → child_exp > parent_exp
+    is False, so the exact boundary is permitted.
+    """
+    m = _manifest("a1")
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy", "tool:sell"])
+    # child_exp == parent_exp is exactly equal — the check is >, so this is allowed
+    child = await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=3600)
+    ctx = await auth.verify(child, presenter=AgentId("a2"))
+    assert ctx.expires_at == pytest.approx(3600.0)
+
+
+# ---------------------------------------------------------------------------
+# Revoked / expired parent cannot be delegated from
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revoked_parent_cannot_be_delegated() -> None:
+    """Delegating from a revoked parent propagates the revocation error."""
+    m = _manifest("a1")
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy"])
+    await auth.revoke(root)
+    with pytest.raises(RevokedAncestorError):
+        await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=60)
+
+
+@pytest.mark.asyncio
+async def test_expired_parent_cannot_be_delegated() -> None:
+    """Delegating from an expired parent propagates the expiry error."""
+    m = _manifest("a1")
+    auth = DelegatableAuth(manifests={AgentId("a1"): m}, clock=0.0)
+    root = await auth.issue(AgentId("a1"), ["tool:buy"])
+    # Advance clock past root expiry
+    auth.set_clock(4000.0)
+    with pytest.raises(ValueError, match="expired"):
+        await auth.delegate(root, AgentId("a2"), ["tool:buy"], ttl=60)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_isinstance_auth_protocol() -> None:
+    """DelegatableAuth satisfies the Auth runtime-checkable protocol."""
+    assert isinstance(DelegatableAuth(), Auth)
+
+
+# ---------------------------------------------------------------------------
+# Plugin registry resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolvable_via_plugin_registry() -> None:
+    """DelegatableAuth is resolvable as ('auth', 'delegatable') via PluginRegistry."""
+    cls = PluginRegistry().resolve("auth", "delegatable")
+    assert cls is DelegatableAuth

--- a/packages/nest-plugins-reference/tests/test_delegatable_properties.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable_properties.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hypothesis property-based tests for DelegatableAuth.
+
+Three invariants checked over generated inputs:
+
+(a) Strict scope containment: for any parent scope set and any request,
+    the delegated child's scopes are always a strict subset of parent scopes
+    (or delegation raises ScopeEscalationError).
+
+(b) Transitive revocation: revoking ANY node in a random chain makes
+    verify raise for that node and all descendants.
+
+(c) Determinism: issue+delegate with clock=0.0 and identical inputs
+    yields byte-for-byte identical tokens across two separate instances.
+
+Example::
+
+    pytest packages/nest-plugins-reference/tests/test_delegatable_properties.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId
+from nest_plugins_reference.auth.delegatable import (
+    DelegatableAuth,
+    RevokedAncestorError,
+    ScopeEscalationError,
+)
+from nest_plugins_reference.identity.ed25519_rotating import Ed25519RotatingIdentity
+from nest_plugins_reference.policy import Budget, PolicyManifest, sign_manifest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TOOL_SCOPES = ["tool:buy", "tool:sell", "tool:transfer", "tool:query", "tool:report"]
+
+_SCOPE_STRAT = st.lists(
+    st.sampled_from(_TOOL_SCOPES),
+    min_size=1,
+    max_size=5,
+    unique=True,
+)
+
+
+def _make_auth(tools: list[str] | None = None) -> DelegatableAuth:
+    all_tools = tools or ["buy", "sell", "transfer", "query", "report"]
+    ident = Ed25519RotatingIdentity(AgentId("root"), seed=b"prop-seed")
+    manifest = PolicyManifest(
+        agent_id=AgentId("root"),
+        tools=all_tools,
+        budget=Budget(cap=100_000),
+    )
+    signed = sign_manifest(ident, manifest)
+    return DelegatableAuth(manifests={AgentId("root"): signed}, clock=0.0)
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# (a) Scope containment invariant
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=200)
+@given(parent_scopes=_SCOPE_STRAT, requested_scopes=_SCOPE_STRAT)
+def test_delegate_scopes_always_subset_of_parent(
+    parent_scopes: list[str], requested_scopes: list[str]
+) -> None:
+    """Child scopes are always a strict subset of parent, or ScopeEscalationError is raised."""
+    auth = _make_auth()
+    root = _run(auth.issue(AgentId("root"), parent_scopes))
+    root_ctx = _run(auth.verify(root))
+    actual_parent_scopes = set(root_ctx.scopes)
+    requested_scope_set = set(requested_scopes)
+
+    escalation_scopes = [s for s in requested_scopes if s not in actual_parent_scopes]
+
+    if not requested_scope_set < actual_parent_scopes:
+        with pytest.raises(ScopeEscalationError) as exc_info:
+            _run(auth.delegate(root, AgentId("child"), requested_scopes, ttl=300))
+        # All offending scopes must be named in the error
+        for s in escalation_scopes:
+            assert s in exc_info.value.offending
+    else:
+        child = _run(auth.delegate(root, AgentId("child"), requested_scopes, ttl=300))
+        child_ctx = _run(auth.verify(child, presenter=AgentId("child")))
+        assert set(child_ctx.scopes) <= actual_parent_scopes
+
+
+# ---------------------------------------------------------------------------
+# (b) Transitive revocation invariant
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(
+    depth=st.integers(min_value=1, max_value=4),
+    revoke_at=st.integers(min_value=0, max_value=3),
+)
+def test_revoking_any_node_invalidates_descendants(depth: int, revoke_at: int) -> None:
+    """Revoking any node in a chain invalidates that node and every descendant."""
+    auth = _make_auth()
+    # root -> chain of `depth` delegations
+    chain: list[Any] = []
+
+    current_scopes = ["tool:buy", "tool:sell", "tool:transfer", "tool:query", "tool:report"]
+    root = _run(auth.issue(AgentId("root"), current_scopes))
+    chain.append(root)
+
+    current = root
+    for i in range(depth):
+        audience = AgentId(f"agent-{i}")
+        child_scopes = current_scopes[:-1]
+        if not child_scopes:
+            break
+        try:
+            child = _run(auth.delegate(current, audience, child_scopes, ttl=3600))
+        except Exception:
+            # If ttl exceeds parent for some reason, stop building the chain
+            break
+        chain.append(child)
+        current = child
+        current_scopes = child_scopes
+
+    if len(chain) < 2:
+        return  # not enough tokens to test
+
+    revoke_idx = min(revoke_at, len(chain) - 1)
+    revoke_token = chain[revoke_idx]
+    _run(auth.revoke(revoke_token))
+
+    # Every token at revoke_idx and later must fail
+    for i in range(revoke_idx, len(chain)):
+        with pytest.raises(RevokedAncestorError):
+            _run(auth.verify(chain[i]))
+
+    # Every token before revoke_idx should still verify (for depth > 0)
+    for i in range(0, revoke_idx):
+        # These should not raise RevokedAncestorError
+        try:
+            _run(auth.verify(chain[i]))
+        except RevokedAncestorError:
+            pytest.fail(
+                f"Token at index {i} (before revoke_idx {revoke_idx}) was unexpectedly invalidated"
+            )
+
+
+# ---------------------------------------------------------------------------
+# (c) Determinism invariant
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(scopes=_SCOPE_STRAT, child_scopes=_SCOPE_STRAT)
+def test_delegate_deterministic_given_clock(scopes: list[str], child_scopes: list[str]) -> None:
+    """issue + delegate with clock=0.0 yields identical bytes across two instances."""
+    # Filter child scopes to be a subset of tool scopes that could appear in root
+    # We'll just use the same scopes for both and accept ScopeEscalationError as a skip
+
+    auth1 = _make_auth()
+    auth2 = _make_auth()
+
+    root1 = _run(auth1.issue(AgentId("root"), scopes))
+    root2 = _run(auth2.issue(AgentId("root"), scopes))
+
+    assert str(root1) == str(root2), "Root tokens must be identical for same inputs"
+
+    # Only proceed with delegation if child_scopes is a strict subset of root scopes
+    root1_ctx = _run(auth1.verify(root1))
+    valid_child_scopes = [s for s in child_scopes if s in set(root1_ctx.scopes)]
+
+    if not set(valid_child_scopes) < set(root1_ctx.scopes):
+        return  # nothing to test
+
+    # Both instances must produce identical child tokens
+    child1 = _run(auth1.delegate(root1, AgentId("child"), valid_child_scopes, ttl=300))
+    child2 = _run(auth2.delegate(root2, AgentId("child"), valid_child_scopes, ttl=300))
+
+    assert str(child1) == str(child2), "Child tokens must be identical for same inputs"

--- a/packages/nest-plugins-reference/tests/test_manifest.py
+++ b/packages/nest-plugins-reference/tests/test_manifest.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for signed, identity-bound policy manifests."""
+
+from __future__ import annotations
+
+from nest_core.types import AgentId
+from nest_plugins_reference.identity.ed25519_rotating import Ed25519RotatingIdentity
+from nest_plugins_reference.policy.manifest import (
+    Approval,
+    Budget,
+    PolicyManifest,
+    sign_manifest,
+    verify_manifest,
+)
+
+
+def _ident(aid: str = "a1", seed: bytes = b"seed") -> Ed25519RotatingIdentity:
+    return Ed25519RotatingIdentity(AgentId(aid), seed=seed)
+
+
+def test_sign_verify_roundtrip() -> None:
+    ident = _ident()
+    manifest = PolicyManifest(agent_id=AgentId("a1"), tools=["buy"], budget=Budget(cap=500))
+    signed = sign_manifest(ident, manifest)
+    assert signed.signature is not None
+    assert verify_manifest(ident, signed)
+
+
+def test_unsigned_manifest_rejected() -> None:
+    ident = _ident()
+    manifest = PolicyManifest(agent_id=AgentId("a1"), tools=["buy"])
+    assert not verify_manifest(ident, manifest)
+
+
+def test_tamper_tools_after_signing_rejected() -> None:
+    ident = _ident()
+    manifest = PolicyManifest(agent_id=AgentId("a1"), tools=["buy"], budget=Budget(cap=500))
+    signed = sign_manifest(ident, manifest)
+    tampered = signed.model_copy(update={"tools": ["buy", "admin"]})
+    assert not verify_manifest(ident, tampered)
+
+
+def test_tamper_budget_after_signing_rejected() -> None:
+    ident = _ident()
+    manifest = PolicyManifest(agent_id=AgentId("a1"), budget=Budget(cap=100))
+    signed = sign_manifest(ident, manifest)
+    tampered = signed.model_copy(update={"budget": Budget(cap=10_000)})
+    assert not verify_manifest(ident, tampered)
+
+
+def test_forged_by_other_identity_rejected() -> None:
+    # Attacker signs a manifest claiming to be a1, using their own key material.
+    attacker = _ident("a1", seed=b"attacker-key")
+    honest = _ident("a1", seed=b"seed")  # the *real* a1 key the verifier trusts
+    manifest = PolicyManifest(agent_id=AgentId("a1"), tools=["admin"])
+    forged = sign_manifest(attacker, manifest)
+    # The honest verifier binds a1 to the real key; the forged signature's
+    # key_id is not among the trusted records, so verification fails.
+    assert not verify_manifest(honest, forged)
+
+
+def test_signing_bytes_deterministic_and_order_independent() -> None:
+    a = PolicyManifest(agent_id=AgentId("a1"), tools=["a", "b"], budget=Budget(cap=5))
+    b = PolicyManifest(agent_id=AgentId("a1"), budget=Budget(cap=5), tools=["a", "b"])
+    assert a.signing_bytes() == a.signing_bytes()
+    assert a.signing_bytes() == b.signing_bytes()
+
+
+def test_tamper_agent_id_after_signing_rejected() -> None:
+    ident = _ident()
+    signed = sign_manifest(ident, PolicyManifest(agent_id=AgentId("a1"), tools=["buy"]))
+    tampered = signed.model_copy(update={"agent_id": AgentId("a2")})
+    assert not verify_manifest(ident, tampered)
+
+
+def test_tamper_issued_at_after_signing_rejected() -> None:
+    ident = _ident()
+    signed = sign_manifest(ident, PolicyManifest(agent_id=AgentId("a1"), issued_at=1.0))
+    tampered = signed.model_copy(update={"issued_at": 999.0})
+    assert not verify_manifest(ident, tampered)
+
+
+def test_tamper_approvals_after_signing_rejected() -> None:
+    ident = _ident()
+    signed = sign_manifest(
+        ident,
+        PolicyManifest(
+            agent_id=AgentId("a1"),
+            budget=Budget(cap=1000),
+            approvals=[Approval(op="pay", threshold=100)],
+        ),
+    )
+    tampered = signed.model_copy(update={"approvals": [Approval(op="pay", threshold=10_000)]})
+    assert not verify_manifest(ident, tampered)
+
+
+def test_signature_transplant_rejected() -> None:
+    ident = _ident()
+    signed_a = sign_manifest(ident, PolicyManifest(agent_id=AgentId("a1"), tools=["buy"]))
+    other = PolicyManifest(agent_id=AgentId("a1"), tools=["admin"])
+    transplanted = other.model_copy(update={"signature": signed_a.signature})
+    assert not verify_manifest(ident, transplanted)
+
+
+def test_signed_manifest_json_roundtrip_still_verifies() -> None:
+    # The signed manifest must serialise to JSON (raw signature bytes -> hex)
+    # and round-trip back to a manifest that still verifies. This is the
+    # trace-announcement / validator-decode contract (JSON round-trip).
+    ident = _ident()
+    signed = sign_manifest(
+        ident,
+        PolicyManifest(
+            agent_id=AgentId("a1"),
+            tools=["buy"],
+            data={"pii": ["seller-1"]},
+            budget=Budget(cap=500),
+            approvals=[Approval(op="pay", threshold=100)],
+        ),
+    )
+    payload = signed.model_dump_json()
+    restored = PolicyManifest.model_validate_json(payload)
+    assert restored.signature is not None
+    assert restored.signature.value == signed.signature.value if signed.signature else False
+    assert verify_manifest(ident, restored)
+
+
+def test_unsigned_manifest_json_roundtrips() -> None:
+    m = PolicyManifest(agent_id=AgentId("a1"), tools=["buy"])
+    restored = PolicyManifest.model_validate_json(m.model_dump_json())
+    assert restored.signature is None
+    assert restored.signing_bytes() == m.signing_bytes()

--- a/packages/nest-plugins-reference/tests/test_policy_core_properties.py
+++ b/packages/nest-plugins-reference/tests/test_policy_core_properties.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hypothesis property-based tests for the policy decision core and manifest.
+
+These check invariants over generated inputs, not just hand-picked cases:
+
+1. Totality: :func:`decide` never raises for any op and arbitrary args mapping.
+2. Purity: :func:`decide` never mutates the :class:`PolicyState` it is given.
+3. Budget soundness: a single ``pay`` is allowed iff ``spent + amount`` is a
+   valid non-negative integer within the cap (and approval, if required, holds).
+4. Manifest canonicality: ``signing_bytes`` is independent of field-insertion
+   order and changes whenever signed content changes.
+
+Example::
+
+    pytest packages/nest-plugins-reference/tests/test_policy_core_properties.py
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId
+from nest_plugins_reference.policy.decide import PolicyState, decide
+from nest_plugins_reference.policy.manifest import Approval, Budget, PolicyManifest
+
+_OPS = st.sampled_from(["tool", "register", "expose", "pay", "frobnicate", ""])
+_SCALARS: st.SearchStrategy[Any] = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(min_value=-1000, max_value=1000),
+    st.floats(allow_nan=False, allow_infinity=False, width=32),
+    st.text(max_size=8),
+    st.lists(st.text(max_size=4), max_size=4),
+)
+_ARGS = st.dictionaries(
+    keys=st.sampled_from(["name", "capabilities", "audience", "data_class", "amount", "currency"]),
+    values=_SCALARS,
+    max_size=6,
+)
+
+
+def _manifest() -> PolicyManifest:
+    return PolicyManifest(
+        agent_id=AgentId("a1"),
+        tools=["buy", "sell"],
+        data={"pii": ["seller-1"], "public": ["*"]},
+        budget=Budget(cap=1000),
+        approvals=[Approval(op="pay", threshold=200)],
+    )
+
+
+@settings(max_examples=300)
+@given(op=_OPS, args=_ARGS)
+def test_decide_is_total_and_pure(op: str, args: dict[str, Any]) -> None:
+    state = PolicyState(spent={"credits": 100}, approvals={"pay:300"})
+    before = copy.deepcopy(state)
+    result = decide(_manifest(), op, args, state)  # must not raise
+    assert isinstance(result.allowed, bool)
+    assert state.spent == before.spent
+    assert state.approvals == before.approvals
+
+
+@settings(max_examples=300)
+@given(
+    spent=st.integers(min_value=0, max_value=2000),
+    amount=st.integers(min_value=-100, max_value=2000),
+)
+def test_pay_budget_soundness(spent: int, amount: int) -> None:
+    cap = 1000
+    m = PolicyManifest(agent_id=AgentId("a1"), budget=Budget(cap=cap))  # no approval rule
+    state = PolicyState(spent={"credits": spent})
+    allowed = decide(m, "pay", {"amount": amount, "currency": "credits"}, state).allowed
+    expected = amount >= 0 and spent + amount <= cap
+    assert allowed == expected
+
+
+@settings(max_examples=200)
+@given(
+    tools=st.lists(st.text(max_size=5), max_size=5),
+    cap=st.integers(min_value=0, max_value=10_000),
+)
+def test_signing_bytes_order_independent(tools: list[str], cap: int) -> None:
+    a = PolicyManifest(agent_id=AgentId("a1"), tools=tools, budget=Budget(cap=cap))
+    b = PolicyManifest(agent_id=AgentId("a1"), budget=Budget(cap=cap), tools=tools)
+    assert a.signing_bytes() == b.signing_bytes()
+
+
+@settings(max_examples=200)
+@given(
+    cap1=st.integers(min_value=0, max_value=5000),
+    delta=st.integers(min_value=1, max_value=5000),
+)
+def test_signing_bytes_changes_with_content(cap1: int, delta: int) -> None:
+    a = PolicyManifest(agent_id=AgentId("a1"), budget=Budget(cap=cap1))
+    b = PolicyManifest(agent_id=AgentId("a1"), budget=Budget(cap=cap1 + delta))
+    assert a.signing_bytes() != b.signing_bytes()

--- a/scenarios/delegated_auth.yaml
+++ b/scenarios/delegated_auth.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegatable capability-token scenario: coordinator -> 3 intermediaries -> 12
+# leaves, then three adversarial probes for scope escalation, stale ancestors,
+# and audience confusion.
+#
+# Under `auth: delegatable` the delegated_auth validators PASS. Switch this to
+# `jwt` to see all three validators FAIL against the central re-issuance
+# baseline.
+name: delegated_auth
+description: "Manifest-bound delegatable auth with cascading revocation and audience binding."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 17
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+    - name: intermediary
+      count: 3
+    - name: leaf
+      count: 12
+    - name: auditor
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: delegatable
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: delegated_auth
+  config:
+    intermediaries: 3
+    leaves_per_intermediary: 4
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/delegated_auth.jsonl


### PR DESCRIPTION
# [Hackathon] Auth: manifest-bound delegatable capability tokens

## Problem Picked

**Problem #04 — Delegatable capability tokens with cascading revocation.**

**Layer 5 — Auth.**

This PR adds `auth: delegatable`, a reference Auth-layer plugin for manifest-bound delegatable capability tokens, plus the required adversarial validators and `scenarios/delegated_auth.yaml` proof scenario. It stays inside the existing 12-layer stack and does not introduce a new framework layer.

## Why

The default `jwt` auth plugin can issue and verify bearer tokens, but it cannot model the delegation pattern called out in problem #04:

> agent A holds a root token; agent A mints a short-lived, narrower token for agent B; revoking A's token invalidates B's token at the next verify.

That pattern matters for agent swarms because orchestrators routinely need constrained handoffs:

- "You may call this tool, but not pass broader authority onward."
- "You may buy this item, but only within my delegated capability."
- "You may act for me until this parent token expires or is revoked."
- "You may use this sub-capability, but only as the declared audience."

This PR makes that capability-delegation contract testable under attack in Nanda Town.

## Core Idea

`DelegatableAuth` issues root tokens whose scopes are clamped to a signed manifest. A holder can mint a child token for another audience, but only under stricter caveats:

- **Manifest-bound roots:** root scopes are clamped to tools allowed by the signed `PolicyManifest`.
- **Strict scope narrowing:** child scopes must be a strict subset of parent scopes.
- **TTL containment:** child expiry cannot exceed parent expiry.
- **Audience binding:** a token minted for one agent cannot be presented by another.
- **Cascading revocation:** revoking any token invalidates that token and all descendants.
- **Tamper resistance:** manifest tampering and token payload/signature tampering are rejected.

The plugin is a deterministic, in-memory reference implementation for the Nanda Town test rig. Distributed revocation and cross-process token registry replication are intentionally out of scope.

## Adversarial Contract

Problem #04 requires validators that catch three attacks. This PR ships all three:

| Attack | Baseline `auth: jwt` | This PR `auth: delegatable` |
|---|---|---|
| Scope escalation | FAIL: broader child authority can be accepted via baseline re-issuance | PASS: child scopes must be a strict subset of parent scopes |
| Stale parent | FAIL: revoking parent authority does not invalidate separately issued child token | PASS: descendant verification checks revoked ancestors |
| Audience confusion | FAIL: baseline verification does not bind delegated presentation to the child audience | PASS: presenter must match token audience |

The bundled scenario builds the required delegation tree: one coordinator, three intermediaries, and twelve leaves.

## What Ships

- `nest_plugins_reference.auth.delegatable.DelegatableAuth`
- minimal signed-manifest primitives used to clamp Auth scopes
- entry-point registration for `auth: delegatable`
- `scenarios/delegated_auth.yaml`
- `delegated_auth` built-in scenario with coordinator, 3 intermediaries, and 12 leaves
- adversarial validators:
  - `delegated_auth_scope_containment`
  - `delegated_auth_no_stale_parent`
  - `delegated_auth_audience_binding`
- unit tests for scope clamping, delegation, revocation, TTL, audience binding, tampering, and plugin resolution
- property tests for strict scope containment, transitive revocation, and deterministic token generation
- end-to-end tests showing `auth: delegatable` PASS and `auth: jwt` FAIL

## Security Properties Covered By Tests

- unsigned manifests are deny-all
- signed manifests widened after signing do not grant new authority
- duplicate root scopes are deduplicated
- child scopes must be narrower than parent scopes
- equal-scope delegation is rejected
- out-of-parent scope escalation is rejected
- child TTL beyond parent expiry is rejected
- revoked ancestors invalidate descendants
- child revocation does not invalidate the root
- root and child tokens are audience-bound when a presenter is supplied
- payload tampering of `aud`, `exp`, `chain`, or `scopes` is rejected
- signature tampering is rejected
- verifier re-checks delegation caveats even for registered forged children
- the scenario trace is deterministic under repeated runs

## How To Test

Run the charter CI gate:

```bash
uv sync
uv run ruff check .
uv run ruff format --check .
uv run pyright
uv run pytest -v
```

Equivalent local shortcut:

```bash
make ci-local
```

Focused Auth checks:

```bash
uv run pytest packages/nest-plugins-reference/tests/test_delegatable.py \
  packages/nest-plugins-reference/tests/test_delegatable_properties.py \
  packages/nest-core/tests/test_delegated_auth.py -q
```

Scenario proof:

```bash
uv run nest run scenarios/delegated_auth.yaml -o /tmp/delegated_auth.jsonl
uv run python -c "from pathlib import Path; from nest_core.validators import validate_trace; p=Path('/tmp/delegated_auth.jsonl'); [print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail) for r in validate_trace(p, 'delegated_auth')]"
```

Expected under `auth: delegatable`: all three validators PASS.

Flip the YAML layer to `auth: jwt`, rerun, and the same three validators FAIL.

## Determinism

The plugin uses deterministic JSON payloads, deterministic HMAC chaining, and the scenario uses the Nanda Town seed path. Re-running the same scenario with the same seed produces a byte-identical trace.

## API Fit

- Implements the existing `Auth` protocol surface: `issue`, `verify`, and `revoke`.
- Adds the problem-required extension method: `delegate(parent_token, audience, scopes_subset, ttl) -> Token`.
- Uses `nest_core.types.AgentId`, `Token`, and `AuthContext`.
- Registers as `auth: delegatable`.
- Public symbols follow the repo docstring style with `Example::` blocks.

## Threat Model And Limits

This is a reference plugin for deterministic Nanda Town simulations. It protects against scope widening, equal-authority delegation, parent TTL bypass, stale descendants after local revocation, audience confusion, manifest tampering, and token payload/signature tampering.

It does not attempt to solve distributed revocation, cross-process token registry replication, agent process sandboxing, hardware-backed key attestation, OAuth2 server endpoints, or network token introspection.

## Persona

Security-minded agent-runtime engineer. The emphasis is on explicit authority boundaries, adversarial tests, deterministic replay, and making the Auth layer catch delegation bugs that the baseline `jwt` plugin cannot catch.

