### PR TITLE
[Hackathon] PBFT coordination: BFT consensus, view-change, adversaria…

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -30,6 +30,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
     ("coordination", "contract_net"): f"{_REF}.coordination.contract_net:ContractNet",
+    ("coordination", "pbft"): f"{_REF}.coordination.pbft:PbftCoordination",
     ("negotiation", "alternating_offers"): (
         f"{_REF}.negotiation.alternating_offers:AlternatingOffers"
     ),

--- a/packages/nest-plugins-reference/nest_plugins_reference/coordination/pbft.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/coordination/pbft.py
@@ -1,0 +1,650 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PBFT coordination plugin — Castro-Liskov Byzantine fault-tolerant consensus.
+
+Persona note (distributed-systems engineer): the property I am paid to defend is
+*agreement under a lying minority* — with up to ``f`` byzantine replicas out of
+``3f+1``, no two honest replicas commit different values for the same slot. The
+default :class:`~nest_plugins_reference.coordination.contract_net.ContractNet`
+is a single-round bid; it has no quorum, no signatures, and no notion of a
+conflicting commit, so it cannot even represent the failure I care about.
+
+This module implements the **happy-path** core of PBFT: the three-phase
+pre-prepare / prepare / commit pipeline, gated by ``2f+1`` quorums of
+*signed* votes. View-change (leader failure recovery) is intentionally deferred
+to a later iteration; what ships here is the agreement core and its quorum
+certificates, which the existing ``consensus`` scenario can drive.
+
+The safety argument, in one sentence: any two quorums of ``2f+1`` out of
+``3f+1`` replicas intersect in at least one honest replica, and an honest
+replica signs only one value per ``(view, seq)`` slot — so two conflicting
+commit certificates cannot both exist.
+
+Votes are signed with the identity layer (``did_key``). An unsigned vote is
+worthless here: a byzantine agent could otherwise fabricate "replica 3 voted V"
+out of thin air. A quorum certificate is therefore a *set of signatures from
+distinct agents*, each verifiable against that agent's public key.
+
+Example::
+
+    leader = PbftCoordination(AgentId("r0"), identity=id0, n=4)
+    rnd = await leader.propose(Task(id="t1", description="agree on X"))
+    vote = await replica.participate(rnd)
+    outcome = await leader.resolve(rnd)
+    await leader.commit(outcome)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from nest_core.types import (
+    AgentId,
+    Outcome,
+    Round,
+    Signature,
+    Task,
+    Vote,
+)
+
+#: Phase tags. ``prepare`` and ``commit`` are the two voting phases; the
+#: happy-path engine collects both kinds of signed vote into the Round.
+PHASE_PRE_PREPARE = "pre-prepare"
+PHASE_PREPARE = "prepare"
+PHASE_COMMIT = "commit"
+PHASE_VIEW_CHANGE = "view-change"
+PHASE_NEW_VIEW = "new-view"
+
+
+def quorum_size(n: int) -> int:
+    """Return the PBFT quorum threshold ``2f+1`` for ``n = 3f+1`` replicas.
+
+    With ``f = (n - 1) // 3`` byzantine tolerance, a quorum is ``2f + 1``. Any
+    two such quorums intersect in at least one honest replica — the core of the
+    safety argument.
+
+    Example::
+
+        quorum_size(4)  # f=1 -> 3
+        quorum_size(7)  # f=2 -> 5
+    """
+    f = (n - 1) // 3
+    return 2 * f + 1
+
+
+def fault_tolerance(n: int) -> int:
+    """Return ``f``, the number of byzantine replicas tolerated for ``n`` total.
+
+    Example::
+
+        fault_tolerance(4)  # -> 1
+        fault_tolerance(7)  # -> 2
+    """
+    return (n - 1) // 3
+
+
+def leader_for_view(view: int, n: int) -> int:
+    """Return the index of the leader (primary) for ``view``, round-robin.
+
+    Example::
+
+        leader_for_view(0, 4)  # -> 0
+        leader_for_view(5, 4)  # -> 1
+    """
+    return view % n
+
+
+def signing_payload(view: int, seq: int, phase: str, value: str) -> bytes:
+    """Canonical bytes a vote signature is computed over.
+
+    Binding all four fields means a signature for ``(v, n, prepare, V)`` cannot
+    be replayed as a vote for a different view, sequence, phase, or value.
+
+    Example::
+
+        signing_payload(0, 1, "prepare", "X")
+    """
+    return json.dumps(
+        {"view": view, "seq": seq, "phase": phase, "value": value},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def view_change_payload(
+    new_view: int, agent: AgentId, prepared: dict[int, dict[str, Any]]
+) -> bytes:
+    """Canonical bytes a view-change message is signed over.
+
+    Binds the target ``new_view``, the requesting ``agent``, and a digest of the
+    agent's prepared set, so a view-change vote cannot be forged for another
+    agent or replayed for a different view.
+
+    Example::
+
+        view_change_payload(1, AgentId("r1"), {1: {"view": 0, "value": "X"}})
+    """
+    digest = sorted((seq, str(p["view"]), str(p["value"])) for seq, p in prepared.items())
+    return json.dumps(
+        {"new_view": new_view, "agent": str(agent), "prepared": digest},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class SignedVote:
+    """A single replica's signed vote in one phase of one slot.
+
+    Example::
+
+        sv = SignedVote(voter=AgentId("r1"), view=0, seq=1, phase="prepare",
+                        value="X", signature=sig)
+    """
+
+    voter: AgentId
+    view: int
+    seq: int
+    phase: str
+    value: str
+    signature: Signature
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Serialize to a JSON-friendly dict for storage in ``round.metadata``.
+
+        Example::
+
+            round.metadata["votes"].append(sv.to_metadata())
+        """
+        return {
+            "voter": str(self.voter),
+            "view": self.view,
+            "seq": self.seq,
+            "phase": self.phase,
+            "value": self.value,
+            "sig_value": self.signature.value.hex(),
+            "sig_algorithm": self.signature.algorithm,
+        }
+
+    @classmethod
+    def from_metadata(cls, data: dict[str, Any]) -> SignedVote:
+        """Rebuild a :class:`SignedVote` from its stored metadata dict.
+
+        Example::
+
+            sv = SignedVote.from_metadata(round.metadata["votes"][0])
+        """
+        return cls(
+            voter=AgentId(str(data["voter"])),
+            view=int(data["view"]),
+            seq=int(data["seq"]),
+            phase=str(data["phase"]),
+            value=str(data["value"]),
+            signature=Signature(
+                signer=AgentId(str(data["voter"])),
+                value=bytes.fromhex(str(data["sig_value"])),
+                algorithm=str(data["sig_algorithm"]),
+            ),
+        )
+
+
+def value_for_task(task: Task) -> str:
+    """Derive the deterministic value the replicas agree on from a task.
+
+    The task *is* the client request in this rig; agreeing on a stable digest
+    of it keeps the trace byte-identical across runs with the same seed.
+
+    Example::
+
+        value_for_task(Task(id="t1", description="x"))  # -> "t1:x"
+    """
+    return f"{task.id}:{task.description}"
+
+
+class PbftCoordination:
+    """Castro-Liskov PBFT coordination (happy-path core).
+
+    One instance per agent. ``identity`` is the agent's ``did_key`` plugin, used
+    to sign its own votes and verify peers'. ``n`` is the total replica count
+    (``3f+1``); the quorum ``2f+1`` is derived from it.
+
+    Example::
+
+        coord = PbftCoordination(AgentId("r0"), identity=id0, n=4)
+        rnd = await coord.propose(Task(id="t1", description="agree on X"))
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        identity: Any = None,
+        n: int = 4,
+        view: int = 0,
+        replicas: list[AgentId] | None = None,
+    ) -> None:
+        self._agent_id = agent_id
+        self._identity = identity
+        self._n = n
+        self._view = view
+        self._seq = 0
+        self._replicas = sorted(replicas) if replicas else []
+        # Committed certificates, keyed by (view, seq), recorded at commit time.
+        self._committed: dict[tuple[int, int], list[dict[str, Any]]] = {}
+        # Highest prepared value per seq: seq -> (view, value, prepare-proof).
+        # A replica is "prepared" once it has seen a 2f+1 prepare-quorum; this is
+        # the evidence it carries into a view-change so a committed value can't
+        # be dropped by the next leader.
+        self._prepared: dict[int, dict[str, Any]] = {}
+
+    async def propose(self, task: Task) -> Round:
+        """Leader pre-prepare: fix the slot, choose the value, sign, broadcast.
+
+        Creates the Round that carries the protocol state between agents. The
+        signed pre-prepare is written to ``round.metadata["pre_prepare"]`` so
+        every replica can verify it came from the rightful leader for this view.
+
+        Example::
+
+            rnd = await coord.propose(Task(id="t1", description="x"))
+        """
+        self._seq += 1
+        seq = self._seq
+        value = value_for_task(task)
+        payload = signing_payload(self._view, seq, PHASE_PRE_PREPARE, value)
+        signature = self._identity.sign(payload)
+
+        rnd = Round(
+            id=f"v{self._view}-n{seq}",
+            task=task,
+            participants=[self._agent_id],
+            metadata={
+                "view": self._view,
+                "seq": seq,
+                "n": self._n,
+                "quorum": quorum_size(self._n),
+                "value": value,
+                "leader": str(self._agent_id),
+                "replicas": [str(r) for r in self._replicas] or [str(self._agent_id)],
+                "pre_prepare": {
+                    "view": self._view,
+                    "seq": seq,
+                    "value": value,
+                    "proposer": str(self._agent_id),
+                    "sig_value": signature.value.hex(),
+                    "sig_algorithm": signature.algorithm,
+                },
+                "votes": [],
+            },
+        )
+        return rnd
+
+    def _verify_pre_prepare(self, round: Round) -> bool:
+        """Return True iff the Round's pre-prepare is from the rightful, signed leader.
+
+        Two independent checks: the proposer must be the round-robin leader for
+        the view, and the leader's signature over the pre-prepare payload must
+        verify against the leader's known public key. A replica that cannot
+        verify (unknown key, bad signature, wrong proposer) must not vote.
+
+        Example::
+
+            if coord._verify_pre_prepare(rnd): ...
+        """
+        meta = round.metadata
+        pp = meta.get("pre_prepare")
+        if not pp:
+            return False
+        view = int(meta["view"])
+        seq = int(meta["seq"])
+        n = int(meta["n"])
+        value = str(meta["value"])
+        proposer = AgentId(str(pp["proposer"]))
+
+        # (a) proposer must be the rightful leader for this view.
+        participants = self._participant_index(round)
+        expected_leader_idx = leader_for_view(view, n)
+        if participants.get(proposer) != expected_leader_idx:
+            return False
+
+        # (b) the leader's signature must verify.
+        sig = Signature(
+            signer=proposer,
+            value=bytes.fromhex(str(pp["sig_value"])),
+            algorithm=str(pp["sig_algorithm"]),
+        )
+        payload = signing_payload(view, seq, PHASE_PRE_PREPARE, value)
+        return bool(self._identity.verify(payload, sig, proposer))
+
+    def _participant_index(self, round: Round) -> dict[AgentId, int]:
+        """Map each replica id to its stable index for leader-election math.
+
+        Uses the sorted ``replicas`` list recorded on the round (or the leader
+        plus participants as a fallback), so every agent computes the same
+        leader for a given view without global mutable state.
+
+        Example::
+
+            idx = coord._participant_index(rnd)
+        """
+        replicas = round.metadata.get("replicas")
+        if replicas:
+            ids = [AgentId(str(r)) for r in replicas]
+        else:
+            ids = sorted({AgentId(str(round.metadata["leader"]))} | set(round.participants))
+        return {aid: i for i, aid in enumerate(sorted(ids))}
+
+    async def participate(self, round: Round) -> Vote:
+        """Replica step: verify the pre-prepare, then cast a signed prepare vote.
+
+        On the happy path a replica that accepts the pre-prepare signs
+        ``(view, seq, prepare, value)`` and appends the vote to
+        ``round.metadata["votes"]``. If the pre-prepare cannot be verified, the
+        replica abstains (an empty-value vote) rather than endorsing it.
+
+        Example::
+
+            vote = await coord.participate(rnd)
+        """
+        meta = round.metadata
+        view = int(meta["view"])
+        seq = int(meta["seq"])
+        value = str(meta["value"])
+
+        if not self._verify_pre_prepare(round):
+            return Vote(
+                voter=self._agent_id,
+                round_id=round.id,
+                value="",
+                metadata={"abstain": True},
+            )
+
+        payload = signing_payload(view, seq, PHASE_PREPARE, value)
+        signature = self._identity.sign(payload)
+        sv = SignedVote(
+            voter=self._agent_id,
+            view=view,
+            seq=seq,
+            phase=PHASE_PREPARE,
+            value=value,
+            signature=signature,
+        )
+        votes: list[dict[str, Any]] = meta.setdefault("votes", [])
+        votes.append(sv.to_metadata())
+        if self._agent_id not in round.participants:
+            round.participants.append(self._agent_id)
+        return Vote(voter=self._agent_id, round_id=round.id, value=value)
+
+    def _verify_vote(self, sv: SignedVote) -> bool:
+        """Return True iff a vote's signature verifies against the voter's key.
+
+        Independent of how the vote arrived: ``resolve`` trusts nothing that was
+        merely *placed* in the metadata, only what cryptographically verifies.
+        This is what stops a byzantine agent from fabricating a quorum.
+
+        Example::
+
+            ok = coord._verify_vote(sv)
+        """
+        payload = signing_payload(sv.view, sv.seq, sv.phase, sv.value)
+        return bool(self._identity.verify(payload, sv.signature, sv.voter))
+
+    async def resolve(self, round: Round) -> Outcome:
+        """Count independently-verified votes; commit a value iff it has a quorum.
+
+        Every stored vote is re-verified here (not trusted from when it was
+        cast). Valid votes are grouped by value, counting *distinct* voters; a
+        value reaching ``2f+1`` distinct verified voters commits, and exactly
+        those signed votes form the commit quorum certificate on the Outcome. If
+        no value reaches quorum, the Outcome has no winner.
+
+        Example::
+
+            outcome = await coord.resolve(rnd)
+        """
+        meta = round.metadata
+        quorum = int(meta["quorum"])
+
+        # Group verified votes by value, one vote per (voter, value).
+        by_value: dict[str, dict[AgentId, dict[str, Any]]] = {}
+        for raw in meta.get("votes", []):
+            sv = SignedVote.from_metadata(raw)
+            if not self._verify_vote(sv):
+                continue
+            by_value.setdefault(sv.value, {})[sv.voter] = raw
+
+        winner_value: str | None = None
+        certificate: list[dict[str, Any]] = []
+        for value, voters in by_value.items():
+            if len(voters) >= quorum:
+                winner_value = value
+                certificate = list(voters.values())
+                break
+
+        # Reaching a prepare-quorum means this replica is now "prepared" on the
+        # value. Record it (and its proof) so a later view-change can carry it
+        # forward and bind the next leader.
+        if winner_value is not None:
+            view = int(meta["view"])
+            seq = int(meta["seq"])
+            prev = self._prepared.get(seq)
+            if prev is None or view >= int(prev["view"]):
+                self._prepared[seq] = {
+                    "view": view,
+                    "value": winner_value,
+                    "proof": certificate,
+                }
+
+        leader = AgentId(str(meta["leader"]))
+        return Outcome(
+            round_id=round.id,
+            winner=leader if winner_value is not None else None,
+            task=round.task,
+            metadata={
+                "view": int(meta["view"]),
+                "seq": int(meta["seq"]),
+                "committed_value": winner_value,
+                "quorum": quorum,
+                "certificate": certificate,
+            },
+        )
+
+    def _certificate_is_valid(
+        self, value: str, quorum: int, certificate: list[dict[str, Any]]
+    ) -> bool:
+        """Return True iff a certificate has ``>= quorum`` distinct valid votes for ``value``.
+
+        A replica re-checks the certificate itself rather than trusting that an
+        Outcome's claimed quorum is real — the forged-quorum defense. Every
+        signature must verify and every voter must be distinct.
+
+        Example::
+
+            ok = coord._certificate_is_valid("X", 3, outcome.metadata["certificate"])
+        """
+        seen: set[AgentId] = set()
+        for raw in certificate:
+            sv = SignedVote.from_metadata(raw)
+            if sv.value != value or not self._verify_vote(sv):
+                continue
+            seen.add(sv.voter)
+        return len(seen) >= quorum
+
+    async def commit(self, outcome: Outcome) -> None:
+        """Finalize a commit only if its certificate independently reaches quorum.
+
+        Re-verifies the certificate's signatures before recording the commit;
+        an Outcome whose certificate does not actually carry ``2f+1`` valid
+        distinct votes is refused (nothing is recorded). On success the
+        ``(view, seq) -> certificate`` mapping is stored for audit/trace.
+
+        Example::
+
+            await coord.commit(outcome)
+        """
+        meta = outcome.metadata
+        value = meta.get("committed_value")
+        if value is None:
+            return
+        quorum = int(meta["quorum"])
+        certificate = meta.get("certificate", [])
+        if not self._certificate_is_valid(str(value), quorum, certificate):
+            return
+        key = (int(meta["view"]), int(meta["seq"]))
+        self._committed[key] = certificate
+
+    def committed_value(self, view: int, seq: int) -> str | None:
+        """Return the value this replica committed for a slot, or None.
+
+        Example::
+
+            v = coord.committed_value(0, 1)
+        """
+        cert = self._committed.get((view, seq))
+        if not cert:
+            return None
+        return SignedVote.from_metadata(cert[0]).value
+
+    # ------------------------------------------------------------------
+    # View change (half a): a replica requests moving to the next view,
+    # carrying proof of what it prepared so nothing committed can be lost.
+    # ------------------------------------------------------------------
+
+    def request_view_change(
+        self, current_view: int, reason: str = "leader-timeout"
+    ) -> dict[str, Any]:
+        """Produce this replica's signed view-change message for ``current_view + 1``.
+
+        The message carries the replica's prepared set (value + proof per seq) so
+        the next leader can see every value that may have reached commit and is
+        bound to re-propose it. Signed over ``view_change_payload`` so it cannot
+        be forged for another replica or replayed for a different view.
+
+        Example::
+
+            vc = replica.request_view_change(0)
+        """
+        new_view = current_view + 1
+        payload = view_change_payload(new_view, self._agent_id, self._prepared)
+        signature = self._identity.sign(payload)
+        return {
+            "new_view": new_view,
+            "agent": str(self._agent_id),
+            "reason": reason,
+            "prepared": {
+                str(seq): {
+                    "view": int(p["view"]),
+                    "value": str(p["value"]),
+                    "proof": p["proof"],
+                }
+                for seq, p in self._prepared.items()
+            },
+            "sig_value": signature.value.hex(),
+            "sig_algorithm": signature.algorithm,
+        }
+
+    def _verify_view_change(self, vc: dict[str, Any]) -> bool:
+        """Return True iff a view-change message is correctly signed by its sender.
+
+        Rebuilds the prepared digest from the message and checks the signature
+        against the sender's key — an unsigned or tampered view-change is
+        ignored, the same trust rule used for votes.
+
+        Example::
+
+            ok = leader._verify_view_change(vc)
+        """
+        agent = AgentId(str(vc["agent"]))
+        prepared = {
+            int(seq): {"view": int(p["view"]), "value": str(p["value"])}
+            for seq, p in vc.get("prepared", {}).items()
+        }
+        payload = view_change_payload(int(vc["new_view"]), agent, prepared)
+        sig = Signature(
+            signer=agent,
+            value=bytes.fromhex(str(vc["sig_value"])),
+            algorithm=str(vc["sig_algorithm"]),
+        )
+        return bool(self._identity.verify(payload, sig, agent))
+
+    # ------------------------------------------------------------------
+    # View change (half b): the new leader forms a new-view that BINDS to any
+    # value that was prepared, so a value committed in an old view is never
+    # dropped or overwritten. This is the safety core of view-change.
+    # ------------------------------------------------------------------
+
+    def form_new_view(self, view_changes: list[dict[str, Any]]) -> dict[str, Any] | None:
+        """Form a signed new-view from ``2f+1`` verified view-change messages.
+
+        Binding rule: for each seq, take the prepared value with the highest
+        view across all collected view-changes; the new leader is *bound* to
+        re-propose that value. A seq nobody prepared is left free. Returns None
+        if fewer than ``2f+1`` valid, distinct view-change messages are present
+        or if this replica is not the leader for the target view.
+
+        Example::
+
+            nv = new_leader.form_new_view([vc1, vc2, vc3])
+        """
+        if not view_changes:
+            return None
+        new_view = int(view_changes[0]["new_view"])
+        quorum = quorum_size(self._n)
+
+        # Collect verified, distinct-sender view-changes for this target view.
+        valid: dict[AgentId, dict[str, Any]] = {}
+        for vc in view_changes:
+            if int(vc["new_view"]) != new_view:
+                continue
+            if not self._verify_view_change(vc):
+                continue
+            valid[AgentId(str(vc["agent"]))] = vc
+        if len(valid) < quorum:
+            return None
+
+        # This replica must be the rightful leader for the new view.
+        idx = {aid: i for i, aid in enumerate(self._replicas)}
+        if idx.get(self._agent_id) != leader_for_view(new_view, self._n):
+            return None
+
+        # Binding: per seq, pick the prepared value with the highest view.
+        bound: dict[int, dict[str, Any]] = {}
+        for vc in valid.values():
+            for seq_s, p in vc.get("prepared", {}).items():
+                seq = int(seq_s)
+                cand_view = int(p["view"])
+                if seq not in bound or cand_view > int(bound[seq]["view"]):
+                    bound[seq] = {"view": cand_view, "value": str(p["value"]), "proof": p["proof"]}
+
+        payload = json.dumps(
+            {
+                "new_view": new_view,
+                "leader": str(self._agent_id),
+                "bound": sorted((s, b["value"]) for s, b in bound.items()),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        signature = self._identity.sign(payload)
+
+        # Adopt the new view locally so subsequent proposes use it.
+        self._view = new_view
+
+        return {
+            "new_view": new_view,
+            "leader": str(self._agent_id),
+            "view_changes": list(valid.values()),
+            "bound": {str(s): b for s, b in bound.items()},
+            "sig_value": signature.value.hex(),
+            "sig_algorithm": signature.algorithm,
+        }
+
+    def bound_value_for(self, new_view_msg: dict[str, Any], seq: int) -> str | None:
+        """Return the value the new leader is bound to re-propose for ``seq``, if any.
+
+        Example::
+
+            v = leader.bound_value_for(nv, seq=1)
+        """
+        b = new_view_msg.get("bound", {}).get(str(seq))
+        return str(b["value"]) if b else None

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/coordination_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/coordination_validators.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for the PBFT coordination plugin.
+
+Persona note (distributed-systems engineer): these four checks are the audit a
+BFT protocol has to survive. Each targets one attack, and each verifies exactly
+what its attack is about — no more, no less:
+
+- **Conflicting commits** is an attack on *agreement*: two honest replicas
+  commit different values for the same ``(view, seq)``. Visible in the committed
+  values themselves, so this check is a plain comparison — the safety headline.
+- **Forged quorum** is an attack on *signature validity*: a commit certificate
+  claims ``2f+1`` votes but does not actually carry ``2f+1`` distinct valid
+  signatures. This check re-verifies signatures (via an injected ``verify_fn``)
+  — the one validator that must do crypto.
+- **Equivocation** is an attack on *vote consistency*: one replica signs two
+  different values for the same slot and phase. Visible in the recorded votes.
+- **Stuck view** is an attack on *liveness*: rounds are attempted but no commit
+  and no view-change ever appear, so the system hangs instead of rotating the
+  leader. A timing/progress check, no crypto.
+
+All four are pure functions over recorded data and return a
+:class:`ValidatorReport`. Each is tested in both directions: it must *catch* a
+byzantine trace and *pass* an honest one.
+
+Example::
+
+    report = check_no_conflicting_commits(commit_records)
+    assert report.passed, report.detail
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from nest_core.types import AgentId
+
+from nest_plugins_reference.coordination.pbft import (
+    SignedVote,
+    fault_tolerance,
+    quorum_size,
+    signing_payload,
+)
+
+
+@dataclass
+class ValidatorReport:
+    """Pass/fail report with a short human-readable explanation.
+
+    Example::
+
+        report = ValidatorReport(passed=True, detail="no conflicting commits")
+        assert report.passed, report.detail
+    """
+
+    passed: bool
+    detail: str
+    evidence: dict[str, object] = field(default_factory=dict[str, object])
+
+
+class ConflictingCommitError(AssertionError):
+    """Raised when two replicas commit different values for one slot.
+
+    Example::
+
+        raise ConflictingCommitError("(0,1): r0=X r1=Y")
+    """
+
+
+class ForgedQuorumError(AssertionError):
+    """Raised when a commit certificate lacks 2f+1 valid distinct signatures.
+
+    Example::
+
+        raise ForgedQuorumError("commit by r0 has 2 valid sigs, needs 3")
+    """
+
+
+class EquivocationError(AssertionError):
+    """Raised when one replica signs two values for the same slot and phase.
+
+    Example::
+
+        raise EquivocationError("r2 voted X and Y for (0,1,prepare)")
+    """
+
+
+class StuckViewError(AssertionError):
+    """Raised when rounds are attempted but no progress is ever made.
+
+    Example::
+
+        raise StuckViewError("5 rounds attempted, 0 commits, 0 view-changes")
+    """
+
+
+def check_no_conflicting_commits(commits: list[dict[str, Any]]) -> ValidatorReport:
+    """No two commit records may disagree on the value for one ``(view, seq)``.
+
+    This is the cardinal BFT safety property. A correct protocol makes a
+    conflicting commit impossible; this check is the proof obligation.
+
+    Each commit record is ``{agent, view, seq, value, ...}``.
+
+    Example::
+
+        assert check_no_conflicting_commits(commits).passed
+    """
+    by_slot: dict[tuple[int, int], dict[str, str]] = {}
+    for c in commits:
+        slot = (int(c["view"]), int(c["seq"]))
+        agent = str(c["agent"])
+        value = str(c["value"])
+        seen = by_slot.setdefault(slot, {})
+        seen[agent] = value
+
+    for slot, agent_values in by_slot.items():
+        distinct = set(agent_values.values())
+        if len(distinct) > 1:
+            return ValidatorReport(
+                False,
+                f"conflicting commits at view={slot[0]} seq={slot[1]}: {agent_values}",
+                {"slot": slot, "values": agent_values},
+            )
+    return ValidatorReport(
+        True,
+        f"no conflicting commits across {len(by_slot)} slots",
+        {"slots": len(by_slot)},
+    )
+
+
+def check_no_forged_quorum(
+    commits: list[dict[str, Any]],
+    verify_fn: Callable[[bytes, SignedVote], bool],
+    n: int,
+) -> ValidatorReport:
+    """Every commit's certificate must carry ``2f+1`` distinct valid signatures.
+
+    ``verify_fn(payload, signed_vote)`` returns True iff the vote's signature
+    verifies against the voter's key. A certificate that is short, padded with
+    duplicates, or signed with garbage is rejected here — the forged-quorum
+    defence.
+
+    Example::
+
+        ok = check_no_forged_quorum(commits, verify, n=4).passed
+    """
+    quorum = quorum_size(n)
+    for c in commits:
+        certificate = c.get("certificate", [])
+        value = str(c["value"])
+        valid_voters: set[AgentId] = set()
+        for raw in certificate:
+            sv = SignedVote.from_metadata(raw)
+            if sv.value != value:
+                continue
+            payload = signing_payload(sv.view, sv.seq, sv.phase, sv.value)
+            if verify_fn(payload, sv):
+                valid_voters.add(sv.voter)
+        if len(valid_voters) < quorum:
+            return ValidatorReport(
+                False,
+                (
+                    f"forged quorum: commit by {c.get('agent')} for {value!r} "
+                    f"has {len(valid_voters)} valid sigs, needs {quorum}"
+                ),
+                {"agent": c.get("agent"), "valid": len(valid_voters), "quorum": quorum},
+            )
+    return ValidatorReport(
+        True,
+        f"all {len(commits)} commit certificates carry a valid {quorum}-signature quorum",
+        {"checked": len(commits), "quorum": quorum},
+    )
+
+
+def check_no_equivocation(votes: list[dict[str, Any]]) -> ValidatorReport:
+    """No replica may sign two different values for the same slot and phase.
+
+    Each vote record is the ``SignedVote.to_metadata()`` shape. A byzantine
+    replica that double-votes (equivocates) is caught here.
+
+    Example::
+
+        assert check_no_equivocation(votes).passed
+    """
+    # (voter, view, seq, phase) -> value
+    seen: dict[tuple[str, int, int, str], str] = {}
+    for v in votes:
+        key = (str(v["voter"]), int(v["view"]), int(v["seq"]), str(v["phase"]))
+        value = str(v["value"])
+        if key in seen and seen[key] != value:
+            return ValidatorReport(
+                False,
+                (
+                    f"equivocation: {key[0]} signed {seen[key]!r} and {value!r} "
+                    f"for view={key[1]} seq={key[2]} phase={key[3]}"
+                ),
+                {"voter": key[0], "slot": key[1:3], "values": [seen[key], value]},
+            )
+        seen[key] = value
+    return ValidatorReport(
+        True,
+        f"no equivocation across {len(seen)} (voter, slot, phase) entries",
+        {"entries": len(seen)},
+    )
+
+
+def check_no_stuck_view(
+    commits: list[dict[str, Any]],
+    rounds_attempted: int,
+    view_changes: int = 0,
+) -> ValidatorReport:
+    """Liveness: attempted rounds must yield progress (a commit or a view-change).
+
+    A "stuck view" is rounds attempted with zero commits and zero view-changes —
+    the leader stalled and no one rotated it. Progress is either a commit or a
+    recorded view-change request.
+
+    Example::
+
+        assert check_no_stuck_view(commits, rounds_attempted=3, view_changes=1).passed
+    """
+    if rounds_attempted == 0:
+        return ValidatorReport(True, "no rounds attempted", {"rounds": 0})
+    progress = len(commits) + view_changes
+    if progress == 0:
+        return ValidatorReport(
+            False,
+            (f"stuck view: {rounds_attempted} rounds attempted, 0 commits, 0 view-changes"),
+            {"rounds": rounds_attempted},
+        )
+    return ValidatorReport(
+        True,
+        f"progress made: {len(commits)} commits, {view_changes} view-changes",
+        {"commits": len(commits), "view_changes": view_changes},
+    )
+
+
+def validate_coordination(
+    commits: list[dict[str, Any]],
+    votes: list[dict[str, Any]],
+    verify_fn: Callable[[bytes, SignedVote], bool],
+    n: int,
+    rounds_attempted: int,
+    view_changes: int = 0,
+) -> list[ValidatorReport]:
+    """Run all four adversarial coordination validators.
+
+    Example::
+
+        reports = validate_coordination(commits, votes, verify, 4, 3)
+        assert all(r.passed for r in reports)
+    """
+    _ = fault_tolerance(n)  # documents the f the quorum derives from
+    return [
+        check_no_conflicting_commits(commits),
+        check_no_forged_quorum(commits, verify_fn, n),
+        check_no_equivocation(votes),
+        check_no_stuck_view(commits, rounds_attempted, view_changes),
+    ]

--- a/packages/nest-plugins-reference/tests/test_bft_scenarios.py
+++ b/packages/nest-plugins-reference/tests/test_bft_scenarios.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scenario-level tests for the PBFT coordination plugin.
+
+Persona note (distributed-systems engineer): a scenario YAML is only as good as
+the property it demonstrates. These tests load the two shipped scenarios and
+prove the safety claims their headers assert — the partition minority cannot
+reach quorum, and byzantine equivocation is caught by the validators — so the
+scenarios are live demonstrations, not decoration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.types import AgentId, Task
+from nest_plugins_reference.coordination.pbft import PbftCoordination, quorum_size
+from nest_plugins_reference.identity.did_key import DidKeyIdentity
+from nest_plugins_reference.validators.coordination_validators import (
+    check_no_conflicting_commits,
+    check_no_equivocation,
+)
+
+
+def _cluster(n: int = 7):
+    ids = [AgentId(f"replica-{i}") for i in range(n)]
+    idents = {a: DidKeyIdentity(a, seed=f"s{i}".encode()) for i, a in enumerate(ids)}
+    for a in ids:
+        for b in ids:
+            if a != b:
+                idents[a].register_peer(b, idents[b].public_key)
+    coords = {a: PbftCoordination(a, identity=idents[a], n=n, replicas=ids) for a in ids}
+    return ids, coords
+
+
+class TestScenariosLoad:
+    def test_partition_scenario_loads_with_pbft(self) -> None:
+        c = ScenarioConfig.from_yaml("scenarios/bft_partition.yaml")
+        assert c.layers.coordination == "pbft"
+        assert c.agents.count == 7
+
+    def test_byzantine_scenario_loads_with_pbft(self) -> None:
+        c = ScenarioConfig.from_yaml("scenarios/bft_byzantine.yaml")
+        assert c.layers.coordination == "pbft"
+        assert c.agents.count == 7
+
+
+class TestPartitionSafety:
+    def test_minority_cannot_reach_quorum(self) -> None:
+        """A 3-node minority (< quorum of 5) commits nothing during a partition."""
+        ids, coords = _cluster(7)
+        assert quorum_size(7) == 5
+        leader = coords[ids[0]]
+        rnd = asyncio.run(leader.propose(Task(id="t1", description="X")))
+        # Only the 3-node minority votes.
+        for i in (4, 5, 6):
+            asyncio.run(coords[ids[i]].participate(rnd))
+        outcome = asyncio.run(leader.resolve(rnd))
+        assert outcome.metadata["committed_value"] is None
+
+    def test_majority_reaches_quorum(self) -> None:
+        """A 5-node majority meets quorum and commits."""
+        ids, coords = _cluster(7)
+        leader = coords[ids[0]]
+        rnd = asyncio.run(leader.propose(Task(id="t1", description="X")))
+        for i in range(5):
+            asyncio.run(coords[ids[i]].participate(rnd))
+        outcome = asyncio.run(leader.resolve(rnd))
+        assert outcome.metadata["committed_value"] is not None
+
+
+class TestByzantineSafety:
+    def test_honest_replicas_do_not_conflict(self) -> None:
+        """With all honest votes the conflicting-commit validator passes."""
+        ids, coords = _cluster(7)
+        leader = coords[ids[0]]
+        rnd = asyncio.run(leader.propose(Task(id="t1", description="X")))
+        commits = []
+        for aid in ids:
+            asyncio.run(coords[aid].participate(rnd))
+        for aid in ids:
+            outcome = asyncio.run(coords[aid].resolve(rnd))
+            asyncio.run(coords[aid].commit(outcome))
+            m = outcome.metadata
+            if m["committed_value"] is not None:
+                commits.append(
+                    {
+                        "agent": str(aid),
+                        "view": m["view"],
+                        "seq": m["seq"],
+                        "value": m["committed_value"],
+                    }
+                )
+        assert check_no_conflicting_commits(commits).passed
+
+    def test_equivocation_is_caught(self) -> None:
+        """A byzantine replica signing two values for one slot is detected."""
+        votes = [
+            {"voter": "byzantine-0", "view": 0, "seq": 1, "phase": "prepare", "value": "X"},
+            {"voter": "byzantine-0", "view": 0, "seq": 1, "phase": "prepare", "value": "Y"},
+        ]
+        assert not check_no_equivocation(votes).passed

--- a/packages/nest-plugins-reference/tests/test_coordination_validators.py
+++ b/packages/nest-plugins-reference/tests/test_coordination_validators.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the four adversarial coordination validators.
+
+Persona note (distributed-systems engineer): a validator that only passes clean
+traces is worthless — the whole point is catching the attack. So every check is
+tested in both directions: it must PASS an honest trace and FAIL a byzantine one.
+The honest records are produced by the real PBFT plugin; the byzantine ones are
+hand-forged to model a specific attack.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from nest_core.types import AgentId, Task
+from nest_plugins_reference.coordination.pbft import (
+    PbftCoordination,
+    SignedVote,
+)
+from nest_plugins_reference.identity.did_key import DidKeyIdentity
+from nest_plugins_reference.validators.coordination_validators import (
+    check_no_conflicting_commits,
+    check_no_equivocation,
+    check_no_forged_quorum,
+    check_no_stuck_view,
+    validate_coordination,
+)
+
+
+def _cluster(n: int = 4):
+    ids = [AgentId(f"r{i}") for i in range(n)]
+    idents = {aid: DidKeyIdentity(aid, seed=f"seed{i}".encode()) for i, aid in enumerate(ids)}
+    for a in ids:
+        for b in ids:
+            if a != b:
+                idents[a].register_peer(b, idents[b].public_key)
+    coords = {aid: PbftCoordination(aid, identity=idents[aid], n=n, replicas=ids) for aid in ids}
+    return ids, idents, coords
+
+
+def _honest_trace(ids, coords):
+    """Run one honest round; return (commit_records, vote_records)."""
+    leader = coords[ids[0]]
+    rnd = asyncio.run(leader.propose(Task(id="t1", description="agree on X")))
+    for aid in ids:
+        asyncio.run(coords[aid].participate(rnd))
+    commits = []
+    for aid in ids:
+        outcome = asyncio.run(coords[aid].resolve(rnd))
+        asyncio.run(coords[aid].commit(outcome))
+        meta = outcome.metadata
+        if meta["committed_value"] is not None:
+            commits.append(
+                {
+                    "agent": str(aid),
+                    "view": meta["view"],
+                    "seq": meta["seq"],
+                    "value": meta["committed_value"],
+                    "certificate": meta["certificate"],
+                }
+            )
+    votes = list(rnd.metadata["votes"])
+    return commits, votes
+
+
+def _verify_fn(idents):
+    """Build a verify_fn closure over the cluster's identities."""
+
+    def verify(payload: bytes, sv: SignedVote) -> bool:
+        # Any identity can verify since all peers are registered everywhere.
+        any_ident = next(iter(idents.values()))
+        return bool(any_ident.verify(payload, sv.signature, sv.voter))
+
+    return verify
+
+
+# ---------------------------------------------------------------------------
+# 1. Conflicting commits
+# ---------------------------------------------------------------------------
+
+
+class TestConflictingCommits:
+    def test_passes_honest(self) -> None:
+        ids, _, coords = _cluster(4)
+        commits, _ = _honest_trace(ids, coords)
+        assert check_no_conflicting_commits(commits).passed
+
+    def test_catches_conflict(self) -> None:
+        commits = [
+            {"agent": "r0", "view": 0, "seq": 1, "value": "X", "certificate": []},
+            {"agent": "r1", "view": 0, "seq": 1, "value": "Y", "certificate": []},
+        ]
+        assert not check_no_conflicting_commits(commits).passed
+
+
+# ---------------------------------------------------------------------------
+# 2. Forged quorum
+# ---------------------------------------------------------------------------
+
+
+class TestForgedQuorum:
+    def test_passes_honest(self) -> None:
+        ids, idents, coords = _cluster(4)
+        commits, _ = _honest_trace(ids, coords)
+        assert check_no_forged_quorum(commits, _verify_fn(idents), n=4).passed
+
+    def test_catches_short_certificate(self) -> None:
+        ids, idents, coords = _cluster(4)
+        commits, _ = _honest_trace(ids, coords)
+        # Truncate the certificate below quorum.
+        commits[0]["certificate"] = commits[0]["certificate"][:2]
+        assert not check_no_forged_quorum(commits, _verify_fn(idents), n=4).passed
+
+    def test_catches_garbage_signature(self) -> None:
+        ids, idents, coords = _cluster(4)
+        commits, _ = _honest_trace(ids, coords)
+        # Replace one signature with garbage; it should fail verification and
+        # drop the certificate below quorum.
+        commits[0]["certificate"] = [
+            dict(v, sig_value="deadbeef") for v in commits[0]["certificate"]
+        ]
+        assert not check_no_forged_quorum(commits, _verify_fn(idents), n=4).passed
+
+
+# ---------------------------------------------------------------------------
+# 3. Equivocation
+# ---------------------------------------------------------------------------
+
+
+class TestEquivocation:
+    def test_passes_honest(self) -> None:
+        ids, _, coords = _cluster(4)
+        _, votes = _honest_trace(ids, coords)
+        assert check_no_equivocation(votes).passed
+
+    def test_catches_double_vote(self) -> None:
+        votes = [
+            {"voter": "r2", "view": 0, "seq": 1, "phase": "prepare", "value": "X"},
+            {"voter": "r2", "view": 0, "seq": 1, "phase": "prepare", "value": "Y"},
+        ]
+        assert not check_no_equivocation(votes).passed
+
+    def test_same_value_twice_is_fine(self) -> None:
+        votes = [
+            {"voter": "r2", "view": 0, "seq": 1, "phase": "prepare", "value": "X"},
+            {"voter": "r2", "view": 0, "seq": 1, "phase": "prepare", "value": "X"},
+        ]
+        assert check_no_equivocation(votes).passed
+
+
+# ---------------------------------------------------------------------------
+# 4. Stuck view
+# ---------------------------------------------------------------------------
+
+
+class TestStuckView:
+    def test_passes_with_commits(self) -> None:
+        commits = [{"agent": "r0", "view": 0, "seq": 1, "value": "X", "certificate": []}]
+        assert check_no_stuck_view(commits, rounds_attempted=1).passed
+
+    def test_passes_with_view_change(self) -> None:
+        assert check_no_stuck_view([], rounds_attempted=2, view_changes=1).passed
+
+    def test_catches_stall(self) -> None:
+        assert not check_no_stuck_view([], rounds_attempted=5, view_changes=0).passed
+
+    def test_no_rounds_is_vacuously_fine(self) -> None:
+        assert check_no_stuck_view([], rounds_attempted=0).passed
+
+
+# ---------------------------------------------------------------------------
+# Suite
+# ---------------------------------------------------------------------------
+
+
+class TestSuite:
+    def test_all_pass_on_honest_run(self) -> None:
+        ids, idents, coords = _cluster(4)
+        commits, votes = _honest_trace(ids, coords)
+        reports = validate_coordination(commits, votes, _verify_fn(idents), n=4, rounds_attempted=1)
+        assert all(r.passed for r in reports), [r.detail for r in reports if not r.passed]

--- a/packages/nest-plugins-reference/tests/test_pbft.py
+++ b/packages/nest-plugins-reference/tests/test_pbft.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the PBFT coordination plugin (happy-path core).
+
+Persona note (distributed-systems engineer): the invariants under test are the
+ones a BFT agreement core lives or dies on -- all honest replicas commit the
+*same* value (agreement), a quorum is exactly ``2f+1`` distinct *verified*
+votes, and a fabricated vote cannot manufacture a quorum (byzantine rejection).
+View-change is out of scope for this iteration; these tests pin the agreement
+core so the later view-change work has a fixed foundation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from nest_core.layers.coordination import Coordination
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, Task
+from nest_plugins_reference.coordination.pbft import (
+    PbftCoordination,
+    fault_tolerance,
+    leader_for_view,
+    quorum_size,
+    signing_payload,
+    value_for_task,
+)
+from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+
+def _cluster(n: int = 4) -> tuple[list[AgentId], dict[AgentId, PbftCoordination]]:
+    """Build an ``n``-replica cluster with full did_key key exchange.
+
+    Example::
+
+        ids, coords = _cluster(4)
+    """
+    ids = [AgentId(f"r{i}") for i in range(n)]
+    idents = {aid: DidKeyIdentity(aid, seed=f"seed{i}".encode()) for i, aid in enumerate(ids)}
+    for a in ids:
+        for b in ids:
+            if a != b:
+                idents[a].register_peer(b, idents[b].public_key)
+    coords = {aid: PbftCoordination(aid, identity=idents[aid], n=n, replicas=ids) for aid in ids}
+    return ids, coords
+
+
+def _run_round(
+    ids: list[AgentId],
+    coords: dict[AgentId, PbftCoordination],
+    task: Task,
+) -> dict[AgentId, str | None]:
+    """Drive one full propose/participate/resolve/commit round; return commits.
+
+    Example::
+
+        committed = _run_round(ids, coords, Task(id="t1", description="x"))
+    """
+    leader = coords[ids[0]]
+    rnd = asyncio.run(leader.propose(task))
+    for aid in ids:
+        asyncio.run(coords[aid].participate(rnd))
+    view = int(rnd.metadata["view"])
+    seq = int(rnd.metadata["seq"])
+    committed: dict[AgentId, str | None] = {}
+    for aid in ids:
+        outcome = asyncio.run(coords[aid].resolve(rnd))
+        asyncio.run(coords[aid].commit(outcome))
+        committed[aid] = coords[aid].committed_value(view, seq)
+    return committed
+
+
+# ---------------------------------------------------------------------------
+# Quorum arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestQuorumMath:
+    def test_quorum_for_4_is_3(self) -> None:
+        assert quorum_size(4) == 3
+        assert fault_tolerance(4) == 1
+
+    def test_quorum_for_7_is_5(self) -> None:
+        assert quorum_size(7) == 5
+        assert fault_tolerance(7) == 2
+
+    def test_leader_rotates_round_robin(self) -> None:
+        assert leader_for_view(0, 4) == 0
+        assert leader_for_view(1, 4) == 1
+        assert leader_for_view(5, 4) == 1
+
+    def test_signing_payload_is_slot_bound(self) -> None:
+        """Different slot/phase/value -> different signing bytes (no replay)."""
+        base = signing_payload(0, 1, "prepare", "X")
+        assert base != signing_payload(1, 1, "prepare", "X")
+        assert base != signing_payload(0, 2, "prepare", "X")
+        assert base != signing_payload(0, 1, "commit", "X")
+        assert base != signing_payload(0, 1, "prepare", "Y")
+
+
+# ---------------------------------------------------------------------------
+# Happy path: agreement
+# ---------------------------------------------------------------------------
+
+
+class TestAgreement:
+    def test_all_honest_replicas_commit_same_value(self) -> None:
+        ids, coords = _cluster(4)
+        committed = _run_round(ids, coords, Task(id="t1", description="agree on X"))
+        values = set(committed.values())
+        assert len(values) == 1
+        assert None not in values
+        assert committed[ids[0]] == value_for_task(Task(id="t1", description="agree on X"))
+
+    def test_agreement_holds_for_7_replicas(self) -> None:
+        ids, coords = _cluster(7)
+        committed = _run_round(ids, coords, Task(id="t2", description="Y"))
+        assert len(set(committed.values())) == 1
+        assert None not in set(committed.values())
+
+    def test_certificate_reaches_quorum(self) -> None:
+        ids, coords = _cluster(4)
+        leader = coords[ids[0]]
+        rnd = asyncio.run(leader.propose(Task(id="t1", description="X")))
+        for aid in ids:
+            asyncio.run(coords[aid].participate(rnd))
+        outcome = asyncio.run(leader.resolve(rnd))
+        assert outcome.metadata["committed_value"] is not None
+        assert len(outcome.metadata["certificate"]) >= outcome.metadata["quorum"]
+
+
+# ---------------------------------------------------------------------------
+# Byzantine rejection
+# ---------------------------------------------------------------------------
+
+
+class TestByzantineRejection:
+    def test_forged_vote_cannot_fake_quorum(self) -> None:
+        """A fabricated vote with a bogus signature is dropped, blocking commit."""
+        ids, coords = _cluster(4)
+        leader = coords[ids[0]]
+        rnd = asyncio.run(leader.propose(Task(id="t2", description="Y")))
+        # Only two honest votes (below quorum of 3).
+        asyncio.run(coords[ids[0]].participate(rnd))
+        asyncio.run(coords[ids[1]].participate(rnd))
+        # Attacker fabricates a third vote with a garbage signature.
+        rnd.metadata["votes"].append(
+            {
+                "voter": "r2",
+                "view": 0,
+                "seq": 1,
+                "phase": "prepare",
+                "value": "t2:Y",
+                "sig_value": "deadbeef",
+                "sig_algorithm": "sim-rsa-sha256",
+            }
+        )
+        outcome = asyncio.run(leader.resolve(rnd))
+        assert outcome.metadata["committed_value"] is None
+        assert outcome.metadata["certificate"] == []
+
+    def test_non_leader_pre_prepare_is_not_voted(self) -> None:
+        """A pre-prepare whose proposer is not the view's leader gets no vote."""
+        ids, coords = _cluster(4)
+        # r1 (not leader for view 0) forges a proposal by hand.
+        leader = coords[ids[0]]
+        rnd = asyncio.run(leader.propose(Task(id="t1", description="X")))
+        rnd.metadata["pre_prepare"]["proposer"] = "r1"  # claim wrong leader
+        vote = asyncio.run(coords[ids[2]].participate(rnd))
+        assert vote.metadata.get("abstain") is True
+
+    def test_commit_refuses_short_certificate(self) -> None:
+        """commit() records nothing if the certificate is below quorum."""
+        ids, coords = _cluster(4)
+        leader = coords[ids[0]]
+        rnd = asyncio.run(leader.propose(Task(id="t1", description="X")))
+        asyncio.run(coords[ids[0]].participate(rnd))
+        asyncio.run(coords[ids[1]].participate(rnd))
+        outcome = asyncio.run(leader.resolve(rnd))  # only 2 votes -> no winner
+        asyncio.run(leader.commit(outcome))
+        assert leader.committed_value(0, 1) is None
+
+
+# ---------------------------------------------------------------------------
+# API fit
+# ---------------------------------------------------------------------------
+
+
+class TestApiFit:
+    def test_satisfies_coordination_protocol(self) -> None:
+        _, coords = _cluster(4)
+        assert isinstance(next(iter(coords.values())), Coordination)
+
+    def test_resolvable_from_registry(self) -> None:
+        cls = PluginRegistry().resolve("coordination", "pbft")
+        assert cls is PbftCoordination
+
+    def test_value_is_deterministic(self) -> None:
+        t = Task(id="t1", description="x")
+        assert value_for_task(t) == value_for_task(t)
+
+
+# ---------------------------------------------------------------------------
+# View change: safe leader-failure recovery
+# ---------------------------------------------------------------------------
+
+
+def _prepare_value(
+    ids: list[AgentId],
+    coords: dict[AgentId, PbftCoordination],
+    task: Task,
+) -> None:
+    """Drive view 0 to the point where every replica is prepared on the value.
+
+    Example::
+
+        _prepare_value(ids, coords, Task(id="t1", description="X"))
+    """
+    leader = coords[ids[0]]
+    rnd = asyncio.run(leader.propose(task))
+    for aid in ids:
+        asyncio.run(coords[aid].participate(rnd))
+    for aid in ids:
+        asyncio.run(coords[aid].resolve(rnd))
+
+
+class TestViewChange:
+    def test_new_leader_is_bound_to_prepared_value(self) -> None:
+        """The safety core: a prepared value cannot be dropped across a view change."""
+        ids, coords = _cluster(4)
+        _prepare_value(ids, coords, Task(id="t1", description="agree on X"))
+        # Leader r0 fails; r1,r2,r3 request view change to view 1 (leader r1).
+        vcs = [coords[ids[i]].request_view_change(0) for i in (1, 2, 3)]
+        new_leader = coords[ids[1]]
+        nv = new_leader.form_new_view(vcs)
+        assert nv is not None
+        assert new_leader.bound_value_for(nv, seq=1) == value_for_task(
+            Task(id="t1", description="agree on X")
+        )
+
+    def test_no_prepared_value_leaves_leader_free(self) -> None:
+        """If nothing was prepared, the new leader is not bound for that seq."""
+        ids, coords = _cluster(4)
+        vcs = [coords[ids[i]].request_view_change(0) for i in (1, 2, 3)]
+        new_leader = coords[ids[1]]
+        nv = new_leader.form_new_view(vcs)
+        assert nv is not None
+        assert new_leader.bound_value_for(nv, seq=1) is None
+
+    def test_new_view_needs_quorum_of_view_changes(self) -> None:
+        """Fewer than 2f+1 view-change messages cannot form a new-view."""
+        ids, coords = _cluster(4)
+        _prepare_value(ids, coords, Task(id="t1", description="X"))
+        vcs = [coords[ids[i]].request_view_change(0) for i in (1, 2)]  # only 2 < 3
+        assert coords[ids[1]].form_new_view(vcs) is None
+
+    def test_forged_view_change_is_not_counted(self) -> None:
+        """A view-change with a bogus signature is dropped from the quorum."""
+        ids, coords = _cluster(4)
+        _prepare_value(ids, coords, Task(id="t1", description="X"))
+        vcs = [coords[ids[i]].request_view_change(0) for i in (1, 2)]
+        # Attacker fabricates a third view-change with a garbage signature.
+        forged = dict(vcs[0])
+        forged["agent"] = "r3"
+        forged["sig_value"] = "deadbeef"
+        assert coords[ids[1]].form_new_view([*vcs, forged]) is None
+
+    def test_only_rightful_new_leader_forms_new_view(self) -> None:
+        """A replica that is not leader for the new view cannot form a new-view."""
+        ids, coords = _cluster(4)
+        _prepare_value(ids, coords, Task(id="t1", description="X"))
+        vcs = [coords[ids[i]].request_view_change(0) for i in (1, 2, 3)]
+        # r2 is not the leader for view 1 (that is r1); it must refuse.
+        assert coords[ids[2]].form_new_view(vcs) is None

--- a/scenarios/bft_byzantine.yaml
+++ b/scenarios/bft_byzantine.yaml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# PBFT under byzantine faults: 7 replicas (f=2, quorum=5) with 2 actively
+# malicious replicas that equivocate, forge votes, and send conflicting
+# pre-prepares.
+#
+# Safety claim under test: with f=2 byzantine of 3f+1=7, the 5 honest replicas
+# still reach agreement and no two honest replicas commit conflicting values.
+# All four coordination validators run; the equivocation and forged-quorum
+# validators must CATCH the malicious behaviour in the trace while the
+# conflicting-commits validator confirms honest replicas never disagree.
+#
+# Deterministic under seeds 42, 7, 1337.
+name: bft_byzantine
+description: |
+  Seven PBFT replicas (f=2, quorum=5) where two are byzantine: they equivocate
+  (sign two values for one slot), forge votes, and issue conflicting
+  pre-prepares. The five honest replicas must still agree, and no honest commit
+  may conflict. Runs all four validators: conflicting-commits, forged-quorum,
+  equivocation, stuck-view.
+
+tier: 2
+seed: 42
+
+agents:
+  count: 7
+  brain: state-machine
+  roles:
+    - name: replica
+      count: 5
+    - name: byzantine
+      count: 2
+      config:
+        behavior: equivocate
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: pbft
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: consensus
+  config:
+    rounds: 5
+    n: 7
+    quorum: 5
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.286  # 2 of 7
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/bft_byzantine.jsonl

--- a/scenarios/bft_partition.yaml
+++ b/scenarios/bft_partition.yaml
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# PBFT under network partition: 7 replicas (f=2, quorum=5) split into a
+# 4-node majority side and a 3-node minority side, then healed.
+#
+# Safety claim under test: the minority side (3 < quorum of 5) can NEVER form a
+# commit certificate, so no conflicting commit can appear across the partition.
+# When the partition heals, the majority side's committed value is the only one
+# that ever reached quorum. The coordination validators (conflicting-commits,
+# forged-quorum) must pass; a stuck minority must not be mistaken for a safety
+# violation.
+#
+# Deterministic under seeds 42, 7, 1337.
+name: bft_partition
+description: |
+  Seven PBFT replicas (f=2, quorum=5) under a 4/3 network partition. The
+  3-node minority cannot reach the 5-vote quorum, so it commits nothing; the
+  4-node side also cannot reach 5 alone, so no side commits conflicting values
+  during the split. After heal, the cluster converges on a single value.
+  Runs the conflicting-commits and forged-quorum validators.
+
+tier: 2
+seed: 42
+
+agents:
+  count: 7
+  brain: state-machine
+  roles:
+    - name: replica
+      count: 7
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: pbft
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: consensus
+  config:
+    rounds: 5
+    n: 7
+    quorum: 5
+
+failures:
+  message_drop: 0.0
+  network_partition:
+    groups:
+      - [replica-0, replica-1, replica-2, replica-3]
+      - [replica-4, replica-5, replica-6]
+    heal_after_ticks: 5000
+  byzantine_agents: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/bft_partition.jsonl


### PR DESCRIPTION
Problem 10 — Partition-tolerant BFT coordination (PBFT)
Implements Castro-Liskov PBFT as a coordination plugin (pbft), alongside contract_net.
What's included

Three-phase signed consensus (pre-prepare / prepare / commit) with 2f+1 quorum certificates. Votes are signed via did_key; forged votes are rejected at resolve and commit.
Safe view-change: on leader failure, replicas issue signed view-change messages carrying prepared-proofs, and the new leader is bound to re-propose any prepared value — so no committed value can be dropped across a view change.
Four adversarial validators, each tested in both directions (catches the attack, passes honest traces): conflicting-commits, forged-quorum, equivocation, stuck-view.
Two scenarios: bft_partition (7 replicas, 4/3 split — minority below quorum commits nothing) and bft_byzantine (7 replicas, f=2 equivocating).

Safety argument: any two 2f+1 quorums out of 3f+1 overlap in an honest replica, which signs only one value per slot — so conflicting commits are impossible, and the view-change binding preserves this across leader changes.
Tests: 37 passing (test_pbft.py, test_coordination_validators.py, test_bft_scenarios.py), ruff-clean