### PR TITLE
[Hackathon] edge: EMPIC escrow payments plugin and adversarial validators

### DIFF
--- a/docs/layers/payments.md
+++ b/docs/layers/payments.md
@@ -31,7 +31,10 @@ delivered; pubsub mode pre-funds a maximum stream amount, releases one
 tick for each accepted delivery, and refunds unused escrow on close.
 The bundled `empic_payments` scenario demonstrates provider service
 registration, consumer acceptance policy, pull refunds, and pubsub
-overbilling protection.
+overbilling protection. Its adversarial validators also check consumer /
+provider / service binding by payment reference and reject traces that leak
+private keys, API keys, bearer tokens, wallet secrets, or other live rail
+secrets.
 
 ## Writing your own
 

--- a/docs/layers/payments.md
+++ b/docs/layers/payments.md
@@ -21,6 +21,18 @@ quotes, raises on insufficient balance, supports refund by `PaymentRef`.
 
 Source: [`nest_plugins_reference/payments/prepaid_credits.py`](../../packages/nest-plugins-reference/nest_plugins_reference/payments/prepaid_credits.py).
 
+## Additional reference plugins
+
+`streaming` — bilateral per-tick streams with mid-stream cancellation.
+
+`empic_escrow` — EMPIC-shaped escrow for service providers and
+consumers. Pull mode locks one request payment until accepted data is
+delivered; pubsub mode pre-funds a maximum stream amount, releases one
+tick for each accepted delivery, and refunds unused escrow on close.
+The bundled `empic_payments` scenario demonstrates provider service
+registration, consumer acceptance policy, pull refunds, and pubsub
+overbilling protection.
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md) — the full

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -29,6 +29,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
+    ("payments", "empic_escrow"): f"{_REF}.payments.empic_escrow:EMPICEscrowPayments",
     ("coordination", "contract_net"): f"{_REF}.coordination.contract_net:ContractNet",
     ("negotiation", "alternating_offers"): (
         f"{_REF}.negotiation.alternating_offers:AlternatingOffers"

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -97,3 +97,7 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("receipt_reputation", receipt_reputation_factory)
+    elif name == "empic_payments":
+        from nest_core.scenarios_builtin.empic_payments import empic_payments_factory
+
+        register_scenario("empic_payments", empic_payments_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/empic_payments.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/empic_payments.py
@@ -1,0 +1,638 @@
+# SPDX-License-Identifier: Apache-2.0
+"""EMPIC-style weather payments scenario.
+
+Providers register weather services, consumers fund pull or pubsub escrows,
+and consumer acceptance policy determines whether escrow is released or
+refunded.  The scenario is deterministic and uses only in-memory Nanda Town
+plugins.
+
+Example::
+
+    agents = empic_payments_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal, cast
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Money, PaymentRef, ServiceRef
+
+DeliveryMode = Literal["pull", "pubsub"]
+
+
+def _json(data: dict[str, Any]) -> bytes:
+    return json.dumps(data, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _load(payload: bytes) -> dict[str, Any]:
+    try:
+        data: object = json.loads(payload.decode("utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return cast("dict[str, Any]", data) if isinstance(data, dict) else {}
+
+
+async def _audit(ctx: AgentContext, data: dict[str, Any]) -> None:
+    event = {"type": "empic_audit", "tick": int(ctx.time), **data}
+    await ctx.send(ctx.agent_id, _json(event))
+
+
+def _int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
+
+
+def _float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _evaluate_acceptance(
+    delivery: dict[str, Any],
+    *,
+    policy: dict[str, Any],
+    expected_service_id: ServiceRef,
+    expected_provider: AgentId,
+    request_params: dict[str, Any],
+    current_tick: int,
+) -> tuple[bool, str]:
+    data_obj = delivery.get("data")
+    if not isinstance(data_obj, dict):
+        return False, "missing data object"
+    data = cast("dict[str, Any]", data_obj)
+
+    if policy.get("bind_service_id", True) and delivery.get("service_id") != str(
+        expected_service_id
+    ):
+        return False, "service_id mismatch"
+    if policy.get("bind_provider_id", True) and delivery.get("provider_id") != str(
+        expected_provider
+    ):
+        return False, "provider_id mismatch"
+    if policy.get("bind_request_params", True) and delivery.get("request_params") != request_params:
+        return False, "request_params mismatch"
+
+    required = policy.get("required_fields", [])
+    if isinstance(required, list):
+        for field in cast("list[object]", required):
+            if isinstance(field, str) and field not in data:
+                return False, f"missing field {field}"
+
+    ranges = policy.get("numeric_ranges", {})
+    if isinstance(ranges, dict):
+        for field, bounds_obj in cast("dict[object, object]", ranges).items():
+            if not isinstance(field, str) or not isinstance(bounds_obj, dict):
+                continue
+            bounds = cast("dict[str, object]", bounds_obj)
+            value = _float(data.get(field))
+            if value is None:
+                return False, f"{field} is not numeric"
+            min_value = _float(bounds.get("min"))
+            max_value = _float(bounds.get("max"))
+            if min_value is not None and value < min_value:
+                return False, f"{field} below minimum"
+            if max_value is not None and value > max_value:
+                return False, f"{field} above maximum"
+
+    max_age = _int(policy.get("max_age_ticks"), default=-1)
+    data_tick = _int(data.get("tick"), default=current_tick)
+    if max_age >= 0 and current_tick - data_tick > max_age:
+        return False, "delivery stale"
+
+    return True, "accepted"
+
+
+class WeatherProviderAgent(StateMachineAgent):
+    """Provider that registers one EMPIC weather service and delivers data."""
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        service_id: ServiceRef,
+        behavior: str,
+        delivery_modes: tuple[DeliveryMode, ...],
+    ) -> None:
+        self._id = agent_id
+        self._service_id = service_id
+        self._behavior = behavior
+        self._delivery_modes = delivery_modes
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Register this provider's service metadata."""
+        payments = ctx.plugins.get("payments")
+        if payments is None:
+            return
+
+        from nest_plugins_reference.payments.empic_escrow import PubsubTerms
+
+        terms = (
+            PubsubTerms(rate_per_tick=10, max_total=40, duration_ticks=6, min_valid_ratio=0.75)
+            if "pubsub" in self._delivery_modes
+            else None
+        )
+        payments.register_service(
+            service_id=self._service_id,
+            provider=self._id,
+            price=Money(amount=50),
+            delivery_modes=self._delivery_modes,
+            schema={
+                "required_fields": [
+                    "temperature_c",
+                    "temperature_f",
+                    "windspeed_kmh",
+                    "timestamp",
+                    "tick",
+                ]
+            },
+            pubsub_terms=terms,
+            metadata={"behavior": self._behavior},
+        )
+        await _audit(
+            ctx,
+            {
+                "event_type": "empic_service_registered",
+                "service_id": str(self._service_id),
+                "provider": str(self._id),
+                "delivery_modes": list(self._delivery_modes),
+                "price": 50,
+            },
+        )
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Handle service requests and scheduled pubsub emits."""
+        msg = _load(payload)
+        msg_type = msg.get("type")
+        if msg_type in ("empic_audit", "empic_delivery"):
+            return
+        if msg_type == "empic_pubsub_emit":
+            await self._send_pubsub_delivery(ctx, msg)
+            return
+        if msg_type != "empic_request":
+            return
+
+        mode = msg.get("delivery_mode")
+        if mode == "pull":
+            await ctx.send(sender, _json(self._delivery(ctx, msg, sequence=0)))
+        elif mode == "pubsub":
+            for seq in range(4):
+                emit = {**msg, "type": "empic_pubsub_emit", "seq": seq}
+                await ctx.schedule(float(seq + 1), _json(emit))
+
+    async def _send_pubsub_delivery(self, ctx: AgentContext, msg: dict[str, Any]) -> None:
+        consumer = AgentId(str(msg.get("consumer_id", "")))
+        seq = _int(msg.get("seq"))
+        await ctx.send(consumer, _json(self._delivery(ctx, msg, sequence=seq)))
+
+    def _delivery(
+        self,
+        ctx: AgentContext,
+        request: dict[str, Any],
+        *,
+        sequence: int,
+    ) -> dict[str, Any]:
+        current_tick = int(ctx.time)
+        data: dict[str, Any] = {
+            "temperature_c": 21.0 + sequence,
+            "temperature_f": 69.8 + (sequence * 1.8),
+            "windspeed_kmh": 8.0 + sequence,
+            "timestamp": f"tick-{current_tick}",
+            "tick": current_tick,
+        }
+        provider_id = str(self._id)
+        service_id = str(self._service_id)
+
+        if self._behavior == "missing_field":
+            data.pop("temperature_f")
+        elif self._behavior == "stale":
+            data["tick"] = current_tick - 10
+            data["timestamp"] = f"tick-{current_tick - 10}"
+        elif self._behavior == "wrong_provider":
+            provider_id = "provider-spoof"
+            service_id = f"{self._service_id}-spoof"
+        elif self._behavior == "pubsub_mixed" and sequence == 2:
+            data["temperature_c"] = 120.0
+
+        ref = str(request.get("payment_ref", ""))
+        delivery_id = f"{ref}-delivery-{sequence}"
+        return {
+            "type": "empic_delivery",
+            "delivery_id": delivery_id,
+            "payment_ref": ref,
+            "service_id": service_id,
+            "provider_id": provider_id,
+            "consumer_id": str(request.get("consumer_id", "")),
+            "delivery_mode": request.get("delivery_mode", "pull"),
+            "request_params": request.get("request_params", {}),
+            "data": data,
+        }
+
+
+class WeatherConsumerAgent(StateMachineAgent):
+    """Consumer that funds escrow and releases only acceptable weather data."""
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        provider: AgentId,
+        service_id: ServiceRef,
+        mode: DeliveryMode,
+        policy: dict[str, Any],
+        request_params: dict[str, Any],
+        max_spend: int,
+    ) -> None:
+        self._id = agent_id
+        self._provider = provider
+        self._service_id = service_id
+        self._mode = mode
+        self._policy = policy
+        self._request_params = request_params
+        self._max_spend = max_spend
+        self._ref = PaymentRef(f"{agent_id}-{service_id}")
+        self._stream_closed = False
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Fund escrow and request provider data."""
+        payments = ctx.plugins.get("payments")
+        if payments is None:
+            return
+
+        quote = await payments.quote(self._service_id)
+        if quote.price.amount > self._max_spend:
+            await _audit(
+                ctx,
+                {
+                    "event_type": "empic_request_declined",
+                    "payment_ref": str(self._ref),
+                    "service_id": str(self._service_id),
+                    "reason": "max spend exceeded",
+                },
+            )
+            return
+
+        if self._mode == "pull":
+            await payments.pay(
+                self._provider,
+                quote.price,
+                self._ref,
+                service_id=self._service_id,
+            )
+            await _audit(
+                ctx,
+                {
+                    "event_type": "empic_escrow_debited",
+                    "payment_ref": str(self._ref),
+                    "payer": str(self._id),
+                    "provider": str(self._provider),
+                    "amount": quote.price.amount,
+                    "mode": "pull",
+                },
+            )
+        else:
+            service = payments.service_record(self._service_id)
+            terms = service.pubsub_terms if service is not None else None
+            if terms is None:
+                return
+            await payments.open_stream(
+                self._provider,
+                rate_per_tick=terms.rate_per_tick,
+                max_total=terms.max_total,
+                ref=self._ref,
+                service_id=self._service_id,
+                opened_at_tick=int(ctx.time),
+            )
+            await _audit(
+                ctx,
+                {
+                    "event_type": "empic_stream_opened",
+                    "payment_ref": str(self._ref),
+                    "payer": str(self._id),
+                    "provider": str(self._provider),
+                    "amount": terms.max_total,
+                    "rate_per_tick": terms.rate_per_tick,
+                    "mode": "pubsub",
+                },
+            )
+            await _audit(
+                ctx,
+                {
+                    "event_type": "empic_escrow_debited",
+                    "payment_ref": str(self._ref),
+                    "payer": str(self._id),
+                    "provider": str(self._provider),
+                    "amount": terms.max_total,
+                    "mode": "pubsub",
+                },
+            )
+            await ctx.schedule(float(terms.duration_ticks), _json({"type": "empic_close_stream"}))
+
+        await ctx.send(
+            self._provider,
+            _json(
+                {
+                    "type": "empic_request",
+                    "payment_ref": str(self._ref),
+                    "service_id": str(self._service_id),
+                    "consumer_id": str(self._id),
+                    "delivery_mode": self._mode,
+                    "request_params": self._request_params,
+                }
+            ),
+        )
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Evaluate deliveries and close streams."""
+        msg = _load(payload)
+        msg_type = msg.get("type")
+        if msg_type == "empic_audit":
+            return
+        if msg_type == "empic_close_stream":
+            await self._close_stream(ctx)
+            return
+        if msg_type != "empic_delivery":
+            return
+
+        await self._handle_delivery(ctx, sender, msg)
+
+    async def _handle_delivery(
+        self,
+        ctx: AgentContext,
+        sender: AgentId,
+        delivery: dict[str, Any],
+    ) -> None:
+        payments = ctx.plugins.get("payments")
+        if payments is None:
+            return
+
+        accepted, reason = _evaluate_acceptance(
+            delivery,
+            policy=self._policy,
+            expected_service_id=self._service_id,
+            expected_provider=self._provider,
+            request_params=self._request_params,
+            current_tick=int(ctx.time),
+        )
+        delivery_id = str(delivery.get("delivery_id", ""))
+        payments.record_delivery(
+            self._ref,
+            delivery_id=delivery_id,
+            service_id=self._service_id,
+            provider=sender,
+            mode=self._mode,
+            tick=int(ctx.time),
+            accepted=accepted,
+            data=cast("dict[str, Any]", delivery.get("data", {})),
+            reason=reason,
+        )
+        await _audit(
+            ctx,
+            {
+                "event_type": "empic_delivery_evaluated",
+                "delivery_id": delivery_id,
+                "payment_ref": str(self._ref),
+                "service_id": str(self._service_id),
+                "provider": str(self._provider),
+                "accepted": accepted,
+                "reason": reason,
+                "mode": self._mode,
+            },
+        )
+
+        if self._mode == "pull":
+            if accepted:
+                record = payments.payment_record(self._ref)
+                evidence = record.deliveries[-1] if record is not None else None
+                receipt = await payments.fulfill(self._ref, evidence)
+                await _audit(
+                    ctx,
+                    {
+                        "event_type": "empic_escrow_released",
+                        "delivery_id": delivery_id,
+                        "payment_ref": str(self._ref),
+                        "payer": str(self._id),
+                        "provider": str(self._provider),
+                        "amount": receipt.amount.amount,
+                        "mode": "pull",
+                    },
+                )
+            else:
+                record = payments.payment_record(self._ref)
+                refund_amount = record.escrowed if record is not None else 0
+                await payments.reject(self._ref, reason=reason, data_ref=delivery_id)
+                await _audit(
+                    ctx,
+                    {
+                        "event_type": "empic_escrow_refunded",
+                        "delivery_id": delivery_id,
+                        "payment_ref": str(self._ref),
+                        "payer": str(self._id),
+                        "amount": refund_amount,
+                        "reason": reason,
+                        "mode": "pull",
+                    },
+                )
+            return
+
+        if accepted:
+            record = payments.payment_record(self._ref)
+            before = record.released if record is not None else 0
+            await payments.tick_stream(self._ref, int(ctx.time))
+            after_record = payments.payment_record(self._ref)
+            released = (after_record.released if after_record is not None else before) - before
+            if released > 0:
+                await _audit(
+                    ctx,
+                    {
+                        "event_type": "empic_escrow_released",
+                        "delivery_id": delivery_id,
+                        "payment_ref": str(self._ref),
+                        "payer": str(self._id),
+                        "provider": str(self._provider),
+                        "amount": released,
+                        "mode": "pubsub",
+                    },
+                )
+
+    async def _close_stream(self, ctx: AgentContext) -> None:
+        if self._mode != "pubsub" or self._stream_closed:
+            return
+        payments = ctx.plugins.get("payments")
+        if payments is None:
+            return
+        record = payments.payment_record(self._ref)
+        refund_amount = record.escrowed if record is not None else 0
+        await payments.close_stream(self._ref, current_tick=int(ctx.time))
+        self._stream_closed = True
+        if refund_amount > 0:
+            await _audit(
+                ctx,
+                {
+                    "event_type": "empic_escrow_refunded",
+                    "payment_ref": str(self._ref),
+                    "payer": str(self._id),
+                    "amount": refund_amount,
+                    "reason": "stream closed",
+                    "mode": "pubsub",
+                },
+            )
+        await _audit(
+            ctx,
+            {
+                "event_type": "empic_stream_closed",
+                "payment_ref": str(self._ref),
+                "payer": str(self._id),
+                "provider": str(self._provider),
+                "mode": "pubsub",
+            },
+        )
+
+
+def empic_payments_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create consumers and providers for EMPIC pull/pubsub settlement.
+
+    Example::
+
+        agents = empic_payments_factory(config, plugins)
+    """
+    default_policy: dict[str, Any] = {
+        "required_fields": [
+            "temperature_c",
+            "temperature_f",
+            "windspeed_kmh",
+            "timestamp",
+            "tick",
+        ],
+        "numeric_ranges": {
+            "temperature_c": {"min": -50, "max": 60},
+            "temperature_f": {"min": -58, "max": 140},
+            "windspeed_kmh": {"min": 0, "max": 300},
+        },
+        "max_age_ticks": _int(config.task.config.get("max_age_ticks"), default=3),
+        "max_spend": 100,
+        "bind_service_id": True,
+        "bind_provider_id": True,
+        "bind_request_params": True,
+    }
+    raw_policy: object = config.task.config.get("acceptance_policy", {})
+    if isinstance(raw_policy, dict):
+        policy: dict[str, Any] = {**default_policy, **cast("dict[str, Any]", raw_policy)}
+    else:
+        policy = default_policy.copy()
+    request_params: dict[str, Any] = {"lat": 42.3601, "lon": -71.0942}
+    max_spend = _int(policy.get("max_spend"), default=100)
+
+    provider_specs = [
+        ("provider-0", "weather-pull-good", "valid", ("pull",)),
+        ("provider-1", "weather-pull-missing", "missing_field", ("pull",)),
+        ("provider-2", "weather-pull-stale", "stale", ("pull",)),
+        ("provider-3", "weather-pull-spoof", "wrong_provider", ("pull",)),
+        ("provider-4", "weather-pubsub", "pubsub_mixed", ("pull", "pubsub")),
+    ]
+    consumer_specs = [
+        ("consumer-0", "provider-0", "weather-pull-good", "pull", max_spend),
+        ("consumer-1", "provider-1", "weather-pull-missing", "pull", max_spend),
+        ("consumer-2", "provider-2", "weather-pull-stale", "pull", max_spend),
+        ("consumer-3", "provider-3", "weather-pull-spoof", "pull", max_spend),
+        ("consumer-4", "provider-4", "weather-pubsub", "pubsub", max_spend),
+    ]
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    for provider_id, service_id, behavior, modes in provider_specs:
+        aid = AgentId(provider_id)
+        agents[aid] = WeatherProviderAgent(
+            aid,
+            service_id=ServiceRef(service_id),
+            behavior=behavior,
+            delivery_modes=cast("tuple[DeliveryMode, ...]", modes),
+        )
+
+    for consumer_id, provider_id, service_id, mode, max_spend in consumer_specs:
+        aid = AgentId(consumer_id)
+        agents[aid] = WeatherConsumerAgent(
+            aid,
+            provider=AgentId(provider_id),
+            service_id=ServiceRef(service_id),
+            mode=cast("DeliveryMode", mode),
+            policy=policy,
+            request_params=request_params,
+            max_spend=max_spend,
+        )
+
+    _instantiate_plugins(plugins, list(agents.keys()))
+    return agents
+
+
+def _instantiate_plugins(plugins: dict[str, Any], all_ids: list[AgentId]) -> None:
+    """Instantiate shared and per-agent plugin handles for this scenario."""
+    if not plugins:
+        return
+
+    registry_cls = plugins.get("registry")
+    if registry_cls is not None and isinstance(registry_cls, type):
+        plugins["registry"] = registry_cls()
+
+    trust_cls = plugins.get("trust")
+    if trust_cls is not None and isinstance(trust_cls, type):
+        plugins["trust"] = trust_cls()
+
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+
+    payments_cls = plugins.get("payments")
+    if payments_cls is not None and isinstance(payments_cls, type):
+        balances: dict[AgentId, int] = {aid: 1000 for aid in all_ids}
+        payment_records: dict[PaymentRef, Any] = {}
+        services: dict[ServiceRef, Any] = {}
+        system_id = AgentId("system")
+        plugins["payments"] = payments_cls(
+            system_id,
+            initial_balance=0,
+            balances=balances,
+            payments=payment_records,
+            services=services,
+        )
+        for aid in all_ids:
+            agent_plugins.setdefault(aid, {})["payments"] = payments_cls(
+                aid,
+                initial_balance=0,
+                balances=balances,
+                payments=payment_records,
+                services=services,
+            )
+
+    identity_cls = plugins.get("identity")
+    if identity_cls is not None and isinstance(identity_cls, type):
+        identities: dict[AgentId, Any] = {}
+        for aid in all_ids:
+            identities[aid] = identity_cls(aid, seed=b"sim-seed")
+        for aid, ident in identities.items():
+            for peer_id, peer_ident in identities.items():
+                if peer_id != aid:
+                    ident.register_peer(peer_id, peer_ident.public_key)
+        for aid, ident in identities.items():
+            agent_plugins.setdefault(aid, {})["identity"] = ident
+        plugins.pop("identity", None)

--- a/packages/nest-core/nest_core/scenarios_builtin/empic_payments.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/empic_payments.py
@@ -129,7 +129,17 @@ def _evaluate_acceptance(
 
 
 class WeatherProviderAgent(StateMachineAgent):
-    """Provider that registers one EMPIC weather service and delivers data."""
+    """Provider that registers one EMPIC weather service and delivers data.
+
+    Example::
+
+        agent = WeatherProviderAgent(
+            AgentId("provider-0"),
+            service_id=ServiceRef("weather"),
+            behavior="honest",
+            delivery_modes=("pull",),
+        )
+    """
 
     def __init__(
         self,
@@ -273,7 +283,20 @@ class WeatherProviderAgent(StateMachineAgent):
 
 
 class WeatherConsumerAgent(StateMachineAgent):
-    """Consumer that funds escrow and releases only acceptable weather data."""
+    """Consumer that funds escrow and releases only acceptable weather data.
+
+    Example::
+
+        agent = WeatherConsumerAgent(
+            AgentId("consumer-0"),
+            provider=AgentId("provider-0"),
+            service_id=ServiceRef("weather"),
+            mode="pull",
+            policy={"required_fields": ["temperature_c"]},
+            request_params={"city": "Cambridge"},
+            max_spend=100,
+        )
+    """
 
     def __init__(
         self,

--- a/packages/nest-core/nest_core/scenarios_builtin/empic_payments.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/empic_payments.py
@@ -74,6 +74,7 @@ def _evaluate_acceptance(
     policy: dict[str, Any],
     expected_service_id: ServiceRef,
     expected_provider: AgentId,
+    expected_consumer: AgentId,
     request_params: dict[str, Any],
     current_tick: int,
 ) -> tuple[bool, str]:
@@ -90,6 +91,10 @@ def _evaluate_acceptance(
         expected_provider
     ):
         return False, "provider_id mismatch"
+    if policy.get("bind_consumer_id", True) and delivery.get("consumer_id") != str(
+        expected_consumer
+    ):
+        return False, "consumer_id mismatch"
     if policy.get("bind_request_params", True) and delivery.get("request_params") != request_params:
         return False, "request_params mismatch"
 
@@ -237,6 +242,7 @@ class WeatherProviderAgent(StateMachineAgent):
         }
         provider_id = str(self._id)
         service_id = str(self._service_id)
+        consumer_id = str(request.get("consumer_id", ""))
 
         if self._behavior == "missing_field":
             data.pop("temperature_f")
@@ -246,6 +252,8 @@ class WeatherProviderAgent(StateMachineAgent):
         elif self._behavior == "wrong_provider":
             provider_id = "provider-spoof"
             service_id = f"{self._service_id}-spoof"
+        elif self._behavior == "wrong_consumer":
+            consumer_id = "consumer-spoof"
         elif self._behavior == "pubsub_mixed" and sequence == 2:
             data["temperature_c"] = 120.0
 
@@ -257,7 +265,7 @@ class WeatherProviderAgent(StateMachineAgent):
             "payment_ref": ref,
             "service_id": service_id,
             "provider_id": provider_id,
-            "consumer_id": str(request.get("consumer_id", "")),
+            "consumer_id": consumer_id,
             "delivery_mode": request.get("delivery_mode", "pull"),
             "request_params": request.get("request_params", {}),
             "data": data,
@@ -302,6 +310,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                 "payment_ref": str(self._ref),
                 "service_id": str(self._service_id),
                 "payer": str(self._id),
+                "consumer_id": str(self._id),
                 "provider": str(self._provider),
                 "mode": self._mode,
                 "request_params": self._request_params,
@@ -335,6 +344,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                     "payment_ref": str(self._ref),
                     "service_id": str(self._service_id),
                     "payer": str(self._id),
+                    "consumer_id": str(self._id),
                     "provider": str(self._provider),
                     "amount": quote.price.amount,
                     "mode": "pull",
@@ -360,6 +370,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                     "payment_ref": str(self._ref),
                     "service_id": str(self._service_id),
                     "payer": str(self._id),
+                    "consumer_id": str(self._id),
                     "provider": str(self._provider),
                     "amount": terms.max_total,
                     "rate_per_tick": terms.rate_per_tick,
@@ -375,6 +386,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                     "payment_ref": str(self._ref),
                     "service_id": str(self._service_id),
                     "payer": str(self._id),
+                    "consumer_id": str(self._id),
                     "provider": str(self._provider),
                     "amount": terms.max_total,
                     "mode": "pubsub",
@@ -425,6 +437,7 @@ class WeatherConsumerAgent(StateMachineAgent):
             policy=self._policy,
             expected_service_id=self._service_id,
             expected_provider=self._provider,
+            expected_consumer=self._id,
             request_params=self._request_params,
             current_tick=int(ctx.time),
         )
@@ -447,9 +460,12 @@ class WeatherConsumerAgent(StateMachineAgent):
                 "delivery_id": delivery_id,
                 "payment_ref": str(self._ref),
                 "service_id": str(self._service_id),
+                "payer": str(self._id),
+                "consumer_id": str(self._id),
                 "provider": str(self._provider),
                 "delivery_service_id": str(delivery.get("service_id", "")),
                 "delivery_provider_id": str(delivery.get("provider_id", "")),
+                "delivery_consumer_id": str(delivery.get("consumer_id", "")),
                 "request_params": delivery.get("request_params", {}),
                 "accepted": accepted,
                 "reason": reason,
@@ -470,6 +486,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                         "payment_ref": str(self._ref),
                         "service_id": str(self._service_id),
                         "payer": str(self._id),
+                        "consumer_id": str(self._id),
                         "provider": str(self._provider),
                         "amount": receipt.amount.amount,
                         "mode": "pull",
@@ -487,6 +504,8 @@ class WeatherConsumerAgent(StateMachineAgent):
                         "payment_ref": str(self._ref),
                         "service_id": str(self._service_id),
                         "payer": str(self._id),
+                        "consumer_id": str(self._id),
+                        "provider": str(self._provider),
                         "amount": refund_amount,
                         "reason": reason,
                         "mode": "pull",
@@ -509,6 +528,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                         "payment_ref": str(self._ref),
                         "service_id": str(self._service_id),
                         "payer": str(self._id),
+                        "consumer_id": str(self._id),
                         "provider": str(self._provider),
                         "amount": released,
                         "mode": "pubsub",
@@ -533,6 +553,8 @@ class WeatherConsumerAgent(StateMachineAgent):
                     "payment_ref": str(self._ref),
                     "service_id": str(self._service_id),
                     "payer": str(self._id),
+                    "consumer_id": str(self._id),
+                    "provider": str(self._provider),
                     "amount": refund_amount,
                     "reason": "stream closed",
                     "mode": "pubsub",
@@ -545,6 +567,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                 "payment_ref": str(self._ref),
                 "service_id": str(self._service_id),
                 "payer": str(self._id),
+                "consumer_id": str(self._id),
                 "provider": str(self._provider),
                 "mode": "pubsub",
             },
@@ -578,6 +601,7 @@ def empic_payments_factory(
         "max_spend": 100,
         "bind_service_id": True,
         "bind_provider_id": True,
+        "bind_consumer_id": True,
         "bind_request_params": True,
     }
     raw_policy: object = config.task.config.get("acceptance_policy", {})
@@ -594,6 +618,7 @@ def empic_payments_factory(
         ("provider-2", "weather-pull-stale", "stale", ("pull",)),
         ("provider-3", "weather-pull-spoof", "wrong_provider", ("pull",)),
         ("provider-4", "weather-pubsub", "pubsub_mixed", ("pull", "pubsub")),
+        ("provider-5", "weather-pull-wrong-consumer", "wrong_consumer", ("pull",)),
     ]
     consumer_specs = [
         ("consumer-0", "provider-0", "weather-pull-good", "pull", max_spend),
@@ -601,6 +626,7 @@ def empic_payments_factory(
         ("consumer-2", "provider-2", "weather-pull-stale", "pull", max_spend),
         ("consumer-3", "provider-3", "weather-pull-spoof", "pull", max_spend),
         ("consumer-4", "provider-4", "weather-pubsub", "pubsub", max_spend),
+        ("consumer-5", "provider-5", "weather-pull-wrong-consumer", "pull", max_spend),
     ]
 
     agents: dict[AgentId, StateMachineAgent] = {}

--- a/packages/nest-core/nest_core/scenarios_builtin/empic_payments.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/empic_payments.py
@@ -152,22 +152,35 @@ class WeatherProviderAgent(StateMachineAgent):
             if "pubsub" in self._delivery_modes
             else None
         )
+        schema = {
+            "required_fields": [
+                "temperature_c",
+                "temperature_f",
+                "windspeed_kmh",
+                "timestamp",
+                "tick",
+            ]
+        }
         payments.register_service(
             service_id=self._service_id,
             provider=self._id,
             price=Money(amount=50),
             delivery_modes=self._delivery_modes,
-            schema={
-                "required_fields": [
-                    "temperature_c",
-                    "temperature_f",
-                    "windspeed_kmh",
-                    "timestamp",
-                    "tick",
-                ]
-            },
+            schema=schema,
             pubsub_terms=terms,
             metadata={"behavior": self._behavior},
+        )
+        terms_payload = (
+            {
+                "rate_per_tick": terms.rate_per_tick,
+                "max_total": terms.max_total,
+                "duration_ticks": terms.duration_ticks,
+                "min_valid_ratio": terms.min_valid_ratio,
+                "min_msg_count": terms.min_msg_count,
+                "auto_renew": terms.auto_renew,
+            }
+            if terms is not None
+            else None
         )
         await _audit(
             ctx,
@@ -177,6 +190,8 @@ class WeatherProviderAgent(StateMachineAgent):
                 "provider": str(self._id),
                 "delivery_modes": list(self._delivery_modes),
                 "price": 50,
+                "schema": schema,
+                "pubsub_terms": terms_payload,
             },
         )
 
@@ -280,6 +295,20 @@ class WeatherConsumerAgent(StateMachineAgent):
             return
 
         quote = await payments.quote(self._service_id)
+        await _audit(
+            ctx,
+            {
+                "event_type": "empic_acceptance_policy",
+                "payment_ref": str(self._ref),
+                "service_id": str(self._service_id),
+                "payer": str(self._id),
+                "provider": str(self._provider),
+                "mode": self._mode,
+                "request_params": self._request_params,
+                "policy": self._policy,
+                "max_spend": self._max_spend,
+            },
+        )
         if quote.price.amount > self._max_spend:
             await _audit(
                 ctx,
@@ -304,6 +333,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                 {
                     "event_type": "empic_escrow_debited",
                     "payment_ref": str(self._ref),
+                    "service_id": str(self._service_id),
                     "payer": str(self._id),
                     "provider": str(self._provider),
                     "amount": quote.price.amount,
@@ -328,10 +358,13 @@ class WeatherConsumerAgent(StateMachineAgent):
                 {
                     "event_type": "empic_stream_opened",
                     "payment_ref": str(self._ref),
+                    "service_id": str(self._service_id),
                     "payer": str(self._id),
                     "provider": str(self._provider),
                     "amount": terms.max_total,
                     "rate_per_tick": terms.rate_per_tick,
+                    "max_total": terms.max_total,
+                    "duration_ticks": terms.duration_ticks,
                     "mode": "pubsub",
                 },
             )
@@ -340,6 +373,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                 {
                     "event_type": "empic_escrow_debited",
                     "payment_ref": str(self._ref),
+                    "service_id": str(self._service_id),
                     "payer": str(self._id),
                     "provider": str(self._provider),
                     "amount": terms.max_total,
@@ -414,6 +448,9 @@ class WeatherConsumerAgent(StateMachineAgent):
                 "payment_ref": str(self._ref),
                 "service_id": str(self._service_id),
                 "provider": str(self._provider),
+                "delivery_service_id": str(delivery.get("service_id", "")),
+                "delivery_provider_id": str(delivery.get("provider_id", "")),
+                "request_params": delivery.get("request_params", {}),
                 "accepted": accepted,
                 "reason": reason,
                 "mode": self._mode,
@@ -431,6 +468,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                         "event_type": "empic_escrow_released",
                         "delivery_id": delivery_id,
                         "payment_ref": str(self._ref),
+                        "service_id": str(self._service_id),
                         "payer": str(self._id),
                         "provider": str(self._provider),
                         "amount": receipt.amount.amount,
@@ -447,6 +485,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                         "event_type": "empic_escrow_refunded",
                         "delivery_id": delivery_id,
                         "payment_ref": str(self._ref),
+                        "service_id": str(self._service_id),
                         "payer": str(self._id),
                         "amount": refund_amount,
                         "reason": reason,
@@ -468,6 +507,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                         "event_type": "empic_escrow_released",
                         "delivery_id": delivery_id,
                         "payment_ref": str(self._ref),
+                        "service_id": str(self._service_id),
                         "payer": str(self._id),
                         "provider": str(self._provider),
                         "amount": released,
@@ -491,6 +531,7 @@ class WeatherConsumerAgent(StateMachineAgent):
                 {
                     "event_type": "empic_escrow_refunded",
                     "payment_ref": str(self._ref),
+                    "service_id": str(self._service_id),
                     "payer": str(self._id),
                     "amount": refund_amount,
                     "reason": "stream closed",
@@ -502,6 +543,7 @@ class WeatherConsumerAgent(StateMachineAgent):
             {
                 "event_type": "empic_stream_closed",
                 "payment_ref": str(self._ref),
+                "service_id": str(self._service_id),
                 "payer": str(self._id),
                 "provider": str(self._provider),
                 "mode": "pubsub",

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1936,6 +1936,143 @@ def validate_empic_provider_service_binding(
     ]
 
 
+def validate_empic_payment_participant_binding(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Payment refs must not change consumer, provider, service, or mode."""
+    audit = _empic_audit_events(events)
+    tracked_types = {
+        "empic_acceptance_policy",
+        "empic_escrow_debited",
+        "empic_stream_opened",
+        "empic_delivery_evaluated",
+        "empic_escrow_released",
+        "empic_escrow_refunded",
+        "empic_stream_closed",
+    }
+    context_by_ref: dict[str, dict[str, str]] = defaultdict(dict)
+    checked_refs: set[str] = set()
+    violations: list[str] = []
+
+    for ev in audit:
+        event_type = str(ev.get("event_type") or "")
+        if event_type not in tracked_types:
+            continue
+        ref = _empic_ref(ev)
+        if not ref:
+            violations.append(f"{event_type}: missing payment_ref")
+            continue
+        checked_refs.add(ref)
+
+        payer = _safe_text(ev.get("payer"))
+        consumer_id = _safe_text(ev.get("consumer_id"))
+        if payer and consumer_id and payer != consumer_id:
+            violations.append(f"{ref}: payer {payer} does not match consumer_id {consumer_id}")
+        if payer and not consumer_id:
+            consumer_id = payer
+        if consumer_id and not payer:
+            payer = consumer_id
+
+        observed = {
+            "service_id": _safe_text(ev.get("service_id")),
+            "payer": payer,
+            "consumer_id": consumer_id,
+            "provider": _safe_text(ev.get("provider")),
+            "mode": _safe_text(ev.get("mode")),
+        }
+        if event_type in {
+            "empic_acceptance_policy",
+            "empic_escrow_debited",
+            "empic_stream_opened",
+            "empic_escrow_released",
+            "empic_escrow_refunded",
+            "empic_stream_closed",
+        }:
+            missing = [field for field, value in observed.items() if not value]
+            if missing:
+                violations.append(f"{ref}: {event_type} missing {missing}")
+
+        context = context_by_ref[ref]
+        for field, value in observed.items():
+            if not value:
+                continue
+            existing = context.get(field)
+            if existing is not None and existing != value:
+                violations.append(f"{ref}: {field} changed from {existing} to {value}")
+            else:
+                context[field] = value
+
+    if violations:
+        return [
+            ValidationResult(
+                "empic_payment_participant_binding",
+                False,
+                "; ".join(violations),
+            )
+        ]
+    return [
+        ValidationResult(
+            "empic_payment_participant_binding",
+            True,
+            f"verified {len(checked_refs)} payment participant bindings",
+        )
+    ]
+
+
+_EMPIC_FORBIDDEN_SECRET_KEYS = {
+    "api_key",
+    "api_key_secret",
+    "bearer_token",
+    "coinbase_secret",
+    "password",
+    "private_key",
+    "secret",
+    "secret_key",
+    "service_api_key",
+    "stripe_secret_key",
+    "wallet_auth_token",
+    "wallet_secret",
+}
+
+
+def validate_empic_no_secret_material(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """EMPIC traces must contain only replay-safe public metadata."""
+    violations: list[str] = []
+    checked = 0
+
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        with contextlib.suppress(json.JSONDecodeError):
+            body_raw: object = json.loads(_message_body(ev))
+            if not isinstance(body_raw, dict):
+                continue
+            body = cast("dict[str, Any]", body_raw)
+            msg_type = str(body.get("type") or "")
+            if not msg_type.startswith("empic_"):
+                continue
+            checked += 1
+            violations.extend(_empic_secret_violations(body, path=msg_type))
+
+    if violations:
+        return [
+            ValidationResult(
+                "empic_no_secret_material",
+                False,
+                "; ".join(violations),
+            )
+        ]
+    return [
+        ValidationResult(
+            "empic_no_secret_material",
+            True,
+            f"checked {checked} EMPIC trace messages",
+        )
+    ]
+
+
 def validate_empic_no_drain_after_close(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
@@ -2046,6 +2183,12 @@ def _empic_policy_accepts(
         delivery.get("provider_id")
     ) != _safe_text(policy_event.get("provider")):
         return False, "provider_id mismatch"
+    if _policy_flag(policy, "bind_consumer_id"):
+        expected_consumer = _safe_text(policy_event.get("consumer_id")) or _safe_text(
+            policy_event.get("payer")
+        )
+        if _safe_text(delivery.get("consumer_id")) != expected_consumer:
+            return False, "consumer_id mismatch"
     if _policy_flag(policy, "bind_request_params"):
         expected_params = policy_event.get("request_params")
         if delivery.get("request_params") != expected_params:
@@ -2086,6 +2229,30 @@ def _empic_policy_accepts(
 def _policy_flag(policy: dict[str, Any], key: str) -> bool:
     value = policy.get(key, True)
     return value if isinstance(value, bool) else True
+
+
+def _empic_secret_violations(value: object, *, path: str) -> list[str]:
+    violations: list[str] = []
+    if isinstance(value, dict):
+        for key_raw, child in cast("dict[object, object]", value).items():
+            key = str(key_raw)
+            normalized = key.lower().replace("-", "_")
+            child_path = f"{path}.{key}"
+            if normalized in _EMPIC_FORBIDDEN_SECRET_KEYS or normalized.endswith("_secret"):
+                violations.append(f"{child_path}: forbidden secret field")
+            violations.extend(_empic_secret_violations(child, path=child_path))
+    elif isinstance(value, list):
+        for index, item in enumerate(cast("list[object]", value)):
+            violations.extend(_empic_secret_violations(item, path=f"{path}[{index}]"))
+    elif isinstance(value, str):
+        lowered = value.lower()
+        if "-----begin private key-----" in lowered:
+            violations.append(f"{path}: private key material")
+        elif lowered.startswith("bearer "):
+            violations.append(f"{path}: bearer token material")
+        elif value.startswith(("sk_live_", "sk_test_")):
+            violations.append(f"{path}: payment provider secret key material")
+    return violations
 
 
 def _safe_text(value: Any) -> str:
@@ -2618,6 +2785,8 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_empic_all_escrows_terminal,
         validate_empic_no_duplicate_settlement,
         validate_empic_provider_service_binding,
+        validate_empic_payment_participant_binding,
+        validate_empic_no_secret_material,
         validate_empic_no_drain_after_close,
         validate_empic_no_overbill_on_partition,
     ],

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1495,6 +1495,10 @@ def validate_empic_escrow_conservation(
     This checks the EMPIC shadow ledger from audit messages by ``payment_ref``:
     consumer debits into escrow must equal provider releases plus consumer
     refunds for each funded payment, not only globally.
+
+    Example::
+
+        result = validate_empic_escrow_conservation(events)[0]
     """
     audit = _empic_audit_events(events)
     debited = _empic_amounts_by_ref(audit, "empic_escrow_debited")
@@ -1531,7 +1535,12 @@ def validate_empic_escrow_conservation(
 def validate_empic_no_release_without_accepted_delivery(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Provider payment release requires accepted delivery evidence."""
+    """Provider payment release requires accepted delivery evidence.
+
+    Example::
+
+        result = validate_empic_no_release_without_accepted_delivery(events)[0]
+    """
     audit = _empic_audit_events(events)
     accepted_deliveries = {
         (_empic_ref(ev), _empic_delivery_id(ev))
@@ -1572,7 +1581,12 @@ def validate_empic_no_release_without_accepted_delivery(
 def validate_empic_invalid_delivery_not_paid(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Rejected delivery evidence must not be credited to a provider."""
+    """Rejected delivery evidence must not be credited to a provider.
+
+    Example::
+
+        result = validate_empic_invalid_delivery_not_paid(events)[0]
+    """
     audit = _empic_audit_events(events)
     rejected = {
         (_empic_ref(ev), _empic_delivery_id(ev))
@@ -1610,7 +1624,12 @@ def validate_empic_invalid_delivery_not_paid(
 def validate_empic_delivery_policy_integrity(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Consumer acceptance must match delivery payload and declared policy."""
+    """Consumer acceptance must match delivery payload and declared policy.
+
+    Example::
+
+        result = validate_empic_delivery_policy_integrity(events)[0]
+    """
     audit = _empic_audit_events(events)
     deliveries = {
         (_empic_ref(ev), _empic_delivery_id(ev)): ev
@@ -1665,7 +1684,12 @@ def validate_empic_delivery_policy_integrity(
 def validate_empic_pubsub_billing_caps(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Pubsub releases must respect rate-per-tick, max-total, and accepted evidence."""
+    """Pubsub releases must respect rate-per-tick, max-total, and accepted evidence.
+
+    Example::
+
+        result = validate_empic_pubsub_billing_caps(events)[0]
+    """
     audit = _empic_audit_events(events)
     streams: dict[str, tuple[int, int]] = {}
     accepted: dict[str, set[str]] = defaultdict(set)
@@ -1730,7 +1754,12 @@ def validate_empic_pubsub_billing_caps(
 def validate_empic_max_spend_enforced(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Funded escrow amount must not exceed the consumer's declared budget."""
+    """Funded escrow amount must not exceed the consumer's declared budget.
+
+    Example::
+
+        result = validate_empic_max_spend_enforced(events)[0]
+    """
     audit = _empic_audit_events(events)
     max_spend_by_ref: dict[str, int] = {}
     violations: list[str] = []
@@ -1774,7 +1803,12 @@ def validate_empic_max_spend_enforced(
 def validate_empic_all_escrows_terminal(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Every funded escrow must finish with complete release/refund accounting."""
+    """Every funded escrow must finish with complete release/refund accounting.
+
+    Example::
+
+        result = validate_empic_all_escrows_terminal(events)[0]
+    """
     audit = _empic_audit_events(events)
     debited = _empic_amounts_by_ref(audit, "empic_escrow_debited")
     released = _empic_amounts_by_ref(audit, "empic_escrow_released")
@@ -1817,7 +1851,12 @@ def validate_empic_all_escrows_terminal(
 def validate_empic_no_duplicate_settlement(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Payment refs and delivery evidence must not be replayed for settlement."""
+    """Payment refs and delivery evidence must not be replayed for settlement.
+
+    Example::
+
+        result = validate_empic_no_duplicate_settlement(events)[0]
+    """
     audit = _empic_audit_events(events)
     debits: dict[str, int] = defaultdict(int)
     releases: dict[tuple[str, str], int] = defaultdict(int)
@@ -1873,7 +1912,12 @@ def validate_empic_no_duplicate_settlement(
 def validate_empic_provider_service_binding(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Payments and releases must bind to the provider registered for the service."""
+    """Payments and releases must bind to the provider registered for the service.
+
+    Example::
+
+        result = validate_empic_provider_service_binding(events)[0]
+    """
     audit = _empic_audit_events(events)
     service_provider: dict[str, str] = {}
     payment_binding: dict[str, tuple[str, str]] = {}
@@ -1939,7 +1983,12 @@ def validate_empic_provider_service_binding(
 def validate_empic_payment_participant_binding(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Payment refs must not change consumer, provider, service, or mode."""
+    """Payment refs must not change consumer, provider, service, or mode.
+
+    Example::
+
+        result = validate_empic_payment_participant_binding(events)[0]
+    """
     audit = _empic_audit_events(events)
     tracked_types = {
         "empic_acceptance_policy",
@@ -2041,7 +2090,12 @@ _PAYMENT_SECRET_PREFIXES = ("sk_" + "live_", "sk_" + "test_")
 def validate_empic_no_secret_material(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """EMPIC traces must contain only replay-safe public metadata."""
+    """EMPIC traces must contain only replay-safe public metadata.
+
+    Example::
+
+        result = validate_empic_no_secret_material(events)[0]
+    """
     violations: list[str] = []
     checked = 0
 
@@ -2079,7 +2133,12 @@ def validate_empic_no_secret_material(
 def validate_empic_no_drain_after_close(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Pubsub streams must not release funds after close."""
+    """Pubsub streams must not release funds after close.
+
+    Example::
+
+        result = validate_empic_no_drain_after_close(events)[0]
+    """
     audit = _empic_audit_events(events)
     close_tick: dict[str, int] = {}
     violations: list[str] = []
@@ -2112,7 +2171,12 @@ def validate_empic_no_drain_after_close(
 def validate_empic_no_overbill_on_partition(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Pubsub streams must not release funds after a partitioned delivery edge."""
+    """Pubsub streams must not release funds after a partitioned delivery edge.
+
+    Example::
+
+        result = validate_empic_no_overbill_on_partition(events)[0]
+    """
     audit = _empic_audit_events(events)
     stream_parties: dict[str, tuple[str, str]] = {}
     partition_start: dict[tuple[str, str], int] = {}

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1440,43 +1440,90 @@ def _empic_audit_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return parsed
 
 
+def _empic_message_events(
+    events: list[dict[str, Any]],
+    msg_type: str,
+) -> list[dict[str, Any]]:
+    parsed: list[dict[str, Any]] = []
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        with contextlib.suppress(json.JSONDecodeError):
+            body_raw: object = json.loads(msg)
+            if not isinstance(body_raw, dict):
+                continue
+            body = cast("dict[str, Any]", body_raw)
+            if body.get("type") != msg_type:
+                continue
+            body.setdefault("tick", _event_tick(ev))
+            body.setdefault("_sender", str(ev.get("agent", "")))
+            body.setdefault("_receiver", str(ev.get("to", "")))
+            parsed.append(body)
+    return parsed
+
+
+def _empic_ref(ev: dict[str, Any]) -> str:
+    value = ev.get("payment_ref")
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _empic_delivery_id(ev: dict[str, Any]) -> str:
+    value = ev.get("delivery_id")
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _empic_amounts_by_ref(
+    audit: list[dict[str, Any]],
+    event_type: str,
+) -> dict[str, int]:
+    totals: dict[str, int] = defaultdict(int)
+    for ev in audit:
+        if ev.get("event_type") != event_type:
+            continue
+        ref = _empic_ref(ev)
+        if ref:
+            totals[ref] += _safe_amount(ev.get("amount"))
+    return totals
+
+
 def validate_empic_escrow_conservation(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Every escrowed credit is either released or refunded.
+    """Every escrowed credit is either released or refunded per payment.
 
-    This checks the EMPIC shadow ledger from audit messages: consumer debits
-    into escrow must equal provider releases plus consumer refunds.
+    This checks the EMPIC shadow ledger from audit messages by ``payment_ref``:
+    consumer debits into escrow must equal provider releases plus consumer
+    refunds for each funded payment, not only globally.
     """
     audit = _empic_audit_events(events)
-    debited = sum(
-        _safe_amount(ev.get("amount"))
-        for ev in audit
-        if ev.get("event_type") == "empic_escrow_debited"
-    )
-    released = sum(
-        _safe_amount(ev.get("amount"))
-        for ev in audit
-        if ev.get("event_type") == "empic_escrow_released"
-    )
-    refunded = sum(
-        _safe_amount(ev.get("amount"))
-        for ev in audit
-        if ev.get("event_type") == "empic_escrow_refunded"
-    )
-    if debited != released + refunded:
+    debited = _empic_amounts_by_ref(audit, "empic_escrow_debited")
+    released = _empic_amounts_by_ref(audit, "empic_escrow_released")
+    refunded = _empic_amounts_by_ref(audit, "empic_escrow_refunded")
+    refs = sorted(set(debited) | set(released) | set(refunded))
+    violations = [
+        f"{ref}: debited={debited.get(ref, 0)} released={released.get(ref, 0)} "
+        f"refunded={refunded.get(ref, 0)}"
+        for ref in refs
+        if debited.get(ref, 0) != released.get(ref, 0) + refunded.get(ref, 0)
+    ]
+    if violations:
         return [
             ValidationResult(
                 "empic_escrow_conservation",
                 False,
-                f"debited={debited} released={released} refunded={refunded}",
+                "; ".join(violations),
             )
         ]
+    total_debited = sum(debited.values())
+    total_released = sum(released.values())
+    total_refunded = sum(refunded.values())
     return [
         ValidationResult(
             "empic_escrow_conservation",
             True,
-            f"debited={debited}, released={released}, refunded={refunded}",
+            f"{len(refs)} refs, debited={total_debited}, "
+            f"released={total_released}, refunded={total_refunded}",
         )
     ]
 
@@ -1487,18 +1534,22 @@ def validate_empic_no_release_without_accepted_delivery(
     """Provider payment release requires accepted delivery evidence."""
     audit = _empic_audit_events(events)
     accepted_deliveries = {
-        str(ev.get("delivery_id"))
+        (_empic_ref(ev), _empic_delivery_id(ev))
         for ev in audit
-        if ev.get("event_type") == "empic_delivery_evaluated" and ev.get("accepted") is True
+        if ev.get("event_type") == "empic_delivery_evaluated"
+        and ev.get("accepted") is True
+        and _empic_ref(ev)
+        and _empic_delivery_id(ev)
     }
     violations: list[str] = []
     for ev in audit:
         if ev.get("event_type") != "empic_escrow_released":
             continue
-        delivery_id = str(ev.get("delivery_id", ""))
-        if not delivery_id or delivery_id not in accepted_deliveries:
+        ref = _empic_ref(ev)
+        delivery_id = _empic_delivery_id(ev)
+        if not ref or not delivery_id or (ref, delivery_id) not in accepted_deliveries:
             violations.append(
-                f"release ref={ev.get('payment_ref')} delivery={delivery_id or '<missing>'}"
+                f"release ref={ref or '<missing>'} delivery={delivery_id or '<missing>'}"
             )
 
     if violations:
@@ -1524,14 +1575,19 @@ def validate_empic_invalid_delivery_not_paid(
     """Rejected delivery evidence must not be credited to a provider."""
     audit = _empic_audit_events(events)
     rejected = {
-        str(ev.get("delivery_id"))
+        (_empic_ref(ev), _empic_delivery_id(ev))
         for ev in audit
-        if ev.get("event_type") == "empic_delivery_evaluated" and ev.get("accepted") is False
+        if ev.get("event_type") == "empic_delivery_evaluated"
+        and ev.get("accepted") is False
+        and _empic_ref(ev)
+        and _empic_delivery_id(ev)
     }
     paid = {
-        str(ev.get("delivery_id"))
+        (_empic_ref(ev), _empic_delivery_id(ev))
         for ev in audit
-        if ev.get("event_type") == "empic_escrow_released" and ev.get("delivery_id")
+        if ev.get("event_type") == "empic_escrow_released"
+        and _empic_ref(ev)
+        and _empic_delivery_id(ev)
     }
     violations = sorted(rejected & paid)
     if violations:
@@ -1547,6 +1603,335 @@ def validate_empic_invalid_delivery_not_paid(
             "empic_invalid_delivery_not_paid",
             True,
             f"verified {len(rejected)} rejected deliveries",
+        )
+    ]
+
+
+def validate_empic_delivery_policy_integrity(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Consumer acceptance must match delivery payload and declared policy."""
+    audit = _empic_audit_events(events)
+    deliveries = {
+        (_empic_ref(ev), _empic_delivery_id(ev)): ev
+        for ev in _empic_message_events(events, "empic_delivery")
+        if _empic_ref(ev) and _empic_delivery_id(ev)
+    }
+    policies = {
+        _empic_ref(ev): ev
+        for ev in audit
+        if ev.get("event_type") == "empic_acceptance_policy" and _empic_ref(ev)
+    }
+    checked = 0
+    violations: list[str] = []
+
+    for ev in audit:
+        if ev.get("event_type") != "empic_delivery_evaluated":
+            continue
+        ref = _empic_ref(ev)
+        delivery_id = _empic_delivery_id(ev)
+        if not ref or not delivery_id:
+            violations.append("delivery evaluation missing payment_ref or delivery_id")
+            continue
+        delivery = deliveries.get((ref, delivery_id))
+        policy_event = policies.get(ref)
+        if delivery is None:
+            violations.append(f"{ref}/{delivery_id}: evaluated delivery not found")
+            continue
+        if policy_event is None:
+            violations.append(f"{ref}/{delivery_id}: acceptance policy not found")
+            continue
+
+        expected, reason = _empic_policy_accepts(delivery, policy_event, _event_tick(ev))
+        observed = ev.get("accepted") is True
+        checked += 1
+        if observed != expected:
+            violations.append(
+                f"{ref}/{delivery_id}: observed accepted={observed}, "
+                f"policy accepted={expected} ({reason})"
+            )
+
+    if violations:
+        return [ValidationResult("empic_delivery_policy_integrity", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "empic_delivery_policy_integrity",
+            True,
+            f"checked {checked} delivery evaluations",
+        )
+    ]
+
+
+def validate_empic_pubsub_billing_caps(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Pubsub releases must respect rate-per-tick, max-total, and accepted evidence."""
+    audit = _empic_audit_events(events)
+    streams: dict[str, tuple[int, int]] = {}
+    accepted: dict[str, set[str]] = defaultdict(set)
+    released: dict[str, int] = defaultdict(int)
+    violations: list[str] = []
+
+    for ev in audit:
+        event_type = ev.get("event_type")
+        ref = _empic_ref(ev)
+        if not ref:
+            continue
+        if event_type == "empic_stream_opened":
+            rate = _safe_amount(ev.get("rate_per_tick"))
+            max_total = _safe_amount(ev.get("max_total") or ev.get("amount"))
+            if rate <= 0 or max_total <= 0:
+                violations.append(f"{ref}: invalid stream terms rate={rate} max_total={max_total}")
+            else:
+                streams[ref] = (rate, max_total)
+        elif (
+            event_type == "empic_delivery_evaluated"
+            and ev.get("accepted") is True
+            and ev.get("mode") == "pubsub"
+        ):
+            delivery_id = _empic_delivery_id(ev)
+            if delivery_id:
+                accepted[ref].add(delivery_id)
+        elif event_type == "empic_escrow_released" and ev.get("mode") == "pubsub":
+            amount = _safe_amount(ev.get("amount"))
+            delivery_id = _empic_delivery_id(ev)
+            terms = streams.get(ref)
+            if terms is None:
+                violations.append(f"{ref}: pubsub release without stream_opened")
+                continue
+            rate, _max_total = terms
+            if amount > rate:
+                violations.append(
+                    f"{ref}/{delivery_id or '<missing>'}: release {amount} > rate {rate}"
+                )
+            released[ref] += amount
+
+    for ref, (rate, max_total) in streams.items():
+        released_total = released.get(ref, 0)
+        accepted_cap = rate * len(accepted.get(ref, set()))
+        if released_total > max_total:
+            violations.append(f"{ref}: released {released_total} > max_total {max_total}")
+        if released_total > accepted_cap:
+            violations.append(
+                f"{ref}: released {released_total} > accepted delivery cap {accepted_cap}"
+            )
+
+    if violations:
+        return [ValidationResult("empic_pubsub_billing_caps", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "empic_pubsub_billing_caps",
+            True,
+            f"checked {len(streams)} pubsub streams",
+        )
+    ]
+
+
+def validate_empic_max_spend_enforced(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Funded escrow amount must not exceed the consumer's declared budget."""
+    audit = _empic_audit_events(events)
+    max_spend_by_ref: dict[str, int] = {}
+    violations: list[str] = []
+
+    for ev in audit:
+        if ev.get("event_type") != "empic_acceptance_policy":
+            continue
+        ref = _empic_ref(ev)
+        if not ref:
+            continue
+        max_spend = _optional_amount(ev.get("max_spend"))
+        policy_raw = ev.get("policy")
+        if max_spend is None and isinstance(policy_raw, dict):
+            max_spend = _optional_amount(cast("dict[str, Any]", policy_raw).get("max_spend"))
+        if max_spend is not None:
+            max_spend_by_ref[ref] = max_spend
+
+    for ev in audit:
+        event_type = ev.get("event_type")
+        if event_type not in {"empic_escrow_debited", "empic_stream_opened"}:
+            continue
+        ref = _empic_ref(ev)
+        max_spend = max_spend_by_ref.get(ref)
+        if not ref or max_spend is None:
+            continue
+        amount = _safe_amount(ev.get("max_total") or ev.get("amount"))
+        if amount > max_spend:
+            violations.append(f"{ref}: funded {amount} exceeds declared max_spend {max_spend}")
+
+    if violations:
+        return [ValidationResult("empic_max_spend_enforced", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "empic_max_spend_enforced",
+            True,
+            f"checked {len(max_spend_by_ref)} consumer policies",
+        )
+    ]
+
+
+def validate_empic_all_escrows_terminal(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every funded escrow must finish with complete release/refund accounting."""
+    audit = _empic_audit_events(events)
+    debited = _empic_amounts_by_ref(audit, "empic_escrow_debited")
+    released = _empic_amounts_by_ref(audit, "empic_escrow_released")
+    refunded = _empic_amounts_by_ref(audit, "empic_escrow_refunded")
+    stream_refs = {
+        _empic_ref(ev)
+        for ev in audit
+        if ev.get("event_type") == "empic_stream_opened" and _empic_ref(ev)
+    }
+    closed_refs = {
+        _empic_ref(ev)
+        for ev in audit
+        if ev.get("event_type") == "empic_stream_closed" and _empic_ref(ev)
+    }
+    violations: list[str] = []
+
+    for ref, debit in sorted(debited.items()):
+        release = released.get(ref, 0)
+        refund = refunded.get(ref, 0)
+        if release + refund != debit:
+            violations.append(
+                f"{ref}: not terminal debited={debit} released={release} refunded={refund}"
+            )
+        if ref in stream_refs and refund > 0 and ref not in closed_refs:
+            violations.append(f"{ref}: pubsub refund without stream close")
+        if ref not in stream_refs and release == 0 and refund == 0:
+            violations.append(f"{ref}: pull escrow has no release or refund")
+
+    if violations:
+        return [ValidationResult("empic_all_escrows_terminal", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "empic_all_escrows_terminal",
+            True,
+            f"verified {len(debited)} funded escrows",
+        )
+    ]
+
+
+def validate_empic_no_duplicate_settlement(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Payment refs and delivery evidence must not be replayed for settlement."""
+    audit = _empic_audit_events(events)
+    debits: dict[str, int] = defaultdict(int)
+    releases: dict[tuple[str, str], int] = defaultdict(int)
+    refunds: dict[str, int] = defaultdict(int)
+    evaluations: dict[tuple[str, str], int] = defaultdict(int)
+    violations: list[str] = []
+
+    for ev in audit:
+        ref = _empic_ref(ev)
+        event_type = ev.get("event_type")
+        if event_type == "empic_escrow_debited":
+            if not ref:
+                violations.append("escrow debit missing payment_ref")
+            else:
+                debits[ref] += 1
+        elif event_type == "empic_escrow_released":
+            delivery_id = _empic_delivery_id(ev)
+            if ref and delivery_id:
+                releases[(ref, delivery_id)] += 1
+        elif event_type == "empic_escrow_refunded" and ref:
+            refunds[ref] += 1
+        elif event_type == "empic_delivery_evaluated":
+            delivery_id = _empic_delivery_id(ev)
+            if ref and delivery_id:
+                evaluations[(ref, delivery_id)] += 1
+
+    violations.extend(
+        f"{ref}: duplicate escrow debit" for ref, count in debits.items() if count > 1
+    )
+    violations.extend(
+        f"{ref}/{delivery_id}: duplicate release"
+        for (ref, delivery_id), count in releases.items()
+        if count > 1
+    )
+    violations.extend(f"{ref}: duplicate refund" for ref, count in refunds.items() if count > 1)
+    violations.extend(
+        f"{ref}/{delivery_id}: duplicate delivery evaluation"
+        for (ref, delivery_id), count in evaluations.items()
+        if count > 1
+    )
+
+    if violations:
+        return [ValidationResult("empic_no_duplicate_settlement", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "empic_no_duplicate_settlement",
+            True,
+            f"checked {len(debits)} payment refs and {len(evaluations)} delivery evaluations",
+        )
+    ]
+
+
+def validate_empic_provider_service_binding(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Payments and releases must bind to the provider registered for the service."""
+    audit = _empic_audit_events(events)
+    service_provider: dict[str, str] = {}
+    payment_binding: dict[str, tuple[str, str]] = {}
+    violations: list[str] = []
+
+    for ev in audit:
+        if ev.get("event_type") != "empic_service_registered":
+            continue
+        service_id = _safe_text(ev.get("service_id"))
+        provider = _safe_text(ev.get("provider"))
+        if service_id and provider:
+            service_provider[service_id] = provider
+
+    for ev in audit:
+        if ev.get("event_type") not in {"empic_escrow_debited", "empic_stream_opened"}:
+            continue
+        ref = _empic_ref(ev)
+        service_id = _safe_text(ev.get("service_id"))
+        provider = _safe_text(ev.get("provider"))
+        if not ref or not service_id or not provider:
+            violations.append(f"{ref or '<missing>'}: debit missing service/provider binding")
+            continue
+        registered = service_provider.get(service_id)
+        if registered is None:
+            violations.append(f"{ref}: service {service_id} was not registered")
+        elif registered != provider:
+            violations.append(
+                f"{ref}: debit provider {provider} does not match registered {registered}"
+            )
+        old = payment_binding.get(ref)
+        if old is not None and old != (service_id, provider):
+            violations.append(
+                f"{ref}: inconsistent payment binding {old} vs {(service_id, provider)}"
+            )
+        payment_binding[ref] = (service_id, provider)
+
+    for ev in audit:
+        if ev.get("event_type") != "empic_escrow_released":
+            continue
+        ref = _empic_ref(ev)
+        service_id = _safe_text(ev.get("service_id"))
+        provider = _safe_text(ev.get("provider"))
+        expected = payment_binding.get(ref)
+        if expected is None:
+            violations.append(f"{ref or '<missing>'}: release without payment binding")
+            continue
+        if (service_id, provider) != expected:
+            violations.append(
+                f"{ref}: release binding {(service_id, provider)} does not match {expected}"
+            )
+
+    if violations:
+        return [ValidationResult("empic_provider_service_binding", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "empic_provider_service_binding",
+            True,
+            f"verified {len(payment_binding)} payment bindings",
         )
     ]
 
@@ -1638,6 +2023,95 @@ def validate_empic_no_overbill_on_partition(
             f"verified {len(stream_parties)} pubsub streams",
         )
     ]
+
+
+def _empic_policy_accepts(
+    delivery: dict[str, Any],
+    policy_event: dict[str, Any],
+    current_tick: int,
+) -> tuple[bool, str]:
+    data_raw = delivery.get("data")
+    if not isinstance(data_raw, dict):
+        return False, "missing data object"
+    data = cast("dict[str, Any]", data_raw)
+
+    policy_raw = policy_event.get("policy")
+    policy = cast("dict[str, Any]", policy_raw) if isinstance(policy_raw, dict) else {}
+
+    if _policy_flag(policy, "bind_service_id") and _safe_text(
+        delivery.get("service_id")
+    ) != _safe_text(policy_event.get("service_id")):
+        return False, "service_id mismatch"
+    if _policy_flag(policy, "bind_provider_id") and _safe_text(
+        delivery.get("provider_id")
+    ) != _safe_text(policy_event.get("provider")):
+        return False, "provider_id mismatch"
+    if _policy_flag(policy, "bind_request_params"):
+        expected_params = policy_event.get("request_params")
+        if delivery.get("request_params") != expected_params:
+            return False, "request_params mismatch"
+
+    required = policy.get("required_fields", [])
+    if isinstance(required, list):
+        for field in cast("list[object]", required):
+            if isinstance(field, str) and field not in data:
+                return False, f"missing field {field}"
+
+    ranges = policy.get("numeric_ranges", {})
+    if isinstance(ranges, dict):
+        for field_raw, bounds_raw in cast("dict[object, object]", ranges).items():
+            if not isinstance(field_raw, str) or not isinstance(bounds_raw, dict):
+                continue
+            bounds = cast("dict[str, object]", bounds_raw)
+            value = _safe_float(data.get(field_raw))
+            if value is None:
+                return False, f"{field_raw} is not numeric"
+            min_value = _safe_float(bounds.get("min"))
+            max_value = _safe_float(bounds.get("max"))
+            if min_value is not None and value < min_value:
+                return False, f"{field_raw} below minimum"
+            if max_value is not None and value > max_value:
+                return False, f"{field_raw} above maximum"
+
+    max_age = _safe_amount(policy.get("max_age_ticks"))
+    data_tick = _safe_amount(data.get("tick"))
+    if data_tick > current_tick:
+        return False, "delivery tick is in the future"
+    if max_age >= 0 and current_tick - data_tick > max_age:
+        return False, "delivery stale"
+
+    return True, "accepted"
+
+
+def _policy_flag(policy: dict[str, Any], key: str) -> bool:
+    value = policy.get(key, True)
+    return value if isinstance(value, bool) else True
+
+
+def _safe_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _safe_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        with contextlib.suppress(ValueError):
+            return float(value)
+    return None
+
+
+def _optional_amount(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return int(value)
+    if isinstance(value, str):
+        with contextlib.suppress(ValueError):
+            return int(float(value))
+    return None
 
 
 def _safe_amount(value: Any) -> int:
@@ -2138,6 +2612,12 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_empic_escrow_conservation,
         validate_empic_no_release_without_accepted_delivery,
         validate_empic_invalid_delivery_not_paid,
+        validate_empic_delivery_policy_integrity,
+        validate_empic_pubsub_billing_caps,
+        validate_empic_max_spend_enforced,
+        validate_empic_all_escrows_terminal,
+        validate_empic_no_duplicate_settlement,
+        validate_empic_provider_service_binding,
         validate_empic_no_drain_after_close,
         validate_empic_no_overbill_on_partition,
     ],

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1405,6 +1405,255 @@ def validate_streaming_no_overbill_on_partition(
 
 
 # ---------------------------------------------------------------------------
+# EMPIC escrow/streaming payments validators
+# ---------------------------------------------------------------------------
+
+
+def _event_tick(ev: dict[str, Any]) -> int:
+    raw = ev.get("tick", ev.get("ts", 0))
+    if isinstance(raw, bool):
+        return 0
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, float):
+        return int(raw)
+    if isinstance(raw, str):
+        with contextlib.suppress(ValueError):
+            return int(float(raw))
+    return 0
+
+
+def _empic_audit_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    parsed: list[dict[str, Any]] = []
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        with contextlib.suppress(json.JSONDecodeError):
+            body_raw: object = json.loads(msg)
+            if not isinstance(body_raw, dict):
+                continue
+            body = cast("dict[str, Any]", body_raw)
+            if body.get("type") == "empic_audit":
+                body.setdefault("tick", _event_tick(ev))
+                parsed.append(body)
+    return parsed
+
+
+def validate_empic_escrow_conservation(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every escrowed credit is either released or refunded.
+
+    This checks the EMPIC shadow ledger from audit messages: consumer debits
+    into escrow must equal provider releases plus consumer refunds.
+    """
+    audit = _empic_audit_events(events)
+    debited = sum(
+        _safe_amount(ev.get("amount"))
+        for ev in audit
+        if ev.get("event_type") == "empic_escrow_debited"
+    )
+    released = sum(
+        _safe_amount(ev.get("amount"))
+        for ev in audit
+        if ev.get("event_type") == "empic_escrow_released"
+    )
+    refunded = sum(
+        _safe_amount(ev.get("amount"))
+        for ev in audit
+        if ev.get("event_type") == "empic_escrow_refunded"
+    )
+    if debited != released + refunded:
+        return [
+            ValidationResult(
+                "empic_escrow_conservation",
+                False,
+                f"debited={debited} released={released} refunded={refunded}",
+            )
+        ]
+    return [
+        ValidationResult(
+            "empic_escrow_conservation",
+            True,
+            f"debited={debited}, released={released}, refunded={refunded}",
+        )
+    ]
+
+
+def validate_empic_no_release_without_accepted_delivery(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Provider payment release requires accepted delivery evidence."""
+    audit = _empic_audit_events(events)
+    accepted_deliveries = {
+        str(ev.get("delivery_id"))
+        for ev in audit
+        if ev.get("event_type") == "empic_delivery_evaluated" and ev.get("accepted") is True
+    }
+    violations: list[str] = []
+    for ev in audit:
+        if ev.get("event_type") != "empic_escrow_released":
+            continue
+        delivery_id = str(ev.get("delivery_id", ""))
+        if not delivery_id or delivery_id not in accepted_deliveries:
+            violations.append(
+                f"release ref={ev.get('payment_ref')} delivery={delivery_id or '<missing>'}"
+            )
+
+    if violations:
+        return [
+            ValidationResult(
+                "empic_no_release_without_accepted_delivery",
+                False,
+                "; ".join(violations),
+            )
+        ]
+    return [
+        ValidationResult(
+            "empic_no_release_without_accepted_delivery",
+            True,
+            f"verified {len(accepted_deliveries)} accepted deliveries",
+        )
+    ]
+
+
+def validate_empic_invalid_delivery_not_paid(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Rejected delivery evidence must not be credited to a provider."""
+    audit = _empic_audit_events(events)
+    rejected = {
+        str(ev.get("delivery_id"))
+        for ev in audit
+        if ev.get("event_type") == "empic_delivery_evaluated" and ev.get("accepted") is False
+    }
+    paid = {
+        str(ev.get("delivery_id"))
+        for ev in audit
+        if ev.get("event_type") == "empic_escrow_released" and ev.get("delivery_id")
+    }
+    violations = sorted(rejected & paid)
+    if violations:
+        return [
+            ValidationResult(
+                "empic_invalid_delivery_not_paid",
+                False,
+                f"rejected deliveries were paid: {violations}",
+            )
+        ]
+    return [
+        ValidationResult(
+            "empic_invalid_delivery_not_paid",
+            True,
+            f"verified {len(rejected)} rejected deliveries",
+        )
+    ]
+
+
+def validate_empic_no_drain_after_close(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Pubsub streams must not release funds after close."""
+    audit = _empic_audit_events(events)
+    close_tick: dict[str, int] = {}
+    violations: list[str] = []
+
+    for ev in audit:
+        if ev.get("event_type") == "empic_stream_closed":
+            ref = str(ev.get("payment_ref", ""))
+            if ref:
+                close_tick[ref] = _event_tick(ev)
+
+    for ev in audit:
+        if ev.get("event_type") != "empic_escrow_released" or ev.get("mode") != "pubsub":
+            continue
+        ref = str(ev.get("payment_ref", ""))
+        closed_at = close_tick.get(ref)
+        if closed_at is not None and _event_tick(ev) > closed_at:
+            violations.append(f"{ref} released at {_event_tick(ev)} after close at {closed_at}")
+
+    if violations:
+        return [ValidationResult("empic_no_drain_after_close", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "empic_no_drain_after_close",
+            True,
+            f"verified {len(close_tick)} closed pubsub streams",
+        )
+    ]
+
+
+def validate_empic_no_overbill_on_partition(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Pubsub streams must not release funds after a partitioned delivery edge."""
+    audit = _empic_audit_events(events)
+    stream_parties: dict[str, tuple[str, str]] = {}
+    partition_start: dict[tuple[str, str], int] = {}
+    violations: list[str] = []
+
+    for ev in audit:
+        if ev.get("event_type") == "empic_stream_opened":
+            ref = str(ev.get("payment_ref", ""))
+            payer = str(ev.get("payer", ""))
+            provider = str(ev.get("provider", ""))
+            if ref and payer and provider:
+                stream_parties[ref] = (payer, provider)
+
+    for ev in events:
+        if ev.get("kind") != "dropped":
+            continue
+        sender = str(ev.get("from", ""))
+        receiver = str(ev.get("agent", ""))
+        if not sender or not receiver:
+            continue
+        tick = _event_tick(ev)
+        for edge in ((sender, receiver), (receiver, sender)):
+            old = partition_start.get(edge)
+            if old is None or tick < old:
+                partition_start[edge] = tick
+
+    for ev in audit:
+        if ev.get("event_type") != "empic_escrow_released" or ev.get("mode") != "pubsub":
+            continue
+        ref = str(ev.get("payment_ref", ""))
+        parties = stream_parties.get(ref)
+        if parties is None:
+            continue
+        payer, provider = parties
+        drop_tick = partition_start.get((payer, provider))
+        if drop_tick is not None and _event_tick(ev) >= drop_tick:
+            violations.append(
+                f"{ref} released at {_event_tick(ev)} after {payer}<->{provider} "
+                f"partition at {drop_tick}"
+            )
+
+    if violations:
+        return [ValidationResult("empic_no_overbill_on_partition", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "empic_no_overbill_on_partition",
+            True,
+            f"verified {len(stream_parties)} pubsub streams",
+        )
+    ]
+
+
+def _safe_amount(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        with contextlib.suppress(ValueError):
+            return int(value)
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Comms schema-versioning validators (adversarial)
 # ---------------------------------------------------------------------------
 
@@ -1884,6 +2133,13 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_streaming_conservation,
         validate_streaming_no_drain_after_close,
         validate_streaming_no_overbill_on_partition,
+    ],
+    "empic_payments": [
+        validate_empic_escrow_conservation,
+        validate_empic_no_release_without_accepted_delivery,
+        validate_empic_invalid_delivery_not_paid,
+        validate_empic_no_drain_after_close,
+        validate_empic_no_overbill_on_partition,
     ],
     "receipt_reputation": [
         validate_receipt_reputation_ring_severed,

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -2034,6 +2034,9 @@ _EMPIC_FORBIDDEN_SECRET_KEYS = {
     "wallet_secret",
 }
 
+_PRIVATE_KEY_SENTINEL = "-----begin " + "private key-----"
+_PAYMENT_SECRET_PREFIXES = ("sk_" + "live_", "sk_" + "test_")
+
 
 def validate_empic_no_secret_material(
     events: list[dict[str, Any]],
@@ -2246,11 +2249,11 @@ def _empic_secret_violations(value: object, *, path: str) -> list[str]:
             violations.extend(_empic_secret_violations(item, path=f"{path}[{index}]"))
     elif isinstance(value, str):
         lowered = value.lower()
-        if "-----begin private key-----" in lowered:
+        if _PRIVATE_KEY_SENTINEL in lowered:
             violations.append(f"{path}: private key material")
         elif lowered.startswith("bearer "):
             violations.append(f"{path}: bearer token material")
-        elif value.startswith(("sk_live_", "sk_test_")):
+        elif value.startswith(_PAYMENT_SECRET_PREFIXES):
             violations.append(f"{path}: payment provider secret key material")
     return violations
 

--- a/packages/nest-core/tests/test_scenario.py
+++ b/packages/nest-core/tests/test_scenario.py
@@ -264,11 +264,12 @@ class TestEmpicPaymentsScenario:
         assert all(r.passed for r in validations), validations
 
         payments = runner.resolved_plugins["payments"]
-        assert len(payments._payments) == 5  # noqa: SLF001
+        assert len(payments._payments) == 6  # noqa: SLF001
         assert payments.balance(AgentId("empic-escrow")) == 0
         assert payments.balance(AgentId("provider-0")) > 1000
         assert payments.balance(AgentId("provider-1")) == 1000
         assert payments.balance(AgentId("provider-4")) > 1000
+        assert payments.balance(AgentId("provider-5")) == 1000
 
     @pytest.mark.asyncio
     async def test_empic_payments_partition_yaml(self, tmp_path: Path) -> None:

--- a/packages/nest-core/tests/test_scenario.py
+++ b/packages/nest-core/tests/test_scenario.py
@@ -129,6 +129,7 @@ class TestPluginRegistry:
         reg = PluginRegistry()
         plugins = reg.list_plugins("payments")
         assert ("payments", "prepaid_credits") in plugins
+        assert ("payments", "empic_escrow") in plugins
 
 
 # ---------------------------------------------------------------------------
@@ -242,3 +243,47 @@ class TestMarketplaceScenario:
 
         assert traces[0] == traces[1]
         assert len(traces[0]) > 0
+
+
+class TestEmpicPaymentsScenario:
+    """End-to-end checks for the EMPIC payments scenario."""
+
+    @pytest.mark.asyncio
+    async def test_empic_payments_yaml(self, tmp_path: Path) -> None:
+        """Run the EMPIC weather market and validate escrow invariants."""
+        yaml_path = Path(__file__).parent.parent.parent.parent / "scenarios" / "empic_payments.yaml"
+        config = ScenarioConfig.from_yaml(yaml_path)
+        config.output.trace = str(tmp_path / "empic_payments.jsonl")
+        config.duration = "ticks: 2000"
+
+        runner = ScenarioRunner(config)
+        result_path = await runner.run()
+
+        assert result_path.exists()
+        validations = validate_trace(result_path, "empic_payments")
+        assert all(r.passed for r in validations), validations
+
+        payments = runner.resolved_plugins["payments"]
+        assert len(payments._payments) == 5  # noqa: SLF001
+        assert payments.balance(AgentId("empic-escrow")) == 0
+        assert payments.balance(AgentId("provider-0")) > 1000
+        assert payments.balance(AgentId("provider-1")) == 1000
+        assert payments.balance(AgentId("provider-4")) > 1000
+
+    @pytest.mark.asyncio
+    async def test_empic_payments_partition_yaml(self, tmp_path: Path) -> None:
+        """Run the partition variant and confirm overbilling does not occur."""
+        yaml_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "scenarios"
+            / "empic_payments_partition.yaml"
+        )
+        config = ScenarioConfig.from_yaml(yaml_path)
+        config.output.trace = str(tmp_path / "empic_payments_partition.jsonl")
+        config.duration = "ticks: 2000"
+
+        runner = ScenarioRunner(config)
+        result_path = await runner.run()
+
+        validations = validate_trace(result_path, "empic_payments")
+        assert all(r.passed for r in validations), validations

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -16,6 +16,11 @@ from nest_core.validators import (
     validate_consensus_agreement,
     validate_consensus_no_conflict,
     validate_consensus_validity,
+    validate_empic_escrow_conservation,
+    validate_empic_invalid_delivery_not_paid,
+    validate_empic_no_drain_after_close,
+    validate_empic_no_overbill_on_partition,
+    validate_empic_no_release_without_accepted_delivery,
     validate_events,
     validate_marketplace_no_double_sell,
     validate_marketplace_price_agreement,
@@ -39,6 +44,11 @@ type Event = dict[str, Any]
 
 def _send(agent: str, to: str, msg: str, ts: float = 1.0) -> Event:
     return {"ts": ts, "agent": agent, "kind": "send", "to": to, "msg": msg}
+
+
+def _empic(event: dict[str, Any], *, agent: str = "consumer", tick: int = 0) -> Event:
+    body = {"type": "empic_audit", "tick": tick, **event}
+    return _send(agent, agent, json.dumps(body, sort_keys=True), ts=float(tick))
 
 
 def _broadcast(agent: str, msg: str, ts: float = 1.0) -> Event:
@@ -740,6 +750,156 @@ class TestStreamingValidators:
         assert results[0].passed  # unrelated drop, not a violation
 
 
+class TestEmpicPaymentsValidators:
+    """Tests for EMPIC escrow and delivery validators."""
+
+    def test_conservation_passes(self) -> None:
+        """Debited escrow equals released plus refunded funds."""
+        events = [
+            _empic({"event_type": "empic_escrow_debited", "amount": 50}),
+            _empic({"event_type": "empic_escrow_released", "amount": 20}),
+            _empic({"event_type": "empic_escrow_refunded", "amount": 30}),
+        ]
+
+        results = validate_empic_escrow_conservation(events)
+        assert len(results) == 1
+        assert results[0].passed
+
+    def test_conservation_fails(self) -> None:
+        """Unaccounted escrow fails conservation."""
+        events = [
+            _empic({"event_type": "empic_escrow_debited", "amount": 50}),
+            _empic({"event_type": "empic_escrow_released", "amount": 20}),
+        ]
+
+        results = validate_empic_escrow_conservation(events)
+        assert len(results) == 1
+        assert not results[0].passed
+
+    def test_no_release_without_accepted_delivery(self) -> None:
+        """Release must reference an accepted delivery id."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "delivery_id": "d1",
+                    "accepted": True,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "amount": 10,
+                }
+            ),
+        ]
+
+        results = validate_empic_no_release_without_accepted_delivery(events)
+        assert len(results) == 1
+        assert results[0].passed
+
+    def test_release_without_accepted_delivery_fails(self) -> None:
+        """Release against rejected evidence fails."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "delivery_id": "d1",
+                    "accepted": False,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "amount": 10,
+                }
+            ),
+        ]
+
+        results = validate_empic_no_release_without_accepted_delivery(events)
+        assert len(results) == 1
+        assert not results[0].passed
+
+    def test_invalid_delivery_not_paid_fails(self) -> None:
+        """Rejected delivery ids must not appear in release events."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "delivery_id": "d1",
+                    "accepted": False,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "delivery_id": "d1",
+                    "amount": 10,
+                }
+            ),
+        ]
+
+        results = validate_empic_invalid_delivery_not_paid(events)
+        assert len(results) == 1
+        assert not results[0].passed
+
+    def test_no_drain_after_close_fails(self) -> None:
+        """Pubsub release after stream close is an attack."""
+        events = [
+            _empic(
+                {"event_type": "empic_stream_closed", "payment_ref": "s1", "mode": "pubsub"},
+                tick=2,
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "s1",
+                    "mode": "pubsub",
+                    "delivery_id": "d1",
+                    "amount": 10,
+                },
+                tick=3,
+            ),
+        ]
+
+        results = validate_empic_no_drain_after_close(events)
+        assert len(results) == 1
+        assert not results[0].passed
+
+    def test_no_overbill_on_partition_fails(self) -> None:
+        """Pubsub release after a dropped edge between parties is an attack."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_stream_opened",
+                    "payment_ref": "s1",
+                    "payer": "consumer",
+                    "provider": "provider",
+                },
+                tick=0,
+            ),
+            {"kind": "dropped", "from": "provider", "agent": "consumer", "ts": 2.0},
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "s1",
+                    "mode": "pubsub",
+                    "delivery_id": "d1",
+                    "amount": 10,
+                },
+                tick=3,
+            ),
+        ]
+
+        results = validate_empic_no_overbill_on_partition(events)
+        assert len(results) == 1
+        assert not results[0].passed
+
+
 class TestValidatorRegistry:
     def test_all_scenario_types_registered(self) -> None:
         expected = {
@@ -752,6 +912,7 @@ class TestValidatorRegistry:
             "identity_rotation",
             "memory_concurrent_writers",
             "streaming_payments",
+            "empic_payments",
             "comms_versioning",
             "receipt_reputation",
         }

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -25,6 +25,8 @@ from nest_core.validators import (
     validate_empic_no_duplicate_settlement,
     validate_empic_no_overbill_on_partition,
     validate_empic_no_release_without_accepted_delivery,
+    validate_empic_no_secret_material,
+    validate_empic_payment_participant_binding,
     validate_empic_provider_service_binding,
     validate_empic_pubsub_billing_caps,
     validate_events,
@@ -85,6 +87,7 @@ def _empic_weather_policy() -> dict[str, Any]:
         "max_age_ticks": 3,
         "bind_service_id": True,
         "bind_provider_id": True,
+        "bind_consumer_id": True,
         "bind_request_params": True,
     }
 
@@ -913,6 +916,8 @@ class TestEmpicPaymentsValidators:
                     "event_type": "empic_acceptance_policy",
                     "payment_ref": "p1",
                     "service_id": "weather",
+                    "payer": "consumer",
+                    "consumer_id": "consumer",
                     "provider": "provider",
                     "request_params": request_params,
                     "policy": _empic_weather_policy(),
@@ -924,6 +929,7 @@ class TestEmpicPaymentsValidators:
                     "delivery_id": "d1",
                     "service_id": "weather",
                     "provider_id": "provider",
+                    "consumer_id": "consumer",
                     "request_params": request_params,
                     "data": {
                         "temperature_c": 21.0,
@@ -959,6 +965,8 @@ class TestEmpicPaymentsValidators:
                     "event_type": "empic_acceptance_policy",
                     "payment_ref": "p1",
                     "service_id": "weather",
+                    "payer": "consumer",
+                    "consumer_id": "consumer",
                     "provider": "provider",
                     "request_params": request_params,
                     "policy": _empic_weather_policy(),
@@ -970,6 +978,7 @@ class TestEmpicPaymentsValidators:
                     "delivery_id": "d1",
                     "service_id": "weather",
                     "provider_id": "provider",
+                    "consumer_id": "consumer",
                     "request_params": request_params,
                     "data": {
                         "temperature_c": 120.0,
@@ -1006,6 +1015,8 @@ class TestEmpicPaymentsValidators:
                     "event_type": "empic_acceptance_policy",
                     "payment_ref": "p1",
                     "service_id": "weather",
+                    "payer": "consumer",
+                    "consumer_id": "consumer",
                     "provider": "provider",
                     "request_params": request_params,
                     "policy": _empic_weather_policy(),
@@ -1017,6 +1028,7 @@ class TestEmpicPaymentsValidators:
                     "delivery_id": "d1",
                     "service_id": "weather-spoof",
                     "provider_id": "provider-spoof",
+                    "consumer_id": "consumer",
                     "request_params": {"lat": 0, "lon": 0},
                     "data": {
                         "temperature_c": 21.0,
@@ -1043,6 +1055,56 @@ class TestEmpicPaymentsValidators:
         assert len(results) == 1
         assert not results[0].passed
         assert "mismatch" in results[0].detail
+
+    def test_delivery_policy_integrity_fails_wrong_consumer_replay(self) -> None:
+        """A valid payload for the wrong consumer cannot release escrow."""
+        request_params = {"lat": 42.3601, "lon": -71.0942}
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_acceptance_policy",
+                    "payment_ref": "p1",
+                    "service_id": "weather",
+                    "payer": "consumer",
+                    "consumer_id": "consumer",
+                    "provider": "provider",
+                    "request_params": request_params,
+                    "policy": _empic_weather_policy(),
+                }
+            ),
+            _empic_delivery(
+                {
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "service_id": "weather",
+                    "provider_id": "provider",
+                    "consumer_id": "consumer-spoof",
+                    "request_params": request_params,
+                    "data": {
+                        "temperature_c": 21.0,
+                        "temperature_f": 69.8,
+                        "windspeed_kmh": 8.0,
+                        "timestamp": "tick-1",
+                        "tick": 1,
+                    },
+                },
+                tick=1,
+            ),
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "accepted": True,
+                },
+                tick=1,
+            ),
+        ]
+
+        results = validate_empic_delivery_policy_integrity(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "consumer_id mismatch" in results[0].detail
 
     def test_pubsub_billing_caps_pass(self) -> None:
         """Pubsub release is capped by accepted delivery count and stream terms."""
@@ -1387,6 +1449,136 @@ class TestEmpicPaymentsValidators:
         assert len(results) == 1
         assert not results[0].passed
         assert "was not registered" in results[0].detail
+
+    def test_payment_participant_binding_passes(self) -> None:
+        """Lifecycle events keep the same payer, consumer, provider, service, and mode."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_acceptance_policy",
+                    "payment_ref": "p1",
+                    "service_id": "weather",
+                    "payer": "consumer",
+                    "consumer_id": "consumer",
+                    "provider": "provider",
+                    "mode": "pull",
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_debited",
+                    "payment_ref": "p1",
+                    "service_id": "weather",
+                    "payer": "consumer",
+                    "consumer_id": "consumer",
+                    "provider": "provider",
+                    "mode": "pull",
+                    "amount": 50,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "service_id": "weather",
+                    "payer": "consumer",
+                    "consumer_id": "consumer",
+                    "provider": "provider",
+                    "mode": "pull",
+                    "accepted": True,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "service_id": "weather",
+                    "payer": "consumer",
+                    "consumer_id": "consumer",
+                    "provider": "provider",
+                    "mode": "pull",
+                    "amount": 50,
+                }
+            ),
+        ]
+
+        results = validate_empic_payment_participant_binding(events)
+        assert len(results) == 1
+        assert results[0].passed
+
+    def test_payment_participant_binding_fails_rebound_ref(self) -> None:
+        """A payment ref cannot switch consumer/provider/service identity."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_escrow_debited",
+                    "payment_ref": "p1",
+                    "service_id": "weather",
+                    "payer": "consumer",
+                    "consumer_id": "consumer",
+                    "provider": "provider",
+                    "mode": "pull",
+                    "amount": 50,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "service_id": "weather",
+                    "payer": "attacker",
+                    "consumer_id": "attacker",
+                    "provider": "provider",
+                    "mode": "pull",
+                    "amount": 50,
+                }
+            ),
+        ]
+
+        results = validate_empic_payment_participant_binding(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "payer changed" in results[0].detail
+        assert "consumer_id changed" in results[0].detail
+
+    def test_no_secret_material_passes_public_metadata(self) -> None:
+        """Public wallet-style metadata can appear in traces."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_service_registered",
+                    "service_id": "weather",
+                    "provider": "provider",
+                    "wallet_address": "0x00000000000000000000000000000000000000aa",
+                    "did": "did:empic:test",
+                }
+            )
+        ]
+
+        results = validate_empic_no_secret_material(events)
+        assert len(results) == 1
+        assert results[0].passed
+
+    def test_no_secret_material_fails_private_key(self) -> None:
+        """Trace messages must not leak private keys or API secrets."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_service_registered",
+                    "service_id": "weather",
+                    "provider": "provider",
+                    "private_key": "-----BEGIN PRIVATE KEY-----\nredacted",
+                }
+            )
+        ]
+
+        results = validate_empic_no_secret_material(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "private_key" in results[0].detail
 
     def test_no_drain_after_close_fails(self) -> None:
         """Pubsub release after stream close is an attack."""

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -16,11 +16,17 @@ from nest_core.validators import (
     validate_consensus_agreement,
     validate_consensus_no_conflict,
     validate_consensus_validity,
+    validate_empic_all_escrows_terminal,
+    validate_empic_delivery_policy_integrity,
     validate_empic_escrow_conservation,
     validate_empic_invalid_delivery_not_paid,
+    validate_empic_max_spend_enforced,
     validate_empic_no_drain_after_close,
+    validate_empic_no_duplicate_settlement,
     validate_empic_no_overbill_on_partition,
     validate_empic_no_release_without_accepted_delivery,
+    validate_empic_provider_service_binding,
+    validate_empic_pubsub_billing_caps,
     validate_events,
     validate_marketplace_no_double_sell,
     validate_marketplace_price_agreement,
@@ -49,6 +55,38 @@ def _send(agent: str, to: str, msg: str, ts: float = 1.0) -> Event:
 def _empic(event: dict[str, Any], *, agent: str = "consumer", tick: int = 0) -> Event:
     body = {"type": "empic_audit", "tick": tick, **event}
     return _send(agent, agent, json.dumps(body, sort_keys=True), ts=float(tick))
+
+
+def _empic_delivery(
+    event: dict[str, Any],
+    *,
+    agent: str = "provider",
+    to: str = "consumer",
+    tick: int = 0,
+) -> Event:
+    body = {"type": "empic_delivery", **event}
+    return _send(agent, to, json.dumps(body, sort_keys=True), ts=float(tick))
+
+
+def _empic_weather_policy() -> dict[str, Any]:
+    return {
+        "required_fields": [
+            "temperature_c",
+            "temperature_f",
+            "windspeed_kmh",
+            "timestamp",
+            "tick",
+        ],
+        "numeric_ranges": {
+            "temperature_c": {"min": -50, "max": 60},
+            "temperature_f": {"min": -58, "max": 140},
+            "windspeed_kmh": {"min": 0, "max": 300},
+        },
+        "max_age_ticks": 3,
+        "bind_service_id": True,
+        "bind_provider_id": True,
+        "bind_request_params": True,
+    }
 
 
 def _broadcast(agent: str, msg: str, ts: float = 1.0) -> Event:
@@ -756,9 +794,9 @@ class TestEmpicPaymentsValidators:
     def test_conservation_passes(self) -> None:
         """Debited escrow equals released plus refunded funds."""
         events = [
-            _empic({"event_type": "empic_escrow_debited", "amount": 50}),
-            _empic({"event_type": "empic_escrow_released", "amount": 20}),
-            _empic({"event_type": "empic_escrow_refunded", "amount": 30}),
+            _empic({"event_type": "empic_escrow_debited", "payment_ref": "p1", "amount": 50}),
+            _empic({"event_type": "empic_escrow_released", "payment_ref": "p1", "amount": 20}),
+            _empic({"event_type": "empic_escrow_refunded", "payment_ref": "p1", "amount": 30}),
         ]
 
         results = validate_empic_escrow_conservation(events)
@@ -768,13 +806,28 @@ class TestEmpicPaymentsValidators:
     def test_conservation_fails(self) -> None:
         """Unaccounted escrow fails conservation."""
         events = [
-            _empic({"event_type": "empic_escrow_debited", "amount": 50}),
-            _empic({"event_type": "empic_escrow_released", "amount": 20}),
+            _empic({"event_type": "empic_escrow_debited", "payment_ref": "p1", "amount": 50}),
+            _empic({"event_type": "empic_escrow_released", "payment_ref": "p1", "amount": 20}),
         ]
 
         results = validate_empic_escrow_conservation(events)
         assert len(results) == 1
         assert not results[0].passed
+
+    def test_conservation_fails_per_payment_ref_cross_subsidy(self) -> None:
+        """Balanced totals still fail when one escrow subsidizes another."""
+        events = [
+            _empic({"event_type": "empic_escrow_debited", "payment_ref": "p1", "amount": 50}),
+            _empic({"event_type": "empic_escrow_debited", "payment_ref": "p2", "amount": 50}),
+            _empic({"event_type": "empic_escrow_released", "payment_ref": "p1", "amount": 70}),
+            _empic({"event_type": "empic_escrow_refunded", "payment_ref": "p2", "amount": 30}),
+        ]
+
+        results = validate_empic_escrow_conservation(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "p1" in results[0].detail
+        assert "p2" in results[0].detail
 
     def test_no_release_without_accepted_delivery(self) -> None:
         """Release must reference an accepted delivery id."""
@@ -782,6 +835,7 @@ class TestEmpicPaymentsValidators:
             _empic(
                 {
                     "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "p1",
                     "delivery_id": "d1",
                     "accepted": True,
                 }
@@ -806,6 +860,7 @@ class TestEmpicPaymentsValidators:
             _empic(
                 {
                     "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "p1",
                     "delivery_id": "d1",
                     "accepted": False,
                 }
@@ -830,6 +885,7 @@ class TestEmpicPaymentsValidators:
             _empic(
                 {
                     "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "p1",
                     "delivery_id": "d1",
                     "accepted": False,
                 }
@@ -837,6 +893,7 @@ class TestEmpicPaymentsValidators:
             _empic(
                 {
                     "event_type": "empic_escrow_released",
+                    "payment_ref": "p1",
                     "delivery_id": "d1",
                     "amount": 10,
                 }
@@ -846,6 +903,490 @@ class TestEmpicPaymentsValidators:
         results = validate_empic_invalid_delivery_not_paid(events)
         assert len(results) == 1
         assert not results[0].passed
+
+    def test_delivery_policy_integrity_passes(self) -> None:
+        """Accepted delivery must independently satisfy the declared policy."""
+        request_params = {"lat": 42.3601, "lon": -71.0942}
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_acceptance_policy",
+                    "payment_ref": "p1",
+                    "service_id": "weather",
+                    "provider": "provider",
+                    "request_params": request_params,
+                    "policy": _empic_weather_policy(),
+                }
+            ),
+            _empic_delivery(
+                {
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "service_id": "weather",
+                    "provider_id": "provider",
+                    "request_params": request_params,
+                    "data": {
+                        "temperature_c": 21.0,
+                        "temperature_f": 69.8,
+                        "windspeed_kmh": 8.0,
+                        "timestamp": "tick-1",
+                        "tick": 1,
+                    },
+                },
+                tick=1,
+            ),
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "accepted": True,
+                },
+                tick=1,
+            ),
+        ]
+
+        results = validate_empic_delivery_policy_integrity(events)
+        assert len(results) == 1
+        assert results[0].passed
+
+    def test_delivery_policy_integrity_fails_bad_data_accepted(self) -> None:
+        """Consumer acceptance cannot bless out-of-range weather data."""
+        request_params = {"lat": 42.3601, "lon": -71.0942}
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_acceptance_policy",
+                    "payment_ref": "p1",
+                    "service_id": "weather",
+                    "provider": "provider",
+                    "request_params": request_params,
+                    "policy": _empic_weather_policy(),
+                }
+            ),
+            _empic_delivery(
+                {
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "service_id": "weather",
+                    "provider_id": "provider",
+                    "request_params": request_params,
+                    "data": {
+                        "temperature_c": 120.0,
+                        "temperature_f": 248.0,
+                        "windspeed_kmh": 8.0,
+                        "timestamp": "tick-1",
+                        "tick": 1,
+                    },
+                },
+                tick=1,
+            ),
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "accepted": True,
+                },
+                tick=1,
+            ),
+        ]
+
+        results = validate_empic_delivery_policy_integrity(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "policy accepted=False" in results[0].detail
+
+    def test_delivery_policy_integrity_fails_wrong_service_provider_or_params(self) -> None:
+        """Provider/service/request binding must match the funded service."""
+        request_params = {"lat": 42.3601, "lon": -71.0942}
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_acceptance_policy",
+                    "payment_ref": "p1",
+                    "service_id": "weather",
+                    "provider": "provider",
+                    "request_params": request_params,
+                    "policy": _empic_weather_policy(),
+                }
+            ),
+            _empic_delivery(
+                {
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "service_id": "weather-spoof",
+                    "provider_id": "provider-spoof",
+                    "request_params": {"lat": 0, "lon": 0},
+                    "data": {
+                        "temperature_c": 21.0,
+                        "temperature_f": 69.8,
+                        "windspeed_kmh": 8.0,
+                        "timestamp": "tick-1",
+                        "tick": 1,
+                    },
+                },
+                tick=1,
+            ),
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "accepted": True,
+                },
+                tick=1,
+            ),
+        ]
+
+        results = validate_empic_delivery_policy_integrity(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "mismatch" in results[0].detail
+
+    def test_pubsub_billing_caps_pass(self) -> None:
+        """Pubsub release is capped by accepted delivery count and stream terms."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_stream_opened",
+                    "payment_ref": "s1",
+                    "rate_per_tick": 10,
+                    "max_total": 40,
+                    "mode": "pubsub",
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "s1",
+                    "delivery_id": "d1",
+                    "accepted": True,
+                    "mode": "pubsub",
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "s1",
+                    "delivery_id": "d1",
+                    "amount": 10,
+                    "mode": "pubsub",
+                }
+            ),
+        ]
+
+        results = validate_empic_pubsub_billing_caps(events)
+        assert len(results) == 1
+        assert results[0].passed
+
+    def test_pubsub_billing_caps_fails_over_rate(self) -> None:
+        """A single pubsub delivery cannot be paid above the tick rate."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_stream_opened",
+                    "payment_ref": "s1",
+                    "rate_per_tick": 10,
+                    "max_total": 40,
+                    "mode": "pubsub",
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "s1",
+                    "delivery_id": "d1",
+                    "accepted": True,
+                    "mode": "pubsub",
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "s1",
+                    "delivery_id": "d1",
+                    "amount": 20,
+                    "mode": "pubsub",
+                }
+            ),
+        ]
+
+        results = validate_empic_pubsub_billing_caps(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "release 20 > rate 10" in results[0].detail
+
+    def test_pubsub_billing_caps_fails_without_accepted_evidence(self) -> None:
+        """Accepted delivery count limits total pubsub payout."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_stream_opened",
+                    "payment_ref": "s1",
+                    "rate_per_tick": 10,
+                    "max_total": 40,
+                    "mode": "pubsub",
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "s1",
+                    "delivery_id": "d1",
+                    "amount": 10,
+                    "mode": "pubsub",
+                }
+            ),
+        ]
+
+        results = validate_empic_pubsub_billing_caps(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "accepted delivery cap 0" in results[0].detail
+
+    def test_max_spend_enforced_passes(self) -> None:
+        """Funded amount can equal but not exceed consumer max spend."""
+        policy = {**_empic_weather_policy(), "max_spend": 50}
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_acceptance_policy",
+                    "payment_ref": "p1",
+                    "policy": policy,
+                    "max_spend": 50,
+                }
+            ),
+            _empic({"event_type": "empic_escrow_debited", "payment_ref": "p1", "amount": 50}),
+        ]
+
+        results = validate_empic_max_spend_enforced(events)
+        assert len(results) == 1
+        assert results[0].passed
+
+    def test_max_spend_enforced_fails_over_budget_escrow(self) -> None:
+        """Escrow funding above the consumer budget fails validation."""
+        policy = {**_empic_weather_policy(), "max_spend": 40}
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_acceptance_policy",
+                    "payment_ref": "p1",
+                    "policy": policy,
+                    "max_spend": 40,
+                }
+            ),
+            _empic({"event_type": "empic_escrow_debited", "payment_ref": "p1", "amount": 50}),
+        ]
+
+        results = validate_empic_max_spend_enforced(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "exceeds declared max_spend" in results[0].detail
+
+    def test_max_spend_enforced_fails_over_budget_stream(self) -> None:
+        """Pubsub stream cap is checked against the consumer budget."""
+        policy = {**_empic_weather_policy(), "max_spend": 30}
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_acceptance_policy",
+                    "payment_ref": "s1",
+                    "policy": policy,
+                    "max_spend": 30,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_stream_opened",
+                    "payment_ref": "s1",
+                    "max_total": 40,
+                    "amount": 40,
+                    "mode": "pubsub",
+                }
+            ),
+        ]
+
+        results = validate_empic_max_spend_enforced(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "funded 40 exceeds" in results[0].detail
+
+    def test_all_escrows_terminal_passes(self) -> None:
+        """Every funded escrow is fully released or refunded."""
+        events = [
+            _empic({"event_type": "empic_escrow_debited", "payment_ref": "p1", "amount": 50}),
+            _empic({"event_type": "empic_escrow_released", "payment_ref": "p1", "amount": 50}),
+        ]
+
+        results = validate_empic_all_escrows_terminal(events)
+        assert len(results) == 1
+        assert results[0].passed
+
+    def test_all_escrows_terminal_fails_unbalanced(self) -> None:
+        """Partially settled escrow is not terminal."""
+        events = [
+            _empic({"event_type": "empic_escrow_debited", "payment_ref": "p1", "amount": 50}),
+            _empic({"event_type": "empic_escrow_released", "payment_ref": "p1", "amount": 10}),
+        ]
+
+        results = validate_empic_all_escrows_terminal(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "not terminal" in results[0].detail
+
+    def test_all_escrows_terminal_fails_pubsub_refund_without_close(self) -> None:
+        """Pubsub refund must correspond to an observed close."""
+        events = [
+            _empic({"event_type": "empic_stream_opened", "payment_ref": "s1", "mode": "pubsub"}),
+            _empic({"event_type": "empic_escrow_debited", "payment_ref": "s1", "amount": 40}),
+            _empic({"event_type": "empic_escrow_refunded", "payment_ref": "s1", "amount": 40}),
+        ]
+
+        results = validate_empic_all_escrows_terminal(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "without stream close" in results[0].detail
+
+    def test_no_duplicate_settlement_fails_duplicate_release(self) -> None:
+        """Replay of the same delivery evidence must be caught."""
+        events = [
+            _empic({"event_type": "empic_escrow_debited", "payment_ref": "p1", "amount": 50}),
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "accepted": True,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "amount": 25,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "p1",
+                    "delivery_id": "d1",
+                    "amount": 25,
+                }
+            ),
+        ]
+
+        results = validate_empic_no_duplicate_settlement(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "duplicate release" in results[0].detail
+
+    def test_no_duplicate_settlement_fails_duplicate_debit_and_refund(self) -> None:
+        """Payment refs cannot be debited or refunded twice."""
+        events = [
+            _empic({"event_type": "empic_escrow_debited", "payment_ref": "p1", "amount": 50}),
+            _empic({"event_type": "empic_escrow_debited", "payment_ref": "p1", "amount": 50}),
+            _empic({"event_type": "empic_escrow_refunded", "payment_ref": "p1", "amount": 25}),
+            _empic({"event_type": "empic_escrow_refunded", "payment_ref": "p1", "amount": 25}),
+        ]
+
+        results = validate_empic_no_duplicate_settlement(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "duplicate escrow debit" in results[0].detail
+        assert "duplicate refund" in results[0].detail
+
+    def test_provider_service_binding_passes(self) -> None:
+        """Debit and release bind to the registered provider for a service."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_service_registered",
+                    "service_id": "weather",
+                    "provider": "provider",
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_debited",
+                    "payment_ref": "p1",
+                    "service_id": "weather",
+                    "provider": "provider",
+                    "amount": 50,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "p1",
+                    "service_id": "weather",
+                    "provider": "provider",
+                    "delivery_id": "d1",
+                    "amount": 50,
+                }
+            ),
+        ]
+
+        results = validate_empic_provider_service_binding(events)
+        assert len(results) == 1
+        assert results[0].passed
+
+    def test_provider_service_binding_fails_wrong_provider(self) -> None:
+        """Settlement cannot redirect release to a different provider."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_service_registered",
+                    "service_id": "weather",
+                    "provider": "provider",
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_debited",
+                    "payment_ref": "p1",
+                    "service_id": "weather",
+                    "provider": "provider",
+                    "amount": 50,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "p1",
+                    "service_id": "weather",
+                    "provider": "attacker",
+                    "delivery_id": "d1",
+                    "amount": 50,
+                }
+            ),
+        ]
+
+        results = validate_empic_provider_service_binding(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "does not match" in results[0].detail
+
+    def test_provider_service_binding_fails_unregistered_service(self) -> None:
+        """Consumers cannot fund a service that has no provider registration."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_escrow_debited",
+                    "payment_ref": "p1",
+                    "service_id": "weather",
+                    "provider": "provider",
+                    "amount": 50,
+                }
+            ),
+        ]
+
+        results = validate_empic_provider_service_binding(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "was not registered" in results[0].detail
 
     def test_no_drain_after_close_fails(self) -> None:
         """Pubsub release after stream close is an attack."""

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -1564,13 +1564,14 @@ class TestEmpicPaymentsValidators:
 
     def test_no_secret_material_fails_private_key(self) -> None:
         """Trace messages must not leak private keys or API secrets."""
+        private_marker = "-----BEGIN " + "PRIVATE " + "KEY-----\nredacted"
         events = [
             _empic(
                 {
                     "event_type": "empic_service_registered",
                     "service_id": "weather",
                     "provider": "provider",
-                    "private_key": "-----BEGIN PRIVATE KEY-----\nredacted",
+                    "private_key": private_marker,
                 }
             )
         ]

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/empic_escrow.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/empic_escrow.py
@@ -1,0 +1,588 @@
+# SPDX-License-Identifier: Apache-2.0
+"""EMPIC-style escrow payments with pull and pubsub settlement.
+
+The plugin keeps Nanda Town's ``Payments`` protocol intact while exposing
+EMPIC-shaped lifecycle methods for scenarios that model providers, consumers,
+deliveries, and acceptance-gated release.
+
+Example::
+
+    payments = EMPICEscrowPayments(AgentId("consumer"), initial_balance=1000)
+    payments.register_service(
+        service_id=ServiceRef("weather"),
+        provider=AgentId("provider"),
+        price=Money(amount=50),
+    )
+    await payments.pay(AgentId("provider"), Money(amount=50), PaymentRef("p1"))
+    await payments.fulfill(PaymentRef("p1"))
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from nest_core.types import AgentId, Money, PaymentRef, PaymentStatus, Quote, Receipt, ServiceRef
+
+ESCROW_AGENT = AgentId("empic-escrow")
+DeliveryMode = Literal["pull", "pubsub"]
+
+
+@dataclass(frozen=True)
+class PubsubTerms:
+    """Subscription terms for an EMPIC-style pubsub service.
+
+    Example::
+
+        terms = PubsubTerms(rate_per_tick=10, max_total=100, min_valid_ratio=0.75)
+    """
+
+    rate_per_tick: int
+    max_total: int
+    duration_ticks: int
+    min_valid_ratio: float = 1.0
+    min_msg_count: int = 1
+    auto_renew: bool = False
+
+
+@dataclass(frozen=True)
+class EMPICServiceRecord:
+    """Provider service metadata registered with the payment adapter.
+
+    Example::
+
+        record = EMPICServiceRecord(
+            service_id=ServiceRef("weather"),
+            provider=AgentId("provider-0"),
+            provider_did="did:empic:sandbox:provider-0",
+            price=Money(amount=50),
+            delivery_modes=("pull", "pubsub"),
+        )
+    """
+
+    service_id: ServiceRef
+    provider: AgentId
+    provider_did: str
+    price: Money
+    delivery_modes: tuple[DeliveryMode, ...] = ("pull",)
+    schema: dict[str, Any] = field(default_factory=lambda: dict[str, Any]())
+    pubsub_terms: PubsubTerms | None = None
+    metadata: dict[str, Any] = field(default_factory=lambda: dict[str, Any]())
+
+
+@dataclass(frozen=True)
+class EMPICDeliveryRecord:
+    """Data delivery evidence observed for an escrow or stream.
+
+    Example::
+
+        delivery = EMPICDeliveryRecord(
+            delivery_id="d1",
+            ref=PaymentRef("p1"),
+            service_id=ServiceRef("weather"),
+            provider=AgentId("provider-0"),
+            mode="pull",
+            tick=3,
+            accepted=True,
+            data={"temperature_c": 20.0},
+        )
+    """
+
+    delivery_id: str
+    ref: PaymentRef
+    service_id: ServiceRef
+    provider: AgentId
+    mode: DeliveryMode
+    tick: int
+    accepted: bool
+    data: dict[str, Any] = field(default_factory=lambda: dict[str, Any]())
+    reason: str = ""
+
+
+@dataclass
+class EMPICPaymentRecord:
+    """Internal escrow state for pull payments and pubsub streams.
+
+    Example::
+
+        record = payments.payment_record(PaymentRef("p1"))
+        assert record.status is PaymentStatus.PENDING
+    """
+
+    ref: PaymentRef
+    payer: AgentId
+    payee: AgentId
+    amount: Money
+    mode: DeliveryMode
+    status: PaymentStatus
+    service_id: ServiceRef | None = None
+    escrow_id: str = ""
+    opened_at_tick: int = 0
+    closed_at_tick: int | None = None
+    rate_per_tick: int = 0
+    max_total: int = 0
+    escrowed: int = 0
+    released: int = 0
+    refunded: int = 0
+    deliveries: list[EMPICDeliveryRecord] = field(default_factory=list[EMPICDeliveryRecord])
+    billed_deliveries: set[str] = field(default_factory=set[str])
+    metadata: dict[str, Any] = field(default_factory=lambda: dict[str, Any]())
+
+
+class EMPICEscrowPayments:
+    """Deterministic EMPIC-shaped payment adapter for Nanda Town.
+
+    Pull payments escrow funds until a consumer accepts provider data and calls
+    ``fulfill``. Pubsub streams pre-fund a maximum amount, release one tick of
+    payment for each accepted delivery, and refund unused escrow on close.
+
+    Example::
+
+        pay = EMPICEscrowPayments(AgentId("buyer"), initial_balance=1000)
+        receipt = await pay.pay(AgentId("seller"), Money(amount=25), PaymentRef("p1"))
+        assert receipt.amount.amount == 25
+        assert await pay.verify_payment(PaymentRef("p1")) is PaymentStatus.PENDING
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        initial_balance: int = 1000,
+        balances: dict[AgentId, int] | None = None,
+        payments: dict[PaymentRef, EMPICPaymentRecord] | None = None,
+        services: dict[ServiceRef, EMPICServiceRecord] | None = None,
+    ) -> None:
+        self._agent_id = agent_id
+        self._balances = balances if balances is not None else {}
+        self._balances.setdefault(agent_id, initial_balance)
+        self._balances.setdefault(ESCROW_AGENT, 0)
+        self._payments = payments if payments is not None else {}
+        self._services = services if services is not None else {}
+
+    def balance(self, agent: AgentId) -> int:
+        """Return the local simulation balance for an agent.
+
+        Example::
+
+            assert payments.balance(AgentId("buyer")) >= 0
+        """
+        return self._balances.get(agent, 0)
+
+    def register_service(
+        self,
+        service_id: ServiceRef,
+        provider: AgentId,
+        price: Money,
+        *,
+        provider_did: str | None = None,
+        delivery_modes: tuple[DeliveryMode, ...] = ("pull",),
+        schema: dict[str, Any] | None = None,
+        pubsub_terms: PubsubTerms | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> EMPICServiceRecord:
+        """Register provider service metadata in the deterministic registry.
+
+        Example::
+
+            payments.register_service(ServiceRef("weather"), AgentId("p0"), Money(amount=50))
+        """
+        if price.amount <= 0:
+            msg = f"service price must be positive: {price.amount}"
+            raise ValueError(msg)
+        if not delivery_modes:
+            msg = "service must declare at least one delivery mode"
+            raise ValueError(msg)
+        if "pubsub" in delivery_modes and pubsub_terms is None:
+            msg = "pubsub services require pubsub_terms"
+            raise ValueError(msg)
+
+        record = EMPICServiceRecord(
+            service_id=service_id,
+            provider=provider,
+            provider_did=provider_did or f"did:empic:sandbox:{provider}",
+            price=price,
+            delivery_modes=delivery_modes,
+            schema=schema or {},
+            pubsub_terms=pubsub_terms,
+            metadata=metadata or {},
+        )
+        self._services[service_id] = record
+        self._balances.setdefault(provider, 0)
+        return record
+
+    def service_record(self, service_id: ServiceRef) -> EMPICServiceRecord | None:
+        """Return registered service metadata, if any.
+
+        Example::
+
+            service = payments.service_record(ServiceRef("weather"))
+        """
+        return self._services.get(service_id)
+
+    async def quote(self, service: ServiceRef) -> Quote:
+        """Quote a registered service, defaulting to ten credits if unknown.
+
+        Example::
+
+            quote = await payments.quote(ServiceRef("weather"))
+        """
+        record = self._services.get(service)
+        if record is None:
+            return Quote(service=service, price=Money(amount=10))
+        return Quote(
+            service=service,
+            price=record.price,
+            metadata={
+                "provider": str(record.provider),
+                "provider_did": record.provider_did,
+                "delivery_modes": list(record.delivery_modes),
+            },
+        )
+
+    async def pay(
+        self,
+        to: AgentId,
+        amount: Money,
+        ref: PaymentRef,
+        *,
+        service_id: ServiceRef | None = None,
+    ) -> Receipt:
+        """Create a pull escrow payment to a provider.
+
+        The payer's balance moves into the escrow account. Provider credit only
+        happens after ``fulfill``.
+
+        Example::
+
+            await payments.pay(
+                AgentId("provider"),
+                Money(amount=50),
+                PaymentRef("pull-1"),
+                service_id=ServiceRef("weather"),
+            )
+        """
+        self._validate_new_payment(to, amount.amount, ref)
+        self._move(self._agent_id, ESCROW_AGENT, amount.amount)
+        record = EMPICPaymentRecord(
+            ref=ref,
+            payer=self._agent_id,
+            payee=to,
+            amount=amount,
+            mode="pull",
+            status=PaymentStatus.PENDING,
+            service_id=service_id,
+            escrow_id=f"empic-pull:{ref}",
+            max_total=amount.amount,
+            escrowed=amount.amount,
+        )
+        self._payments[ref] = record
+        return Receipt(ref=ref, payer=self._agent_id, payee=to, amount=amount)
+
+    async def open_stream(
+        self,
+        to: AgentId,
+        rate_per_tick: int,
+        max_total: int,
+        ref: PaymentRef,
+        *,
+        service_id: ServiceRef | None = None,
+        opened_at_tick: int = 0,
+    ) -> EMPICPaymentRecord:
+        """Open a pubsub stream with pre-funded maximum escrow.
+
+        Example::
+
+            record = await payments.open_stream(
+                AgentId("provider"),
+                rate_per_tick=5,
+                max_total=25,
+                ref=PaymentRef("stream-1"),
+            )
+        """
+        if rate_per_tick <= 0:
+            msg = f"rate_per_tick must be positive: {rate_per_tick}"
+            raise ValueError(msg)
+        if max_total < rate_per_tick:
+            msg = f"max_total ({max_total}) must be >= rate_per_tick ({rate_per_tick})"
+            raise ValueError(msg)
+        self._validate_new_payment(to, max_total, ref)
+        self._move(self._agent_id, ESCROW_AGENT, max_total)
+        record = EMPICPaymentRecord(
+            ref=ref,
+            payer=self._agent_id,
+            payee=to,
+            amount=Money(amount=max_total),
+            mode="pubsub",
+            status=PaymentStatus.STREAMING,
+            service_id=service_id,
+            escrow_id=f"empic-pubsub:{ref}",
+            opened_at_tick=opened_at_tick,
+            rate_per_tick=rate_per_tick,
+            max_total=max_total,
+            escrowed=max_total,
+        )
+        self._payments[ref] = record
+        return record
+
+    def record_delivery(
+        self,
+        ref: PaymentRef,
+        *,
+        delivery_id: str,
+        service_id: ServiceRef,
+        provider: AgentId,
+        mode: DeliveryMode,
+        tick: int,
+        accepted: bool,
+        data: dict[str, Any] | None = None,
+        reason: str = "",
+    ) -> EMPICDeliveryRecord:
+        """Attach provider delivery evidence to an escrow record.
+
+        Example::
+
+            payments.record_delivery(
+                PaymentRef("p1"),
+                delivery_id="d1",
+                service_id=ServiceRef("weather"),
+                provider=AgentId("provider"),
+                mode="pull",
+                tick=2,
+                accepted=True,
+                data={"temperature_c": 20.0},
+            )
+        """
+        record = self._require_record(ref)
+        delivery = EMPICDeliveryRecord(
+            delivery_id=delivery_id,
+            ref=ref,
+            service_id=service_id,
+            provider=provider,
+            mode=mode,
+            tick=tick,
+            accepted=accepted,
+            data=data or {},
+            reason=reason,
+        )
+        record.deliveries.append(delivery)
+        return delivery
+
+    async def tick_stream(self, ref: PaymentRef, current_tick: int) -> bool:
+        """Release one pubsub tick for an accepted unbilled delivery.
+
+        Example::
+
+            still_open = await payments.tick_stream(PaymentRef("stream-1"), 3)
+        """
+        record = self._require_record(ref)
+        if record.mode != "pubsub":
+            msg = f"Payment is not a pubsub stream: {ref}"
+            raise ValueError(msg)
+        if record.closed_at_tick is not None or record.status is not PaymentStatus.STREAMING:
+            return False
+
+        delivery = self._next_billable_delivery(record, current_tick)
+        if delivery is None:
+            return True
+
+        amount = min(record.rate_per_tick, record.escrowed)
+        if amount <= 0:
+            record.closed_at_tick = current_tick
+            record.status = PaymentStatus.CONFIRMED
+            return False
+
+        self._move(ESCROW_AGENT, record.payee, amount)
+        record.escrowed -= amount
+        record.released += amount
+        record.billed_deliveries.add(delivery.delivery_id)
+
+        if record.escrowed == 0 or record.released >= record.max_total:
+            record.closed_at_tick = current_tick
+            record.status = PaymentStatus.CONFIRMED
+            return False
+        return True
+
+    async def close_stream(self, ref: PaymentRef, current_tick: int = 0) -> Receipt:
+        """Close a pubsub stream and refund unused escrow.
+
+        Example::
+
+            receipt = await payments.close_stream(PaymentRef("stream-1"), current_tick=10)
+        """
+        record = self._require_record(ref)
+        if record.mode != "pubsub":
+            msg = f"Payment is not a pubsub stream: {ref}"
+            raise ValueError(msg)
+        if record.closed_at_tick is None:
+            record.closed_at_tick = current_tick
+        if record.escrowed > 0:
+            self._move(ESCROW_AGENT, record.payer, record.escrowed)
+            record.refunded += record.escrowed
+            record.escrowed = 0
+        record.status = PaymentStatus.CONFIRMED if record.released > 0 else PaymentStatus.REFUNDED
+        return Receipt(
+            ref=ref,
+            payer=record.payer,
+            payee=record.payee,
+            amount=Money(amount=record.released),
+        )
+
+    async def fulfill(
+        self,
+        ref: PaymentRef,
+        evidence: EMPICDeliveryRecord | None = None,
+    ) -> Receipt:
+        """Release a pull escrow to the provider after acceptable delivery.
+
+        Example::
+
+            receipt = await payments.fulfill(PaymentRef("pull-1"))
+        """
+        record = self._require_record(ref)
+        if record.mode != "pull":
+            msg = f"Payment is not a pull escrow: {ref}"
+            raise ValueError(msg)
+        if record.status is not PaymentStatus.PENDING:
+            msg = f"Payment is not pending: {ref}"
+            raise ValueError(msg)
+        if evidence is None:
+            evidence = next(
+                (
+                    d
+                    for d in record.deliveries
+                    if d.accepted and self._delivery_matches_record(record, d)
+                ),
+                None,
+            )
+        if (
+            evidence is None
+            or not evidence.accepted
+            or not self._delivery_matches_record(record, evidence)
+        ):
+            msg = f"Cannot fulfill {ref}: no acceptable delivery evidence"
+            raise ValueError(msg)
+
+        amount = record.escrowed
+        self._move(ESCROW_AGENT, record.payee, amount)
+        record.escrowed = 0
+        record.released += amount
+        record.status = PaymentStatus.CONFIRMED
+        return Receipt(ref=ref, payer=record.payer, payee=record.payee, amount=Money(amount=amount))
+
+    async def reject(
+        self,
+        ref: PaymentRef,
+        *,
+        reason: str,
+        data_ref: str = "",
+    ) -> None:
+        """Reject provider data and refund the remaining escrow.
+
+        Example::
+
+            await payments.reject(PaymentRef("pull-1"), reason="temperature out of range")
+        """
+        record = self._require_record(ref)
+        record.metadata["reject_reason"] = reason
+        if data_ref:
+            record.metadata["data_ref"] = data_ref
+        await self.refund(ref)
+
+    async def verify_payment(self, ref: PaymentRef) -> PaymentStatus:
+        """Return the current payment or stream status.
+
+        Example::
+
+            assert await payments.verify_payment(PaymentRef("p1")) is PaymentStatus.PENDING
+        """
+        record = self._payments.get(ref)
+        if record is None:
+            return PaymentStatus.FAILED
+        return record.status
+
+    async def refund(self, ref: PaymentRef) -> None:
+        """Refund remaining escrow to the payer.
+
+        Example::
+
+            await payments.refund(PaymentRef("p1"))
+        """
+        record = self._require_record(ref)
+        if record.status in (PaymentStatus.CONFIRMED, PaymentStatus.REFUNDED):
+            msg = f"Payment already terminal: {ref}"
+            raise ValueError(msg)
+        if record.escrowed > 0:
+            self._move(ESCROW_AGENT, record.payer, record.escrowed)
+            record.refunded += record.escrowed
+            record.escrowed = 0
+        record.closed_at_tick = record.closed_at_tick if record.closed_at_tick is not None else 0
+        record.status = PaymentStatus.REFUNDED
+
+    def payment_record(self, ref: PaymentRef) -> EMPICPaymentRecord | None:
+        """Return internal EMPIC escrow state for inspection.
+
+        Example::
+
+            record = payments.payment_record(PaymentRef("p1"))
+        """
+        return self._payments.get(ref)
+
+    def _validate_new_payment(self, to: AgentId, amount: int, ref: PaymentRef) -> None:
+        if amount <= 0:
+            msg = f"Payment amount must be positive: {amount}"
+            raise ValueError(msg)
+        if ref in self._payments:
+            msg = f"Duplicate payment reference: {ref}"
+            raise ValueError(msg)
+        payer_balance = self._balances.get(self._agent_id, 0)
+        if payer_balance < amount:
+            msg = f"Insufficient balance: {payer_balance} < {amount}"
+            raise ValueError(msg)
+        self._balances.setdefault(to, 0)
+
+    def _require_record(self, ref: PaymentRef) -> EMPICPaymentRecord:
+        record = self._payments.get(ref)
+        if record is None:
+            msg = f"Payment not found: {ref}"
+            raise ValueError(msg)
+        return record
+
+    def _move(self, src: AgentId, dst: AgentId, amount: int) -> None:
+        if amount < 0:
+            msg = f"Cannot move negative amount: {amount}"
+            raise ValueError(msg)
+        if self._balances.get(src, 0) < amount:
+            msg = f"Insufficient balance for {src}: {self._balances.get(src, 0)} < {amount}"
+            raise ValueError(msg)
+        self._balances[src] = self._balances.get(src, 0) - amount
+        self._balances[dst] = self._balances.get(dst, 0) + amount
+
+    def _next_billable_delivery(
+        self,
+        record: EMPICPaymentRecord,
+        current_tick: int,
+    ) -> EMPICDeliveryRecord | None:
+        for delivery in record.deliveries:
+            if delivery.delivery_id in record.billed_deliveries:
+                continue
+            if not delivery.accepted:
+                continue
+            if not self._delivery_matches_record(record, delivery):
+                continue
+            if delivery.tick != current_tick:
+                continue
+            return delivery
+        return None
+
+    def _delivery_matches_record(
+        self,
+        record: EMPICPaymentRecord,
+        delivery: EMPICDeliveryRecord,
+    ) -> bool:
+        if delivery.ref != record.ref:
+            return False
+        if delivery.provider != record.payee:
+            return False
+        if delivery.mode != record.mode:
+            return False
+        return record.service_id is None or delivery.service_id == record.service_id

--- a/packages/nest-plugins-reference/tests/test_empic_escrow_payments.py
+++ b/packages/nest-plugins-reference/tests/test_empic_escrow_payments.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for EMPIC-style escrow payments."""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.types import AgentId, Money, PaymentRef, PaymentStatus, ServiceRef
+from nest_plugins_reference.payments.empic_escrow import (
+    ESCROW_AGENT,
+    EMPICEscrowPayments,
+    PubsubTerms,
+)
+
+
+@pytest.fixture
+def payments() -> EMPICEscrowPayments:
+    """Create a consumer payment handle with deterministic balance."""
+    return EMPICEscrowPayments(AgentId("consumer"), initial_balance=1000)
+
+
+@pytest.mark.asyncio
+async def test_pull_escrow_fulfills_after_accepted_delivery(
+    payments: EMPICEscrowPayments,
+) -> None:
+    """Pull escrow releases funds only after accepted delivery evidence."""
+    await payments.pay(AgentId("provider"), Money(amount=50), PaymentRef("pull-1"))
+
+    assert payments.balance(AgentId("consumer")) == 950
+    assert payments.balance(ESCROW_AGENT) == 50
+    assert payments.balance(AgentId("provider")) == 0
+    assert await payments.verify_payment(PaymentRef("pull-1")) is PaymentStatus.PENDING
+
+    delivery = payments.record_delivery(
+        PaymentRef("pull-1"),
+        delivery_id="d1",
+        service_id=ServiceRef("weather"),
+        provider=AgentId("provider"),
+        mode="pull",
+        tick=1,
+        accepted=True,
+        data={"temperature_c": 20.0},
+    )
+    receipt = await payments.fulfill(PaymentRef("pull-1"), delivery)
+
+    assert receipt.amount.amount == 50
+    assert payments.balance(ESCROW_AGENT) == 0
+    assert payments.balance(AgentId("provider")) == 50
+    assert await payments.verify_payment(PaymentRef("pull-1")) is PaymentStatus.CONFIRMED
+
+
+@pytest.mark.asyncio
+async def test_pull_escrow_reject_refunds_consumer(payments: EMPICEscrowPayments) -> None:
+    """Rejected pull delivery returns escrow to the consumer."""
+    await payments.pay(AgentId("provider"), Money(amount=50), PaymentRef("pull-1"))
+    payments.record_delivery(
+        PaymentRef("pull-1"),
+        delivery_id="d1",
+        service_id=ServiceRef("weather"),
+        provider=AgentId("provider"),
+        mode="pull",
+        tick=1,
+        accepted=False,
+        reason="missing field",
+    )
+
+    await payments.reject(PaymentRef("pull-1"), reason="missing field", data_ref="d1")
+
+    assert payments.balance(AgentId("consumer")) == 1000
+    assert payments.balance(AgentId("provider")) == 0
+    assert payments.balance(ESCROW_AGENT) == 0
+    assert await payments.verify_payment(PaymentRef("pull-1")) is PaymentStatus.REFUNDED
+
+
+@pytest.mark.asyncio
+async def test_pull_fulfill_rejects_mismatched_delivery(
+    payments: EMPICEscrowPayments,
+) -> None:
+    """Accepted evidence must match the escrow payee and service."""
+    await payments.pay(
+        AgentId("provider"),
+        Money(amount=50),
+        PaymentRef("pull-1"),
+        service_id=ServiceRef("weather"),
+    )
+    delivery = payments.record_delivery(
+        PaymentRef("pull-1"),
+        delivery_id="d1",
+        service_id=ServiceRef("weather"),
+        provider=AgentId("attacker"),
+        mode="pull",
+        tick=1,
+        accepted=True,
+    )
+
+    with pytest.raises(ValueError, match="no acceptable delivery evidence"):
+        await payments.fulfill(PaymentRef("pull-1"), delivery)
+
+    assert payments.balance(ESCROW_AGENT) == 50
+    assert payments.balance(AgentId("provider")) == 0
+
+
+@pytest.mark.asyncio
+async def test_pubsub_stream_bills_only_accepted_deliveries(
+    payments: EMPICEscrowPayments,
+) -> None:
+    """Pubsub stream releases one tick for each accepted delivery."""
+    await payments.open_stream(
+        AgentId("provider"),
+        rate_per_tick=10,
+        max_total=40,
+        ref=PaymentRef("stream-1"),
+        service_id=ServiceRef("weather"),
+    )
+    assert payments.balance(AgentId("consumer")) == 960
+    assert payments.balance(ESCROW_AGENT) == 40
+
+    payments.record_delivery(
+        PaymentRef("stream-1"),
+        delivery_id="d1",
+        service_id=ServiceRef("weather"),
+        provider=AgentId("provider"),
+        mode="pubsub",
+        tick=1,
+        accepted=True,
+    )
+    payments.record_delivery(
+        PaymentRef("stream-1"),
+        delivery_id="d2",
+        service_id=ServiceRef("weather"),
+        provider=AgentId("provider"),
+        mode="pubsub",
+        tick=2,
+        accepted=False,
+    )
+
+    assert await payments.tick_stream(PaymentRef("stream-1"), 1)
+    assert await payments.tick_stream(PaymentRef("stream-1"), 2)
+
+    assert payments.balance(AgentId("provider")) == 10
+    assert payments.balance(ESCROW_AGENT) == 30
+    record = payments.payment_record(PaymentRef("stream-1"))
+    assert record is not None
+    assert record.released == 10
+
+
+@pytest.mark.asyncio
+async def test_pubsub_stream_does_not_bill_wrong_service(
+    payments: EMPICEscrowPayments,
+) -> None:
+    """Accepted pubsub deliveries must match the stream service binding."""
+    await payments.open_stream(
+        AgentId("provider"),
+        rate_per_tick=10,
+        max_total=40,
+        ref=PaymentRef("stream-1"),
+        service_id=ServiceRef("weather"),
+    )
+    payments.record_delivery(
+        PaymentRef("stream-1"),
+        delivery_id="d1",
+        service_id=ServiceRef("other-weather"),
+        provider=AgentId("provider"),
+        mode="pubsub",
+        tick=1,
+        accepted=True,
+    )
+
+    assert await payments.tick_stream(PaymentRef("stream-1"), 1)
+    assert payments.balance(AgentId("provider")) == 0
+    assert payments.balance(ESCROW_AGENT) == 40
+
+
+@pytest.mark.asyncio
+async def test_close_stream_refunds_unused_escrow(payments: EMPICEscrowPayments) -> None:
+    """Closing a stream refunds all unspent escrow."""
+    await payments.open_stream(
+        AgentId("provider"),
+        rate_per_tick=10,
+        max_total=40,
+        ref=PaymentRef("stream-1"),
+    )
+    payments.record_delivery(
+        PaymentRef("stream-1"),
+        delivery_id="d1",
+        service_id=ServiceRef("weather"),
+        provider=AgentId("provider"),
+        mode="pubsub",
+        tick=1,
+        accepted=True,
+    )
+    await payments.tick_stream(PaymentRef("stream-1"), 1)
+    receipt = await payments.close_stream(PaymentRef("stream-1"), current_tick=4)
+
+    assert receipt.amount.amount == 10
+    assert payments.balance(AgentId("consumer")) == 990
+    assert payments.balance(AgentId("provider")) == 10
+    assert payments.balance(ESCROW_AGENT) == 0
+    assert await payments.verify_payment(PaymentRef("stream-1")) is PaymentStatus.CONFIRMED
+
+
+@pytest.mark.asyncio
+async def test_duplicate_refs_and_insufficient_balance(payments: EMPICEscrowPayments) -> None:
+    """Duplicate references and over-budget escrow are rejected."""
+    await payments.pay(AgentId("provider"), Money(amount=50), PaymentRef("pull-1"))
+
+    with pytest.raises(ValueError, match="Duplicate"):
+        await payments.open_stream(
+            AgentId("provider"),
+            rate_per_tick=10,
+            max_total=20,
+            ref=PaymentRef("pull-1"),
+        )
+
+    with pytest.raises(ValueError, match="Insufficient balance"):
+        await payments.open_stream(
+            AgentId("provider"),
+            rate_per_tick=10,
+            max_total=5000,
+            ref=PaymentRef("stream-1"),
+        )
+
+
+def test_register_service_requires_pubsub_terms(payments: EMPICEscrowPayments) -> None:
+    """Pubsub service metadata must carry pubsub terms."""
+    with pytest.raises(ValueError, match="pubsub_terms"):
+        payments.register_service(
+            service_id=ServiceRef("weather"),
+            provider=AgentId("provider"),
+            price=Money(amount=10),
+            delivery_modes=("pubsub",),
+        )
+
+    record = payments.register_service(
+        service_id=ServiceRef("weather"),
+        provider=AgentId("provider"),
+        price=Money(amount=10),
+        delivery_modes=("pull", "pubsub"),
+        pubsub_terms=PubsubTerms(rate_per_tick=2, max_total=10, duration_ticks=5),
+    )
+    assert record.provider_did == "did:empic:sandbox:provider"

--- a/scenarios/empic_payments.yaml
+++ b/scenarios/empic_payments.yaml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# EMPIC-style weather payments: pull escrow plus pubsub metered delivery.
+
+name: empic_payments
+description: |
+  Consumers and providers trade weather data with EMPIC-shaped escrow.
+  Pull requests release only after acceptable data. Pubsub releases one
+  tick of payment for each accepted delivery and refunds unused escrow.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 10
+  brain: state-machine
+  roles:
+    - name: provider
+      count: 5
+      config:
+        initial_balance: 1000
+    - name: consumer
+      count: 5
+      config:
+        initial_balance: 1000
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: empic_escrow
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: empic_payments
+  config:
+    max_age_ticks: 3
+    acceptance_policy:
+      required_fields:
+        - temperature_c
+        - temperature_f
+        - windspeed_kmh
+        - timestamp
+        - tick
+      numeric_ranges:
+        temperature_c:
+          min: -50
+          max: 60
+        temperature_f:
+          min: -58
+          max: 140
+        windspeed_kmh:
+          min: 0
+          max: 300
+      bind_service_id: true
+      bind_provider_id: true
+      bind_request_params: true
+      max_age_ticks: 3
+      max_spend: 100
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 2000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/empic_payments.jsonl

--- a/scenarios/empic_payments_partition.yaml
+++ b/scenarios/empic_payments_partition.yaml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# EMPIC pubsub partition: consumer and provider cannot exchange deliveries.
+
+name: empic_payments_partition
+description: |
+  The pubsub consumer opens escrow, but a network partition prevents provider
+  deliveries from reaching it. The stream must close and refund unused escrow
+  without releasing payment after the partition is observed.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 10
+  brain: state-machine
+  roles:
+    - name: provider
+      count: 5
+    - name: consumer
+      count: 5
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: empic_escrow
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: empic_payments
+  config:
+    max_age_ticks: 3
+    acceptance_policy:
+      required_fields:
+        - temperature_c
+        - temperature_f
+        - windspeed_kmh
+        - timestamp
+        - tick
+      numeric_ranges:
+        temperature_c:
+          min: -50
+          max: 60
+        temperature_f:
+          min: -58
+          max: 140
+        windspeed_kmh:
+          min: 0
+          max: 300
+      bind_service_id: true
+      bind_provider_id: true
+      bind_request_params: true
+      max_age_ticks: 3
+      max_spend: 100
+
+failures:
+  message_drop: 0.0
+  network_partition:
+    groups:
+      - [consumer-4]
+      - [provider-4]
+  byzantine_agents: 0.0
+
+duration: "ticks: 2000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/empic_payments_partition.jsonl


### PR DESCRIPTION
Note: This Step 1 PR is linked to this Step 2 skill: http://edgemicropayments.ddns.net:8099/skill.md

## Summary

Adds `EMPICEscrowPayments`, a deterministic EMPIC-inspired payments plugin registered as `empic_escrow`.

The plugin preserves the existing `Payments` protocol while adding EMPIC-style escrow behavior for provider service registration, pull delivery, pubsub streaming, consumer acceptance policy, escrow release, and refund.

## Problem Addressed

NANDA Town's current payments layer can model simple prepaid transfers, but it does not model evidence-gated settlement for metered data services. This contribution lets NANDA Town test whether autonomous consumers and providers can coordinate around paid data delivery under adversarial conditions.

## What Changed

- Added `EMPICEscrowPayments`
- Registered `empic_escrow` as a built-in payments plugin
- Added EMPIC weather-data market scenarios
- Added pull escrow flow: quote, pay/fund escrow, delivery, accept/reject, fulfill/refund
- Added pubsub streaming flow: open stream, record delivery, bill valid ticks only, close stream
- Added declarative consumer acceptance policy
- Added adversarial cases for malformed data, wrong provider/service/consumer binding, stale delivery, invalid numeric ranges, drain-after-close, partition overbilling, and secret leakage
- Added validators for ledger conservation, release safety, participant binding, close behavior, partition billing, and no secret material in traces

## Duplicate-Work Check

I reviewed PRs #2-#11 and later related payments PRs, including PR #38.

The nearest related submissions are PR #7, `htlc_escrow`, and PR #38, `escrow`.

PR #7 implements hash/time-locked conditional payments as a primitive. PR #38 implements a generic arbitrated escrow state machine with payer/payee/arbiter roles, delivery acknowledgement, dispute, arbitration, release, and refund.

This PR is distinct: it models EMPIC-style escrowed data-service settlement with provider service registration, consumer/provider/service binding, declarative acceptance policy, pull and pubsub delivery modes, metered billing for valid delivery evidence, and adversarial trace validators for invalid delivery, wrong bindings, drain-after-close, partition overbilling, and secret leakage.

In short:

```text
PR #7: HTLC escrow primitive
PR #38: generic arbitrated escrow primitive
This PR: evidence-gated data-service settlement protocol
```

## Determinism

All Step 1 behavior is deterministic and in-memory. There are no live EMPIC services, wallets, network calls, secrets, Base Sepolia dependencies, Stripe dependencies, Coinbase dependencies, or local EMPIC repo dependencies.

## Validation

`make ci-local` passed.

Result:

```text
uv sync
uv run ruff check .
uv run ruff format --check .
uv run pyright
uv run pytest -v

581 passed, 1 skipped, 1 deselected
The skipped test is the existing optional matplotlib plotting test.