### PR TITLE
[Hackathon] kavya-escrow-payments: conditional, arbitrated escrow plugin for the payments layer

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -29,6 +29,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
+    ("payments", "escrow"): f"{_REF}.payments.escrow:EscrowPayments",
     ("coordination", "contract_net"): f"{_REF}.coordination.contract_net:ContractNet",
     ("coordination", "hotstuff"): f"{_REF}.coordination.hotstuff:HotStuff",
     ("negotiation", "alternating_offers"): (

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -113,3 +113,9 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.bft_hotstuff import bft_hotstuff_factory
 
         register_scenario("bft_hotstuff", bft_hotstuff_factory)
+    elif name == "escrow_marketplace":
+        from nest_core.scenarios_builtin.escrow_marketplace import (
+            escrow_marketplace_factory,
+        )
+
+        register_scenario("escrow_marketplace", escrow_marketplace_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/escrow_marketplace.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/escrow_marketplace.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Escrow marketplace scenario -- three buyer/seller/arbiter triples.
+
+Drives the escrow plugin through both the happy path and two dispute paths,
+emitting one structured ``escrow:<kind>:<fields>`` broadcast per state
+transition. The four ``escrow_marketplace`` validators (see
+:mod:`nest_core.validators`) read those broadcasts and confirm:
+
+* every escrow walked a legal state-machine path;
+* every transition was broadcast by the role authorized to perform it;
+* every arbitration verdict stayed in ``[0, 10000]`` bps;
+* no payout happened without a preceding delivery proof.
+
+If the underlying payments plugin lacks the escrow protocol (e.g.
+``prepaid_credits``), the agents fall back to a plain ``pay()`` and the
+trace will contain **no** ``escrow:*`` events -- which the validators
+report as a failure ("no escrow lifecycle observed"). That is the
+adversarial discrimination the charter asks for.
+
+Example::
+
+    agents = escrow_marketplace_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Money, PaymentRef
+
+# Per-triple tick schedule -- spaced wide enough that ticks land in order
+# regardless of broadcast latency in the simulator.
+_TICK_OPEN = 1.0
+_TICK_DELIVER = 4.0
+_TICK_RESOLVE = 7.0
+_TICK_ARBITRATE = 10.0
+
+_OP_OPEN = b"op:open"
+_OP_DELIVER = b"op:deliver"
+_OP_RESOLVE = b"op:resolve"
+_OP_ARBITRATE = b"op:arbitrate"
+
+
+def _emit(fields: dict[str, str | int]) -> str:
+    """Build a structured ``escrow:<kind>:k=v:...`` broadcast payload.
+
+    The colon-separated ``k=v`` form matches the parser in
+    :func:`nest_core.validators._parse_escrow_events`.
+    """
+    kind = str(fields.pop("kind"))
+    body = ":".join(f"{k}={v}" for k, v in fields.items())
+    return f"escrow:{kind}:{body}" if body else f"escrow:{kind}"
+
+
+class BuyerAgent(StateMachineAgent):
+    """Opens an escrow, then resolves it as either ``release`` or ``dispute``.
+
+    The buyer owns the payer's plugin instance and is the only agent that
+    can ``open_escrow`` / ``release`` / ``dispute`` / ``refund``.
+
+    Example::
+
+        agent = BuyerAgent(
+            AgentId("buyer-0"),
+            payee=AgentId("seller-0"),
+            arbiter=AgentId("arbiter-0"),
+            amount=250,
+            ref=PaymentRef("e-0"),
+            mode="happy",
+        )
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        payee: AgentId,
+        arbiter: AgentId,
+        amount: int,
+        ref: PaymentRef,
+        mode: str,
+    ) -> None:
+        self._id = agent_id
+        self._payee = payee
+        self._arbiter = arbiter
+        self._amount = amount
+        self._ref = ref
+        self._mode = mode
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        await ctx.schedule(_TICK_OPEN, _OP_OPEN)
+        await ctx.schedule(_TICK_RESOLVE, _OP_RESOLVE)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        payments = ctx.plugins["payments"]
+        if payload == _OP_OPEN:
+            if hasattr(payments, "open_escrow"):
+                await payments.open_escrow(
+                    payee=self._payee,
+                    arbiter=self._arbiter,
+                    amount=Money(amount=self._amount),
+                    ref=self._ref,
+                )
+                await ctx.broadcast(
+                    _emit(
+                        {
+                            "kind": "opened",
+                            "ref": self._ref,
+                            "payer": str(self._id),
+                            "payee": str(self._payee),
+                            "arbiter": str(self._arbiter),
+                            "amount": self._amount,
+                        }
+                    ).encode()
+                )
+            else:
+                # Fallback for plugins without escrow (e.g. prepaid_credits):
+                # pay() upfront. Trace will then contain no escrow:* events,
+                # which is exactly what the validators flag.
+                await payments.pay(self._payee, Money(amount=self._amount), self._ref)
+            return
+        if payload == _OP_RESOLVE:
+            if not hasattr(payments, "release"):
+                return  # prepaid_credits has nothing left to do
+            if self._mode == "happy":
+                await payments.release(self._ref)
+                await ctx.broadcast(_emit({"kind": "released", "ref": self._ref}).encode())
+            else:
+                reason = f"mode={self._mode}"
+                await payments.dispute(self._ref, reason=reason)
+                await ctx.broadcast(
+                    _emit({"kind": "disputed", "ref": self._ref, "reason": reason}).encode()
+                )
+
+
+class SellerAgent(StateMachineAgent):
+    """Posts a delivery proof against ``ref``. Payee-only by construction.
+
+    Example::
+
+        agent = SellerAgent(AgentId("seller-0"), ref=PaymentRef("e-0"))
+    """
+
+    def __init__(self, agent_id: AgentId, ref: PaymentRef) -> None:
+        self._id = agent_id
+        self._ref = ref
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        await ctx.schedule(_TICK_DELIVER, _OP_DELIVER)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        if payload != _OP_DELIVER:
+            return
+        payments = ctx.plugins["payments"]
+        if not hasattr(payments, "deliver"):
+            return
+        proof = f"sha256-{self._ref}"
+        await payments.deliver(self._ref, proof=proof)
+        await ctx.broadcast(_emit({"kind": "delivered", "ref": self._ref, "proof": proof}).encode())
+
+
+class ArbiterAgent(StateMachineAgent):
+    """Settles a disputed escrow with a pre-configured ``payee_bps`` verdict.
+
+    No-op in the ``happy`` mode (never asked to arbitrate).
+
+    Example::
+
+        agent = ArbiterAgent(
+            AgentId("arbiter-1"),
+            ref=PaymentRef("e-1"),
+            payee_bps=3000,
+            mode="dispute",
+        )
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        ref: PaymentRef,
+        payee_bps: int,
+        mode: str,
+    ) -> None:
+        self._id = agent_id
+        self._ref = ref
+        self._payee_bps = payee_bps
+        self._mode = mode
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        if self._mode != "happy":
+            await ctx.schedule(_TICK_ARBITRATE, _OP_ARBITRATE)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        if payload != _OP_ARBITRATE:
+            return
+        payments = ctx.plugins["payments"]
+        if not hasattr(payments, "arbitrate"):
+            return
+        await payments.arbitrate(
+            self._ref,
+            payee_bps=self._payee_bps,
+            rationale=f"verdict from arbiter for mode {self._mode}",
+        )
+        await ctx.broadcast(
+            _emit(
+                {
+                    "kind": "arbitrated",
+                    "ref": self._ref,
+                    "payee_bps": self._payee_bps,
+                }
+            ).encode()
+        )
+
+
+# Three triples: one happy + two dispute (different bps).
+_TRIPLES: list[dict[str, Any]] = [
+    {"suffix": "0", "mode": "happy", "amount": 250, "payee_bps": 10_000},
+    {"suffix": "1", "mode": "dispute", "amount": 400, "payee_bps": 3_000},
+    {"suffix": "2", "mode": "dispute", "amount": 600, "payee_bps": 8_000},
+]
+
+
+def escrow_marketplace_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Build the 9 agents (3 triples) and wire shared per-agent payments.
+
+    Each triple's three agents share the same balances + payments +
+    escrows dicts (so the vault is a single ledger), but each agent
+    holds its own plugin instance keyed by ``self._agent_id``. The
+    factory installs them as per-agent overrides via the
+    ``_agent_plugins`` channel the runner understands.
+
+    For payment plugins that do not accept ``balances`` / ``payments`` /
+    ``escrows`` kwargs (e.g. a future plugin with a different ctor),
+    the factory falls back to a single shared instance.
+
+    Example::
+
+        agents = escrow_marketplace_factory(config, plugins)
+    """
+    payments_cls = plugins["payments"]
+    agents: dict[AgentId, StateMachineAgent] = {}
+    overrides: dict[AgentId, dict[str, Any]] = {}
+
+    # All triples share one global ledger, so a buyer with insufficient
+    # balance for triple-2 would propagate naturally; the per-triple amounts
+    # below total < the buyer's default 1000.
+    shared_balances: dict[AgentId, int] = {}
+    shared_payments: dict[PaymentRef, Any] = {}
+    shared_escrows: dict[PaymentRef, Any] = {}
+
+    def _instance(agent_id: AgentId) -> Any:
+        try:
+            return payments_cls(
+                agent_id,
+                initial_balance=2000,
+                balances=shared_balances,
+                payments=shared_payments,
+                escrows=shared_escrows,
+            )
+        except TypeError:
+            try:
+                return payments_cls(
+                    agent_id,
+                    initial_balance=2000,
+                    balances=shared_balances,
+                    payments=shared_payments,
+                )
+            except TypeError:
+                return payments_cls(agent_id, initial_balance=2000)
+
+    for triple in _TRIPLES:
+        suffix = str(triple["suffix"])
+        mode = str(triple["mode"])
+        amount = int(triple["amount"])
+        payee_bps = int(triple["payee_bps"])
+        buyer_id = AgentId(f"buyer-{suffix}")
+        seller_id = AgentId(f"seller-{suffix}")
+        arbiter_id = AgentId(f"arbiter-{suffix}")
+        ref = PaymentRef(f"e-{suffix}")
+
+        agents[buyer_id] = BuyerAgent(
+            buyer_id,
+            payee=seller_id,
+            arbiter=arbiter_id,
+            amount=amount,
+            ref=ref,
+            mode=mode,
+        )
+        agents[seller_id] = SellerAgent(seller_id, ref=ref)
+        agents[arbiter_id] = ArbiterAgent(
+            arbiter_id,
+            ref=ref,
+            payee_bps=payee_bps,
+            mode=mode,
+        )
+
+        for aid in (buyer_id, seller_id, arbiter_id):
+            overrides[aid] = {"payments": _instance(aid)}
+
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/yaml/escrow_marketplace.yaml
+++ b/packages/nest-core/nest_core/scenarios_builtin/yaml/escrow_marketplace.yaml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Escrow marketplace: 3 buyer/seller/arbiter triples drive the escrow plugin
+# through the happy path and two dispute paths. The four escrow_marketplace
+# validators must all pass under `payments: escrow` and all fail under
+# `payments: prepaid_credits` (no escrow protocol, no escrow events emitted).
+
+name: escrow_marketplace
+description: |
+  Three buyer/seller/arbiter triples. Triple 0 runs the happy path
+  (open -> deliver -> release). Triples 1 and 2 run the dispute path
+  with different arbitrator splits (3000 and 8000 bps). All four
+  escrow validators (state-machine, role-binding, bps-range,
+  no-payout-without-delivery) must pass under the escrow plugin.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 9
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 3
+      config: {}
+    - name: seller
+      count: 3
+      config: {}
+    - name: arbiter
+      count: 3
+      config: {}
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: escrow
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: escrow_marketplace
+  config: {}
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 200"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/escrow_marketplace.jsonl

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1709,6 +1709,252 @@ def _collect_scores(events: list[dict[str, Any]]) -> dict[str, tuple[float, floa
     return scores
 
 
+# ---------------------------------------------------------------------------
+# Escrow validators
+#
+# The escrow scenario broadcasts structured ``escrow:<kind>:<fields>`` events,
+# one per state transition, parsed by the validators below. The four checks
+# together catch the attacks the default ``prepaid_credits`` plugin would not
+# block: payouts without delivery, releases by non-payers, arbitration outside
+# the bps range, and broken state-machine transitions.
+# ---------------------------------------------------------------------------
+
+
+def _parse_escrow_events(
+    events: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    """Parse trace broadcasts of the form ``escrow:<kind>:k=v:k=v...``.
+
+    Returns one dict per matching event with ``kind`` and parsed ``key=value``
+    fields. Non-matching broadcasts are skipped silently.
+    """
+    out: list[dict[str, str]] = []
+    for ev in events:
+        # Only inspect broadcast emissions (sender-recorded). Filter out the
+        # per-recipient "deliver" copies of the same payload so a 9-agent
+        # mesh does not multiply each escrow event by 8.
+        if ev.get("kind") != "broadcast":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("escrow:"):
+            continue
+        parts = msg.split(":")
+        if len(parts) < 2:
+            continue
+        parsed: dict[str, str] = {"kind": parts[1], "agent": str(ev.get("agent", ""))}
+        for piece in parts[2:]:
+            if "=" in piece:
+                k, _, v = piece.partition("=")
+                parsed[k] = v
+        out.append(parsed)
+    return out
+
+
+def validate_escrow_state_machine(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every per-escrow transition sequence is a legal state-machine path.
+
+    Legal sequences (per escrow ``ref``):
+
+    * ``opened -> delivered -> released``
+    * ``opened -> delivered -> disputed -> arbitrated``
+    * ``opened -> refunded``
+
+    Any transition outside this graph (e.g. ``opened -> released`` with no
+    ``delivered``, or two ``released`` for the same ref) is a failure.
+    """
+    legal: dict[str, set[str]] = {
+        "_initial": {"opened"},
+        "opened": {"delivered", "refunded"},
+        "delivered": {"released", "disputed"},
+        "disputed": {"arbitrated"},
+        "released": set(),
+        "arbitrated": set(),
+        "refunded": set(),
+    }
+    state: dict[str, str] = {}
+    violations: list[str] = []
+    for ev in _parse_escrow_events(events):
+        ref = ev.get("ref", "")
+        kind = ev["kind"]
+        prev = state.get(ref, "_initial")
+        if kind not in legal.get(prev, set()):
+            violations.append(f"ref={ref!r}: illegal transition {prev!r} -> {kind!r}")
+            continue
+        state[ref] = kind
+    if violations:
+        return [ValidationResult("escrow_state_machine", False, "; ".join(violations))]
+    if not state:
+        return [
+            ValidationResult(
+                "escrow_state_machine",
+                False,
+                "no escrow lifecycle events observed in trace -- plugin lacks escrow protocol",
+            )
+        ]
+    return [
+        ValidationResult(
+            "escrow_state_machine",
+            True,
+            f"{len(state)} escrows transitioned only along legal edges",
+        )
+    ]
+
+
+def validate_escrow_role_binding(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every state-changing event is broadcast by the role authorized to make it.
+
+    * ``opened`` MUST be broadcast by the named ``payer``.
+    * ``delivered`` MUST be broadcast by the named ``payee``.
+    * ``released``, ``disputed``, ``refunded`` MUST be broadcast by the
+      named ``payer`` (from the originating ``opened``).
+    * ``arbitrated`` MUST be broadcast by the named ``arbiter``.
+
+    Detects forged-actor attacks: a non-payee posting a fake delivery, a
+    third party trying to release someone else's escrow, etc.
+    """
+    parsed = _parse_escrow_events(events)
+    parties: dict[str, dict[str, str]] = {}
+    violations: list[str] = []
+    for ev in parsed:
+        ref = ev.get("ref", "")
+        kind = ev["kind"]
+        actor = ev.get("agent", "")
+        if kind == "opened":
+            parties[ref] = {
+                "payer": ev.get("payer", ""),
+                "payee": ev.get("payee", ""),
+                "arbiter": ev.get("arbiter", ""),
+            }
+            if actor != ev.get("payer", ""):
+                violations.append(
+                    f"ref={ref!r}: opened by {actor!r} but payer is {ev.get('payer', '')!r}"
+                )
+            continue
+        named = parties.get(ref)
+        if named is None:
+            violations.append(f"ref={ref!r}: {kind!r} without prior opened")
+            continue
+        if kind == "delivered" and actor != named["payee"]:
+            violations.append(
+                f"ref={ref!r}: delivered by {actor!r} but payee is {named['payee']!r}"
+            )
+        elif kind in ("released", "disputed", "refunded") and actor != named["payer"]:
+            violations.append(f"ref={ref!r}: {kind!r} by {actor!r} but payer is {named['payer']!r}")
+        elif kind == "arbitrated" and actor != named["arbiter"]:
+            violations.append(
+                f"ref={ref!r}: arbitrated by {actor!r} but arbiter is {named['arbiter']!r}"
+            )
+    if violations:
+        return [ValidationResult("escrow_role_binding", False, "; ".join(violations))]
+    if not parties:
+        return [
+            ValidationResult(
+                "escrow_role_binding",
+                False,
+                "no escrow opened events observed -- plugin lacks escrow protocol",
+            )
+        ]
+    return [
+        ValidationResult(
+            "escrow_role_binding",
+            True,
+            f"{len(parsed)} escrow events all signed by the correct role-holder",
+        )
+    ]
+
+
+def validate_escrow_bps_in_range(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every ``arbitrated`` event carries ``payee_bps`` strictly in ``[0, 10000]``.
+
+    Catches an arbiter (or a forged arbitrate broadcast) that attempts to
+    settle outside the allowed split window -- either negative (paying the
+    payee a negative share) or over 10000 (paying more than was escrowed).
+    """
+    parsed = _parse_escrow_events(events)
+    violations: list[str] = []
+    checked = 0
+    for ev in parsed:
+        if ev["kind"] != "arbitrated":
+            continue
+        checked += 1
+        raw = ev.get("payee_bps", "")
+        try:
+            bps = int(raw)
+        except ValueError:
+            violations.append(f"ref={ev.get('ref', '')!r}: non-integer payee_bps={raw!r}")
+            continue
+        if not 0 <= bps <= 10_000:
+            violations.append(f"ref={ev.get('ref', '')!r}: payee_bps={bps} outside [0, 10000]")
+    if violations:
+        return [ValidationResult("escrow_bps_in_range", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "escrow_bps_in_range",
+            True,
+            f"{checked} arbitration verdicts all within [0, 10000]",
+        )
+    ]
+
+
+def validate_escrow_no_payout_without_delivery(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """No ``released`` or ``arbitrated`` may occur for a ref that wasn't delivered.
+
+    The escrow protocol's whole point is that the payee cannot be paid
+    until they post a delivery proof. A plugin that ships funds without
+    a preceding ``delivered`` event for the same ref bypasses the
+    contract.
+
+    Also catches the most common ``prepaid_credits`` failure mode in
+    this scenario: the plugin has no escrow concept, so the buyer falls
+    back to ``pay()``, which credits the payee with no delivery proof
+    in the trace.
+    """
+    parsed = _parse_escrow_events(events)
+    delivered: set[str] = set()
+    violations: list[str] = []
+    saw_payout = False
+    for ev in parsed:
+        ref = ev.get("ref", "")
+        kind = ev["kind"]
+        if kind == "delivered":
+            delivered.add(ref)
+        elif kind in ("released", "arbitrated"):
+            saw_payout = True
+            if ref not in delivered:
+                violations.append(f"ref={ref!r}: {kind!r} settled without prior delivered event")
+    if violations:
+        return [
+            ValidationResult(
+                "escrow_no_payout_without_delivery",
+                False,
+                "; ".join(violations),
+            )
+        ]
+    if not saw_payout:
+        return [
+            ValidationResult(
+                "escrow_no_payout_without_delivery",
+                False,
+                "no escrow payouts observed -- plugin lacks escrow protocol",
+            )
+        ]
+    return [
+        ValidationResult(
+            "escrow_no_payout_without_delivery",
+            True,
+            "every payout was preceded by a matching delivered event",
+        )
+    ]
+
+
 def validate_receipt_reputation_ring_severed(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
@@ -2594,5 +2840,11 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_bft_no_equivocation,
         validate_bft_forged_quorum,
         validate_bft_no_stuck_view,
+    ],
+    "escrow_marketplace": [
+        validate_escrow_state_machine,
+        validate_escrow_role_binding,
+        validate_escrow_bps_in_range,
+        validate_escrow_no_payout_without_delivery,
     ],
 }

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -16,6 +16,10 @@ from nest_core.validators import (
     validate_consensus_agreement,
     validate_consensus_no_conflict,
     validate_consensus_validity,
+    validate_escrow_bps_in_range,
+    validate_escrow_no_payout_without_delivery,
+    validate_escrow_role_binding,
+    validate_escrow_state_machine,
     validate_events,
     validate_marketplace_no_double_sell,
     validate_marketplace_price_agreement,
@@ -740,6 +744,172 @@ class TestStreamingValidators:
         assert results[0].passed  # unrelated drop, not a violation
 
 
+class TestEscrowValidators:
+    """Direct validator tests with synthetic broadcast events."""
+
+    @staticmethod
+    def _ev(agent: str, msg: str) -> dict[str, Any]:
+        return {"kind": "broadcast", "agent": agent, "msg": msg}
+
+    @staticmethod
+    def _happy(ref: str = "e1") -> list[dict[str, Any]]:
+        return [
+            TestEscrowValidators._ev(
+                "buyer",
+                f"escrow:opened:ref={ref}:payer=buyer:payee=seller:arbiter=arbiter:amount=250",
+            ),
+            TestEscrowValidators._ev("seller", f"escrow:delivered:ref={ref}:proof=sha256-cafe"),
+            TestEscrowValidators._ev("buyer", f"escrow:released:ref={ref}"),
+        ]
+
+    @staticmethod
+    def _dispute(ref: str = "e2", bps: int = 3000) -> list[dict[str, Any]]:
+        return [
+            TestEscrowValidators._ev(
+                "buyer",
+                f"escrow:opened:ref={ref}:payer=buyer:payee=seller:arbiter=arbiter:amount=400",
+            ),
+            TestEscrowValidators._ev("seller", f"escrow:delivered:ref={ref}:proof=partial"),
+            TestEscrowValidators._ev("buyer", f"escrow:disputed:ref={ref}:reason=incomplete"),
+            TestEscrowValidators._ev("arbiter", f"escrow:arbitrated:ref={ref}:payee_bps={bps}"),
+        ]
+
+    def test_state_machine_passes_happy_path(self) -> None:
+        results = validate_escrow_state_machine(self._happy())
+        assert len(results) == 1
+        assert results[0].passed, results[0].detail
+
+    def test_state_machine_passes_dispute_path(self) -> None:
+        results = validate_escrow_state_machine(self._dispute())
+        assert results[0].passed, results[0].detail
+
+    def test_state_machine_passes_combined(self) -> None:
+        results = validate_escrow_state_machine(self._happy("a") + self._dispute("b"))
+        assert results[0].passed, results[0].detail
+
+    def test_state_machine_fails_on_release_without_delivery(self) -> None:
+        events = [
+            self._ev(
+                "buyer",
+                "escrow:opened:ref=x:payer=buyer:payee=seller:arbiter=arbiter:amount=100",
+            ),
+            self._ev("buyer", "escrow:released:ref=x"),  # skipped delivered
+        ]
+        results = validate_escrow_state_machine(events)
+        assert not results[0].passed
+        assert "illegal transition" in results[0].detail
+
+    def test_state_machine_fails_on_arbitrate_without_dispute(self) -> None:
+        events = [
+            self._ev(
+                "buyer",
+                "escrow:opened:ref=y:payer=buyer:payee=seller:arbiter=arbiter:amount=100",
+            ),
+            self._ev("seller", "escrow:delivered:ref=y:proof=x"),
+            self._ev("arbiter", "escrow:arbitrated:ref=y:payee_bps=5000"),
+        ]
+        results = validate_escrow_state_machine(events)
+        assert not results[0].passed
+
+    def test_state_machine_fails_on_double_release(self) -> None:
+        events = self._happy()
+        events.append(self._ev("buyer", "escrow:released:ref=e1"))
+        results = validate_escrow_state_machine(events)
+        assert not results[0].passed
+
+    def test_state_machine_fails_when_no_escrow_events(self) -> None:
+        # Mirrors what happens under prepaid_credits (no escrow protocol).
+        events = [
+            {"kind": "payment_debited", "agent": "buyer", "amount": 100, "tick": 0},
+            {"kind": "payment_credited", "agent": "seller", "amount": 100, "tick": 0},
+        ]
+        results = validate_escrow_state_machine(events)
+        assert not results[0].passed
+        assert "no escrow lifecycle" in results[0].detail
+
+    def test_role_binding_passes_happy(self) -> None:
+        results = validate_escrow_role_binding(self._happy() + self._dispute())
+        assert results[0].passed, results[0].detail
+
+    def test_role_binding_fails_on_forged_delivery(self) -> None:
+        events = [
+            self._ev(
+                "buyer",
+                "escrow:opened:ref=e1:payer=buyer:payee=seller:arbiter=arbiter:amount=100",
+            ),
+            # An ATTACKER (not seller) tries to claim delivery.
+            self._ev("attacker", "escrow:delivered:ref=e1:proof=fake"),
+        ]
+        results = validate_escrow_role_binding(events)
+        assert not results[0].passed
+        assert "delivered" in results[0].detail and "attacker" in results[0].detail
+
+    def test_role_binding_fails_on_unauthorized_release(self) -> None:
+        events = self._happy()
+        # Replace the legitimate release with an unauthorized one.
+        events[-1] = self._ev("attacker", "escrow:released:ref=e1")
+        results = validate_escrow_role_binding(events)
+        assert not results[0].passed
+
+    def test_role_binding_fails_on_arbitrate_by_non_arbiter(self) -> None:
+        events = self._dispute()
+        events[-1] = self._ev("buyer", "escrow:arbitrated:ref=e2:payee_bps=10000")
+        results = validate_escrow_role_binding(events)
+        assert not results[0].passed
+
+    def test_bps_in_range_passes_at_bounds(self) -> None:
+        results = validate_escrow_bps_in_range(
+            self._dispute("a", bps=0) + self._dispute("b", bps=10000)
+        )
+        assert results[0].passed, results[0].detail
+
+    def test_bps_in_range_fails_negative(self) -> None:
+        events = self._dispute(bps=-1)
+        results = validate_escrow_bps_in_range(events)
+        assert not results[0].passed
+
+    def test_bps_in_range_fails_over_max(self) -> None:
+        events = self._dispute(bps=15000)
+        results = validate_escrow_bps_in_range(events)
+        assert not results[0].passed
+
+    def test_bps_in_range_fails_non_integer(self) -> None:
+        events = [
+            self._ev(
+                "buyer",
+                "escrow:opened:ref=z:payer=buyer:payee=seller:arbiter=arbiter:amount=100",
+            ),
+            self._ev("seller", "escrow:delivered:ref=z:proof=x"),
+            self._ev("buyer", "escrow:disputed:ref=z:reason=x"),
+            self._ev("arbiter", "escrow:arbitrated:ref=z:payee_bps=NaN"),
+        ]
+        results = validate_escrow_bps_in_range(events)
+        assert not results[0].passed
+        assert "non-integer" in results[0].detail
+
+    def test_no_payout_without_delivery_passes(self) -> None:
+        results = validate_escrow_no_payout_without_delivery(self._happy() + self._dispute())
+        assert results[0].passed, results[0].detail
+
+    def test_no_payout_without_delivery_fails_on_skipped_delivery(self) -> None:
+        events = [
+            self._ev(
+                "buyer",
+                "escrow:opened:ref=q:payer=buyer:payee=seller:arbiter=arbiter:amount=100",
+            ),
+            self._ev("buyer", "escrow:released:ref=q"),
+        ]
+        results = validate_escrow_no_payout_without_delivery(events)
+        assert not results[0].passed
+        assert "without prior delivered" in results[0].detail
+
+    def test_no_payout_without_delivery_fails_when_no_payouts_at_all(self) -> None:
+        # Plugin lacks escrow -- no escrow events ever emitted.
+        results = validate_escrow_no_payout_without_delivery([])
+        assert not results[0].passed
+        assert "no escrow payouts" in results[0].detail
+
+
 class TestValidatorRegistry:
     def test_all_scenario_types_registered(self) -> None:
         expected = {
@@ -757,6 +927,7 @@ class TestValidatorRegistry:
             "multi_attribute_market",
             "provenance_supply_chain",
             "bft_hotstuff",
+            "escrow_marketplace",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/escrow.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/escrow.py
@@ -1,0 +1,469 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Escrow payments plugin — conditional, arbitrated, multi-party value transfer.
+
+Extends the prepaid-credit ledger with a three-phase escrow protocol:
+
+    FUNDED -> DELIVERED -> RELEASED            (happy path)
+    FUNDED -> DELIVERED -> DISPUTED -> ARBITRATED   (contested path)
+    FUNDED -> REFUNDED                         (payer recalls before delivery)
+
+Funds are debited from the payer at ``open_escrow`` and held by the vault
+until the payer signs ``release`` (full payout to payee), the payer signs
+``dispute`` and the named arbiter signs ``arbitrate`` (basis-point split),
+or the payer signs ``refund`` while the work is still undelivered.
+
+Authorization is enforced by ``self._agent_id``: only the role-holding
+agent's plugin instance can advance the state. The shared ``escrows``
+dict mirrors the shared ``balances`` dict used by ``prepaid_credits`` and
+``streaming``, so a scenario can hand the same vault to all three roles.
+
+Satisfies the ``Payments`` protocol; ``pay()`` is a one-call shortcut
+that opens and releases an escrow in a single step (no arbiter, no
+delivery proof) so existing Payments callers still work.
+
+Example::
+
+    payments = EscrowPayments(AgentId("buyer"), initial_balance=1000)
+    handle = await payments.open_escrow(
+        payee=AgentId("seller"),
+        arbiter=AgentId("arbiter"),
+        amount=Money(amount=250),
+        ref=PaymentRef("job-1"),
+    )
+    # ... later, on the payee's instance (sharing the same balances + escrows dicts) ...
+    await payee_payments.deliver(PaymentRef("job-1"), proof="sha256:cafe")
+    # ... back on the buyer's instance ...
+    receipt = await payments.release(PaymentRef("job-1"))
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nest_core.types import (
+    AgentId,
+    Money,
+    PaymentRef,
+    PaymentStatus,
+    Quote,
+    Receipt,
+    ServiceRef,
+)
+
+_BPS_DENOM = 10_000
+
+
+class EscrowError(ValueError):
+    """Raised on any escrow state-machine or authorization violation.
+
+    Example::
+
+        try:
+            await payments.release(PaymentRef("x"))
+        except EscrowError as e:
+            print(e)
+    """
+
+
+@dataclass
+class EscrowHandle:
+    """Per-escrow state held by the shared vault.
+
+    Example::
+
+        handle = EscrowHandle(
+            ref=PaymentRef("job-1"),
+            payer=AgentId("buyer"),
+            payee=AgentId("seller"),
+            arbiter=AgentId("arbiter"),
+            amount=250,
+            state="FUNDED",
+        )
+    """
+
+    ref: PaymentRef
+    payer: AgentId
+    payee: AgentId
+    arbiter: AgentId
+    amount: int
+    state: str
+    proof: str | None = None
+    dispute_reason: str | None = None
+    payee_bps_paid: int | None = None
+    rationale: str | None = None
+
+
+class EscrowPayments:
+    """Conditional, arbitrated escrow on top of a debit-credit ledger.
+
+    Three roles per escrow, named at ``open_escrow`` time and bound to
+    agent ids:
+
+    * **payer** — funds the vault; can ``release``, ``dispute``, or
+      ``refund`` (only while still ``FUNDED``).
+    * **payee** — can ``deliver`` against the open escrow once.
+    * **arbiter** — can ``arbitrate`` only after the payer disputes;
+      issues a basis-point split (``payee_bps`` in ``[0, 10000]``) that
+      decides how much of the locked amount each side receives.
+
+    Every transition checks ``self._agent_id`` against the role the
+    transition is reserved for; calling out of role raises
+    :class:`EscrowError`. Calling out of state (e.g. releasing an
+    escrow that has not been delivered) also raises.
+
+    The plugin satisfies the ``Payments`` protocol. ``pay()`` is a
+    one-call shortcut that opens and releases an escrow in a single
+    step so existing Payments callers continue to work; ``refund()``
+    only succeeds on escrows that are still ``FUNDED``.
+
+    Example::
+
+        payments = EscrowPayments(AgentId("buyer"), initial_balance=1000)
+        handle = await payments.open_escrow(
+            payee=AgentId("seller"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=250),
+            ref=PaymentRef("job-1"),
+        )
+        assert handle.state == "FUNDED"
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        initial_balance: int = 1000,
+        balances: dict[AgentId, int] | None = None,
+        payments: dict[PaymentRef, Receipt] | None = None,
+        escrows: dict[PaymentRef, EscrowHandle] | None = None,
+    ) -> None:
+        self._agent_id = agent_id
+        self._balances = balances if balances is not None else {}
+        self._balances.setdefault(agent_id, initial_balance)
+        self._payments = payments if payments is not None else {}
+        self._escrows = escrows if escrows is not None else {}
+
+    # -- read helpers ----------------------------------------------------
+
+    def balance(self, agent: AgentId) -> int:
+        """Return an agent's balance.
+
+        Example::
+
+            bal = payments.balance(AgentId("buyer"))
+        """
+        return self._balances.get(agent, 0)
+
+    def escrow(self, ref: PaymentRef) -> EscrowHandle | None:
+        """Return the escrow handle for ``ref`` if it exists.
+
+        Example::
+
+            handle = payments.escrow(PaymentRef("job-1"))
+            assert handle is not None and handle.state == "FUNDED"
+        """
+        return self._escrows.get(ref)
+
+    # -- escrow lifecycle ------------------------------------------------
+
+    async def open_escrow(
+        self,
+        payee: AgentId,
+        arbiter: AgentId,
+        amount: Money,
+        ref: PaymentRef,
+    ) -> EscrowHandle:
+        """Lock ``amount`` in a new escrow vault. Only the payer may call.
+
+        The payer's balance is debited immediately; the funds are held
+        by the vault until ``release``, ``arbitrate``, or ``refund``.
+
+        Example::
+
+            handle = await payments.open_escrow(
+                payee=AgentId("seller"),
+                arbiter=AgentId("arbiter"),
+                amount=Money(amount=250),
+                ref=PaymentRef("job-1"),
+            )
+
+        Raises:
+            EscrowError: If amount is not positive, ``ref`` already used,
+                payer's balance is insufficient, or arbiter equals payer
+                or payee.
+        """
+        if amount.amount <= 0:
+            msg = f"escrow amount must be positive: {amount.amount}"
+            raise EscrowError(msg)
+        if ref in self._payments or ref in self._escrows:
+            msg = f"reference already used: {ref}"
+            raise EscrowError(msg)
+        if arbiter == self._agent_id or arbiter == payee:
+            msg = "arbiter must be distinct from payer and payee"
+            raise EscrowError(msg)
+
+        payer_balance = self._balances.get(self._agent_id, 0)
+        if payer_balance < amount.amount:
+            msg = f"insufficient balance to fund escrow: {payer_balance} < {amount.amount}"
+            raise EscrowError(msg)
+
+        self._balances[self._agent_id] = payer_balance - amount.amount
+        handle = EscrowHandle(
+            ref=ref,
+            payer=self._agent_id,
+            payee=payee,
+            arbiter=arbiter,
+            amount=amount.amount,
+            state="FUNDED",
+        )
+        self._escrows[ref] = handle
+        return handle
+
+    async def deliver(self, ref: PaymentRef, proof: str) -> EscrowHandle:
+        """Attach a delivery proof to ``ref``. Only the named payee may call.
+
+        ``proof`` is opaque to the plugin (a content hash, URL, or
+        signed receipt). The payer reads it off-band and decides to
+        ``release`` or ``dispute``.
+
+        Example::
+
+            handle = await payee_payments.deliver(
+                PaymentRef("job-1"),
+                proof="sha256:cafe",
+            )
+            assert handle.state == "DELIVERED"
+
+        Raises:
+            EscrowError: If escrow does not exist, caller is not the
+                payee, or state is not ``FUNDED``.
+        """
+        handle = self._require_escrow(ref)
+        if self._agent_id != handle.payee:
+            msg = f"only payee {handle.payee} may deliver escrow {ref}"
+            raise EscrowError(msg)
+        if handle.state != "FUNDED":
+            msg = f"cannot deliver escrow {ref} from state {handle.state}"
+            raise EscrowError(msg)
+        handle.proof = proof
+        handle.state = "DELIVERED"
+        return handle
+
+    async def release(self, ref: PaymentRef) -> Receipt:
+        """Pay out the full escrow amount to the payee. Payer-only.
+
+        Example::
+
+            receipt = await payments.release(PaymentRef("job-1"))
+            assert receipt.amount.amount == 250
+
+        Raises:
+            EscrowError: If escrow does not exist, caller is not the
+                payer, or state is not ``DELIVERED``.
+        """
+        handle = self._require_escrow(ref)
+        if self._agent_id != handle.payer:
+            msg = f"only payer {handle.payer} may release escrow {ref}"
+            raise EscrowError(msg)
+        if handle.state != "DELIVERED":
+            msg = f"cannot release escrow {ref} from state {handle.state}"
+            raise EscrowError(msg)
+        self._balances[handle.payee] = self._balances.get(handle.payee, 0) + handle.amount
+        handle.state = "RELEASED"
+        handle.payee_bps_paid = _BPS_DENOM
+        receipt = Receipt(
+            ref=ref,
+            payer=handle.payer,
+            payee=handle.payee,
+            amount=Money(amount=handle.amount),
+        )
+        self._payments[ref] = receipt
+        return receipt
+
+    async def dispute(self, ref: PaymentRef, reason: str) -> EscrowHandle:
+        """Contest the delivery. Payer-only; transitions to ``DISPUTED``.
+
+        Once disputed the payer can no longer ``release`` -- only the
+        named arbiter can resolve, via :meth:`arbitrate`.
+
+        Example::
+
+            handle = await payments.dispute(
+                PaymentRef("job-1"),
+                reason="transcript missing last 4 minutes",
+            )
+
+        Raises:
+            EscrowError: If escrow does not exist, caller is not the
+                payer, or state is not ``DELIVERED``.
+        """
+        handle = self._require_escrow(ref)
+        if self._agent_id != handle.payer:
+            msg = f"only payer {handle.payer} may dispute escrow {ref}"
+            raise EscrowError(msg)
+        if handle.state != "DELIVERED":
+            msg = f"cannot dispute escrow {ref} from state {handle.state}"
+            raise EscrowError(msg)
+        handle.state = "DISPUTED"
+        handle.dispute_reason = reason
+        return handle
+
+    async def arbitrate(
+        self,
+        ref: PaymentRef,
+        payee_bps: int,
+        rationale: str,
+    ) -> Receipt:
+        """Resolve a disputed escrow with a basis-point payout split.
+
+        ``payee_bps`` is the payee's share in basis points ``[0, 10000]``.
+        The payee receives ``amount * payee_bps / 10000``; the payer is
+        credited the remainder. Settlement is atomic.
+
+        Example::
+
+            receipt = await arbiter_payments.arbitrate(
+                PaymentRef("job-1"),
+                payee_bps=6000,
+                rationale="approx 60% usable",
+            )
+
+        Raises:
+            EscrowError: If escrow does not exist, caller is not the
+                named arbiter, state is not ``DISPUTED``, or
+                ``payee_bps`` is outside ``[0, 10000]``.
+        """
+        handle = self._require_escrow(ref)
+        if self._agent_id != handle.arbiter:
+            msg = f"only arbiter {handle.arbiter} may arbitrate escrow {ref}"
+            raise EscrowError(msg)
+        if handle.state != "DISPUTED":
+            msg = f"cannot arbitrate escrow {ref} from state {handle.state}"
+            raise EscrowError(msg)
+        if not 0 <= payee_bps <= _BPS_DENOM:
+            msg = f"payee_bps must be in [0, {_BPS_DENOM}]: {payee_bps}"
+            raise EscrowError(msg)
+
+        to_payee = handle.amount * payee_bps // _BPS_DENOM
+        to_payer = handle.amount - to_payee
+        if to_payee:
+            self._balances[handle.payee] = self._balances.get(handle.payee, 0) + to_payee
+        if to_payer:
+            self._balances[handle.payer] = self._balances.get(handle.payer, 0) + to_payer
+        handle.state = "ARBITRATED"
+        handle.payee_bps_paid = payee_bps
+        handle.rationale = rationale
+        receipt = Receipt(
+            ref=ref,
+            payer=handle.payer,
+            payee=handle.payee,
+            amount=Money(amount=to_payee),
+        )
+        self._payments[ref] = receipt
+        return receipt
+
+    # -- Payments protocol -----------------------------------------------
+
+    async def quote(self, service: ServiceRef) -> Quote:
+        """Return a fixed quote for any service.
+
+        Example::
+
+            q = await payments.quote(ServiceRef("svc"))
+        """
+        return Quote(service=service, price=Money(amount=10))
+
+    async def pay(self, to: AgentId, amount: Money, ref: PaymentRef) -> Receipt:
+        """Open and release an escrow in one call (no arbiter, no proof).
+
+        Provided so the plugin satisfies the bare ``Payments`` protocol.
+        The escrow's ``arbiter`` is set to the recipient as a sentinel;
+        the escrow is auto-released before any third party can act, so
+        the arbiter never matters.
+
+        Example::
+
+            receipt = await payments.pay(
+                AgentId("seller"),
+                Money(amount=50),
+                PaymentRef("p1"),
+            )
+
+        Raises:
+            EscrowError: If amount is not positive, ``ref`` already used,
+                or payer balance is insufficient.
+        """
+        if amount.amount <= 0:
+            msg = f"payment amount must be positive: {amount.amount}"
+            raise EscrowError(msg)
+        if ref in self._payments or ref in self._escrows:
+            msg = f"reference already used: {ref}"
+            raise EscrowError(msg)
+        payer_balance = self._balances.get(self._agent_id, 0)
+        if payer_balance < amount.amount:
+            msg = f"insufficient balance: {payer_balance} < {amount.amount}"
+            raise EscrowError(msg)
+        self._balances[self._agent_id] = payer_balance - amount.amount
+        self._balances[to] = self._balances.get(to, 0) + amount.amount
+        receipt = Receipt(ref=ref, payer=self._agent_id, payee=to, amount=amount)
+        self._payments[ref] = receipt
+        return receipt
+
+    async def verify_payment(self, ref: PaymentRef) -> PaymentStatus:
+        """Map escrow/payment state to a ``PaymentStatus``.
+
+        Returns ``CONFIRMED`` once an escrow reaches ``RELEASED`` or
+        ``ARBITRATED`` (or for any straight ``pay()`` receipt), and
+        ``PENDING`` while an escrow is mid-flight.
+
+        Example::
+
+            status = await payments.verify_payment(PaymentRef("job-1"))
+        """
+        if ref in self._payments and ref not in self._escrows:
+            return PaymentStatus.CONFIRMED
+        handle = self._escrows.get(ref)
+        if handle is None:
+            return PaymentStatus.FAILED
+        if handle.state in ("RELEASED", "ARBITRATED"):
+            return PaymentStatus.CONFIRMED
+        if handle.state == "REFUNDED":
+            return PaymentStatus.FAILED
+        return PaymentStatus.PENDING
+
+    async def refund(self, ref: PaymentRef) -> None:
+        """Recall funds from an escrow that has not been delivered. Payer-only.
+
+        Only succeeds while the escrow is still ``FUNDED`` (the payee
+        has not posted a delivery proof yet). After delivery, the
+        payer must either ``release`` or ``dispute``; ``refund`` is no
+        longer available.
+
+        Example::
+
+            await payments.refund(PaymentRef("job-1"))
+
+        Raises:
+            EscrowError: If escrow does not exist, caller is not the
+                payer, or state is not ``FUNDED``.
+        """
+        handle = self._escrows.get(ref)
+        if handle is None:
+            msg = f"escrow not found: {ref}"
+            raise EscrowError(msg)
+        if self._agent_id != handle.payer:
+            msg = f"only payer {handle.payer} may refund escrow {ref}"
+            raise EscrowError(msg)
+        if handle.state != "FUNDED":
+            msg = f"cannot refund escrow {ref} from state {handle.state}"
+            raise EscrowError(msg)
+        self._balances[handle.payer] = self._balances.get(handle.payer, 0) + handle.amount
+        handle.state = "REFUNDED"
+
+    # -- private ---------------------------------------------------------
+
+    def _require_escrow(self, ref: PaymentRef) -> EscrowHandle:
+        handle = self._escrows.get(ref)
+        if handle is None:
+            msg = f"escrow not found: {ref}"
+            raise EscrowError(msg)
+        return handle

--- a/packages/nest-plugins-reference/tests/test_escrow.py
+++ b/packages/nest-plugins-reference/tests/test_escrow.py
@@ -1,0 +1,579 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the escrow payments plugin.
+
+Covers happy path, dispute path with arbitration, refund, role-bound authz,
+state-machine guards, the ``Payments`` protocol shortcut, and conservation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.types import AgentId, Money, PaymentRef, PaymentStatus, ServiceRef
+from nest_plugins_reference.payments.escrow import (
+    EscrowError,
+    EscrowPayments,
+)
+
+
+def _triple(
+    initial_payer: int = 1000,
+    initial_payee: int = 0,
+    initial_arbiter: int = 0,
+) -> tuple[EscrowPayments, EscrowPayments, EscrowPayments]:
+    """Build payer/payee/arbiter plugin instances sharing one vault.
+
+    The shared ``balances``/``payments``/``escrows`` dicts mirror the
+    pattern used by ``prepaid_credits`` and ``streaming``: each agent
+    has its own plugin instance, but they all see the same ledger.
+    """
+    balances: dict[AgentId, int] = {
+        AgentId("payer"): initial_payer,
+        AgentId("payee"): initial_payee,
+        AgentId("arbiter"): initial_arbiter,
+    }
+    payments: dict[PaymentRef, object] = {}
+    escrows: dict[PaymentRef, object] = {}
+    payer = EscrowPayments(
+        AgentId("payer"),
+        balances=balances,
+        payments=payments,  # type: ignore[arg-type]
+        escrows=escrows,  # type: ignore[arg-type]
+    )
+    payee = EscrowPayments(
+        AgentId("payee"),
+        balances=balances,
+        payments=payments,  # type: ignore[arg-type]
+        escrows=escrows,  # type: ignore[arg-type]
+    )
+    arbiter = EscrowPayments(
+        AgentId("arbiter"),
+        balances=balances,
+        payments=payments,  # type: ignore[arg-type]
+        escrows=escrows,  # type: ignore[arg-type]
+    )
+    return payer, payee, arbiter
+
+
+class TestInit:
+    """Construction and balance bookkeeping."""
+
+    def test_default_balance(self) -> None:
+        p = EscrowPayments(AgentId("a1"), initial_balance=500)
+        assert p.balance(AgentId("a1")) == 500
+        assert p.balance(AgentId("a2")) == 0
+
+    def test_shared_balances_override_initial(self) -> None:
+        balances = {AgentId("a1"): 1234}
+        p = EscrowPayments(AgentId("a1"), initial_balance=999, balances=balances)
+        # initial_balance is only applied via setdefault; explicit pre-seed wins
+        assert p.balance(AgentId("a1")) == 1234
+
+
+class TestOpenEscrow:
+    """``open_escrow`` -- payer-only, debits immediately."""
+
+    @pytest.mark.asyncio
+    async def test_open_escrow_debits_payer_and_funds_vault(self) -> None:
+        payer, payee, _ = _triple()
+        handle = await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=250),
+            ref=PaymentRef("job-1"),
+        )
+        assert handle.state == "FUNDED"
+        assert handle.amount == 250
+        assert handle.payer == AgentId("payer")
+        assert handle.payee == AgentId("payee")
+        assert handle.arbiter == AgentId("arbiter")
+        assert payer.balance(AgentId("payer")) == 750
+        # Funds are held by the vault, NOT yet credited to the payee.
+        assert payee.balance(AgentId("payee")) == 0
+
+    @pytest.mark.asyncio
+    async def test_open_escrow_zero_amount_raises(self) -> None:
+        payer, _, _ = _triple()
+        with pytest.raises(EscrowError, match="positive"):
+            await payer.open_escrow(
+                payee=AgentId("payee"),
+                arbiter=AgentId("arbiter"),
+                amount=Money(amount=0),
+                ref=PaymentRef("job-1"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_open_escrow_duplicate_ref_raises(self) -> None:
+        payer, _, _ = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("job-1"),
+        )
+        with pytest.raises(EscrowError, match="already used"):
+            await payer.open_escrow(
+                payee=AgentId("payee"),
+                arbiter=AgentId("arbiter"),
+                amount=Money(amount=100),
+                ref=PaymentRef("job-1"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_open_escrow_insufficient_balance_raises(self) -> None:
+        payer, _, _ = _triple(initial_payer=100)
+        with pytest.raises(EscrowError, match="insufficient balance"):
+            await payer.open_escrow(
+                payee=AgentId("payee"),
+                arbiter=AgentId("arbiter"),
+                amount=Money(amount=200),
+                ref=PaymentRef("job-1"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_arbiter_must_be_distinct_from_payer(self) -> None:
+        payer, _, _ = _triple()
+        with pytest.raises(EscrowError, match="distinct"):
+            await payer.open_escrow(
+                payee=AgentId("payee"),
+                arbiter=AgentId("payer"),  # invalid
+                amount=Money(amount=100),
+                ref=PaymentRef("job-1"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_arbiter_must_be_distinct_from_payee(self) -> None:
+        payer, _, _ = _triple()
+        with pytest.raises(EscrowError, match="distinct"):
+            await payer.open_escrow(
+                payee=AgentId("payee"),
+                arbiter=AgentId("payee"),  # invalid
+                amount=Money(amount=100),
+                ref=PaymentRef("job-1"),
+            )
+
+
+class TestDeliver:
+    """``deliver`` -- payee-only, only valid from FUNDED."""
+
+    @pytest.mark.asyncio
+    async def test_deliver_happy(self) -> None:
+        payer, payee, _ = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=250),
+            ref=PaymentRef("job-1"),
+        )
+        handle = await payee.deliver(PaymentRef("job-1"), proof="sha256:cafe")
+        assert handle.state == "DELIVERED"
+        assert handle.proof == "sha256:cafe"
+
+    @pytest.mark.asyncio
+    async def test_deliver_by_non_payee_raises(self) -> None:
+        payer, _, arbiter = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("job-1"),
+        )
+        with pytest.raises(EscrowError, match="only payee"):
+            await arbiter.deliver(PaymentRef("job-1"), proof="x")
+        with pytest.raises(EscrowError, match="only payee"):
+            await payer.deliver(PaymentRef("job-1"), proof="x")
+
+    @pytest.mark.asyncio
+    async def test_deliver_missing_escrow_raises(self) -> None:
+        _, payee, _ = _triple()
+        with pytest.raises(EscrowError, match="not found"):
+            await payee.deliver(PaymentRef("nope"), proof="x")
+
+    @pytest.mark.asyncio
+    async def test_deliver_twice_raises(self) -> None:
+        payer, payee, _ = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("job-1"),
+        )
+        await payee.deliver(PaymentRef("job-1"), proof="x")
+        with pytest.raises(EscrowError, match="DELIVERED"):
+            await payee.deliver(PaymentRef("job-1"), proof="y")
+
+
+class TestRelease:
+    """``release`` -- payer-only, only valid from DELIVERED."""
+
+    @pytest.mark.asyncio
+    async def test_release_happy_credits_payee(self) -> None:
+        payer, payee, _ = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=250),
+            ref=PaymentRef("job-1"),
+        )
+        await payee.deliver(PaymentRef("job-1"), proof="x")
+        receipt = await payer.release(PaymentRef("job-1"))
+        assert receipt.amount.amount == 250
+        assert receipt.payee == AgentId("payee")
+        assert payer.balance(AgentId("payee")) == 250
+        assert payer.balance(AgentId("payer")) == 750
+        h = payer.escrow(PaymentRef("job-1"))
+        assert h is not None
+        assert h.state == "RELEASED"
+
+    @pytest.mark.asyncio
+    async def test_release_by_non_payer_raises(self) -> None:
+        payer, payee, arbiter = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("job-1"),
+        )
+        await payee.deliver(PaymentRef("job-1"), proof="x")
+        with pytest.raises(EscrowError, match="only payer"):
+            await payee.release(PaymentRef("job-1"))
+        with pytest.raises(EscrowError, match="only payer"):
+            await arbiter.release(PaymentRef("job-1"))
+
+    @pytest.mark.asyncio
+    async def test_release_before_delivery_raises(self) -> None:
+        payer, _, _ = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("job-1"),
+        )
+        with pytest.raises(EscrowError, match="FUNDED"):
+            await payer.release(PaymentRef("job-1"))
+
+
+class TestDisputeAndArbitrate:
+    """``dispute`` and ``arbitrate`` -- bps splits, role-bound, range-checked."""
+
+    @pytest.mark.asyncio
+    async def test_dispute_then_arbitrate_partial(self) -> None:
+        payer, payee, arbiter = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=1000),
+            ref=PaymentRef("job-1"),
+        )
+        await payee.deliver(PaymentRef("job-1"), proof="partial")
+        await payer.dispute(PaymentRef("job-1"), reason="incomplete")
+        receipt = await arbiter.arbitrate(
+            PaymentRef("job-1"),
+            payee_bps=3000,
+            rationale="approx 30% usable",
+        )
+        # 30% to payee, 70% back to payer
+        assert receipt.amount.amount == 300
+        assert payer.balance(AgentId("payee")) == 300
+        assert payer.balance(AgentId("payer")) == 700  # 1000 - 1000 + 700
+
+    @pytest.mark.asyncio
+    async def test_arbitrate_zero_pays_back_payer(self) -> None:
+        payer, payee, arbiter = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=500),
+            ref=PaymentRef("job-1"),
+        )
+        await payee.deliver(PaymentRef("job-1"), proof="garbage")
+        await payer.dispute(PaymentRef("job-1"), reason="all wrong")
+        await arbiter.arbitrate(PaymentRef("job-1"), payee_bps=0, rationale="zero credit")
+        assert payer.balance(AgentId("payee")) == 0
+        assert payer.balance(AgentId("payer")) == 1000  # fully refunded
+
+    @pytest.mark.asyncio
+    async def test_arbitrate_full_pays_payee(self) -> None:
+        payer, payee, arbiter = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=500),
+            ref=PaymentRef("job-1"),
+        )
+        await payee.deliver(PaymentRef("job-1"), proof="ok")
+        await payer.dispute(PaymentRef("job-1"), reason="actually fine")
+        await arbiter.arbitrate(PaymentRef("job-1"), payee_bps=10000, rationale="full credit")
+        assert payer.balance(AgentId("payee")) == 500
+        assert payer.balance(AgentId("payer")) == 500
+
+    @pytest.mark.asyncio
+    async def test_dispute_by_non_payer_raises(self) -> None:
+        payer, payee, arbiter = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("job-1"),
+        )
+        await payee.deliver(PaymentRef("job-1"), proof="x")
+        with pytest.raises(EscrowError, match="only payer"):
+            await payee.dispute(PaymentRef("job-1"), reason="x")
+        with pytest.raises(EscrowError, match="only payer"):
+            await arbiter.dispute(PaymentRef("job-1"), reason="x")
+
+    @pytest.mark.asyncio
+    async def test_arbitrate_by_non_arbiter_raises(self) -> None:
+        payer, payee, _ = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("job-1"),
+        )
+        await payee.deliver(PaymentRef("job-1"), proof="x")
+        await payer.dispute(PaymentRef("job-1"), reason="x")
+        with pytest.raises(EscrowError, match="only arbiter"):
+            await payer.arbitrate(PaymentRef("job-1"), payee_bps=5000, rationale="x")
+        with pytest.raises(EscrowError, match="only arbiter"):
+            await payee.arbitrate(PaymentRef("job-1"), payee_bps=5000, rationale="x")
+
+    @pytest.mark.asyncio
+    async def test_arbitrate_without_dispute_raises(self) -> None:
+        payer, payee, arbiter = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("job-1"),
+        )
+        await payee.deliver(PaymentRef("job-1"), proof="x")
+        with pytest.raises(EscrowError, match="DELIVERED"):
+            await arbiter.arbitrate(PaymentRef("job-1"), payee_bps=5000, rationale="x")
+
+    @pytest.mark.parametrize("bad_bps", [-1, 10001, 999999])
+    @pytest.mark.asyncio
+    async def test_arbitrate_out_of_range_bps_raises(self, bad_bps: int) -> None:
+        payer, payee, arbiter = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("job-1"),
+        )
+        await payee.deliver(PaymentRef("job-1"), proof="x")
+        await payer.dispute(PaymentRef("job-1"), reason="x")
+        with pytest.raises(EscrowError, match=r"\[0, 10000\]"):
+            await arbiter.arbitrate(PaymentRef("job-1"), payee_bps=bad_bps, rationale="x")
+
+    @pytest.mark.asyncio
+    async def test_release_blocked_after_dispute(self) -> None:
+        payer, payee, _ = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("job-1"),
+        )
+        await payee.deliver(PaymentRef("job-1"), proof="x")
+        await payer.dispute(PaymentRef("job-1"), reason="x")
+        with pytest.raises(EscrowError, match="DISPUTED"):
+            await payer.release(PaymentRef("job-1"))
+
+
+class TestRefund:
+    """``refund`` is payer-only and only allowed while still ``FUNDED``."""
+
+    @pytest.mark.asyncio
+    async def test_refund_credits_payer_back(self) -> None:
+        payer, _, _ = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=250),
+            ref=PaymentRef("job-1"),
+        )
+        assert payer.balance(AgentId("payer")) == 750
+        await payer.refund(PaymentRef("job-1"))
+        assert payer.balance(AgentId("payer")) == 1000
+        h = payer.escrow(PaymentRef("job-1"))
+        assert h is not None and h.state == "REFUNDED"
+
+    @pytest.mark.asyncio
+    async def test_refund_after_delivery_raises(self) -> None:
+        payer, payee, _ = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("job-1"),
+        )
+        await payee.deliver(PaymentRef("job-1"), proof="x")
+        with pytest.raises(EscrowError, match="DELIVERED"):
+            await payer.refund(PaymentRef("job-1"))
+
+    @pytest.mark.asyncio
+    async def test_refund_by_non_payer_raises(self) -> None:
+        payer, payee, _ = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("job-1"),
+        )
+        with pytest.raises(EscrowError, match="only payer"):
+            await payee.refund(PaymentRef("job-1"))
+
+
+class TestPaymentsProtocol:
+    """``pay``/``verify_payment``/``quote`` so existing Payments callers work."""
+
+    @pytest.mark.asyncio
+    async def test_pay_shortcut_credits_immediately(self) -> None:
+        payer, payee, _ = _triple()
+        receipt = await payer.pay(AgentId("payee"), Money(amount=50), PaymentRef("p1"))
+        assert receipt.amount.amount == 50
+        assert payer.balance(AgentId("payer")) == 950
+        assert payee.balance(AgentId("payee")) == 50
+
+    @pytest.mark.asyncio
+    async def test_pay_duplicate_ref_raises(self) -> None:
+        payer, _, _ = _triple()
+        await payer.pay(AgentId("payee"), Money(amount=10), PaymentRef("p1"))
+        with pytest.raises(EscrowError, match="already used"):
+            await payer.pay(AgentId("payee"), Money(amount=10), PaymentRef("p1"))
+
+    @pytest.mark.asyncio
+    async def test_pay_collides_with_escrow_ref(self) -> None:
+        payer, _, _ = _triple()
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=10),
+            ref=PaymentRef("p1"),
+        )
+        with pytest.raises(EscrowError, match="already used"):
+            await payer.pay(AgentId("payee"), Money(amount=5), PaymentRef("p1"))
+
+    @pytest.mark.asyncio
+    async def test_verify_payment_states(self) -> None:
+        payer, payee, arbiter = _triple()
+        # 1. Unknown ref -> FAILED
+        assert await payer.verify_payment(PaymentRef("nope")) == PaymentStatus.FAILED
+
+        # 2. Funded but not delivered -> PENDING
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=100),
+            ref=PaymentRef("e1"),
+        )
+        assert await payer.verify_payment(PaymentRef("e1")) == PaymentStatus.PENDING
+
+        # 3. Released -> CONFIRMED
+        await payee.deliver(PaymentRef("e1"), proof="x")
+        await payer.release(PaymentRef("e1"))
+        assert await payer.verify_payment(PaymentRef("e1")) == PaymentStatus.CONFIRMED
+
+        # 4. Refunded -> FAILED
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=50),
+            ref=PaymentRef("e2"),
+        )
+        await payer.refund(PaymentRef("e2"))
+        assert await payer.verify_payment(PaymentRef("e2")) == PaymentStatus.FAILED
+
+        # 5. Arbitrated -> CONFIRMED
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=200),
+            ref=PaymentRef("e3"),
+        )
+        await payee.deliver(PaymentRef("e3"), proof="x")
+        await payer.dispute(PaymentRef("e3"), reason="x")
+        await arbiter.arbitrate(PaymentRef("e3"), payee_bps=4000, rationale="x")
+        assert await payer.verify_payment(PaymentRef("e3")) == PaymentStatus.CONFIRMED
+
+        # 6. Pure pay() (no escrow row) -> CONFIRMED
+        await payer.pay(AgentId("payee"), Money(amount=10), PaymentRef("e4"))
+        assert await payer.verify_payment(PaymentRef("e4")) == PaymentStatus.CONFIRMED
+
+    @pytest.mark.asyncio
+    async def test_quote(self) -> None:
+        payer, _, _ = _triple()
+        q = await payer.quote(ServiceRef("svc"))
+        assert q.service == ServiceRef("svc")
+        assert q.price.amount == 10
+
+    @pytest.mark.asyncio
+    async def test_refund_protocol_call_on_unknown_raises(self) -> None:
+        payer, _, _ = _triple()
+        with pytest.raises(EscrowError, match="not found"):
+            await payer.refund(PaymentRef("nope"))
+
+
+class TestConservation:
+    """Funds are conserved across every terminal state."""
+
+    @pytest.mark.asyncio
+    async def test_conservation_release(self) -> None:
+        payer, payee, _ = _triple()
+        total_before = (
+            payer.balance(AgentId("payer"))
+            + payer.balance(AgentId("payee"))
+            + payer.balance(AgentId("arbiter"))
+        )
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=400),
+            ref=PaymentRef("e1"),
+        )
+        await payee.deliver(PaymentRef("e1"), proof="x")
+        await payer.release(PaymentRef("e1"))
+        total_after = (
+            payer.balance(AgentId("payer"))
+            + payer.balance(AgentId("payee"))
+            + payer.balance(AgentId("arbiter"))
+        )
+        assert total_before == total_after
+
+    @pytest.mark.parametrize("bps", [0, 1, 1234, 5000, 9999, 10000])
+    @pytest.mark.asyncio
+    async def test_conservation_arbitrate(self, bps: int) -> None:
+        payer, payee, arbiter = _triple()
+        total_before = (
+            payer.balance(AgentId("payer"))
+            + payer.balance(AgentId("payee"))
+            + payer.balance(AgentId("arbiter"))
+        )
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=777),
+            ref=PaymentRef("e1"),
+        )
+        await payee.deliver(PaymentRef("e1"), proof="x")
+        await payer.dispute(PaymentRef("e1"), reason="x")
+        await arbiter.arbitrate(PaymentRef("e1"), payee_bps=bps, rationale="x")
+        total_after = (
+            payer.balance(AgentId("payer"))
+            + payer.balance(AgentId("payee"))
+            + payer.balance(AgentId("arbiter"))
+        )
+        assert total_before == total_after
+
+    @pytest.mark.asyncio
+    async def test_conservation_refund(self) -> None:
+        payer, _, _ = _triple()
+        total_before = payer.balance(AgentId("payer"))
+        await payer.open_escrow(
+            payee=AgentId("payee"),
+            arbiter=AgentId("arbiter"),
+            amount=Money(amount=600),
+            ref=PaymentRef("e1"),
+        )
+        await payer.refund(PaymentRef("e1"))
+        assert payer.balance(AgentId("payer")) == total_before

--- a/packages/nest-plugins-reference/tests/test_escrow_properties.py
+++ b/packages/nest-plugins-reference/tests/test_escrow_properties.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hypothesis property tests for the escrow plugin.
+
+Pins invariants the example-based tests can't enumerate:
+
+* Conservation of funds across arbitrary amounts and bps splits.
+* Floor-division split: payee + payer credits exactly equal the original amount
+  (no money created or destroyed by rounding).
+* Out-of-state transitions raise across every state-pair the type system allows.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Money, PaymentRef
+from nest_plugins_reference.payments.escrow import EscrowError, EscrowPayments
+
+
+def _triple(
+    initial_payer: int,
+) -> tuple[EscrowPayments, EscrowPayments, EscrowPayments]:
+    balances: dict[AgentId, int] = {
+        AgentId("payer"): initial_payer,
+        AgentId("payee"): 0,
+        AgentId("arbiter"): 0,
+    }
+    payments: dict[PaymentRef, object] = {}
+    escrows: dict[PaymentRef, object] = {}
+    payer = EscrowPayments(
+        AgentId("payer"),
+        balances=balances,
+        payments=payments,  # type: ignore[arg-type]
+        escrows=escrows,  # type: ignore[arg-type]
+    )
+    payee = EscrowPayments(
+        AgentId("payee"),
+        balances=balances,
+        payments=payments,  # type: ignore[arg-type]
+        escrows=escrows,  # type: ignore[arg-type]
+    )
+    arbiter = EscrowPayments(
+        AgentId("arbiter"),
+        balances=balances,
+        payments=payments,  # type: ignore[arg-type]
+        escrows=escrows,  # type: ignore[arg-type]
+    )
+    return payer, payee, arbiter
+
+
+@given(
+    amount=st.integers(min_value=1, max_value=10_000),
+    bps=st.integers(min_value=0, max_value=10_000),
+)
+@settings(max_examples=200, deadline=None)
+@pytest.mark.asyncio
+async def test_arbitrate_conserves_total_ledger(amount: int, bps: int) -> None:
+    """For any amount and any bps split, the three-party total is preserved."""
+    payer, payee, arbiter = _triple(initial_payer=amount)
+    total_before = (
+        payer.balance(AgentId("payer"))
+        + payer.balance(AgentId("payee"))
+        + payer.balance(AgentId("arbiter"))
+    )
+    await payer.open_escrow(
+        payee=AgentId("payee"),
+        arbiter=AgentId("arbiter"),
+        amount=Money(amount=amount),
+        ref=PaymentRef("e"),
+    )
+    await payee.deliver(PaymentRef("e"), proof="x")
+    await payer.dispute(PaymentRef("e"), reason="x")
+    await arbiter.arbitrate(PaymentRef("e"), payee_bps=bps, rationale="x")
+    total_after = (
+        payer.balance(AgentId("payer"))
+        + payer.balance(AgentId("payee"))
+        + payer.balance(AgentId("arbiter"))
+    )
+    assert total_before == total_after
+
+
+@given(
+    amount=st.integers(min_value=1, max_value=10_000),
+    bps=st.integers(min_value=0, max_value=10_000),
+)
+@settings(max_examples=200, deadline=None)
+@pytest.mark.asyncio
+async def test_split_sums_exactly_to_amount(amount: int, bps: int) -> None:
+    """payee_credit + payer_refund == amount, even under floor division."""
+    payer, payee, arbiter = _triple(initial_payer=amount)
+    await payer.open_escrow(
+        payee=AgentId("payee"),
+        arbiter=AgentId("arbiter"),
+        amount=Money(amount=amount),
+        ref=PaymentRef("e"),
+    )
+    await payee.deliver(PaymentRef("e"), proof="x")
+    await payer.dispute(PaymentRef("e"), reason="x")
+    await arbiter.arbitrate(PaymentRef("e"), payee_bps=bps, rationale="x")
+    payee_credit = payer.balance(AgentId("payee"))
+    payer_refund = payer.balance(AgentId("payer"))  # was drained to 0 by open
+    assert payee_credit + payer_refund == amount
+
+
+@given(amount=st.integers(min_value=1, max_value=10_000))
+@settings(max_examples=100, deadline=None)
+@pytest.mark.asyncio
+async def test_release_before_deliver_always_raises(amount: int) -> None:
+    """For any amount, releasing a FUNDED-but-not-DELIVERED escrow raises."""
+    payer, _, _ = _triple(initial_payer=amount)
+    await payer.open_escrow(
+        payee=AgentId("payee"),
+        arbiter=AgentId("arbiter"),
+        amount=Money(amount=amount),
+        ref=PaymentRef("e"),
+    )
+    with pytest.raises(EscrowError):
+        await payer.release(PaymentRef("e"))
+
+
+@given(bad_bps=st.one_of(st.integers(max_value=-1), st.integers(min_value=10_001)))
+@settings(max_examples=100, deadline=None)
+@pytest.mark.asyncio
+async def test_arbitrate_out_of_range_always_raises(bad_bps: int) -> None:
+    """Any bps outside [0, 10000] raises -- no off-by-one survives."""
+    payer, payee, arbiter = _triple(initial_payer=100)
+    await payer.open_escrow(
+        payee=AgentId("payee"),
+        arbiter=AgentId("arbiter"),
+        amount=Money(amount=100),
+        ref=PaymentRef("e"),
+    )
+    await payee.deliver(PaymentRef("e"), proof="x")
+    await payer.dispute(PaymentRef("e"), reason="x")
+    with pytest.raises(EscrowError):
+        await arbiter.arbitrate(PaymentRef("e"), payee_bps=bad_bps, rationale="x")

--- a/packages/nest-plugins-reference/tests/test_escrow_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_escrow_scenario.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end scenario test for the escrow plugin.
+
+Boots the ``escrow_marketplace`` scenario through the real ``Simulator``
+twice -- once with ``payments: escrow`` and once with
+``payments: prepaid_credits`` -- and proves the four validators
+discriminate: ALL PASS under the escrow plugin, ALL FAIL under the
+default plugin (which has no escrow protocol).
+
+Also pins determinism: same seed → byte-identical trace.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "escrow_marketplace.yaml"
+
+
+def _swap_payments(config: ScenarioConfig, plugin_name: str) -> ScenarioConfig:
+    """Return ``config`` with the payments layer pointing at ``plugin_name``."""
+    new_layers = config.layers.model_copy(update={"payments": plugin_name})
+    return config.model_copy(update={"layers": new_layers})
+
+
+def _run(plugin_name: str, seed: int = 42) -> Path:
+    """Run the scenario with the chosen payments plugin; return the trace path."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    config = _swap_payments(config, plugin_name)
+    config = config.model_copy(update={"seed": seed})
+    tmp = Path(tempfile.mkdtemp())
+    trace_path = tmp / f"escrow_{plugin_name}_{seed}.jsonl"
+    config = config.model_copy(
+        update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+    )
+    runner = ScenarioRunner(config, registry=PluginRegistry())
+    asyncio.run(runner.run())
+    return trace_path
+
+
+def _all_passed(plugin_name: str) -> tuple[bool, list[str]]:
+    trace_path = _run(plugin_name)
+    results = validate_trace(trace_path, "escrow_marketplace")
+    summary = [f"{'PASS' if r.passed else 'FAIL'} {r.name}: {r.detail}" for r in results]
+    return all(r.passed for r in results), summary
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_escrow_plugin_passes_all_four_validators() -> None:
+    """The escrow plugin satisfies state-machine, role-binding, bps, and payout-gating."""
+    passed, summary = _all_passed("escrow")
+    assert passed, "expected all validators to pass under escrow plugin:\n" + "\n".join(summary)
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_prepaid_credits_fails_validators() -> None:
+    """The default ``prepaid_credits`` plugin lacks the escrow protocol.
+
+    Three of the four validators MUST flag this: state-machine,
+    role-binding, and no-payout-without-delivery all report 'no escrow
+    lifecycle observed'. (The bps-range validator vacuously passes
+    because there are no arbitrate events to range-check; that is the
+    correct behavior -- the rule is 'every arbitrate ∈ range'.)
+    """
+    trace_path = _run("prepaid_credits")
+    results = validate_trace(trace_path, "escrow_marketplace")
+    by_name = {r.name: r for r in results}
+    assert not by_name["escrow_state_machine"].passed
+    assert not by_name["escrow_role_binding"].passed
+    assert not by_name["escrow_no_payout_without_delivery"].passed
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_escrow_scenario_deterministic_under_replay() -> None:
+    """Two runs with seed 42 produce identical trace bytes."""
+    a = _run("escrow", seed=42).read_bytes()
+    b = _run("escrow", seed=42).read_bytes()
+    assert a == b
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_escrow_scenario_passes_across_seeds(seed: int) -> None:
+    """Validator discrimination holds across multiple seeds."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    config = _swap_payments(config, "escrow")
+    config = config.model_copy(update={"seed": seed})
+    tmp = Path(tempfile.mkdtemp())
+    trace_path = tmp / f"escrow_seed_{seed}.jsonl"
+    config = config.model_copy(
+        update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+    )
+    runner = ScenarioRunner(config, registry=PluginRegistry())
+    asyncio.run(runner.run())
+    results = validate_trace(trace_path, "escrow_marketplace")
+    assert all(r.passed for r in results), [
+        f"{r.name}: {r.detail}" for r in results if not r.passed
+    ]

--- a/scenarios/escrow_marketplace.yaml
+++ b/scenarios/escrow_marketplace.yaml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Escrow marketplace: 3 buyer/seller/arbiter triples drive the escrow plugin
+# through the happy path and two dispute paths. The four escrow_marketplace
+# validators must all pass under `payments: escrow` and all fail under
+# `payments: prepaid_credits` (no escrow protocol, no escrow events emitted).
+
+name: escrow_marketplace
+description: |
+  Three buyer/seller/arbiter triples. Triple 0 runs the happy path
+  (open -> deliver -> release). Triples 1 and 2 run the dispute path
+  with different arbitrator splits (3000 and 8000 bps). All four
+  escrow validators (state-machine, role-binding, bps-range,
+  no-payout-without-delivery) must pass under the escrow plugin.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 9
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 3
+      config: {}
+    - name: seller
+      count: 3
+      config: {}
+    - name: arbiter
+      count: 3
+      config: {}
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: escrow
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: escrow_marketplace
+  config: {}
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 200"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/escrow_marketplace.jsonl


### PR DESCRIPTION
## Motivation

The `payments` layer currently has two plugins: `prepaid_credits` (a 122-line debit/credit ledger) and the merged PR #21 `streaming` plugin (per-tick streaming with mid-stream cancel). Neither models the most common multi-party payment pattern on the agentic web: an **escrow** where a payer locks funds against work to be delivered by a payee, with a third-party arbiter empowered to settle disputes.

Without this primitive, every test scenario that simulates a marketplace, a sub-contracting pipeline, or any "pay-on-delivery" workflow has to either trust the counterparty or model bespoke ledger glue. The `docs/layers/payments.md` wishlist explicitly calls out "escrow + dispute resolution" — no PRs had touched it.

## Design

A new `escrow` plugin under the payments layer that adds the standard three-phase escrow flow:

```
FUNDED → DELIVERED → RELEASED                      (happy path)
FUNDED → DELIVERED → DISPUTED → ARBITRATED         (dispute path)
FUNDED → REFUNDED                                  (payer recalls undelivered)
```

Roles are bound to agent ids at `open_escrow` time. Only the payer can `release`/`dispute`/`refund`; only the payee can `deliver`; only the named arbiter can `arbitrate`, and only after the payer has disputed. Arbitration splits the locked amount in basis points (`payee_bps ∈ [0, 10000]`) — strict integer floor-division, no money created or destroyed.

`pay()` is implemented as a one-call shortcut (open + immediate release) so the plugin satisfies the bare `Payments` protocol and any existing caller that just needs to move credits still works.

## Adversarial validators

Four validators read the trace (`escrow:<kind>:<fields>` broadcasts) and check:

1. **`escrow_state_machine`** — every per-ref transition follows a legal edge (no `released` without `delivered`, no double-arbitrate).
2. **`escrow_role_binding`** — the broadcasting agent for every transition matches the role named in the originating `opened` event.
3. **`escrow_bps_in_range`** — every `arbitrated` carries `payee_bps` strictly in `[0, 10000]`.
4. **`escrow_no_payout_without_delivery`** — no `released`/`arbitrated` may settle for a ref that wasn't `delivered` first.

Together they catch: forged delivery proofs, unauthorized releases, arbiter over-bounds, and the most common ambient failure of the `prepaid_credits` baseline — paying upfront with no delivery acknowledgment in the trace.

## Adversarial result

The `escrow_marketplace` scenario drives 3 buyer/seller/arbiter triples: one happy, two dispute (3000 and 8000 bps). Same scenario, two plugins:

- **`payments: escrow`** → all four validators **PASS** under seeds 42, 7, 1337.
- **`payments: prepaid_credits`** → three of four validators **FAIL** with "no escrow lifecycle observed in trace — plugin lacks escrow protocol." (`escrow_bps_in_range` vacuously passes because there are no arbitrate events to range-check; that is the correct behavior — the rule is "every arbitrate ∈ range.")

Tested end-to-end against the real `Simulator`, real `ScenarioRunner`, real `validate_trace`. No mocking past the plugin boundary.

## Determinism

Tier 1: no wall-clock, no unseeded RNG. The plugin uses pure integer/float arithmetic and a deterministic state machine. The scenario factory uses fixed per-triple tick schedules. `test_escrow_scenario_deterministic_under_replay` pins **byte-identical** traces across two runs with seed 42, and `test_escrow_scenario_passes_across_seeds[42|7|1337]` confirms the same validator verdict across three seeds.

## Test rigor (70 new tests)

- **42 unit tests** (`test_escrow.py`) — every state transition, every role-bound rejection, every state-machine guard, the `Payments`-protocol shortcut, and explicit conservation across release / arbitrate (parametrized over six bps values) / refund.
- **4 Hypothesis property tests** (`test_escrow_properties.py`) — `@given(amount, bps)` over the full domain pins: (a) three-party ledger conservation, (b) split exactness (`payee_credit + payer_refund == amount` even under floor division), (c) out-of-state release always raises, (d) out-of-range bps always raises.
- **18 validator unit tests** (`test_validators.py::TestEscrowValidators`) — direct, synthetic-event coverage of each validator's pass/fail code paths.
- **6 integration tests** (`test_escrow_scenario.py`) — escrow plugin passes, `prepaid_credits` fails the discriminating three, byte-deterministic replay, three-seed parametrization.

## Runnable verification

```bash
# 1. Run the scenario (deterministic; writes ./traces/escrow_marketplace.jsonl)
uv run nest run escrow_marketplace

# 2. Validate the trace (all four PASS under escrow plugin)
uv run python - <<'PY'
from pathlib import Path
from nest_core.validators import validate_trace
for r in validate_trace(Path("traces/escrow_marketplace.jsonl"), "escrow_marketplace"):
    print(("PASS" if r.passed else "FAIL"), r.name, "-", r.detail)
PY

# 3. The discrimination + integration test
uv run pytest -v packages/nest-plugins-reference/tests/test_escrow_scenario.py
```

## Files added / changed

- `packages/nest-plugins-reference/nest_plugins_reference/payments/escrow.py` — the `EscrowPayments` plugin (new, ~370 LOC).
- `packages/nest-plugins-reference/tests/test_escrow.py` — 42 unit tests (new).
- `packages/nest-plugins-reference/tests/test_escrow_properties.py` — 4 Hypothesis property tests (new).
- `packages/nest-plugins-reference/tests/test_escrow_scenario.py` — 6 integration tests (new).
- `packages/nest-core/nest_core/scenarios_builtin/escrow_marketplace.py` — scenario factory (new, ~270 LOC).
- `packages/nest-core/nest_core/scenarios_builtin/yaml/escrow_marketplace.yaml` — bundled YAML (new).
- `scenarios/escrow_marketplace.yaml` — scenario YAML (new).
- `packages/nest-core/nest_core/validators.py` — 4 escrow validators + `VALIDATORS["escrow_marketplace"]` entry.
- `packages/nest-core/nest_core/plugins.py` — one line registering `("payments", "escrow")` in `_BUILTINS`.
- `packages/nest-core/nest_core/scenarios.py` — lazy registration branch for the scenario.
- `packages/nest-core/tests/test_validators.py` — `TestEscrowValidators` class + one line in `TestValidatorRegistry`.

Nothing outside the payments layer plus its scenario, validators, and tests was modified. No changes to the rubric, seed bank, `docs/hackathon/scores.json`, `scripts/judge/*`, or any other submission.

`make ci-local` (uv sync; ruff check; ruff format --check; pyright; pytest) is green: **611 passed, 1 skipped**.
