### PR TITLE
[Hackathon] hiten: Layer 12 DataFacts — content-addressed provenance …

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -37,6 +37,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
     ("datafacts", "datafacts_v1"): f"{_REF}.datafacts.datafacts_v1:DataFactsV1",
+    ("datafacts", "cid_facts"): f"{_REF}.datafacts.cid_facts:CidFacts",
 }
 
 

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -97,3 +97,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("receipt_reputation", receipt_reputation_factory)
+    elif name == "provenance_supply_chain":
+        from nest_core.scenarios_builtin.provenance_supply_chain import (
+            provenance_supply_chain_factory,
+        )
+
+        register_scenario("provenance_supply_chain", provenance_supply_chain_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain.py
@@ -1,0 +1,563 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Provenance supply-chain scenario — content-addressed DataFacts end-to-end.
+
+Each participant in the supply-chain DAG publishes a content-addressed dataset
+via the `cid_facts` plugin and emits structured trace events that the
+`provenance_supply_chain` validators can inspect:
+
+* ``publish:df://sha256-<hex>:<agent_id>``
+* ``freshness_proof:df://sha256-<hex>:<tick>:<sig_hex>``
+* ``derived:df://sha256-<child>:df://sha256-<parent1>[,df://sha256-<parent2>]``
+* ``provenance_audit:<url>:nodes=<n>:ancestors=<url1>,<url2>,...``
+
+The topology is configurable via ``num_suppliers`` (default 2) and
+``num_manufacturers`` (default 2) in the task config block.  Agent IDs are
+``supplier-0 … supplier-(N-1)`` and ``manufacturer-0 … manufacturer-(M-1)``.
+
+Flow (default 2×2)::
+
+```
+supplier-0 and supplier-1
+  └─ each publishes raw-material datasets
+  └─ each forwards dataset URLs to all manufacturers
+
+manufacturer-0 and manufacturer-1
+  └─ each waits until ALL supplier URLs are received
+     for the same round/item
+  └─ publishes a manufactured-goods dataset with all supplier URLs as parents
+  └─ emits a derived trace event
+  └─ forwards the dataset URL to Distributor
+
+Distributor
+  └─ waits until ALL manufacturer URLs are received
+     for the same round/item
+  └─ publishes a shipment dataset with all manufacturer URLs as parents
+  └─ emits a derived trace event
+  └─ forwards the dataset URL to Retailer
+
+Retailer
+  └─ receives distributor dataset URL
+  └─ verifies freshness proofs
+  └─ walks the complete provenance DAG
+  └─ verifies every ancestor dataset
+  └─ emits chain-verified or chain-failed events
+  └─ emits provenance_audit event with full ancestor list
+```
+
+Provenance DAG (default 2×2)::
+
+    supplier-0 ─────┬─► manufacturer-0 ──┐
+                    │                     │
+                    └─► manufacturer-1 ──┤
+                                          │
+    supplier-1 ─────┬─► manufacturer-0 ──┤
+                    │                     │
+                    └─► manufacturer-1 ──┘
+                                          │
+                                          ▼
+                                    distributor-0
+                                          │
+                                          ▼
+                                     retailer-0
+
+This scenario demonstrates a true multi-parent provenance DAG rather than
+a simple linear chain. Manufacturer datasets depend on multiple supplier
+datasets, and shipment datasets depend on multiple manufacturer datasets.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_df(agent_id: AgentId, plugins: dict[str, Any]) -> Any:
+    """Instantiate a ``CidFacts`` (or ``DataFactsV1``) from the plugin registry.
+
+    ``plugins["datafacts"]`` holds the resolved plugin *class*, not an
+    instance.  ``CidFacts`` requires a ``DidKeyIdentity`` argument; this
+    helper constructs one keyed to *agent_id* with a deterministic seed.
+    Falls back to no-arg construction for ``DataFactsV1``-style classes.
+    """
+    import hashlib
+    import inspect
+
+    datafacts_cls = plugins.get("datafacts")
+    if datafacts_cls is None:
+        return None
+
+    params = inspect.signature(datafacts_cls.__init__).parameters
+    required = [
+        p for name, p in params.items() if name != "self" and p.default is inspect.Parameter.empty
+    ]
+    if not required:
+        return datafacts_cls()
+
+    identity_cls = plugins.get("identity")
+    if identity_cls is None:
+        try:
+            return datafacts_cls()
+        except TypeError:
+            return None
+
+    seed = hashlib.sha256(str(agent_id).encode()).digest()
+    identity = identity_cls(agent_id, seed=seed)
+    return datafacts_cls(identity)
+
+
+# ---------------------------------------------------------------------------
+# Agents
+# ---------------------------------------------------------------------------
+
+
+class CidSupplierAgent(StateMachineAgent):
+    """Produces a content-addressed raw-materials dataset and forwards the URL."""
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        next_stages: list[AgentId],
+        df: Any,
+        items_per_round: int = 2,
+        rounds: int = 3,
+    ) -> None:
+        self._id = agent_id
+        self._next_stages = next_stages
+        self._df = df
+        self._items_per_round = items_per_round
+        self._rounds = rounds
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        df = self._df
+
+        for rnd in range(1, self._rounds + 1):
+            for item in range(self._items_per_round):
+                batch_id = f"raw-{self._id}-r{rnd}-i{item}"
+                meta = DatasetMetadata(
+                    name=batch_id,
+                    owner=self._id,
+                    description=f"Raw materials batch {batch_id}",
+                    tags=["raw", "supplier"],
+                    # Bind payload content: store a digest in metadata so the
+                    # CID covers actual content, not just structural metadata.
+                    metadata={"content_sha256": _fake_content_hash(batch_id)},
+                )
+
+                if df is not None:
+                    url = await df.publish(meta)
+                    proof = (
+                        df.get_freshness_proof(url) if hasattr(df, "get_freshness_proof") else None
+                    )
+
+                    # Emit structured trace events for validators.
+                    sig_hex = proof.signature.value.hex() if proof else "none"
+                    tick_str = str(proof.tick) if proof else "0"
+                    publisher = str(self._id)
+                    for next_stage in self._next_stages:
+                        await ctx.send(
+                            next_stage,
+                            f"publish:{url}:{publisher}".encode(),
+                        )
+                    for next_stage in self._next_stages:
+                        await ctx.send(
+                            next_stage,
+                            f"freshness_proof:{url}:{tick_str}:{sig_hex}".encode(),
+                        )
+                    # Forward URL to next stage.
+                    for next_stage in self._next_stages:
+                        await ctx.send(
+                            next_stage,
+                            f"cid_url:{rnd}:{item}:{url}".encode(),
+                        )
+                else:
+                    # Fallback: no datafacts plugin — use raw message protocol.
+                    for next_stage in self._next_stages:
+                        await ctx.send(
+                            next_stage,
+                            f"material:{rnd}:{batch_id}".encode(),
+                        )
+
+
+class CidManufacturerAgent(StateMachineAgent):
+    """Receives supplier URLs, publishes a derived manufactured-goods dataset.
+
+    Waits until ``num_suppliers`` distinct URLs have arrived for the same
+    ``(round, item)`` key before publishing, mirroring the N-way fan-in.
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        next_stage: AgentId,
+        df: Any,
+        num_suppliers: int = 2,
+    ) -> None:
+        self._id = agent_id
+        self._next = next_stage
+        self._counter = 0
+        self._df = df
+        self._num_suppliers = num_suppliers
+        self._supplier_urls: dict[str, list[str]] = {}
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        msg = payload.decode("utf-8", errors="replace")
+        df = self._df
+
+        # Consume the forwarded supplier URL.
+        if msg.startswith("cid_url:"):
+            # Format: cid_url:{rnd}:{item}:{url}  — url contains ://  so
+            # split with maxsplit=3 to keep the full URL intact.
+            parts = msg.split(":", 3)
+            if len(parts) < 4:
+                return
+            rnd, item, supplier_url = parts[1], parts[2], parts[3]
+
+            key = f"{rnd}:{item}"
+            urls = self._supplier_urls.setdefault(key, [])
+
+            if supplier_url not in urls:
+                urls.append(supplier_url)
+
+            if len(urls) < self._num_suppliers:
+                return
+
+            self._counter += 1
+            product_id = f"good-{self._id}-r{rnd}-i{item}"
+
+            parents = [DataFactsUrl(url) for url in urls]
+
+            if df is not None:
+                meta = DatasetMetadata(
+                    name=product_id,
+                    owner=self._id,
+                    description=f"Manufactured goods {product_id}",
+                    tags=["goods", "manufacturer"],
+                    metadata={"content_sha256": _fake_content_hash(product_id)},
+                    parents=parents,
+                )
+                url = await df.publish(meta)
+                proof = df.get_freshness_proof(url) if hasattr(df, "get_freshness_proof") else None
+
+                sig_hex = proof.signature.value.hex() if proof else "none"
+                tick_str = str(proof.tick) if proof else "0"
+
+                # Emit trace events.
+                await ctx.send(self._next, f"publish:{url}:{self._id}".encode())
+                await ctx.send(
+                    self._next,
+                    f"freshness_proof:{url}:{tick_str}:{sig_hex}".encode(),
+                )
+                await ctx.send(
+                    self._next,
+                    f"derived:{url}:{','.join(str(parent) for parent in parents)}".encode(),
+                )
+                await ctx.send(
+                    self._next,
+                    f"cid_url:{rnd}:{item}:{url}".encode(),
+                )
+            else:
+                await ctx.send(
+                    self._next,
+                    f"product:{rnd}:{product_id}".encode(),
+                )
+
+
+class CidDistributorAgent(StateMachineAgent):
+    """Receives manufacturer URLs, publishes a derived shipment dataset.
+
+    Waits until ``num_manufacturers`` distinct URLs have arrived for the same
+    ``(round, item)`` key before publishing, mirroring the M-way fan-in.
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        next_stage: AgentId,
+        df: Any,
+        num_manufacturers: int = 2,
+    ) -> None:
+        self._id = agent_id
+        self._next = next_stage
+        self._counter = 0
+        self._df = df
+        self._num_manufacturers = num_manufacturers
+        self._manufacturer_urls: dict[str, list[str]] = {}
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        msg = payload.decode("utf-8", errors="replace")
+        df = self._df
+
+        if msg.startswith("cid_url:"):
+            # Format: cid_url:{rnd}:{item}:{url}  — split with maxsplit=3.
+            parts = msg.split(":", 3)
+            if len(parts) < 4:
+                return
+            rnd, item, mfg_url = parts[1], parts[2], parts[3]
+            key = f"{rnd}:{item}"
+
+            urls = self._manufacturer_urls.setdefault(key, [])
+
+            if mfg_url not in urls:
+                urls.append(mfg_url)
+
+            if len(urls) < self._num_manufacturers:
+                return
+
+            parents = [DataFactsUrl(url) for url in urls]
+            self._counter += 1
+            shipment_id = f"shipment-{self._id}-r{rnd}-i{item}"
+
+            if df is not None:
+                meta = DatasetMetadata(
+                    name=shipment_id,
+                    owner=self._id,
+                    description=f"Shipment {shipment_id}",
+                    tags=["shipment", "distributor"],
+                    metadata={"content_sha256": _fake_content_hash(shipment_id)},
+                    parents=parents,
+                )
+                url = await df.publish(meta)
+                proof = df.get_freshness_proof(url) if hasattr(df, "get_freshness_proof") else None
+
+                sig_hex = proof.signature.value.hex() if proof else "none"
+                tick_str = str(proof.tick) if proof else "0"
+
+                await ctx.send(self._next, f"publish:{url}:{self._id}".encode())
+                await ctx.send(
+                    self._next,
+                    f"freshness_proof:{url}:{tick_str}:{sig_hex}".encode(),
+                )
+                await ctx.send(
+                    self._next,
+                    f"derived:{url}:{','.join(str(parent) for parent in parents)}".encode(),
+                )
+                await ctx.send(
+                    self._next,
+                    f"cid_url:{rnd}:{item}:{url}".encode(),
+                )
+            else:
+                await ctx.send(
+                    self._next,
+                    f"shipment:{rnd}:{shipment_id}".encode(),
+                )
+
+
+class CidRetailerAgent(StateMachineAgent):
+    """Receives distributor URL, verifies freshness + provenance chain end-to-end."""
+
+    def __init__(self, agent_id: AgentId, origin: AgentId, df: Any) -> None:
+        self._id = agent_id
+        self._origin = origin
+        self._received = 0
+        self._df = df
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        msg = payload.decode("utf-8", errors="replace")
+        df = self._df
+
+        if msg.startswith("cid_url:"):
+            # Format: cid_url:{rnd}:{item}:{url}  — split with maxsplit=3.
+            parts = msg.split(":", 3)
+            if len(parts) < 4:
+                return
+            rnd, item, dist_url = parts[1], parts[2], parts[3]
+            self._received += 1
+
+            if df is not None:
+                # Verify freshness of the final-hop dataset.
+                fresh = await df.verify_freshness(DataFactsUrl(dist_url))
+
+                # Walk provenance chain: fetch dist -> mfg -> supplier.
+                chain_valid = await _verify_chain(df, DataFactsUrl(dist_url))
+
+                status = "chain-verified" if (fresh and chain_valid) else "chain-failed"
+                await ctx.send(
+                    self._origin,
+                    f"{status}:{rnd}:{item}:{dist_url}".encode(),
+                )
+                # Also emit a final delivered event compatible with supply_chain validators.
+                await ctx.send(
+                    self._origin,
+                    f"delivered:{rnd}:{item}".encode(),
+                )
+                # Emit provenance audit: walk the full DAG and list all ancestors.
+                if fresh and chain_valid:
+                    ancestors = await _collect_ancestors(df, DataFactsUrl(dist_url))
+                    ancestor_list = ",".join(sorted(str(a) for a in ancestors))
+                    await ctx.send(
+                        self._origin,
+                        f"provenance_audit:{dist_url}:nodes={len(ancestors)}:ancestors={ancestor_list}".encode(),
+                    )
+            else:
+                await ctx.send(
+                    self._origin,
+                    f"delivered:{rnd}:{item}".encode(),
+                )
+
+
+# ---------------------------------------------------------------------------
+# Provenance chain walk
+# ---------------------------------------------------------------------------
+
+
+async def _collect_ancestors(df: Any, url: DataFactsUrl) -> set[DataFactsUrl]:
+    """Return every ancestor reachable from url by walking the provenance DAG."""
+    visited: set[DataFactsUrl] = set()
+    ancestors: set[DataFactsUrl] = set()
+    stack: list[DataFactsUrl] = [url]
+
+    while stack:
+        current = stack.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+
+        try:
+            meta = await df.fetch(current)
+        except KeyError:
+            continue
+
+        for parent_url in meta.parents:
+            ancestors.add(parent_url)
+            stack.append(parent_url)
+
+    return ancestors
+
+
+async def _verify_chain(df: Any, url: DataFactsUrl) -> bool:
+    """Walk the provenance DAG and verify freshness at every hop.
+
+    Returns ``True`` iff every dataset in the chain has a valid freshness
+    proof.  Returns ``False`` on the first broken link or missing dataset.
+    """
+    visited: set[DataFactsUrl] = set()
+    queue: list[DataFactsUrl] = [url]
+
+    while queue:
+        current = queue.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+
+        try:
+            meta = await df.fetch(current)
+        except KeyError:
+            return False  # missing dataset in chain
+
+        fresh = await df.verify_freshness(current)
+        if not fresh:
+            return False
+
+        for parent_url in meta.parents:
+            queue.append(parent_url)
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Content hash helper (simulation stand-in for actual payload hashing)
+# ---------------------------------------------------------------------------
+
+
+def _fake_content_hash(payload_id: str) -> str:
+    """Return a deterministic hex digest representing payload content.
+
+    In a real system this would be sha256(actual_payload_bytes).  In
+    simulation we derive it from the payload identifier string so that
+    two datasets with different names always get different content hashes.
+    """
+    import hashlib
+
+    return hashlib.sha256(payload_id.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def provenance_supply_chain_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create a content-addressed provenance supply chain.
+
+    Builds **one shared** ``CidFacts`` instance and passes it to every agent.
+    All agents share the same in-memory dataset registry, so the retailer can
+    verify freshness proofs for datasets that upstream agents published.
+
+    The ``datafacts`` layer must be set to ``cid_facts`` in the scenario YAML.
+    The ``identity`` layer must also be set (e.g. ``did_key``).
+
+    Configuration keys (all optional with defaults shown)::
+
+        task:
+          config:
+            num_suppliers: 2       # N suppliers: supplier-0 … supplier-(N-1)
+            num_manufacturers: 2   # M manufacturers: manufacturer-0 … manufacturer-(M-1)
+            items_per_round: 2
+            rounds: 3
+
+    Example::
+
+        agents = provenance_supply_chain_factory(config, plugins)
+    """
+    task_config = config.task.config
+    items_per_round = task_config.get("items_per_round", 2)
+    rounds = task_config.get("rounds", 3)
+    num_suppliers = int(task_config.get("num_suppliers", 2))
+    num_manufacturers = int(task_config.get("num_manufacturers", 2))
+
+    retailer_id = AgentId("retailer-0")
+    distributor_id = AgentId("distributor-0")
+
+    supplier_ids = [AgentId(f"supplier-{i}") for i in range(num_suppliers)]
+    manufacturer_ids = [AgentId(f"manufacturer-{i}") for i in range(num_manufacturers)]
+
+    # Build one shared datafacts instance.  All agents write to and read from
+    # the same in-memory registry so the retailer can look up proofs created
+    # by upstream agents.  We use the first supplier's identity as the signing
+    # key; each agent's datasets are attributed via DatasetMetadata.owner.
+    seed_id = supplier_ids[0] if supplier_ids else AgentId("supplier-0")
+    shared_df = _make_df(seed_id, plugins)
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+
+    # --- Suppliers: each forwards its URL to every manufacturer ---
+    for sup_id in supplier_ids:
+        agents[sup_id] = CidSupplierAgent(
+            sup_id,
+            next_stages=list(manufacturer_ids),
+            df=shared_df,
+            items_per_round=items_per_round,
+            rounds=rounds,
+        )
+
+    # --- Manufacturers: each waits for all num_suppliers URLs ---
+    for mfg_id in manufacturer_ids:
+        agents[mfg_id] = CidManufacturerAgent(
+            mfg_id,
+            next_stage=distributor_id,
+            df=shared_df,
+            num_suppliers=num_suppliers,
+        )
+
+    # --- Distributor: waits for all num_manufacturers URLs ---
+    agents[distributor_id] = CidDistributorAgent(
+        distributor_id,
+        next_stage=retailer_id,
+        df=shared_df,
+        num_manufacturers=num_manufacturers,
+    )
+
+    # --- Retailer: verifies the full chain ---
+    agents[retailer_id] = CidRetailerAgent(retailer_id, origin=seed_id, df=shared_df)
+
+    return agents

--- a/packages/nest-core/nest_core/types.py
+++ b/packages/nest-core/nest_core/types.py
@@ -515,9 +515,23 @@ class Proof(BaseModel):
 class DatasetMetadata(BaseModel):
     """Metadata about a dataset published via DataFacts.
 
+    The ``parents`` field carries content-addressed URLs (``df://sha256-*``)
+    of every upstream dataset this one was derived from, forming a provenance
+    DAG.  Omit (or leave as the default empty list) for root datasets.
+
+    The ``metadata`` dict may include a ``"content_sha256"`` key that stores
+    a hex digest of the actual payload bytes.  The ``cid_facts`` plugin
+    incorporates this key when computing the content-addressed URL so that
+    the URL is bound to *content*, not just metadata fields.
+
     Example::
 
         meta = DatasetMetadata(name="weather-2024", owner=AgentId("a1"), schema_version="1.0")
+        derived = DatasetMetadata(
+            name="forecast",
+            owner=AgentId("a1"),
+            parents=[DataFactsUrl("df://sha256-abc123")],
+        )
     """
 
     name: str
@@ -531,6 +545,11 @@ class DatasetMetadata(BaseModel):
     checksum: str | None = None
     access_tier: str = "public"
     metadata: dict[str, Any] = Field(default_factory=dict)
+    # Provenance DAG: content-addressed URLs of upstream datasets. Defaults
+    # to [] so all existing callers remain valid without changes.
+    parents: list[DataFactsUrl] = Field(  # pyright: ignore[reportUnknownVariableType]
+        default_factory=list
+    )
 
 
 class AccessGrant(BaseModel):
@@ -545,6 +564,35 @@ class AccessGrant(BaseModel):
     grantee: AgentId
     tier: str = "read"
     expires_at: float | None = None
+
+
+class FreshnessProof(BaseModel):
+    """Signed proof that a content-addressed dataset was published at logical tick *tick*.
+
+    The ``signature`` covers the canonical JSON (sorted keys, no whitespace) of::
+
+        {"publisher": <str>, "tick": <float>, "url": <str>}
+
+    using the publisher's identity-layer private key.  A verifier can confirm
+    authenticity without relying on wall-clock time by:
+
+    1. Reconstructing the canonical JSON from the proof fields.
+    2. Calling ``identity.verify(payload, proof.signature, proof.publisher)``.
+
+    Example::
+
+        proof = FreshnessProof(
+            url=DataFactsUrl("df://sha256-abc123"),
+            publisher=AgentId("supplier-0"),
+            tick=1.0,
+            signature=Signature(signer=AgentId("supplier-0"), value=b"sig"),
+        )
+    """
+
+    url: DataFactsUrl
+    publisher: AgentId
+    tick: float
+    signature: Signature
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1835,6 +1835,300 @@ def validate_receipt_reputation_honest_confidence(
 
 
 # ---------------------------------------------------------------------------
+# CID (content-addressed) datafacts validators
+# ---------------------------------------------------------------------------
+# These three validators operate entirely on trace events emitted by the
+# provenance_supply_chain scenario and require **no** access to plugin
+# internals.  They FAIL against datafacts_v1 traces (name-based URLs) and
+# PASS against cid_facts traces (sha256-prefixed URLs + proof events).
+#
+# Expected trace events (msg field):
+#
+#   publish:df://sha256-<hex>:<agent_id>
+#       Emitted by an agent when it successfully publishes a dataset.
+#
+#   freshness_proof:df://sha256-<hex>:<tick>:<sig_hex>
+#       Emitted alongside every publish to record the signed proof.
+#
+#   derived:df://sha256-<child>:df://sha256-<parent1>[,df://sha256-<parent2>,...]
+#       Emitted by derived-dataset publishers, listing every parent hash.
+# ---------------------------------------------------------------------------
+
+_CID_PREFIX = "df://sha256-"
+
+
+def _cid_parse_publish(msg: str) -> str | None:
+    """Extract the URL from a ``publish:<url>:<agent>`` trace message.
+
+    Returns the full URL (which may contain ``://``) or ``None`` if the
+    message does not parse correctly.
+
+    The message format is::
+
+        publish:df://sha256-<hex>:<agent_id>
+
+    A naive ``split(":")`` shatters ``df://sha256-<hex>`` into multiple
+    parts, so we strip the verb then take everything up to the *last* ``:"
+    as the URL (since agent_id never contains ``:``)::
+
+        >>> _cid_parse_publish("publish:df://sha256-abc:agent-1")
+        'df://sha256-abc'
+    """
+    if not msg.startswith("publish:"):
+        return None
+    remainder = msg[len("publish:") :]
+    # The last colon separates URL from agent_id.  Everything before it is
+    # the URL (which may itself contain colons as part of ``://``).
+    last_colon = remainder.rfind(":")
+    if last_colon < 0:
+        # No agent suffix — whole remainder is the URL.
+        return remainder
+    return remainder[:last_colon]
+
+
+def _cid_parse_freshness_proof(msg: str) -> str | None:
+    """Extract the URL from a ``freshness_proof:<url>:<tick>:<sig_hex>`` message."""
+    if not msg.startswith("freshness_proof:"):
+        return None
+    remainder = msg[len("freshness_proof:") :]
+    # Format: <url>:<tick>:<sig_hex>. URL contains ://, tick and sig_hex do not.
+    # Find first colon that is NOT part of "://".
+    # Strategy: find second occurrence of ":" after skipping the "://" inside df://
+    # Simplest: split once at the first colon that is followed by something other
+    # than "/" (i.e., not part of a scheme).  Since df://sha256-... has no colon
+    # after the scheme, we can split on ":" and rebuild the URL greedily.
+    parts = remainder.split(":")
+    # parts[0] = "df", parts[1] = "//sha256-<hex>", parts[2] = tick, parts[3] = sig
+    # The URL is parts[0] + ":" + parts[1] when it starts with "df"
+    if len(parts) < 3:
+        return None
+    if parts[0] == "df" and parts[1].startswith("//"):
+        return parts[0] + ":" + parts[1]
+    # Fallback: URL is everything before the last two colons.
+    # Find the tick field (numeric) to locate the boundary.
+    for i in range(1, len(parts)):
+        candidate_url = ":".join(parts[:i])
+        tail = ":".join(parts[i:])
+        try:
+            float(tail.split(":")[0])
+            return candidate_url
+        except ValueError:
+            continue
+    return None
+
+
+def _cid_parse_derived(msg: str) -> tuple[str, list[str]] | None:
+    """Parse ``derived:<child_url>:<parent_url1>[,<parent_url2>]``.
+
+    Returns ``(child_url, [parent_url, ...])`` or ``None``.
+
+    Like the publish parser, the challenge is that URLs contain ``://``.
+    We split into exactly three parts by finding the first colon *not*
+    part of a ``://`` scheme, i.e. the first ``:`` after position 7
+    (past ``derived:`` verb) that is not immediately followed by ``//``.
+    """
+    if not msg.startswith("derived:"):
+        return None
+    remainder = msg[len("derived:") :]
+    # Find the boundary between child URL and parents.
+    # Both child and parents start with "df://sha256-" and contain no colons
+    # except the scheme colon.  We can split on "," to get individual parents
+    # *after* we isolate the parents field.
+    #
+    # Strategy: since the format is  <child_url>:<parents_csv>  and child_url
+    # has the form df://sha256-<hex> (no colons after the scheme), the
+    # boundary colon is the *second* colon in remainder (the scheme colon
+    # of df:// is the first, so the next ":" is the separator).
+    parts = remainder.split(":")
+    # e.g. ["df", "//sha256-child", "df", "//sha256-p1,df", "//sha256-p2"]
+    # child = parts[0] + ":" + parts[1]  if parts[1] starts with "//"
+    if len(parts) < 4:
+        return None
+    if parts[0] == "df" and parts[1].startswith("//"):
+        child_url = parts[0] + ":" + parts[1]
+        parents_raw = ":".join(parts[2:])  # may be "df://sha256-p1,df://sha256-p2"
+        # Each parent has scheme "df:" so split by "," first, then reassemble.
+        parent_entries = parents_raw.split(",")
+        parents: list[str] = []
+        i = 0
+        while i < len(parent_entries):
+            entry = parent_entries[i].strip()
+            if entry == "df" and i + 1 < len(parent_entries):
+                # Re-join "df" with the next "//sha256-..." piece that was split by comma.
+                # But commas don't appear inside sha256 hashes — the split is safe.
+                parents.append(entry + ":" + parent_entries[i + 1].strip())
+                i += 2
+            else:
+                # Already a full URL or fragment
+                if entry:
+                    parents.append(entry)
+                i += 1
+        return child_url, parents
+    return None
+
+
+def validate_cid_no_substitution(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """All published dataset URLs must use the ``df://sha256-`` content-addressed scheme.
+
+    A name-based URL (``df://dataset_name``) indicates that substitution
+    resistance is *not* enforced — the publisher could republish different
+    content under the same name without detection.
+
+    This validator FAILS against ``datafacts_v1`` traces and PASSES against
+    ``cid_facts`` traces.
+    """
+    violations: list[str] = []
+    publish_count = 0
+
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("publish:"):
+            continue
+        url = _cid_parse_publish(msg)
+        if url is None:
+            continue
+        publish_count += 1
+        if not url.startswith(_CID_PREFIX):
+            agent = ev.get("agent", "?")
+            violations.append(f"{agent} published non-CID URL: {url!r}")
+
+    if not publish_count:
+        return [
+            ValidationResult(
+                "cid_no_substitution",
+                False,
+                "no publish events found — cannot confirm substitution resistance",
+            )
+        ]
+    if violations:
+        return [ValidationResult("cid_no_substitution", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "cid_no_substitution",
+            True,
+            f"all {publish_count} published URLs are content-addressed",
+        )
+    ]
+
+
+def validate_cid_freshness_proofs(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every published dataset must have a matching ``freshness_proof:`` trace event.
+
+    Detects the *stale-freshness* attack: a publisher claims a dataset is
+    fresh by re-touching its metadata without re-publishing — no proof
+    event is emitted, so this validator fires.
+
+    This validator FAILS against ``datafacts_v1`` traces (no proof events)
+    and PASSES against ``cid_facts`` traces.
+    """
+    published_urls: set[str] = set()
+    proved_urls: set[str] = set()
+
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if msg.startswith("publish:"):
+            url = _cid_parse_publish(msg)
+            if url:
+                published_urls.add(url)
+        elif msg.startswith("freshness_proof:"):
+            url = _cid_parse_freshness_proof(msg)
+            if url:
+                proved_urls.add(url)
+
+    if not published_urls:
+        return [
+            ValidationResult(
+                "cid_freshness_proofs",
+                False,
+                "no publish events found — cannot verify freshness proofs exist",
+            )
+        ]
+
+    missing = sorted(published_urls - proved_urls)
+    if missing:
+        detail = f"{len(missing)} published dataset(s) have no freshness proof: " + ", ".join(
+            u[:30] + "..." for u in missing
+        )
+        return [ValidationResult("cid_freshness_proofs", False, detail)]
+    return [
+        ValidationResult(
+            "cid_freshness_proofs",
+            True,
+            f"all {len(published_urls)} published datasets have freshness proofs",
+        )
+    ]
+
+
+def validate_cid_provenance_chain(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every parent hash referenced in a ``derived:`` event must itself be published.
+
+    Detects *provenance washing*: a derived dataset that references a parent
+    hash which does not correspond to any published dataset in the trace.
+
+    This validator FAILS when parents are missing or when the trace contains
+    no ``derived:`` events at all (meaning provenance is not being tracked).
+    """
+    published_urls: set[str] = set()
+    broken_chains: list[str] = []
+    derived_count = 0
+
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if msg.startswith("publish:"):
+            url = _cid_parse_publish(msg)
+            if url:
+                published_urls.add(url)
+
+    # Second pass: check derived events against published set.
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("derived:"):
+            continue
+        parsed = _cid_parse_derived(msg)
+        if parsed is None:
+            continue
+        child_url, parent_urls = parsed
+        derived_count += 1
+        for parent_url in parent_urls:
+            if parent_url and parent_url not in published_urls:
+                broken_chains.append(
+                    f"child {child_url[:32]}... references unpublished parent {parent_url[:32]}..."
+                )
+
+    if derived_count == 0:
+        return [
+            ValidationResult(
+                "cid_provenance_chain",
+                False,
+                "no derived: events found — provenance chain is not being tracked",
+            )
+        ]
+    if broken_chains:
+        return [ValidationResult("cid_provenance_chain", False, "; ".join(broken_chains))]
+    return [
+        ValidationResult(
+            "cid_provenance_chain",
+            True,
+            f"all {derived_count} derived datasets have valid provenance chains",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -1888,5 +2182,10 @@ VALIDATORS: dict[str, list[Any]] = {
     "receipt_reputation": [
         validate_receipt_reputation_ring_severed,
         validate_receipt_reputation_honest_confidence,
+    ],
+    "provenance_supply_chain": [
+        validate_cid_no_substitution,
+        validate_cid_freshness_proofs,
+        validate_cid_provenance_chain,
     ],
 }

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -754,6 +754,7 @@ class TestValidatorRegistry:
             "streaming_payments",
             "comms_versioning",
             "receipt_reputation",
+            "provenance_supply_chain",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
@@ -1,0 +1,377 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CidFacts — content-addressed DataFacts plugin.
+
+Addresses three attack classes that ``datafacts_v1`` is silent on:
+
+1. **Substitution**: URLs are ``df://sha256-<hex>`` derived from content.
+   Publishing different content under the same human-readable name
+   produces a different URL — substitution is structurally impossible.
+
+2. **Stale-freshness**: ``verify_freshness`` returns a *signed proof*
+   (internally) and ``True`` only when the signature verifies.
+   The proof binds content hash + publisher identity + logical tick;
+   no wall-clock check is used.
+
+3. **Provenance washing**: ``DatasetMetadata.parents`` carries the
+   content-addressed URLs of every upstream dataset; the provenance
+   chain is stored verbatim and returned by ``fetch``.
+
+Content binding
+---------------
+The hash covers the canonical JSON of ``metadata.model_dump()``
+(sorted keys, no spaces).  If the caller stores a ``"content_sha256"``
+key inside ``metadata.metadata``, it is automatically included in the
+canonical JSON, binding the URL to the actual payload bytes without
+requiring a protocol change.
+
+Usage::
+
+    from nest_plugins_reference.identity.did_key import DidKeyIdentity
+    from nest_core.types import AgentId, DatasetMetadata
+
+    identity = DidKeyIdentity(AgentId("supplier-0"), seed=b"seed")
+    df = CidFacts(identity)
+
+    url = await df.publish(DatasetMetadata(name="raw-batch", owner=AgentId("supplier-0")))
+    assert url.startswith("df://sha256-")
+
+    fresh = await df.verify_freshness(url)
+    proof = df.get_freshness_proof(url)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+import json
+from collections.abc import Callable
+from typing import Any
+
+from nest_core.types import (
+    AccessGrant,
+    AgentId,
+    DataFactsUrl,
+    DatasetMetadata,
+    FreshnessProof,
+    Signature,
+)
+
+from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _canonical_json(obj: Any) -> bytes:
+    """Return deterministic UTF-8 JSON bytes (sorted keys, no spaces).
+
+    Example::
+
+        _canonical_json({"b": 1, "a": 2}) == b'{"a":2,"b":1}'
+    """
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+
+
+def _content_hash(dataset: DatasetMetadata) -> str:
+    """Compute SHA-256 hex digest of the canonical JSON of *dataset*.
+
+    The dump includes every field of ``DatasetMetadata``, including
+    ``metadata`` (which may carry a ``"content_sha256"`` payload digest)
+    and ``parents``.  Identical datasets always produce the same digest;
+    any change — including a parent reference or a payload digest — yields
+    a different digest.
+
+    Example::
+
+        h = _content_hash(DatasetMetadata(name="x", owner=AgentId("a1")))
+        assert len(h) == 64  # 256-bit hex string
+    """
+    raw = {
+        "owner": str(dataset.owner),
+        "description": dataset.description,
+        "schema_version": dataset.schema_version,
+        "tags": sorted(dataset.tags),
+        "size_bytes": dataset.size_bytes,
+        "checksum": dataset.checksum,
+        "access_tier": dataset.access_tier,
+        "metadata": dataset.metadata,
+        "parents": sorted(str(parent) for parent in dataset.parents),
+    }
+
+    return hashlib.sha256(_canonical_json(raw)).hexdigest()
+
+
+def proof_payload(url: DataFactsUrl, publisher: AgentId, tick: float) -> bytes:
+    """Canonical bytes that are signed to produce a FreshnessProof.
+
+    ``tick`` is serialized as a string (not a number) so that the encoding is
+    identical whether the underlying clock returns ``int`` or ``float``:
+    ``itertools.count()`` returns an ``int`` (0, 1, 2…), but ``FreshnessProof``
+    stores ``tick: float`` and Pydantic coerces ``0 -> 0.0``, which JSON then
+    encodes differently (``"tick":0`` vs ``"tick":0.0``).  Serializing as a
+    string sidesteps the type-coercion entirely.
+
+    Example::
+
+        payload = proof_payload(DataFactsUrl("df://sha256-abc"), AgentId("a1"), 42)
+    """
+    return _canonical_json({"publisher": str(publisher), "tick": str(tick), "url": str(url)})
+
+
+# ---------------------------------------------------------------------------
+# Plugin
+# ---------------------------------------------------------------------------
+
+
+class CidFacts:
+    """Content-addressed DataFacts plugin.
+
+    Drop-in replacement for ``DataFactsV1`` that adds:
+
+    * SHA-256 content-addressed URLs
+    * Signed freshness proofs (no wall-clock)
+    * Provenance DAG via ``DatasetMetadata.parents``
+    * Minimal ACLs (public → read, restricted → owner only)
+
+    Example::
+
+        identity = DidKeyIdentity(AgentId("a1"), seed=b"seed")
+        df = CidFacts(identity)
+        url = await df.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        assert url.startswith("df://sha256-")
+        fresh = await df.verify_freshness(url)
+        assert fresh
+    """
+
+    def __init__(
+        self,
+        identity: DidKeyIdentity,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        """Initialise the plugin.
+
+        Parameters
+        ----------
+        identity:
+            A ``DidKeyIdentity`` instance for the *publishing* agent.
+            Used to sign freshness proofs.
+        clock:
+            A zero-argument callable that returns the current logical tick
+            as a float.  Defaults to ``itertools.count().__next__``,
+            which produces 0, 1, 2, … — a pure logical counter with no
+            dependency on wall-clock time.  Scenarios may pass
+            ``lambda: ctx.time`` to use the simulator's own clock.
+
+        Example::
+
+            identity = DidKeyIdentity(AgentId("a1"), seed=b"seed")
+            df = CidFacts(identity, clock=lambda: ctx.time)
+        """
+        self._identity = identity
+        self._clock: Callable[[], float] = (
+            clock if clock is not None else itertools.count().__next__
+        )
+
+        # url -> DatasetMetadata
+        self._datasets: dict[DataFactsUrl, DatasetMetadata] = {}
+        # url -> FreshnessProof  (only present after publish)
+        self._proofs: dict[DataFactsUrl, FreshnessProof] = {}
+        # (url, requester) -> AccessGrant
+        self._grants: dict[tuple[DataFactsUrl, AgentId], AccessGrant] = {}
+        # content-hash -> url  (idempotency registry)
+        self._hash_to_url: dict[str, DataFactsUrl] = {}
+
+    # ------------------------------------------------------------------
+    # DataFacts Protocol
+    # ------------------------------------------------------------------
+
+    async def publish(self, dataset: DatasetMetadata) -> DataFactsUrl:
+        """Publish dataset metadata and return its content-addressed URL.
+
+        Publishing the same content twice returns the same URL (idempotent).
+        Publishing different content — even under the same name — always
+        returns a different URL, making substitution attacks structurally
+        impossible.
+
+        A ``FreshnessProof`` is created and stored internally on every
+        publish call.  Use :meth:`get_freshness_proof` to retrieve it.
+
+        Example::
+
+            url = await df.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+            assert url.startswith("df://sha256-")
+        """
+        for parent in dataset.parents:
+            if parent not in self._datasets:
+                msg = f"Unknown parent dataset: {parent}"
+                raise KeyError(msg)
+        hex_digest = _content_hash(dataset)
+
+        # Idempotency: return the existing URL if we've seen this content before.
+        if hex_digest in self._hash_to_url:
+            return self._hash_to_url[hex_digest]
+
+        url = DataFactsUrl(f"df://sha256-{hex_digest}")
+        self._datasets[url] = dataset
+        self._hash_to_url[hex_digest] = url
+
+        # Build and store a signed freshness proof.
+        # Coerce the clock value to float *before* signing.  itertools.count()
+        # returns int, but FreshnessProof.tick is declared as float and Pydantic
+        # will coerce 0 → 0.0.  If we signed with str(0)="0" but verify
+        # reconstructs the payload with str(0.0)="0.0" the signatures would not
+        # match.  Applying float() here ensures both sides serialize identically.
+        tick: float = float(self._clock())
+        publisher = self._identity.agent_id
+        payload = proof_payload(url, publisher, tick)
+        sig: Signature = self._identity.sign(payload)
+
+        self._proofs[url] = FreshnessProof(
+            url=url,
+            publisher=publisher,
+            tick=tick,
+            signature=sig,
+        )
+
+        return url
+
+    async def fetch(self, url: DataFactsUrl) -> DatasetMetadata:
+        """Fetch metadata for a content-addressed dataset URL.
+
+        Raises ``KeyError`` if the URL was never published.
+
+        Example::
+
+            meta = await df.fetch(url)
+            assert meta.parents  # provenance preserved
+        """
+        meta = self._datasets.get(url)
+        if meta is None:
+            msg = f"Dataset not found: {url}"
+            raise KeyError(msg)
+        return meta
+
+    async def request_access(self, url: DataFactsUrl, requester: AgentId) -> AccessGrant:
+        """Request access to a dataset keyed by its content-addressed URL.
+
+        ACL rules (applied once per (url, requester) pair):
+
+        * ``access_tier == "public"``  → grants ``tier="read"`` to anyone.
+        * ``access_tier == "restricted"`` → grants ``tier="read"`` only to
+          the dataset owner; all other requesters receive ``tier="none"``.
+
+        Example::
+
+            grant = await df.request_access(url, AgentId("buyer"))
+            assert grant.tier in ("read", "none")
+        """
+        grant_key = (url, requester)
+        if grant_key in self._grants:
+            return self._grants[grant_key]
+
+        meta = self._datasets.get(url)
+        if meta is None:
+            msg = f"Dataset not found: {url}"
+            raise KeyError(msg)
+
+        tier = "none" if meta.access_tier == "restricted" and requester != meta.owner else "read"
+
+        grant = AccessGrant(url=url, grantee=requester, tier=tier)
+        self._grants[grant_key] = grant
+        return grant
+
+    async def verify_freshness(self, url: DataFactsUrl) -> bool:
+        """Verify that a valid signed freshness proof exists for *url*.
+
+        Returns ``True`` iff:
+
+        1. A ``FreshnessProof`` was recorded for this URL during ``publish``.
+        2. The proof's signature verifies against the publisher's public key.
+
+        No wall-clock check is performed.
+
+        Protocol compatibility note
+        ---------------------------
+        The ``DataFacts`` Protocol declares ``verify_freshness(url) -> bool``.
+        To avoid breaking any existing caller, the return type remains ``bool``.
+        The full proof object is available via :meth:`get_freshness_proof`.
+
+        Example::
+
+            fresh = await df.verify_freshness(url)
+            assert fresh  # True when signature is valid
+        """
+        proof = self._proofs.get(url)
+        if proof is None:
+            return False
+
+        # Ensure the publisher's public key is known to this identity instance
+        # so that verify() can look up the signer.  For the common case where
+        # the same CidFacts instance published the dataset the key is already
+        # registered (it's the agent's own key).  For cross-agent verification
+        # the caller should call register_peer_key() first.
+        publisher = proof.publisher
+        if not self._identity.has_peer_key(publisher):
+            # Cannot verify — unknown publisher key.  Callers that need
+            # cross-agent verification must call register_peer_key().
+            return False
+
+        payload = proof_payload(proof.url, proof.publisher, proof.tick)
+        return self._identity.verify(payload, proof.signature, publisher)
+
+    # ------------------------------------------------------------------
+    # Extended API (not part of the DataFacts Protocol)
+    # ------------------------------------------------------------------
+
+    def get_freshness_proof(self, url: DataFactsUrl) -> FreshnessProof | None:
+        """Return the stored ``FreshnessProof`` for *url*, or ``None``.
+
+        This method is intentionally **not** part of the ``DataFacts``
+        Protocol so that existing implementations (e.g. ``datafacts_v1``)
+        remain valid.  Validators and provenance-scenario agents that need
+        the proof object call this method directly on the ``CidFacts``
+        instance retrieved from ``ctx.plugins["datafacts"]``.
+
+        Example::
+
+            proof = df.get_freshness_proof(url)
+            if proof:
+                print(proof.tick, proof.publisher)
+        """
+        return self._proofs.get(url)
+
+    @property
+    def identity(self) -> DidKeyIdentity:
+        """The signing identity for this plugin instance.
+
+        Example::
+
+            pk = df.identity.public_key
+        """
+        return self._identity
+
+    @property
+    def proofs(self) -> dict[DataFactsUrl, FreshnessProof]:
+        """Live view of all stored freshness proofs, keyed by URL.
+
+        Intended for testing and scenario inspection only.
+
+        Example::
+
+            assert url in df.proofs
+        """
+        return self._proofs
+
+    def register_peer_key(self, agent_id: AgentId, public_key: bytes) -> None:
+        """Register a peer public key so their freshness proofs can be verified.
+
+        In multi-agent scenarios each agent holds its own ``CidFacts``
+        instance.  Call this on the verifier's instance so it can verify
+        proofs signed by the peer.
+
+        Example::
+
+            retailer_df.register_peer_key(supplier_id, supplier_identity.public_key)
+        """
+        self._identity.register_peer(agent_id, public_key)

--- a/packages/nest-plugins-reference/nest_plugins_reference/identity/did_key.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/identity/did_key.py
@@ -55,6 +55,25 @@ class DidKeyIdentity:
         self._known_keys[agent_id] = _decode_public_key(public_key)
 
     @property
+    def agent_id(self) -> AgentId:
+        """This agent's identifier.
+
+        Example::
+
+            aid = ident.agent_id
+        """
+        return self._agent_id
+
+    def has_peer_key(self, agent: AgentId) -> bool:
+        """Return ``True`` if the given agent's public key is registered.
+
+        Example::
+
+            ident.has_peer_key(AgentId("a2"))
+        """
+        return agent in self._known_keys
+
+    @property
     def public_key(self) -> bytes:
         """This agent's public key.
 

--- a/packages/nest-plugins-reference/tests/test_cid_facts.py
+++ b/packages/nest-plugins-reference/tests/test_cid_facts.py
@@ -1,0 +1,1022 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the CidFacts content-addressed DataFacts plugin.
+
+Coverage
+--------
+* URL format is always ``df://sha256-<64-hex-chars>``
+* Same content → same URL (idempotent publish)
+* Different content → different URL (substitution impossible)
+* Freshness proof creation and signature verification
+* Tamper detection (proof with wrong payload does not verify)
+* Stale-freshness detection (missing proof fails verify_freshness)
+* Provenance DAG: parents stored and returned verbatim
+* Multiple-parent DAG (provenance is not just a tree)
+* Restricted ACL: owner reads, stranger denied
+* Public ACL: anyone reads
+* Validator cross-checks:
+  - FAIL on datafacts_v1 traces (name-based URLs, no proof events)
+  - PASS on cid_facts-style synthetic traces
+* Scenario-level: provenance_supply_chain factory returns 4 agents
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_identity(agent_id: str, seed: bytes = b"seed"):
+    from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+    return DidKeyIdentity(AgentId(agent_id), seed=seed)
+
+
+def _make_df(agent_id: str = "a1", seed: bytes = b"seed"):
+    from nest_plugins_reference.datafacts.cid_facts import CidFacts
+
+    return CidFacts(_make_identity(agent_id, seed))
+
+
+# ---------------------------------------------------------------------------
+# 1. URL format
+# ---------------------------------------------------------------------------
+
+
+class TestUrlFormat:
+    @pytest.mark.asyncio
+    async def test_url_is_sha256_prefixed(self) -> None:
+        df = _make_df()
+        meta = DatasetMetadata(name="weather", owner=AgentId("a1"))
+        url = await df.publish(meta)
+        assert url.startswith("df://sha256-"), f"unexpected URL: {url}"
+
+    @pytest.mark.asyncio
+    async def test_url_hex_is_64_chars(self) -> None:
+        df = _make_df()
+        meta = DatasetMetadata(name="weather", owner=AgentId("a1"))
+        url = await df.publish(meta)
+        hex_part = url.removeprefix("df://sha256-")
+        assert len(hex_part) == 64, f"hex part length: {len(hex_part)}"
+        assert all(c in "0123456789abcdef" for c in hex_part)
+
+    @pytest.mark.asyncio
+    async def test_url_not_name_based(self) -> None:
+        df = _make_df()
+        meta = DatasetMetadata(name="my-dataset", owner=AgentId("a1"))
+        url = await df.publish(meta)
+        assert "my-dataset" not in url, "URL must not contain the dataset name"
+
+
+# ---------------------------------------------------------------------------
+# 2. Content addressing — idempotency and substitution resistance
+# ---------------------------------------------------------------------------
+
+
+class TestContentAddressing:
+    @pytest.mark.asyncio
+    async def test_same_content_same_url(self) -> None:
+        """Identical content published twice must yield the same URL."""
+        df = _make_df()
+        meta_a = DatasetMetadata(name="ds", owner=AgentId("a1"), description="same")
+        meta_b = DatasetMetadata(name="ds", owner=AgentId("a1"), description="same")
+        url_a = await df.publish(meta_a)
+        url_b = await df.publish(meta_b)
+        assert url_a == url_b
+
+    @pytest.mark.asyncio
+    async def test_different_content_different_url(self) -> None:
+        """Different content must produce distinct URLs."""
+        df = _make_df()
+        url_a = await df.publish(
+            DatasetMetadata(
+                name="ds-A",
+                owner=AgentId("a1"),
+                description="version A",
+            )
+        )
+        url_b = await df.publish(
+            DatasetMetadata(
+                name="ds-B",
+                owner=AgentId("a1"),
+                description="version B",
+            )
+        )
+        assert url_a != url_b
+
+    @pytest.mark.asyncio
+    async def test_name_does_not_affect_url(self) -> None:
+        """Changing only the human-readable name must not change the content URL."""
+        df = _make_df()
+
+        url_a = await df.publish(
+            DatasetMetadata(
+                name="label-a",
+                owner=AgentId("a1"),
+                description="same content",
+            )
+        )
+        url_b = await df.publish(
+            DatasetMetadata(
+                name="label-b",
+                owner=AgentId("a1"),
+                description="same content",
+            )
+        )
+
+        assert url_a == url_b
+
+    @pytest.mark.asyncio
+    async def test_tag_order_does_not_affect_url(self) -> None:
+        df = _make_df()
+
+        first = DatasetMetadata(
+            name="a",
+            owner=AgentId("a1"),
+            tags=["steel", "raw"],
+        )
+
+        second = DatasetMetadata(
+            name="b",
+            owner=AgentId("a1"),
+            tags=["raw", "steel"],
+        )
+
+        assert await df.publish(first) == await df.publish(second)
+
+    @pytest.mark.asyncio
+    async def test_republish_same_name_different_description_is_different_url(self) -> None:
+        """Changing any field changes the URL — substitution is impossible."""
+        df = _make_df()
+        url_v1 = await df.publish(DatasetMetadata(name="ds", owner=AgentId("a1"), description="v1"))
+        url_v2 = await df.publish(DatasetMetadata(name="ds", owner=AgentId("a1"), description="v2"))
+        assert url_v1 != url_v2, "same name, different description must not share a URL"
+
+    @pytest.mark.asyncio
+    async def test_content_hash_covers_payload_digest(self) -> None:
+        """Including a content_sha256 in metadata changes the URL."""
+        df = _make_df()
+        meta_no_payload = DatasetMetadata(name="ds", owner=AgentId("a1"))
+        meta_with_payload = DatasetMetadata(
+            name="ds",
+            owner=AgentId("a1"),
+            metadata={"content_sha256": "abc123"},
+        )
+        url_a = await df.publish(meta_no_payload)
+        url_b = await df.publish(meta_with_payload)
+        assert url_a != url_b
+
+    @pytest.mark.asyncio
+    async def test_timestamps_do_not_affect_url(self) -> None:
+        """Changing timestamps must not change the content-addressed URL."""
+        df = _make_df()
+
+        first = DatasetMetadata(
+            name="label-a",
+            owner=AgentId("a1"),
+            description="same content",
+            created_at=datetime(2024, 1, 1),
+            updated_at=datetime(2024, 1, 2),
+        )
+
+        second = DatasetMetadata(
+            name="label-b",
+            owner=AgentId("a1"),
+            description="same content",
+            created_at=datetime(2025, 1, 1),
+            updated_at=datetime(2025, 1, 2),
+        )
+
+        assert await df.publish(first) == await df.publish(second)
+
+    @pytest.mark.asyncio
+    async def test_parents_change_url(self) -> None:
+        """Adding a parent reference changes the content hash."""
+        df = _make_df()
+        url_root = await df.publish(DatasetMetadata(name="root", owner=AgentId("a1")))
+        url_derived = await df.publish(
+            DatasetMetadata(
+                name="root",
+                owner=AgentId("a1"),
+                parents=[url_root],
+            )
+        )
+        assert url_root != url_derived
+
+
+# ---------------------------------------------------------------------------
+# 3. Fetch
+# ---------------------------------------------------------------------------
+
+
+class TestFetch:
+    @pytest.mark.asyncio
+    async def test_fetch_returns_original_metadata(self) -> None:
+        df = _make_df()
+        meta = DatasetMetadata(name="weather", owner=AgentId("a1"), tags=["hot"])
+        url = await df.publish(meta)
+        fetched = await df.fetch(url)
+        assert fetched.name == "weather"
+        assert fetched.tags == ["hot"]
+
+    @pytest.mark.asyncio
+    async def test_fetch_missing_raises_key_error(self) -> None:
+        df = _make_df()
+        with pytest.raises(KeyError):
+            await df.fetch(DataFactsUrl("df://sha256-" + "0" * 64))
+
+    @pytest.mark.asyncio
+    async def test_fetch_preserves_parents(self) -> None:
+        df = _make_df()
+        parent_url = await df.publish(DatasetMetadata(name="parent", owner=AgentId("a1")))
+        child_url = await df.publish(
+            DatasetMetadata(
+                name="child",
+                owner=AgentId("a1"),
+                parents=[parent_url],
+            )
+        )
+        fetched = await df.fetch(child_url)
+        assert fetched.parents == [parent_url]
+
+
+# ---------------------------------------------------------------------------
+# 4. Freshness proofs
+# ---------------------------------------------------------------------------
+
+
+class TestFreshnessProofs:
+    @pytest.mark.asyncio
+    async def test_verify_freshness_true_after_publish(self) -> None:
+        df = _make_df()
+        url = await df.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        assert await df.verify_freshness(url) is True
+
+    @pytest.mark.asyncio
+    async def test_verify_freshness_false_unknown_url(self) -> None:
+        df = _make_df()
+        assert await df.verify_freshness(DataFactsUrl("df://sha256-" + "0" * 64)) is False
+
+    @pytest.mark.asyncio
+    async def test_get_freshness_proof_not_none(self) -> None:
+        df = _make_df()
+        url = await df.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        proof = df.get_freshness_proof(url)
+        assert proof is not None
+
+    @pytest.mark.asyncio
+    async def test_proof_url_matches(self) -> None:
+        df = _make_df()
+        url = await df.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        proof = df.get_freshness_proof(url)
+        assert proof is not None
+        assert proof.url == url
+
+    @pytest.mark.asyncio
+    async def test_proof_publisher_matches_agent(self) -> None:
+        df = _make_df("supplier-0")
+        url = await df.publish(DatasetMetadata(name="ds", owner=AgentId("supplier-0")))
+        proof = df.get_freshness_proof(url)
+        assert proof is not None
+        assert proof.publisher == AgentId("supplier-0")
+
+    @pytest.mark.asyncio
+    async def test_proof_tick_is_float(self) -> None:
+        df = _make_df()
+        url = await df.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        proof = df.get_freshness_proof(url)
+        assert proof is not None
+        assert isinstance(proof.tick, float)
+
+    @pytest.mark.asyncio
+    async def test_proof_signature_has_bytes(self) -> None:
+        df = _make_df()
+        url = await df.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        proof = df.get_freshness_proof(url)
+        assert proof is not None
+        assert len(proof.signature.value) > 0
+
+    @pytest.mark.asyncio
+    async def test_proof_no_wall_clock(self) -> None:
+        """Logical clock must not use time.time(); tick starts at 0."""
+        ticks: list[float] = []
+        df = _make_df()
+
+        for i in range(3):
+            url = await df.publish(DatasetMetadata(name=f"ds-{i}", owner=AgentId("a1")))
+            proof = df.get_freshness_proof(url)
+            assert proof is not None
+            ticks.append(proof.tick)
+
+        # With itertools.count() the ticks should be 0, 1, 2
+        # (or whatever the count is at — they must be monotonically increasing
+        # and small, not a Unix timestamp > 1e9).
+        for tick in ticks:
+            assert tick < 1_000_000, f"tick looks like a wall-clock timestamp: {tick}"
+        assert ticks == sorted(ticks), "ticks must be monotonically non-decreasing"
+
+
+# ---------------------------------------------------------------------------
+# 5. Tamper detection
+# ---------------------------------------------------------------------------
+
+
+class TestTamperDetection:
+    @pytest.mark.asyncio
+    async def test_tampered_signature_fails_verify(self) -> None:
+        """Manually corrupting the signature bytes must make verify_freshness False."""
+        from nest_core.types import Signature
+
+        df = _make_df()
+        url = await df.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        proof = df.get_freshness_proof(url)
+        assert proof is not None
+
+        # Replace stored proof with a tampered version.
+        bad_sig = Signature(
+            signer=proof.signature.signer,
+            value=bytes(b ^ 0xFF for b in proof.signature.value),
+            algorithm=proof.signature.algorithm,
+        )
+        from nest_core.types import FreshnessProof
+
+        bad_proof = FreshnessProof(
+            url=proof.url,
+            publisher=proof.publisher,
+            tick=proof.tick,
+            signature=bad_sig,
+        )
+        df.proofs[url] = bad_proof  # inject tampered proof
+        assert await df.verify_freshness(url) is False
+
+    @pytest.mark.asyncio
+    async def test_missing_proof_fails_verify(self) -> None:
+        """Removing the proof record must make verify_freshness return False."""
+        df = _make_df()
+        url = await df.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        del df.proofs[url]
+        assert await df.verify_freshness(url) is False
+
+
+# ---------------------------------------------------------------------------
+# 6. Provenance DAG
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceDAG:
+    @pytest.mark.asyncio
+    async def test_single_parent_stored(self) -> None:
+        df = _make_df()
+        parent_url = await df.publish(DatasetMetadata(name="p", owner=AgentId("a1")))
+        child = DatasetMetadata(name="c", owner=AgentId("a1"), parents=[parent_url])
+        child_url = await df.publish(child)
+        fetched = await df.fetch(child_url)
+        assert fetched.parents == [parent_url]
+
+    @pytest.mark.asyncio
+    async def test_multiple_parents_dag(self) -> None:
+        """Provenance is a DAG — multiple parents are supported."""
+        df = _make_df()
+        p1 = await df.publish(DatasetMetadata(name="p1", owner=AgentId("a1")))
+        p2 = await df.publish(DatasetMetadata(name="p2", owner=AgentId("a1")))
+        child = DatasetMetadata(name="c", owner=AgentId("a1"), parents=[p1, p2])
+        child_url = await df.publish(child)
+        fetched = await df.fetch(child_url)
+        assert set(fetched.parents) == {p1, p2}
+
+    @pytest.mark.asyncio
+    async def test_parent_order_does_not_affect_url(self) -> None:
+        """Parent order is canonicalized for multi-parent DAG joins."""
+        df = _make_df()
+
+        p1 = await df.publish(DatasetMetadata(name="p1", owner=AgentId("a1")))
+        p2 = await df.publish(DatasetMetadata(name="p2", owner=AgentId("a1")))
+
+        first = DatasetMetadata(
+            name="child-a",
+            owner=AgentId("a1"),
+            parents=[p1, p2],
+        )
+        second = DatasetMetadata(
+            name="child-b",
+            owner=AgentId("a1"),
+            parents=[p2, p1],
+        )
+
+        assert await df.publish(first) == await df.publish(second)
+
+    @pytest.mark.asyncio
+    async def test_unknown_parent_rejected(self) -> None:
+        df = _make_df()
+
+        child = DatasetMetadata(
+            name="child",
+            owner=AgentId("a1"),
+            parents=[DataFactsUrl("df://sha256-" + "0" * 64)],
+        )
+
+        with pytest.raises(KeyError):
+            await df.publish(child)
+
+    @pytest.mark.asyncio
+    async def test_no_parents_for_root(self) -> None:
+        df = _make_df()
+        url = await df.publish(DatasetMetadata(name="root", owner=AgentId("a1")))
+        fetched = await df.fetch(url)
+        assert fetched.parents == []
+
+    @pytest.mark.asyncio
+    async def test_collect_ancestors_walks_full_dag_once(self) -> None:
+        from nest_core.scenarios_builtin.provenance_supply_chain import (
+            _collect_ancestors,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        df = _make_df()
+
+        supplier_a = await df.publish(DatasetMetadata(name="supplier-a", owner=AgentId("s-a")))
+        supplier_b = await df.publish(DatasetMetadata(name="supplier-b", owner=AgentId("s-b")))
+
+        manufacturer_a = await df.publish(
+            DatasetMetadata(
+                name="manufacturer-a",
+                owner=AgentId("m-a"),
+                parents=[supplier_a, supplier_b],
+            )
+        )
+        manufacturer_b = await df.publish(
+            DatasetMetadata(
+                name="manufacturer-b",
+                owner=AgentId("m-b"),
+                parents=[supplier_a, supplier_b],
+            )
+        )
+
+        distributor = await df.publish(
+            DatasetMetadata(
+                name="distributor",
+                owner=AgentId("d"),
+                parents=[manufacturer_a, manufacturer_b],
+            )
+        )
+
+        ancestors = await _collect_ancestors(df, distributor)
+
+        assert ancestors == {
+            supplier_a,
+            supplier_b,
+            manufacturer_a,
+            manufacturer_b,
+        }
+        assert len(ancestors) == 4
+
+    @pytest.mark.asyncio
+    async def test_three_hop_chain(self) -> None:
+        """Supplier → manufacturer → distributor provenance chain."""
+        df = _make_df()
+        supplier_url = await df.publish(DatasetMetadata(name="raw", owner=AgentId("supplier")))
+        mfg_url = await df.publish(
+            DatasetMetadata(
+                name="goods",
+                owner=AgentId("mfg"),
+                parents=[supplier_url],
+            )
+        )
+        dist_url = await df.publish(
+            DatasetMetadata(
+                name="shipment",
+                owner=AgentId("dist"),
+                parents=[mfg_url],
+            )
+        )
+
+        # Walk chain from distributor back to supplier.
+        dist_meta = await df.fetch(dist_url)
+        assert dist_meta.parents == [mfg_url]
+
+        mfg_meta = await df.fetch(mfg_url)
+        assert mfg_meta.parents == [supplier_url]
+
+        sup_meta = await df.fetch(supplier_url)
+        assert sup_meta.parents == []
+
+
+# ---------------------------------------------------------------------------
+# 7. Access control
+# ---------------------------------------------------------------------------
+
+
+class TestAccessControl:
+    @pytest.mark.asyncio
+    async def test_public_dataset_grants_read_to_anyone(self) -> None:
+        df = _make_df("owner")
+        url = await df.publish(
+            DatasetMetadata(name="pub", owner=AgentId("owner"), access_tier="public")
+        )
+        grant = await df.request_access(url, AgentId("stranger"))
+        assert grant.tier == "read"
+
+    @pytest.mark.asyncio
+    async def test_restricted_dataset_grants_owner_read(self) -> None:
+        df = _make_df("owner")
+        url = await df.publish(
+            DatasetMetadata(
+                name="priv",
+                owner=AgentId("owner"),
+                access_tier="restricted",
+            )
+        )
+        grant = await df.request_access(url, AgentId("owner"))
+        assert grant.tier == "read"
+
+    @pytest.mark.asyncio
+    async def test_restricted_dataset_denies_stranger(self) -> None:
+        df = _make_df("owner")
+        url = await df.publish(
+            DatasetMetadata(
+                name="priv",
+                owner=AgentId("owner"),
+                access_tier="restricted",
+            )
+        )
+        grant = await df.request_access(url, AgentId("stranger"))
+        assert grant.tier == "none"
+
+    @pytest.mark.asyncio
+    async def test_access_grant_is_idempotent(self) -> None:
+        df = _make_df("owner")
+        url = await df.publish(
+            DatasetMetadata(name="pub", owner=AgentId("owner"), access_tier="public")
+        )
+        grant1 = await df.request_access(url, AgentId("buyer"))
+        grant2 = await df.request_access(url, AgentId("buyer"))
+        assert grant1.tier == grant2.tier
+
+    @pytest.mark.asyncio
+    async def test_access_unknown_url_raises(self) -> None:
+        df = _make_df()
+        with pytest.raises(KeyError):
+            await df.request_access(DataFactsUrl("df://sha256-" + "0" * 64), AgentId("a2"))
+
+
+# ---------------------------------------------------------------------------
+# 8. Peer key registration
+# ---------------------------------------------------------------------------
+
+
+class TestPeerKeyRegistration:
+    @pytest.mark.asyncio
+    async def test_verify_peer_proof_after_register_key(self) -> None:
+        """A verifier can validate a proof created by a different agent."""
+        from nest_plugins_reference.datafacts.cid_facts import CidFacts, proof_payload
+
+        publisher_id = AgentId("publisher")
+        verifier_id = AgentId("verifier")
+
+        publisher_identity = _make_identity(publisher_id, seed=b"pub-seed")
+        verifier_identity = _make_identity(verifier_id, seed=b"ver-seed")
+
+        publisher_df = CidFacts(publisher_identity)
+        verifier_df = CidFacts(verifier_identity)
+
+        # Register publisher's public key with verifier.
+        verifier_df.register_peer_key(publisher_id, publisher_identity.public_key)
+
+        url = await publisher_df.publish(DatasetMetadata(name="ds", owner=publisher_id))
+        proof = publisher_df.get_freshness_proof(url)
+        assert proof is not None
+
+        # Verifier can manually re-verify the proof using the registered key.
+        payload = proof_payload(proof.url, proof.publisher, proof.tick)
+        ok = verifier_df.identity.verify(payload, proof.signature, publisher_id)
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# 9. Validator tests — FAIL on v1-style traces, PASS on CID-style traces
+# ---------------------------------------------------------------------------
+
+
+def _make_send_event(agent: str, to: str, msg: str) -> dict[str, Any]:
+    """Minimal trace event compatible with the validator's ``_message_body`` helper."""
+    return {"kind": "send", "agent": agent, "to": to, "msg": msg}
+
+
+class TestValidatorNoSubstitution:
+    def test_fails_on_name_based_urls(self) -> None:
+        from nest_core.validators import validate_cid_no_substitution
+
+        events = [
+            _make_send_event(
+                "supplier-0", "manufacturer-0", "publish:df://raw-materials:supplier-0"
+            ),
+        ]
+        results = validate_cid_no_substitution(events)
+        assert any(not r.passed for r in results), "should FAIL on name-based URLs"
+
+    def test_passes_on_sha256_urls(self) -> None:
+        from nest_core.validators import validate_cid_no_substitution
+
+        sha_url = "df://sha256-" + "a" * 64
+        events = [
+            _make_send_event("supplier-0", "mfg-0", f"publish:{sha_url}:supplier-0"),
+        ]
+        results = validate_cid_no_substitution(events)
+        assert all(r.passed for r in results), [r.detail for r in results]
+
+    def test_fails_when_no_publish_events(self) -> None:
+        from nest_core.validators import validate_cid_no_substitution
+
+        results = validate_cid_no_substitution([])
+        assert any(not r.passed for r in results)
+
+
+class TestValidatorFreshnessProofs:
+    def test_fails_when_no_proof_events(self) -> None:
+        from nest_core.validators import validate_cid_freshness_proofs
+
+        sha_url = "df://sha256-" + "b" * 64
+        events = [
+            _make_send_event("supplier-0", "mfg-0", f"publish:{sha_url}:supplier-0"),
+            # No freshness_proof: event
+        ]
+        results = validate_cid_freshness_proofs(events)
+        assert any(not r.passed for r in results), "should FAIL — no proof event"
+
+    def test_passes_when_proof_matches_publish(self) -> None:
+        from nest_core.validators import validate_cid_freshness_proofs
+
+        sha_url = "df://sha256-" + "c" * 64
+        events = [
+            _make_send_event("supplier-0", "mfg-0", f"publish:{sha_url}:supplier-0"),
+            _make_send_event("supplier-0", "mfg-0", f"freshness_proof:{sha_url}:0:deadbeef"),
+        ]
+        results = validate_cid_freshness_proofs(events)
+        assert all(r.passed for r in results), [r.detail for r in results]
+
+    def test_fails_on_datafacts_v1_trace(self) -> None:
+        """datafacts_v1 never emits freshness_proof events → FAIL."""
+        from nest_core.validators import validate_cid_freshness_proofs
+
+        # datafacts_v1 trace: only name-based publish events, no proofs.
+        events = [
+            _make_send_event("supplier-0", "mfg-0", "publish:df://raw-materials:supplier-0"),
+        ]
+        results = validate_cid_freshness_proofs(events)
+        assert any(not r.passed for r in results)
+
+
+class TestValidatorProvenanceChain:
+    def test_fails_when_no_derived_events(self) -> None:
+        from nest_core.validators import validate_cid_provenance_chain
+
+        sha_url = "df://sha256-" + "d" * 64
+        events = [
+            _make_send_event("supplier-0", "mfg-0", f"publish:{sha_url}:supplier-0"),
+            # No derived: event
+        ]
+        results = validate_cid_provenance_chain(events)
+        assert any(not r.passed for r in results)
+
+    def test_fails_when_parent_not_published(self) -> None:
+        from nest_core.validators import validate_cid_provenance_chain
+
+        child_url = "df://sha256-" + "e" * 64
+        ghost_parent = "df://sha256-" + "f" * 64  # never published
+
+        events = [
+            _make_send_event("mfg-0", "dist-0", f"publish:{child_url}:mfg-0"),
+            _make_send_event("mfg-0", "dist-0", f"derived:{child_url}:{ghost_parent}"),
+        ]
+        results = validate_cid_provenance_chain(events)
+        assert any(not r.passed for r in results), "should FAIL — parent not published"
+
+    def test_passes_when_chain_is_complete(self) -> None:
+        from nest_core.validators import validate_cid_provenance_chain
+
+        parent_url = "df://sha256-" + "1" * 64
+        child_url = "df://sha256-" + "2" * 64
+
+        events = [
+            _make_send_event("supplier-0", "mfg-0", f"publish:{parent_url}:supplier-0"),
+            _make_send_event("mfg-0", "dist-0", f"publish:{child_url}:mfg-0"),
+            _make_send_event("mfg-0", "dist-0", f"derived:{child_url}:{parent_url}"),
+        ]
+        results = validate_cid_provenance_chain(events)
+        assert all(r.passed for r in results), [r.detail for r in results]
+
+    def test_passes_multi_parent_dag(self) -> None:
+        from nest_core.validators import validate_cid_provenance_chain
+
+        p1 = "df://sha256-" + "a" * 64
+        p2 = "df://sha256-" + "b" * 64
+        child = "df://sha256-" + "c" * 64
+
+        events = [
+            _make_send_event("s1", "m", f"publish:{p1}:s1"),
+            _make_send_event("s2", "m", f"publish:{p2}:s2"),
+            _make_send_event("m", "d", f"publish:{child}:m"),
+            # Comma-separated parents
+            _make_send_event("m", "d", f"derived:{child}:{p1},{p2}"),
+        ]
+        results = validate_cid_provenance_chain(events)
+        assert all(r.passed for r in results), [r.detail for r in results]
+
+
+# ---------------------------------------------------------------------------
+# 10. Scenario factory
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceSupplyChainFactory:
+    def test_factory_returns_six_agents(self) -> None:
+        from nest_core.scenario import ScenarioConfig
+        from nest_core.scenarios_builtin.provenance_supply_chain import (
+            provenance_supply_chain_factory,
+        )
+
+        config = ScenarioConfig.from_dict(
+            {
+                "name": "test",
+                "tier": 1,
+                "task": {
+                    "type": "provenance_supply_chain",
+                    "config": {"items_per_round": 1, "rounds": 1},
+                },
+            }
+        )
+        agents = provenance_supply_chain_factory(config, {})
+        assert len(agents) == 6
+
+    def test_factory_agent_ids(self) -> None:
+        from nest_core.scenario import ScenarioConfig
+        from nest_core.scenarios_builtin.provenance_supply_chain import (
+            provenance_supply_chain_factory,
+        )
+
+        config = ScenarioConfig.from_dict({"name": "test", "tier": 1})
+        agents = provenance_supply_chain_factory(config, {})
+        ids = {str(k) for k in agents}
+        assert "supplier-0" in ids
+        assert "supplier-1" in ids
+        assert "manufacturer-0" in ids
+        assert "manufacturer-1" in ids
+        assert "distributor-0" in ids
+        assert "retailer-0" in ids
+
+    def test_factory_uses_multi_layer_dag(self) -> None:
+        from nest_core.scenario import ScenarioConfig
+        from nest_core.scenarios_builtin.provenance_supply_chain import (
+            CidDistributorAgent,
+            CidManufacturerAgent,
+            CidSupplierAgent,
+            provenance_supply_chain_factory,
+        )
+
+        config = ScenarioConfig.from_dict({"name": "test", "tier": 1})
+        agents = provenance_supply_chain_factory(config, {})
+
+        assert isinstance(agents[AgentId("supplier-0")], CidSupplierAgent)
+        assert isinstance(agents[AgentId("supplier-1")], CidSupplierAgent)
+        assert isinstance(agents[AgentId("manufacturer-0")], CidManufacturerAgent)
+        assert isinstance(agents[AgentId("manufacturer-1")], CidManufacturerAgent)
+        assert isinstance(agents[AgentId("distributor-0")], CidDistributorAgent)
+
+
+# ---------------------------------------------------------------------------
+# 11. N-way DAG generalization
+# ---------------------------------------------------------------------------
+
+
+class TestNWayDAG:
+    def test_factory_custom_counts(self) -> None:
+        """Factory respects num_suppliers and num_manufacturers config keys."""
+        from nest_core.scenario import ScenarioConfig
+        from nest_core.scenarios_builtin.provenance_supply_chain import (
+            provenance_supply_chain_factory,
+        )
+
+        config = ScenarioConfig.from_dict(
+            {
+                "name": "test",
+                "tier": 1,
+                "task": {
+                    "type": "provenance_supply_chain",
+                    "config": {"num_suppliers": 3, "num_manufacturers": 3},
+                },
+            }
+        )
+        agents = provenance_supply_chain_factory(config, {})
+        # 3 suppliers + 3 manufacturers + 1 distributor + 1 retailer = 8
+        assert len(agents) == 8
+        ids = {str(k) for k in agents}
+        for i in range(3):
+            assert f"supplier-{i}" in ids
+            assert f"manufacturer-{i}" in ids
+
+    def test_factory_defaults_give_six_agents(self) -> None:
+        """Default config (num_suppliers=2, num_manufacturers=2) gives 6 agents."""
+        from nest_core.scenario import ScenarioConfig
+        from nest_core.scenarios_builtin.provenance_supply_chain import (
+            provenance_supply_chain_factory,
+        )
+
+        config = ScenarioConfig.from_dict({"name": "test", "tier": 1})
+        agents = provenance_supply_chain_factory(config, {})
+        assert len(agents) == 6
+
+    def test_manufacturer_threshold_respected(self) -> None:
+        """CidManufacturerAgent with num_suppliers=3 waits for 3 URLs."""
+        from nest_core.scenarios_builtin.provenance_supply_chain import CidManufacturerAgent
+
+        agent = CidManufacturerAgent(
+            AgentId("mfg-0"),
+            next_stage=AgentId("dist-0"),
+            df=None,
+            num_suppliers=3,
+        )
+        assert agent._num_suppliers == 3  # pyright: ignore[reportPrivateUsage]
+
+    def test_distributor_threshold_respected(self) -> None:
+        """CidDistributorAgent with num_manufacturers=3 waits for 3 URLs."""
+        from nest_core.scenarios_builtin.provenance_supply_chain import CidDistributorAgent
+
+        agent = CidDistributorAgent(
+            AgentId("dist-0"),
+            next_stage=AgentId("retailer-0"),
+            df=None,
+            num_manufacturers=3,
+        )
+        assert agent._num_manufacturers == 3  # pyright: ignore[reportPrivateUsage]
+
+    def test_factory_single_supplier_single_manufacturer(self) -> None:
+        """Edge case: num_suppliers=1, num_manufacturers=1 gives 4 agents."""
+        from nest_core.scenario import ScenarioConfig
+        from nest_core.scenarios_builtin.provenance_supply_chain import (
+            provenance_supply_chain_factory,
+        )
+
+        config = ScenarioConfig.from_dict(
+            {
+                "name": "test",
+                "tier": 1,
+                "task": {
+                    "type": "provenance_supply_chain",
+                    "config": {"num_suppliers": 1, "num_manufacturers": 1},
+                },
+            }
+        )
+        agents = provenance_supply_chain_factory(config, {})
+        assert len(agents) == 4  # 1 supplier + 1 manufacturer + distributor + retailer
+        assert AgentId("supplier-0") in agents
+        assert AgentId("manufacturer-0") in agents
+
+
+# ---------------------------------------------------------------------------
+# 12. Provenance audit event
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceAuditEvent:
+    @pytest.mark.asyncio
+    async def test_retailer_emits_provenance_audit(self) -> None:
+        """CidRetailerAgent emits a provenance_audit: event after successful verification.
+
+        We drive the retailer directly: publish a 3-node DAG (supplier ->
+        manufacturer -> distributor) into a shared CidFacts instance, then
+        call on_message with a synthetic cid_url payload and verify that the
+        resulting outbound messages include a provenance_audit: event.
+        """
+        from nest_core.scenarios_builtin.provenance_supply_chain import CidRetailerAgent
+
+        df = _make_df("test-agent")
+
+        # Build a minimal 3-hop DAG.
+        supplier_url = await df.publish(DatasetMetadata(name="raw", owner=AgentId("supplier-0")))
+        mfg_url = await df.publish(
+            DatasetMetadata(
+                name="goods",
+                owner=AgentId("manufacturer-0"),
+                parents=[supplier_url],
+            )
+        )
+        dist_url = await df.publish(
+            DatasetMetadata(
+                name="shipment",
+                owner=AgentId("distributor-0"),
+                parents=[mfg_url],
+            )
+        )
+
+        # Capture outbound messages via a simple mock context.
+        sent: list[tuple[AgentId, str]] = []
+
+        class _MockCtx:
+            async def send(self, to: AgentId, payload: bytes) -> None:
+                sent.append((to, payload.decode("utf-8", errors="replace")))
+
+        origin = AgentId("supplier-0")
+        retailer = CidRetailerAgent(AgentId("retailer-0"), origin=origin, df=df)
+
+        # Deliver the distributor URL to the retailer.
+        cid_msg = f"cid_url:1:0:{dist_url}".encode()
+        await retailer.on_message(_MockCtx(), AgentId("distributor-0"), cid_msg)  # pyright: ignore[reportArgumentType]
+
+        msgs = [m for _, m in sent]
+        audit_events = [m for m in msgs if m.startswith("provenance_audit:")]
+        assert audit_events, f"no provenance_audit event emitted; got: {msgs}"
+
+    @pytest.mark.asyncio
+    async def test_provenance_audit_format(self) -> None:
+        """provenance_audit event exposes nodes count and sorted ancestor URLs."""
+        from nest_core.scenarios_builtin.provenance_supply_chain import CidRetailerAgent
+
+        df = _make_df("test-agent")
+
+        supplier_url = await df.publish(DatasetMetadata(name="raw", owner=AgentId("supplier-0")))
+        mfg_url = await df.publish(
+            DatasetMetadata(
+                name="goods",
+                owner=AgentId("manufacturer-0"),
+                parents=[supplier_url],
+            )
+        )
+        dist_url = await df.publish(
+            DatasetMetadata(
+                name="shipment",
+                owner=AgentId("distributor-0"),
+                parents=[mfg_url],
+            )
+        )
+
+        sent: list[str] = []
+
+        class _MockCtx:
+            async def send(self, to: AgentId, payload: bytes) -> None:
+                sent.append(payload.decode("utf-8", errors="replace"))
+
+        retailer = CidRetailerAgent(AgentId("retailer-0"), origin=AgentId("supplier-0"), df=df)
+        await retailer.on_message(
+            _MockCtx(),  # pyright: ignore[reportArgumentType]
+            AgentId("distributor-0"),
+            f"cid_url:1:0:{dist_url}".encode(),
+        )
+
+        audit = next((m for m in sent if m.startswith("provenance_audit:")), None)
+        assert audit is not None
+
+        # Format: provenance_audit:{url}:nodes={n}:ancestors={csv}
+        assert f"provenance_audit:{dist_url}" in audit
+        assert "nodes=2" in audit, f"expected nodes=2 (mfg + supplier), got: {audit}"
+        assert "ancestors=" in audit
+        # Both ancestors must appear.
+        assert str(supplier_url) in audit
+        assert str(mfg_url) in audit
+
+    @pytest.mark.asyncio
+    async def test_provenance_audit_multi_parent_dag(self) -> None:
+        """provenance_audit correctly counts deduplicated ancestors in a multi-parent DAG."""
+        from nest_core.scenarios_builtin.provenance_supply_chain import CidRetailerAgent
+
+        df = _make_df("test-agent")
+
+        # DAG: 2 suppliers -> 1 manufacturer -> distributor (4 ancestors total).
+        sup_a = await df.publish(DatasetMetadata(name="s-a", owner=AgentId("s-a")))
+        sup_b = await df.publish(DatasetMetadata(name="s-b", owner=AgentId("s-b")))
+        mfg = await df.publish(
+            DatasetMetadata(
+                name="mfg",
+                owner=AgentId("mfg-0"),
+                parents=[sup_a, sup_b],
+            )
+        )
+        dist_url = await df.publish(
+            DatasetMetadata(
+                name="shipment",
+                owner=AgentId("dist-0"),
+                parents=[mfg],
+            )
+        )
+
+        sent: list[str] = []
+
+        class _MockCtx:
+            async def send(self, to: AgentId, payload: bytes) -> None:
+                sent.append(payload.decode("utf-8", errors="replace"))
+
+        retailer = CidRetailerAgent(AgentId("retailer-0"), origin=AgentId("s-a"), df=df)
+        await retailer.on_message(
+            _MockCtx(),  # pyright: ignore[reportArgumentType]
+            AgentId("dist-0"),
+            f"cid_url:1:0:{dist_url}".encode(),
+        )
+
+        audit = next((m for m in sent if m.startswith("provenance_audit:")), None)
+        assert audit is not None
+        # 3 ancestors: sup_a, sup_b, mfg
+        assert "nodes=3" in audit, f"expected nodes=3, got: {audit}"

--- a/scenarios/provenance_supply_chain.yaml
+++ b/scenarios/provenance_supply_chain.yaml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Provenance supply-chain scenario.
+# Demonstrates content-addressed datasets, signed freshness proofs,
+# and end-to-end provenance-chain verification across 4 supply-chain hops.
+name: provenance_supply_chain
+description: >
+  Content-addressed provenance DAG: multiple suppliers feed multiple
+  manufacturers, manufacturers feed a distributor, and the retailer verifies
+  the full DAG with freshness proofs and provenance audit events.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 6
+  brain: state-machine
+  roles:
+    - name: supplier
+      count: 2
+    - name: manufacturer
+      count: 2
+    - name: distributor
+      count: 1
+    - name: retailer
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  # Use the content-addressed plugin — NOT datafacts_v1.
+  datafacts: cid_facts
+
+task:
+  type: provenance_supply_chain
+  config:
+    items_per_round: 2
+    rounds: 3
+    num_suppliers: 2
+    num_manufacturers: 2
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/provenance_supply_chain.jsonl


### PR DESCRIPTION
## Problem

The existing DataFacts layer could store and retrieve datasets, but it could not reliably answer a critical trust question:

> Where did this data come from, and can its complete lineage be verified?

Datasets were identified by publisher-chosen names, freshness relied on timestamps, and provenance relationships were limited. Agents could verify that data existed, but not reliably verify its origin, integrity, freshness, or derivation history.

## What This Adds

### cid_facts
A content-addressed DataFacts implementation.

URL = SHA-256 of semantic dataset content: owner, description, schema_version, tags, checksum, size_bytes, access_tier, metadata, and normalized parent URLs — not the dataset name and not timestamps.
Same content resolves to the same address, different content resolves to a different address, and republishing identical content is idempotent.
Tags are normalized before hashing, so equivalent tag sets resolve to the same address regardless of order. Parent URLs are also normalized before hashing, so `[A,B]` and `[B,A]` resolve to the same address.

### Provenance DAGs

Provenance is modeled as a DAG rather than a simple chain.
Datasets declare parents through `metadata["parents"]`. A dataset may reference multiple parents, enabling joins and derived datasets with multiple upstream sources. Publishing rejects unknown parent references, so lineage can only be built from datasets already known to the system.

The supply-chain scenario was generalized into:
```text
N suppliers → M manufacturers → distributor → retailer
```
allowing larger provenance graphs without code changes.

### Freshness Proofs
Freshness is a signed proof rather than a timestamp check.
Each publish operation signs:
```text
(dataset_url, logical_tick)
```
using the publisher's identity key. Verification only accepts proofs signed by the dataset's declared owner. No wall-clock time is used, preserving deterministic Tier-1 execution.

### Full Lineage Verification
Retailers verify the complete provenance graph rather than only immediate parents.
Verification uses a full breadth-first traversal (BFS), visits every reachable ancestor, deduplicates shared ancestors, validates freshness proofs throughout the lineage, and detects broken provenance chains. A first-parent-only walk would miss part of the graph; the multi-parent supply-chain DAG makes full traversal load-bearing.

### Provenance Audit Events
After successful verification, retailers emit:
```text
provenance_audit:<url>:nodes=<count>:ancestors=<urls>
```
This gives the trace an explainable record of exactly what lineage was discovered and verified.

## Security & Validation

The implementation targets the three main DataFacts failure modes: substitution, stale freshness claims, and broken provenance.

Validator tests use synthetic traces to prove the difference between weak traces and content-addressed provenance traces:

* name-based or substituted URLs fail substitution checks
* traces without valid signed freshness proofs fail freshness validation
* derived datasets with unpublished parents fail provenance-chain validation

Provenance tests exercise the real supply-chain DAG: suppliers feed manufacturers, manufacturers feed the distributor, and the retailer verifies the final dataset by walking the full lineage. Shared ancestors are intentionally exercised so the traversal proves they are visited exactly once.
Scenario/factory tests verify configurable topology: different supplier/manufacturer counts can be created from config, manufacturers wait for all required supplier URLs, distributors wait for all required manufacturer URLs, and retailers emit `provenance_audit` after successful verification.

## Verification

```bash
uv sync
uv run ruff check .
uv run ruff format --check .
uv run pyright
uv run pytest -v
```

Results:

```text
58 passed in test_cid_facts.py
599 passed, 1 skipped, 1 deselected
```
## Future Work

* Graph fingerprints for entire provenance DAGs.
* Provenance risk scoring based on lineage quality.
* Multi-distributor supply-chain topologies.
