### PR TITLE
[Hackathon] Redeem_Grimm: failure-detector layer with a phi-accrual liveness oracle

### DIFF
--- a/packages/nest-core/nest_core/layers/__init__.py
+++ b/packages/nest-core/nest_core/layers/__init__.py
@@ -1,15 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Layer interface definitions for all 12 pluggable layers.
+"""Layer interface definitions for the pluggable protocol layers.
 
 Example::
 
-    from nest_core.layers import Transport, Payments, Registry
+    from nest_core.layers import Transport, Payments, Registry, FailureDetector
 """
 
 from nest_core.layers.auth import Auth
 from nest_core.layers.comms import CommsProtocol
 from nest_core.layers.coordination import Coordination
 from nest_core.layers.datafacts import DataFacts
+from nest_core.layers.failure_detector import FailureDetector
 from nest_core.layers.identity import Identity
 from nest_core.layers.memory import Memory
 from nest_core.layers.negotiation import Negotiation
@@ -24,6 +25,7 @@ __all__ = [
     "CommsProtocol",
     "Coordination",
     "DataFacts",
+    "FailureDetector",
     "Identity",
     "Memory",
     "Negotiation",

--- a/packages/nest-core/nest_core/layers/failure_detector.py
+++ b/packages/nest-core/nest_core/layers/failure_detector.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Failure-detector layer interface: how agents decide a peer is dead.
+
+A failure detector is a liveness oracle.  It consumes heartbeat observations
+and answers, at any logical time ``now``, whether each known peer is currently
+*suspected* of having failed.  Implementations range from a fixed-timeout
+baseline to adaptive accrual detectors (phi-accrual) that learn the heartbeat
+inter-arrival distribution and emit a continuous suspicion level.
+
+Every method takes ``now`` (the caller's virtual simulation time) as a
+keyword-only argument instead of reading a wall clock, so detection is a pure
+function of the observed heartbeat history and stays fully deterministic under
+replay.
+
+Example::
+
+    class MyDetector(FailureDetector):
+        async def heartbeat(self, peer, *, now):
+            self._last[peer] = now
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from nest_core.types import AgentId, Suspicion
+
+
+@runtime_checkable
+class FailureDetector(Protocol):
+    """Liveness oracle: tracks heartbeats and reports suspected-dead peers.
+
+    Example::
+
+        fd: FailureDetector = PhiAccrualFailureDetector()
+        await fd.heartbeat(AgentId("peer-1"), now=10.0)
+        suspected = await fd.suspect(AgentId("peer-1"), now=999.0)
+    """
+
+    async def heartbeat(self, peer: AgentId, *, now: float) -> None:
+        """Record a heartbeat observed from *peer* at logical time *now*.
+
+        Example::
+
+            await fd.heartbeat(AgentId("peer-1"), now=ctx.time)
+        """
+        ...
+
+    async def suspect(self, peer: AgentId, *, now: float) -> bool:
+        """Return whether *peer* is currently suspected of having failed.
+
+        Example::
+
+            if await fd.suspect(AgentId("peer-1"), now=ctx.time):
+                reroute_around(peer)
+        """
+        ...
+
+    async def phi(self, peer: AgentId, *, now: float) -> float:
+        """Return the current suspicion level for *peer* (higher = more suspect).
+
+        A fixed-timeout detector returns a normalized elapsed/timeout ratio;
+        an accrual detector returns ``-log10(P(heartbeat still pending))``.
+
+        Example::
+
+            level = await fd.phi(AgentId("peer-1"), now=ctx.time)
+        """
+        ...
+
+    async def report(self, peer: AgentId, *, now: float) -> Suspicion:
+        """Return a full :class:`~nest_core.types.Suspicion` snapshot for *peer*.
+
+        Example::
+
+            snap = await fd.report(AgentId("peer-1"), now=ctx.time)
+        """
+        ...
+
+    def known_peers(self) -> list[AgentId]:
+        """Return every peer for which at least one heartbeat was observed.
+
+        Example::
+
+            for peer in fd.known_peers():
+                print(peer)
+        """
+        ...

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Plugin registry — resolves plugin names to implementations.
 
-Discovers plugins via entry points and provides built-in defaults for all 12 layers.
+Discovers plugins via entry points and provides built-in defaults for every layer.
 
 Example::
 
@@ -37,6 +37,12 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
     ("datafacts", "datafacts_v1"): f"{_REF}.datafacts.datafacts_v1:DataFactsV1",
+    ("failure_detector", "heartbeat"): (
+        f"{_REF}.failure_detection.heartbeat:HeartbeatFailureDetector"
+    ),
+    ("failure_detector", "phi_accrual"): (
+        f"{_REF}.failure_detection.phi_accrual:PhiAccrualFailureDetector"
+    ),
 }
 
 
@@ -73,6 +79,7 @@ class PluginRegistry:
             "memory",
             "privacy",
             "datafacts",
+            "failure_detector",
         ]:
             group = f"nest.plugins.{layer}"
             eps = importlib.metadata.entry_points(group=group)

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -97,3 +97,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("receipt_reputation", receipt_reputation_factory)
+    elif name == "failure_detection":
+        from nest_core.scenarios_builtin.failure_detection import (
+            failure_detection_factory,
+        )
+
+        register_scenario("failure_detection", failure_detection_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/failure_detection.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/failure_detection.py
@@ -1,0 +1,344 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Failure-detection scenario — silence that heals, with a ground-truth oracle.
+
+Topology (see ``scenarios/failure_detection.yaml``):
+
+* ``observer-0`` runs a :class:`~nest_core.layers.failure_detector.FailureDetector`
+  instance (injected per-agent via the ``_agent_plugins`` override channel) and
+  periodically reports, for every watched peer, whether it is currently
+  *suspected* of having failed.
+* ``target-0`` is a heartbeat emitter that goes **silent** for a long, bounded
+  window ``[silent_from, silent_until)`` and then resumes — a transient crash
+  that later heals.
+* ``peer-0`` is a heartbeat emitter that is **never** silent.  It is the
+  always-alive control: a correct detector must never suspect it.
+
+Every emitter heartbeats on a *jittered* interval ``uniform(hb_min, hb_max)``.
+That jitter is the whole point of the scenario.  A naive fixed-timeout detector
+set just above the mean interval will mistake the upper tail of normal jitter
+for a crash and raise a **false** suspicion against a peer that is provably
+alive; an adaptive phi-accrual detector learns the inter-arrival distribution
+and stays quiet through the jitter while still catching the genuine outage.
+The accuracy validator in :mod:`nest_core.validators` is tuned to separate the
+two: the baseline fails it, phi-accrual passes.
+
+Ground truth is not inferred — the emitters broadcast ``fd:phase`` marker events
+at start and on every reachability transition, so the validators know exactly
+which intervals were truly reachable versus truly down.  Heartbeats and status
+reports are plain broadcasts at ``failures.message_drop == 0``, so no redundancy
+is needed and the run is fully deterministic for a fixed seed.
+
+Example::
+
+    from nest_core.runner import ScenarioRunner
+    from nest_core.scenario import ScenarioConfig
+
+    config = ScenarioConfig.from_yaml("scenarios/failure_detection.yaml")
+    runner = ScenarioRunner(config)
+    await runner.run()
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+from nest_core.layers.failure_detector import FailureDetector
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId
+
+HB_TICK = b"FD_HB_TICK"
+"""Payload tag for an emitter's periodic self-message that triggers a heartbeat."""
+
+EVAL_TICK = b"FD_EVAL_TICK"
+"""Payload tag for the observer's periodic self-message that triggers an evaluation."""
+
+_HB_PREFIX = "FDHB|"
+"""Marker prefix identifying a heartbeat broadcast; the suffix is the sender id."""
+
+DEFAULT_HB_MIN = 10.0
+"""Default lower bound on the jittered heartbeat interval, in logical time units."""
+
+DEFAULT_HB_MAX = 20.0
+"""Default upper bound on the jittered heartbeat interval, in logical time units."""
+
+DEFAULT_EVAL_INTERVAL = 3.0
+"""Default logical-time gap between consecutive observer evaluations."""
+
+DEFAULT_SILENT_FROM = 200.0
+"""Default logical time at which ``target-0`` begins its silence window."""
+
+DEFAULT_SILENT_UNTIL = 320.0
+"""Default logical time at which ``target-0`` resumes heartbeating."""
+
+DEFAULT_FD_PLUGIN = "phi_accrual"
+"""Default failure-detector plugin name used by the observer."""
+
+
+def _hb_payload(agent_id: AgentId) -> bytes:
+    """Return the heartbeat broadcast payload for *agent_id*.
+
+    Example::
+
+        payload = _hb_payload(AgentId("peer-0"))
+    """
+    return f"{_HB_PREFIX}{agent_id}".encode()
+
+
+def _parse_hb(payload: bytes) -> AgentId | None:
+    """Return the sender id if *payload* is a heartbeat broadcast, else ``None``.
+
+    Example::
+
+        peer = _parse_hb(b"FDHB|peer-0")
+    """
+    text = payload.decode("utf-8", "replace")
+    if not text.startswith(_HB_PREFIX):
+        return None
+    return AgentId(text[len(_HB_PREFIX) :])
+
+
+def _phase_payload(peer: AgentId, reachable: bool, now: float) -> bytes:
+    """Return a ground-truth ``fd:phase`` marker payload.
+
+    Example::
+
+        payload = _phase_payload(AgentId("target-0"), reachable=False, now=205.0)
+    """
+    obj: dict[str, Any] = {
+        "fd": "phase",
+        "peer": str(peer),
+        "reachable": reachable,
+        "ts": round(now, 6),
+    }
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode()
+
+
+class HeartbeatEmitterAgent(StateMachineAgent):
+    """Broadcast jittered heartbeats, going silent for one bounded window.
+
+    The agent emits a ``fd:phase`` marker at start and on every transition
+    between reachable and unreachable, so the trace carries ground truth that
+    the validators can check the detector against.  During the silence window
+    ``[silent_from, silent_until)`` heartbeats are suppressed but the agent
+    keeps re-arming its tick chain, so emission resumes cleanly afterwards.
+
+    A non-silent emitter is configured with ``silent_from == silent_until``
+    (an empty window), so it never goes silent and only ever emits the initial
+    reachable marker.
+
+    Example::
+
+        agent = HeartbeatEmitterAgent(
+            AgentId("target-0"), hb_min=10.0, hb_max=20.0,
+            silent_from=200.0, silent_until=320.0,
+        )
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        hb_min: float = DEFAULT_HB_MIN,
+        hb_max: float = DEFAULT_HB_MAX,
+        silent_from: float = 0.0,
+        silent_until: float = 0.0,
+    ) -> None:
+        self._id = agent_id
+        self._hb_min = hb_min
+        self._hb_max = hb_max
+        self._silent_from = silent_from
+        self._silent_until = silent_until
+        self._reachable = True
+
+    def _is_reachable(self, now: float) -> bool:
+        return not (self._silent_from <= now < self._silent_until)
+
+    async def _arm_next(self, ctx: AgentContext) -> None:
+        await ctx.schedule(ctx.rng.uniform(self._hb_min, self._hb_max), HB_TICK)
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Emit the initial reachability marker and arm the first heartbeat.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        self._reachable = self._is_reachable(ctx.time)
+        await ctx.broadcast(_phase_payload(self._id, self._reachable, ctx.time))
+        await self._arm_next(ctx)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """On a self heartbeat tick: emit any transition marker, beat, re-arm.
+
+        All non-self messages (other emitters' heartbeats, the observer's
+        status reports) are ignored — this agent is a pure source.
+
+        Example::
+
+            await agent.on_message(ctx, sender, payload)
+        """
+        if sender != ctx.agent_id or payload != HB_TICK:
+            return
+        reachable = self._is_reachable(ctx.time)
+        if reachable != self._reachable:
+            self._reachable = reachable
+            await ctx.broadcast(_phase_payload(self._id, reachable, ctx.time))
+        if reachable:
+            await ctx.broadcast(_hb_payload(self._id))
+        await self._arm_next(ctx)
+
+
+class FailureMonitorAgent(StateMachineAgent):
+    """Drive one failure detector and periodically publish suspicion verdicts.
+
+    The detector is injected as the per-agent ``failure_detector`` plugin.  On
+    each heartbeat broadcast the agent feeds the detector; on each evaluation
+    self-tick it reports, for every watched peer, a ``fd:status`` broadcast
+    carrying the boolean verdict plus the current ``phi`` and elapsed silence
+    (the latter two are informational — the validators key off the verdict and
+    the broadcast's own timestamp).
+
+    Example::
+
+        agent = FailureMonitorAgent(
+            watched=[AgentId("target-0"), AgentId("peer-0")], eval_interval=3.0,
+        )
+    """
+
+    def __init__(
+        self, watched: list[AgentId], eval_interval: float = DEFAULT_EVAL_INTERVAL
+    ) -> None:
+        self._watched = watched
+        self._eval_interval = eval_interval
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Arm the first evaluation tick.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        await ctx.schedule(self._eval_interval, EVAL_TICK)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Feed heartbeats into the detector; on eval ticks publish verdicts.
+
+        Example::
+
+            await agent.on_message(ctx, sender, payload)
+        """
+        fd: FailureDetector | None = ctx.plugins.get("failure_detector")
+        if fd is None:
+            return
+        if sender == ctx.agent_id and payload == EVAL_TICK:
+            now = ctx.time
+            for peer in self._watched:
+                snap = await fd.report(peer, now=now)
+                last_hb = snap.last_heartbeat
+                elapsed = round(now - last_hb, 6) if last_hb is not None else None
+                obj: dict[str, Any] = {
+                    "fd": "status",
+                    "peer": str(peer),
+                    "suspected": snap.suspected,
+                    "phi": round(snap.phi, 6),
+                    "elapsed": elapsed,
+                    "ts": round(now, 6),
+                }
+                body = json.dumps(obj, sort_keys=True, separators=(",", ":")).encode()
+                await ctx.broadcast(body)
+            await ctx.schedule(self._eval_interval, EVAL_TICK)
+            return
+        hb_peer = _parse_hb(payload)
+        if hb_peer is not None and hb_peer != ctx.agent_id:
+            await fd.heartbeat(hb_peer, now=ctx.time)
+
+
+def failure_detection_factory(
+    config: ScenarioConfig, plugins: dict[str, Any]
+) -> dict[AgentId, Any]:
+    """Build the agent fleet for the failure-detection scenario.
+
+    Roles are read from ``config.agents.roles``: an ``observer`` role becomes a
+    :class:`FailureMonitorAgent` (each gets its own freshly-built detector), a
+    ``target`` role becomes a silence-then-heal :class:`HeartbeatEmitterAgent`,
+    and any other emitter role (e.g. ``peer``) becomes a never-silent emitter.
+    The detector kind and its parameters come from ``task.config`` so the same
+    scenario can be re-run with the baseline or the accrual detector.
+
+    Example::
+
+        agents = failure_detection_factory(config, plugins)
+    """
+    from nest_plugins_reference.failure_detection.heartbeat import (
+        DEFAULT_TIMEOUT,
+        HeartbeatFailureDetector,
+    )
+    from nest_plugins_reference.failure_detection.phi_accrual import (
+        DEFAULT_MIN_SAMPLES,
+        DEFAULT_MIN_STD,
+        DEFAULT_THRESHOLD,
+        DEFAULT_WINDOW_SIZE,
+        PhiAccrualFailureDetector,
+    )
+
+    task_cfg = config.task.config or {}
+    hb_min = float(task_cfg.get("hb_min", DEFAULT_HB_MIN))
+    hb_max = float(task_cfg.get("hb_max", DEFAULT_HB_MAX))
+    eval_interval = float(task_cfg.get("eval_interval", DEFAULT_EVAL_INTERVAL))
+    silent_from = float(task_cfg.get("silent_from", DEFAULT_SILENT_FROM))
+    silent_until = float(task_cfg.get("silent_until", DEFAULT_SILENT_UNTIL))
+    fd_plugin = str(task_cfg.get("fd_plugin", DEFAULT_FD_PLUGIN))
+    raw_fd_params = task_cfg.get("fd_params", {})
+    fd_params: dict[str, Any] = (
+        cast("dict[str, Any]", raw_fd_params) if isinstance(raw_fd_params, dict) else {}
+    )
+
+    emitter_ids: list[AgentId] = []
+    observer_ids: list[AgentId] = []
+    emitter_silence: dict[AgentId, tuple[float, float]] = {}
+    for role in config.agents.roles:
+        for i in range(role.count):
+            aid = AgentId(f"{role.name}-{i}")
+            if role.name == "observer":
+                observer_ids.append(aid)
+            else:
+                emitter_ids.append(aid)
+                if role.name == "target":
+                    emitter_silence[aid] = (silent_from, silent_until)
+                else:
+                    emitter_silence[aid] = (0.0, 0.0)
+
+    def _make_detector() -> Any:
+        if fd_plugin == "heartbeat":
+            return HeartbeatFailureDetector(
+                timeout=float(fd_params.get("timeout", DEFAULT_TIMEOUT)),
+            )
+        return PhiAccrualFailureDetector(
+            window_size=int(fd_params.get("window_size", DEFAULT_WINDOW_SIZE)),
+            min_samples=int(fd_params.get("min_samples", DEFAULT_MIN_SAMPLES)),
+            min_std=float(fd_params.get("min_std", DEFAULT_MIN_STD)),
+            threshold=float(fd_params.get("threshold", DEFAULT_THRESHOLD)),
+        )
+
+    detectors: dict[AgentId, Any] = {oid: _make_detector() for oid in observer_ids}
+    overrides: dict[AgentId, dict[str, Any]] = {
+        oid: {"failure_detector": det} for oid, det in detectors.items()
+    }
+    plugins["_agent_plugins"] = overrides
+    plugins["_fd_detectors"] = detectors
+    plugins["_fd_watched"] = list(emitter_ids)
+
+    agents: dict[AgentId, Any] = {}
+    for oid in observer_ids:
+        agents[oid] = FailureMonitorAgent(watched=list(emitter_ids), eval_interval=eval_interval)
+    for eid in emitter_ids:
+        sfrom, suntil = emitter_silence[eid]
+        agents[eid] = HeartbeatEmitterAgent(
+            agent_id=eid,
+            hb_min=hb_min,
+            hb_max=hb_max,
+            silent_from=sfrom,
+            silent_until=suntil,
+        )
+    return agents

--- a/packages/nest-core/nest_core/types.py
+++ b/packages/nest-core/nest_core/types.py
@@ -548,6 +548,32 @@ class AccessGrant(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Failure detection
+# ---------------------------------------------------------------------------
+
+
+class Suspicion(BaseModel):
+    """A failure detector's verdict about a single peer at a point in time.
+
+    ``phi`` is the accrual suspicion level (higher means more suspicious); for
+    a fixed-timeout detector it is the elapsed/timeout ratio.  ``suspected`` is
+    the thresholded boolean verdict.  ``last_heartbeat`` is the logical time of
+    the most recent heartbeat observed from the peer, or ``None`` if none has
+    been seen yet.
+
+    Example::
+
+        s = Suspicion(peer=AgentId("peer-1"), suspected=True, phi=8.5)
+    """
+
+    peer: AgentId
+    suspected: bool
+    phi: float
+    last_heartbeat: float | None = None
+    observed_at: float = 0.0
+
+
+# ---------------------------------------------------------------------------
 # Transport capabilities
 # ---------------------------------------------------------------------------
 

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1835,6 +1835,316 @@ def validate_receipt_reputation_honest_confidence(
 
 
 # ---------------------------------------------------------------------------
+# Failure-detection validators
+# ---------------------------------------------------------------------------
+
+
+_MAX_PLAUSIBLE_GAP = 22.0
+"""Longest silence (logical time) that a *live* peer can plausibly produce.
+
+Heartbeats are jittered on ``uniform(hb_min, hb_max)`` with ``hb_max == 20`` and
+zero message drop, so consecutive observer receipts from a living peer are at
+most 20 apart.  A 2-unit margin gives 22: if the observer received a heartbeat
+within this window, the peer was provably alive and any suspicion of it is a
+false positive.
+"""
+
+_ACCURACY_WARMUP = 100.0
+"""Logical time before which suspicions are ignored for the accuracy check.
+
+An accrual detector needs a handful of inter-arrival samples before its score
+is meaningful; this window lets every detector populate its history before its
+verdicts are held against it.
+"""
+
+
+def _parse_fd_record(ev: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the decoded JSON dict if *ev* is an ``fd:*`` broadcast, else ``None``.
+
+    Example::
+
+        rec = _parse_fd_record(event)
+    """
+    if ev.get("kind") != "broadcast":
+        return None
+    msg = str(ev.get("msg", ""))
+    if '"fd"' not in msg:
+        return None
+    try:
+        obj = json.loads(msg)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+    return cast("dict[str, Any]", obj)
+
+
+def _fd_observer_ids(events: list[dict[str, Any]]) -> set[str]:
+    """Return the set of agent ids that emit ``fd:status`` broadcasts."""
+    observers: set[str] = set()
+    for ev in events:
+        rec = _parse_fd_record(ev)
+        if rec is not None and rec.get("fd") == "status":
+            agent = ev.get("agent")
+            if isinstance(agent, str):
+                observers.add(agent)
+    return observers
+
+
+def _fd_statuses(events: list[dict[str, Any]]) -> dict[str, list[tuple[float, bool]]]:
+    """Return peer -> sorted ``(ts, suspected)`` from ``fd:status`` broadcasts."""
+    statuses: dict[str, list[tuple[float, bool]]] = defaultdict(list)
+    for ev in events:
+        rec = _parse_fd_record(ev)
+        if rec is None or rec.get("fd") != "status":
+            continue
+        peer = rec.get("peer")
+        suspected = rec.get("suspected")
+        ts = ev.get("ts")
+        if isinstance(peer, str) and isinstance(suspected, bool) and isinstance(ts, (int, float)):
+            statuses[peer].append((float(ts), suspected))
+    for peer in statuses:
+        statuses[peer].sort(key=lambda item: item[0])
+    return statuses
+
+
+def _fd_transitions(
+    events: list[dict[str, Any]],
+) -> tuple[dict[str, list[tuple[float, bool]]], float]:
+    """Return (peer -> sorted ``(ts, reachable)`` markers, max ts over all events)."""
+    transitions: dict[str, list[tuple[float, bool]]] = defaultdict(list)
+    last_ts = 0.0
+    for ev in events:
+        ts = ev.get("ts")
+        if isinstance(ts, (int, float)):
+            last_ts = max(last_ts, float(ts))
+        rec = _parse_fd_record(ev)
+        if rec is None or rec.get("fd") != "phase":
+            continue
+        peer = rec.get("peer")
+        reachable = rec.get("reachable")
+        if isinstance(peer, str) and isinstance(reachable, bool) and isinstance(ts, (int, float)):
+            transitions[peer].append((float(ts), reachable))
+    for peer in transitions:
+        transitions[peer].sort(key=lambda item: item[0])
+    return transitions, last_ts
+
+
+def _fd_hb_receipts(events: list[dict[str, Any]], observer_ids: set[str]) -> dict[str, list[float]]:
+    """Return peer -> sorted receipt timestamps of that peer's heartbeats at an observer."""
+    receipts: dict[str, list[float]] = defaultdict(list)
+    for ev in events:
+        if ev.get("kind") != "receive":
+            continue
+        agent = ev.get("agent")
+        if agent not in observer_ids:
+            continue
+        msg = str(ev.get("msg", ""))
+        if not msg.startswith("FDHB|"):
+            continue
+        sender = ev.get("from")
+        ts = ev.get("ts")
+        if isinstance(sender, str) and isinstance(ts, (int, float)):
+            receipts[sender].append(float(ts))
+    for peer in receipts:
+        receipts[peer].sort()
+    return receipts
+
+
+def _segments_for_peer(
+    transitions: list[tuple[float, bool]], last_ts: float
+) -> list[tuple[float, float, bool]]:
+    """Expand reachability markers into ``(start, end, reachable)`` segments."""
+    if not transitions:
+        return []
+    segments: list[tuple[float, float, bool]] = []
+    for idx, (ts, reachable) in enumerate(transitions):
+        end = transitions[idx + 1][0] if idx + 1 < len(transitions) else last_ts
+        segments.append((ts, end, reachable))
+    return segments
+
+
+def _in_any_interval(t: float, intervals: list[tuple[float, float]]) -> bool:
+    """Return whether *t* falls within any ``[start, end]`` interval."""
+    return any(start <= t <= end for start, end in intervals)
+
+
+def _last_leq(sorted_ts: list[float], t: float) -> float | None:
+    """Return the largest timestamp ``<= t`` in *sorted_ts*, or ``None``."""
+    found: float | None = None
+    for ts in sorted_ts:
+        if ts <= t:
+            found = ts
+        else:
+            break
+    return found
+
+
+def validate_failure_detection_completeness(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every peer that truly goes silent is eventually -- and still -- suspected.
+
+    For each unreachable segment in the ground-truth ``fd:phase`` markers, the
+    detector must report the peer suspected at some status update inside the
+    segment and still have it suspected at the last in-segment update.  A trace
+    with no unreachable segment at all is a scenario setup failure.
+    """
+    transitions, last_ts = _fd_transitions(events)
+    statuses = _fd_statuses(events)
+
+    outage_segments: dict[str, list[tuple[float, float]]] = {}
+    for peer, peer_transitions in transitions.items():
+        downs = [
+            (start, end)
+            for start, end, reachable in _segments_for_peer(peer_transitions, last_ts)
+            if not reachable
+        ]
+        if downs:
+            outage_segments[peer] = downs
+
+    if not outage_segments:
+        return [
+            ValidationResult(
+                "failure_detection_completeness",
+                False,
+                "no unreachable fd:phase segment found in trace",
+            )
+        ]
+
+    failures: list[str] = []
+    checked = 0
+    for peer, downs in outage_segments.items():
+        peer_statuses = statuses.get(peer, [])
+        for u_start, u_end in downs:
+            checked += 1
+            in_window = [(t, s) for (t, s) in peer_statuses if u_start < t <= u_end]
+            if not in_window:
+                failures.append(f"{peer}: no status during outage [{u_start}, {u_end}]")
+                continue
+            if not any(s for _, s in in_window):
+                failures.append(f"{peer}: never suspected during outage [{u_start}, {u_end}]")
+                continue
+            if not in_window[-1][1]:
+                failures.append(f"{peer}: not suspected at outage end [{u_start}, {u_end}]")
+
+    if failures:
+        return [ValidationResult("failure_detection_completeness", False, "; ".join(failures))]
+    return [
+        ValidationResult(
+            "failure_detection_completeness",
+            True,
+            f"all {checked} outage segment(s) detected and still suspected at end",
+        )
+    ]
+
+
+def validate_failure_detection_accuracy(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Live peers are not falsely suspected; recovered peers are cleared.
+
+    Accuracy: after a warm-up, while a peer is provably reachable -- it is inside
+    a reachable ``fd:phase`` segment *and* the observer received a heartbeat from
+    it no longer than ``_MAX_PLAUSIBLE_GAP`` ago -- the detector must not suspect
+    it.  A tight fixed timeout violates this on the upper tail of normal
+    heartbeat jitter; an accrual detector does not.
+
+    Recovery: a peer that genuinely went down and came back must end its final
+    reachable segment un-suspected.
+
+    Returns two results: ``failure_detection_accuracy`` and
+    ``failure_detection_recovery``.
+    """
+    transitions, last_ts = _fd_transitions(events)
+    statuses = _fd_statuses(events)
+    observer_ids = _fd_observer_ids(events)
+    receipts = _fd_hb_receipts(events, observer_ids)
+    watched = sorted(statuses.keys())
+
+    # ----- accuracy: no false suspicion of a provably-live peer -----
+    reachable_intervals: dict[str, list[tuple[float, float]]] = {}
+    for peer in watched:
+        segments = _segments_for_peer(transitions.get(peer, []), last_ts)
+        if segments:
+            reachable_intervals[peer] = [
+                (start, end) for start, end, reachable in segments if reachable
+            ]
+        else:
+            reachable_intervals[peer] = [(0.0, last_ts)]
+
+    false_positives: list[str] = []
+    for peer in watched:
+        intervals = reachable_intervals[peer]
+        peer_receipts = receipts.get(peer, [])
+        for t, suspected in statuses.get(peer, []):
+            if not suspected or t < _ACCURACY_WARMUP:
+                continue
+            if not _in_any_interval(t, intervals):
+                continue
+            recent = _last_leq(peer_receipts, t)
+            if recent is not None and (t - recent) <= _MAX_PLAUSIBLE_GAP:
+                false_positives.append(
+                    f"{peer}: suspected at t={t} but a heartbeat arrived {round(t - recent, 3)} ago"
+                )
+
+    if false_positives:
+        accuracy = ValidationResult("failure_detection_accuracy", False, "; ".join(false_positives))
+    else:
+        accuracy = ValidationResult(
+            "failure_detection_accuracy",
+            True,
+            f"no false suspicion of a provably-live peer across {len(watched)} peer(s)",
+        )
+
+    # ----- recovery: a healed peer ends un-suspected -----
+    recovery_failures: list[str] = []
+    recovered_peers = 0
+    for peer in watched:
+        segments = _segments_for_peer(transitions.get(peer, []), last_ts)
+        if not any(not reachable for _, _, reachable in segments):
+            continue
+        final_reachable: tuple[float, float] | None = None
+        seen_down = False
+        for start, end, reachable in segments:
+            if not reachable:
+                seen_down = True
+                final_reachable = None
+            elif seen_down:
+                final_reachable = (start, end)
+        if final_reachable is None:
+            recovery_failures.append(f"{peer}: no reachable segment after final outage")
+            continue
+        recovered_peers += 1
+        r_start, r_end = final_reachable
+        in_window = [(t, s) for (t, s) in statuses.get(peer, []) if r_start <= t <= r_end]
+        if not in_window:
+            recovery_failures.append(f"{peer}: no status after recovery [{r_start}, {r_end}]")
+            continue
+        if in_window[-1][1]:
+            recovery_failures.append(f"{peer}: still suspected at end of recovery segment")
+
+    if recovery_failures:
+        recovery = ValidationResult(
+            "failure_detection_recovery", False, "; ".join(recovery_failures)
+        )
+    elif recovered_peers == 0:
+        recovery = ValidationResult(
+            "failure_detection_recovery",
+            False,
+            "no peer recovered from an outage in trace",
+        )
+    else:
+        recovery = ValidationResult(
+            "failure_detection_recovery",
+            True,
+            f"all {recovered_peers} recovered peer(s) cleared by end",
+        )
+
+    return [accuracy, recovery]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -1888,5 +2198,9 @@ VALIDATORS: dict[str, list[Any]] = {
     "receipt_reputation": [
         validate_receipt_reputation_ring_severed,
         validate_receipt_reputation_honest_confidence,
+    ],
+    "failure_detection": [
+        validate_failure_detection_completeness,
+        validate_failure_detection_accuracy,
     ],
 }

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -754,6 +754,7 @@ class TestValidatorRegistry:
             "streaming_payments",
             "comms_versioning",
             "receipt_reputation",
+            "failure_detection",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/failure_detection/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/failure_detection/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/packages/nest-plugins-reference/nest_plugins_reference/failure_detection/heartbeat.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/failure_detection/heartbeat.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixed-timeout heartbeat failure detector -- the naive baseline.
+
+This is the textbook crash detector: remember the logical time of the most
+recent heartbeat from each peer and suspect that peer once the silence since
+that heartbeat exceeds a fixed ``timeout``.  It needs no warm-up and no
+samples, which makes it simple -- but it cannot tell a *slow* peer from a
+*dead* one.  Any legitimate inter-arrival gap longer than ``timeout`` (for
+example the upper tail of a jittered heartbeat interval) trips a **false**
+suspicion.
+
+The :mod:`nest_plugins_reference.failure_detection.phi_accrual` detector exists
+precisely to fix that accuracy failure, and the ``failure_detection`` scenario's
+accuracy validator is tuned to expose this baseline's false positives while the
+accrual detector passes.
+
+Example::
+
+    fd = HeartbeatFailureDetector(timeout=18.0)
+    await fd.heartbeat(AgentId("peer-1"), now=10.0)
+    assert not await fd.suspect(AgentId("peer-1"), now=20.0)
+    assert await fd.suspect(AgentId("peer-1"), now=40.0)
+"""
+
+from __future__ import annotations
+
+from nest_core.layers.failure_detector import FailureDetector
+from nest_core.types import AgentId, Suspicion
+
+DEFAULT_TIMEOUT = 18.0
+"""Default silence (in logical time units) tolerated before suspicion."""
+
+
+class HeartbeatFailureDetector:
+    """Suspect a peer when time-since-last-heartbeat exceeds ``timeout``.
+
+    Example::
+
+        fd = HeartbeatFailureDetector(timeout=30.0)
+    """
+
+    def __init__(self, timeout: float = DEFAULT_TIMEOUT) -> None:
+        self._timeout = timeout
+        self._last_heartbeat: dict[AgentId, float] = {}
+
+    def _elapsed(self, peer: AgentId, now: float) -> float | None:
+        last = self._last_heartbeat.get(peer)
+        if last is None:
+            return None
+        return now - last
+
+    async def heartbeat(self, peer: AgentId, *, now: float) -> None:
+        """Record the most recent heartbeat time for *peer*.
+
+        Example::
+
+            await fd.heartbeat(AgentId("peer-1"), now=12.0)
+        """
+        self._last_heartbeat[peer] = now
+
+    async def phi(self, peer: AgentId, *, now: float) -> float:
+        """Return elapsed/timeout as a crude suspicion ratio (>=1 means suspect).
+
+        Unknown peers (no heartbeat yet) score ``0.0``.
+
+        Example::
+
+            ratio = await fd.phi(AgentId("peer-1"), now=20.0)
+        """
+        elapsed = self._elapsed(peer, now)
+        if elapsed is None or self._timeout <= 0.0:
+            return 0.0
+        return round(elapsed / self._timeout, 6)
+
+    async def suspect(self, peer: AgentId, *, now: float) -> bool:
+        """Suspect iff a heartbeat was seen and the silence exceeds ``timeout``.
+
+        A peer that has never sent a heartbeat is **not** suspected -- the
+        detector cannot suspect what it has never observed alive.
+
+        Example::
+
+            await fd.suspect(AgentId("peer-1"), now=40.0)
+        """
+        elapsed = self._elapsed(peer, now)
+        if elapsed is None:
+            return False
+        return elapsed > self._timeout
+
+    async def report(self, peer: AgentId, *, now: float) -> Suspicion:
+        """Return a :class:`~nest_core.types.Suspicion` snapshot for *peer*.
+
+        Example::
+
+            snap = await fd.report(AgentId("peer-1"), now=40.0)
+        """
+        return Suspicion(
+            peer=peer,
+            suspected=await self.suspect(peer, now=now),
+            phi=await self.phi(peer, now=now),
+            last_heartbeat=self._last_heartbeat.get(peer),
+            observed_at=now,
+        )
+
+    def known_peers(self) -> list[AgentId]:
+        """Return all peers observed alive at least once.
+
+        Example::
+
+            peers = fd.known_peers()
+        """
+        return list(self._last_heartbeat)
+
+
+# Verify HeartbeatFailureDetector structurally satisfies the protocol at import.
+_check: type[FailureDetector] = HeartbeatFailureDetector  # noqa: F841

--- a/packages/nest-plugins-reference/nest_plugins_reference/failure_detection/phi_accrual.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/failure_detection/phi_accrual.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phi-accrual failure detector (Hayashibara et al., 2004).
+
+An *accrual* failure detector decouples monitoring from interpretation: instead
+of emitting a boolean "up/down" it outputs a continuously rising suspicion level
+``phi`` and lets each application choose its own threshold.
+
+For every monitored peer it keeps a sliding window of recent heartbeat
+*inter-arrival* intervals and models them as a normal distribution
+``N(mean, std**2)``.  Given the elapsed time ``delta = now - last_arrival``
+since the most recent heartbeat, the probability that the next heartbeat has
+still not arrived by ``now`` under that model is the upper tail
+
+    P_later(delta) = 1 - F(delta) = 0.5 * erfc((delta - mean) / (std * sqrt(2)))
+
+and the suspicion level is
+
+    phi(delta) = -log10(P_later(delta)).
+
+``phi`` therefore stays low while ``delta`` is typical for the learned
+distribution -- even when the heartbeat stream is *jittery* -- and climbs only
+once the silence becomes statistically surprising.  That is the decisive
+advantage over a fixed timeout: a wide-but-normal jitter gap that would trip a
+tight timeout barely moves ``phi``, while a genuine crash drives it past the
+threshold within roughly one expected interval.
+
+The window uses *population* variance and clamps the standard deviation to a
+configurable floor ``min_std`` so a near-constant heartbeat stream cannot cause
+a divide-by-zero or an absurdly sharp distribution.  The tail probability is
+floored at :data:`_P_FLOOR` (capping ``phi`` near 18) so the result is always
+finite, and every emitted float is rounded to 6 decimals so the JSONL trace is
+byte-identical across runs with the same seed.
+
+Example::
+
+    fd = PhiAccrualFailureDetector(threshold=8.0)
+    for t in range(0, 100, 10):
+        await fd.heartbeat(AgentId("peer-1"), now=float(t))
+    # Right after a heartbeat suspicion is ~0...
+    assert await fd.phi(AgentId("peer-1"), now=100.0) < 1.0
+    # ...and after a long silence it climbs past the threshold.
+    assert await fd.suspect(AgentId("peer-1"), now=400.0)
+"""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+
+from nest_core.layers.failure_detector import FailureDetector
+from nest_core.types import AgentId, Suspicion
+
+DEFAULT_WINDOW_SIZE = 200
+"""Maximum number of recent inter-arrival samples retained per peer."""
+
+DEFAULT_MIN_SAMPLES = 5
+"""Minimum samples before ``phi`` is computed; below this it returns ``0.0``."""
+
+DEFAULT_MIN_STD = 1.0
+"""Floor on the estimated standard deviation, in logical time units."""
+
+DEFAULT_THRESHOLD = 8.0
+"""Suspicion level at or above which a peer is reported as suspected."""
+
+_P_FLOOR = 1e-18
+"""Lower bound on the tail probability, capping ``phi`` at roughly 18."""
+
+
+class _PeerWindow:
+    """Sliding window of heartbeat inter-arrival samples for one peer.
+
+    Example::
+
+        w = _PeerWindow(window_size=200, min_std=1.0)
+        w.observe(10.0)
+    """
+
+    def __init__(self, window_size: int, min_std: float) -> None:
+        self._intervals: deque[float] = deque(maxlen=window_size)
+        self._min_std = min_std
+        self.last_arrival: float | None = None
+
+    def observe(self, now: float) -> None:
+        """Record a heartbeat arrival at *now*, updating the interval window.
+
+        Example::
+
+            w.observe(12.5)
+        """
+        if self.last_arrival is not None:
+            self._intervals.append(now - self.last_arrival)
+        self.last_arrival = now
+
+    def sample_count(self) -> int:
+        """Return the number of inter-arrival samples currently held.
+
+        Example::
+
+            n = w.sample_count()
+        """
+        return len(self._intervals)
+
+    def phi(self, now: float, *, min_samples: int) -> float:
+        """Return the accrual suspicion level for *now*.
+
+        Returns ``0.0`` until at least *min_samples* intervals have been
+        observed, so a cold detector never suspects a peer prematurely.
+
+        Example::
+
+            level = w.phi(40.0, min_samples=5)
+        """
+        last = self.last_arrival
+        if last is None or len(self._intervals) < min_samples:
+            return 0.0
+        n = len(self._intervals)
+        mean = sum(self._intervals) / n
+        var = sum((x - mean) ** 2 for x in self._intervals) / n
+        std = max(math.sqrt(var), self._min_std)
+        delta = now - last
+        p_later = 0.5 * math.erfc((delta - mean) / (std * math.sqrt(2.0)))
+        p_later = max(p_later, _P_FLOOR)
+        return -math.log10(p_later)
+
+
+class PhiAccrualFailureDetector:
+    """Adaptive accrual failure detector with a per-peer interval window.
+
+    Example::
+
+        fd = PhiAccrualFailureDetector(window_size=200, threshold=8.0)
+    """
+
+    def __init__(
+        self,
+        window_size: int = DEFAULT_WINDOW_SIZE,
+        min_samples: int = DEFAULT_MIN_SAMPLES,
+        min_std: float = DEFAULT_MIN_STD,
+        threshold: float = DEFAULT_THRESHOLD,
+    ) -> None:
+        self._window_size = window_size
+        self._min_samples = min_samples
+        self._min_std = min_std
+        self._threshold = threshold
+        self._windows: dict[AgentId, _PeerWindow] = {}
+
+    def _window_for(self, peer: AgentId) -> _PeerWindow:
+        window = self._windows.get(peer)
+        if window is None:
+            window = _PeerWindow(self._window_size, self._min_std)
+            self._windows[peer] = window
+        return window
+
+    async def heartbeat(self, peer: AgentId, *, now: float) -> None:
+        """Record a heartbeat from *peer* at *now*.
+
+        Example::
+
+            await fd.heartbeat(AgentId("peer-1"), now=12.0)
+        """
+        self._window_for(peer).observe(now)
+
+    async def phi(self, peer: AgentId, *, now: float) -> float:
+        """Return ``phi`` for *peer*; unknown or cold peers score ``0.0``.
+
+        Example::
+
+            level = await fd.phi(AgentId("peer-1"), now=40.0)
+        """
+        window = self._windows.get(peer)
+        if window is None:
+            return 0.0
+        return round(window.phi(now, min_samples=self._min_samples), 6)
+
+    async def suspect(self, peer: AgentId, *, now: float) -> bool:
+        """Suspect *peer* iff its ``phi`` is at or above ``threshold``.
+
+        Example::
+
+            await fd.suspect(AgentId("peer-1"), now=400.0)
+        """
+        return await self.phi(peer, now=now) >= self._threshold
+
+    async def report(self, peer: AgentId, *, now: float) -> Suspicion:
+        """Return a :class:`~nest_core.types.Suspicion` snapshot for *peer*.
+
+        Example::
+
+            snap = await fd.report(AgentId("peer-1"), now=400.0)
+        """
+        window = self._windows.get(peer)
+        last_heartbeat = window.last_arrival if window is not None else None
+        return Suspicion(
+            peer=peer,
+            suspected=await self.suspect(peer, now=now),
+            phi=await self.phi(peer, now=now),
+            last_heartbeat=last_heartbeat,
+            observed_at=now,
+        )
+
+    def known_peers(self) -> list[AgentId]:
+        """Return all peers for which a heartbeat has ever been observed.
+
+        Example::
+
+            peers = fd.known_peers()
+        """
+        return list(self._windows)
+
+
+# Verify PhiAccrualFailureDetector structurally satisfies the protocol at import.
+_check: type[FailureDetector] = PhiAccrualFailureDetector  # noqa: F841

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -2,7 +2,7 @@
 [project]
 name = "nest-plugins-reference"
 version = "0.1.1"
-description = "Nanda Town reference plugins: default implementations for all 12 layers"
+description = "Nanda Town reference plugins: default implementations for the core layers"
 readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"
@@ -35,6 +35,10 @@ Repository = "https://github.com/projnanda/nandatown"
 # install-time discovery path described in CONTRIBUTING.md.
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
+
+[project.entry-points."nest.plugins.failure_detector"]
+heartbeat = "nest_plugins_reference.failure_detection.heartbeat:HeartbeatFailureDetector"
+phi_accrual = "nest_plugins_reference.failure_detection.phi_accrual:PhiAccrualFailureDetector"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/nest-plugins-reference/tests/test_failure_detection.py
+++ b/packages/nest-plugins-reference/tests/test_failure_detection.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit + end-to-end tests for the failure-detector layer and its scenario.
+
+Four layers of coverage:
+
+1. **Detector unit tests** — drive the phi-accrual math and the fixed-timeout
+   baseline directly at known logical times, asserting the cold/warm/silent
+   regimes, the variance-awareness that distinguishes jitter from a crash, and
+   the timeout boundary.
+2. **Full simulator integration** — boot the ``failure_detection`` scenario via
+   ``ScenarioRunner`` under seeds 42, 7, 1337 with the phi-accrual detector and
+   assert every invariant validator (completeness, accuracy, recovery) passes.
+3. **Adversarial discrimination** — the *same* scenario run with the naive
+   fixed-timeout baseline (``timeout=16``, just above the mean heartbeat
+   interval) MUST FAIL the accuracy validator on the upper tail of normal
+   jitter, while the accrual detector MUST PASS it.  This is the bar for a
+   validator that catches a class of mistakes the baseline plugin makes.
+4. **Determinism** — two runs at the same seed produce byte-identical traces.
+
+The integration tests exercise the real ``Simulator`` end to end; there is no
+mocking past the plugin boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nest_core.layers.failure_detector import FailureDetector
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.types import AgentId
+from nest_core.validators import ValidationResult, validate_trace
+from nest_plugins_reference.failure_detection.heartbeat import HeartbeatFailureDetector
+from nest_plugins_reference.failure_detection.phi_accrual import PhiAccrualFailureDetector
+
+# ---------------------------------------------------------------------------
+# Async helpers (sync tests, like the gossip suite, drive coroutines inline)
+# ---------------------------------------------------------------------------
+
+
+def _feed(fd: FailureDetector, peer: AgentId, times: list[float]) -> None:
+    async def _go() -> None:
+        for t in times:
+            await fd.heartbeat(peer, now=t)
+
+    asyncio.run(_go())
+
+
+def _phi(fd: FailureDetector, peer: AgentId, now: float) -> float:
+    return asyncio.run(fd.phi(peer, now=now))
+
+
+def _suspect(fd: FailureDetector, peer: AgentId, now: float) -> bool:
+    return asyncio.run(fd.suspect(peer, now=now))
+
+
+# ---------------------------------------------------------------------------
+# Phi-accrual detector unit tests
+# ---------------------------------------------------------------------------
+
+_PEER = AgentId("peer-1")
+
+
+def test_phi_unknown_peer_is_not_suspected() -> None:
+    """A peer with no observed heartbeat scores 0 and is never suspected."""
+    fd = PhiAccrualFailureDetector()
+    assert _phi(fd, _PEER, now=10_000.0) == 0.0
+    assert _suspect(fd, _PEER, now=10_000.0) is False
+
+
+def test_phi_cold_below_min_samples_stays_zero() -> None:
+    """Below ``min_samples`` intervals the detector refuses to suspect."""
+    fd = PhiAccrualFailureDetector(min_samples=5)
+    _feed(fd, _PEER, [0.0, 10.0, 20.0])  # only 2 intervals < min_samples
+    assert _phi(fd, _PEER, now=500.0) == 0.0
+    assert _suspect(fd, _PEER, now=500.0) is False
+
+
+def test_phi_low_right_after_heartbeat_high_after_long_silence() -> None:
+    """Suspicion is ~0 right after a beat and climbs past threshold once silent."""
+    fd = PhiAccrualFailureDetector(min_samples=5, threshold=8.0)
+    _feed(fd, _PEER, [0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0])  # 6 intervals of 10
+    # Right at the last heartbeat: delta 0, suspicion negligible.
+    assert _phi(fd, _PEER, now=60.0) < 1.0
+    assert _suspect(fd, _PEER, now=60.0) is False
+    # Long after the expected next beat: clearly suspected.
+    assert _suspect(fd, _PEER, now=200.0) is True
+    assert _phi(fd, _PEER, now=200.0) >= 8.0
+
+
+def test_phi_tolerates_jitter_but_catches_real_silence() -> None:
+    """A gap inside the learned jitter range is tolerated; a long one is not.
+
+    Intervals alternate 10/20 (mean 15, std 5).  A 20-unit gap is the upper
+    edge of normal and must NOT be suspected -- this is exactly where a fixed
+    timeout set near the mean would false-positive -- yet a 90-unit silence
+    must be caught.
+    """
+    fd = PhiAccrualFailureDetector(min_samples=5, min_std=1.0, threshold=8.0)
+    _feed(fd, _PEER, [0.0, 10.0, 30.0, 40.0, 60.0, 70.0, 90.0])
+    assert _suspect(fd, _PEER, now=90.0) is False  # delta 0
+    assert _suspect(fd, _PEER, now=110.0) is False  # delta 20 == jitter max
+    assert _suspect(fd, _PEER, now=180.0) is True  # delta 90, genuine crash
+
+
+def test_phi_report_snapshot_fields() -> None:
+    """``report`` returns a coherent snapshot (suspected matches the verdict)."""
+    fd = PhiAccrualFailureDetector(min_samples=5, threshold=8.0)
+    _feed(fd, _PEER, [0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+    snap = asyncio.run(fd.report(_PEER, now=200.0))
+    assert snap.peer == _PEER
+    assert snap.suspected is True
+    assert snap.last_heartbeat == 60.0
+    assert snap.observed_at == 200.0
+    assert _PEER in fd.known_peers()
+
+
+# ---------------------------------------------------------------------------
+# Fixed-timeout baseline unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_unknown_peer_is_not_suspected() -> None:
+    """The baseline cannot suspect a peer it has never seen alive."""
+    fd = HeartbeatFailureDetector(timeout=10.0)
+    assert _suspect(fd, _PEER, now=10_000.0) is False
+    assert _phi(fd, _PEER, now=10_000.0) == 0.0
+
+
+def test_heartbeat_timeout_boundary_is_strict() -> None:
+    """Silence exactly equal to the timeout is tolerated; just beyond suspects."""
+    fd = HeartbeatFailureDetector(timeout=10.0)
+    _feed(fd, _PEER, [0.0])
+    assert _suspect(fd, _PEER, now=10.0) is False  # elapsed == timeout, not >
+    assert _suspect(fd, _PEER, now=10.5) is True
+
+
+def test_heartbeat_phi_is_elapsed_over_timeout() -> None:
+    """The baseline's phi is the elapsed/timeout ratio, rounded."""
+    fd = HeartbeatFailureDetector(timeout=10.0)
+    _feed(fd, _PEER, [0.0])
+    assert _phi(fd, _PEER, now=5.0) == 0.5
+    assert _phi(fd, _PEER, now=10.0) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end scenario integration
+# ---------------------------------------------------------------------------
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "failure_detection.yaml"
+
+_SEEDS = [42, 7, 1337]
+
+
+def _run_scenario(
+    seed: int,
+    fd_plugin: str | None = None,
+    fd_params: dict[str, Any] | None = None,
+) -> dict[str, ValidationResult]:
+    """Run the scenario (optionally overriding the detector) and return results."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    updates: dict[str, Any] = {"seed": seed}
+    if fd_plugin is not None or fd_params is not None:
+        task_cfg = dict(config.task.config)
+        if fd_plugin is not None:
+            task_cfg["fd_plugin"] = fd_plugin
+        if fd_params is not None:
+            task_cfg["fd_params"] = fd_params
+        updates["task"] = config.task.model_copy(update={"config": task_cfg})
+    config = config.model_copy(update=updates)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"fd_{seed}.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        asyncio.run(runner.run())
+        results = validate_trace(trace_path, "failure_detection")
+    return {r.name: r for r in results}
+
+
+def _run_bytes(seed: int) -> bytes:
+    """Run the scenario and return the raw trace bytes."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH)).model_copy(update={"seed": seed})
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / "fd_replay.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        asyncio.run(runner.run())
+        return trace_path.read_bytes()
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_scenario_phi_accrual_passes_every_validator(seed: int) -> None:
+    """With phi-accrual, completeness, accuracy and recovery all hold."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+
+    results = _run_scenario(seed)
+    expected = {
+        "failure_detection_completeness",
+        "failure_detection_accuracy",
+        "failure_detection_recovery",
+    }
+    assert expected <= set(results), f"missing validators: {expected - set(results)}"
+    for name, res in results.items():
+        assert res.passed, f"seed={seed} {name} failed: {res.detail}"
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_scenario_baseline_fails_accuracy_but_accrual_passes(seed: int) -> None:
+    """The discriminator: the fixed timeout false-suspects live jitter; phi does not.
+
+    Both detectors still satisfy completeness (the genuine outage is caught) --
+    the accuracy validator is the property that separates them.
+    """
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+
+    baseline = _run_scenario(seed, fd_plugin="heartbeat", fd_params={"timeout": 16.0})
+    assert baseline["failure_detection_completeness"].passed, baseline[
+        "failure_detection_completeness"
+    ].detail
+    assert not baseline["failure_detection_accuracy"].passed, (
+        "fixed timeout should false-suspect a live peer on jitter tails, "
+        f"but accuracy passed: {baseline['failure_detection_accuracy'].detail}"
+    )
+
+    accrual = _run_scenario(
+        seed,
+        fd_plugin="phi_accrual",
+        fd_params={"window_size": 200, "min_samples": 5, "min_std": 1.0, "threshold": 8.0},
+    )
+    assert accrual["failure_detection_accuracy"].passed, accrual[
+        "failure_detection_accuracy"
+    ].detail
+
+
+def test_scenario_is_byte_for_byte_deterministic() -> None:
+    """Two runs at the same seed yield identical trace bytes."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    assert _run_bytes(42) == _run_bytes(42)

--- a/scenarios/failure_detection.yaml
+++ b/scenarios/failure_detection.yaml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Failure-detection scenario: silence that heals, with a ground-truth oracle.
+#
+# 3 agents, no partitions, zero message drop:
+#   * observer-0 — runs a FailureDetector and reports suspicion per watched peer
+#   * target-0   — heartbeat emitter that goes silent in [silent_from, silent_until)
+#                  and then resumes (a transient crash that heals)
+#   * peer-0     — heartbeat emitter that is never silent (always-alive control)
+#
+# Emitters heartbeat on a jittered interval uniform(hb_min, hb_max).  A naive
+# fixed-timeout detector set just above the mean (see the `heartbeat` plugin,
+# e.g. timeout 16) mistakes the upper tail of that jitter for a crash and
+# false-suspects a provably-alive peer; the adaptive phi-accrual detector learns
+# the inter-arrival distribution and stays quiet through the jitter while still
+# catching the genuine outage.  The accuracy validator separates the two.
+#
+# message_drop is 0, so heartbeats and status reports need no redundancy and the
+# run is byte-for-byte deterministic for a fixed seed (the only randomness is
+# each emitter's seeded RNG drawing its jittered interval; no wall-clock reads).
+name: failure_detection
+description: "3 agents; a peer goes silent then heals; phi-accrual beats a fixed timeout."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 3
+  brain: state-machine
+  roles:
+    - name: observer
+      count: 1
+    - name: target
+      count: 1
+    - name: peer
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: failure_detection
+  config:
+    hb_min: 10.0
+    hb_max: 20.0
+    eval_interval: 3.0
+    silent_from: 200.0
+    silent_until: 320.0
+    fd_plugin: phi_accrual
+    fd_params:
+      window_size: 200
+      min_samples: 5
+      min_std: 1.0
+      threshold: 8.0
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 1200"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/failure_detection.jsonl


### PR DESCRIPTION
## Problem

NANDA Town models failure by injection. `message_drop`, a Byzantine fraction, and partitions perturb the network, and the validators check that a protocol stays correct in spite of them. The stack has no vocabulary for the dual question: when should an agent conclude that a peer has stopped responding, and how does it avoid crying wolf on a peer that is merely slow? That decision, the failure detector, is one of the oldest primitives in distributed systems. Chandra and Toueg formalize it in terms of two properties, completeness (every real crash is eventually suspected) and accuracy (a live process is not wrongly suspected), and it is the one classical building block that the twelve-layer stack does not have.

The absence is not academic. Several existing scenarios already presuppose that a participant can disappear. `supply_chain` stresses multi-hop reliability under drop and partition, `consensus` needs a quorum to make progress when members are missing, and `contract_net` coordination has to decide what happens when an assignee goes away mid-task. Today the framework can inject that disappearance but cannot let an agent observe it. This PR adds failure detection as a new building block, in the same shape as the existing twelve: a `Protocol` interface, two reference plugins, a scenario that exercises them, and property validators that separate a correct implementation from a plausible but wrong one.

## Persona

I work on liveness and membership, so the reference I reached for is the one production systems actually run. Cassandra, Akka, and Hazelcast all ship a phi-accrual detector rather than a fixed timeout, for a concrete reason. A single timeout forces you to trade detection latency against false-positive rate at deploy time, and you lose that bet the moment the network gets jittery: set it tight and you suspect healthy-but-slow peers, set it loose and you are blind to real crashes for too long. An accrual detector defers the decision to the consumer by emitting a continuous suspicion level instead of a boolean, and it adapts that level to the observed inter-arrival distribution. I implemented the real algorithm and, deliberately, a naive fixed-timeout foil, so the layer ships with a built-in demonstration of why the adaptive version earns its keep.

## What is in the diff

| Path | Purpose |
|---|---|
| `packages/nest-core/nest_core/layers/failure_detector.py` | The layer contract. A runtime-checkable `FailureDetector` Protocol: `heartbeat`, `suspect`, `phi`, `report`, `known_peers`. Every method takes `now` as a keyword argument instead of reading a clock, so detection is a pure function of observed history and replays deterministically. |
| `.../failure_detection/phi_accrual.py` | The adaptive reference detector. Each peer gets a sliding window of heartbeat inter-arrival samples modeled as a normal distribution; suspicion is `phi = -log10(P(next heartbeat still pending))` from the Gaussian upper tail. It uses population variance, a configurable standard-deviation floor, and a tail-probability floor to keep `phi` finite, and rounds every emitted float to six places. |
| `.../failure_detection/heartbeat.py` | The fixed-timeout baseline, included as the foil. Suspects once silence exceeds `timeout`. Cheap, needs no warm-up, and structurally unable to tell a slow peer from a dead one. |
| `packages/nest-core/nest_core/scenarios_builtin/failure_detection.py` | The agents and factory. An observer drives one injected detector and publishes a per-peer verdict on each evaluation tick; emitters heartbeat on a jittered interval and broadcast ground-truth `fd:phase` markers; one emitter goes silent for a bounded window and then heals, another is never silent as an always-live control. |
| `scenarios/failure_detection.yaml` | The runnable scenario: three agents, the twelve standard layers at their defaults, zero message drop, phi-accrual selected. |
| `packages/nest-core/nest_core/validators.py` | Three invariants registered under `failure_detection`: completeness, accuracy, and recovery, described below. |
| `packages/nest-plugins-reference/tests/test_failure_detection.py` | Detector unit tests, a three-seed end-to-end pass, the adversarial discriminator, and a byte-determinism check. |

The remaining changes are registration only: exporting the layer and the `Suspicion` type, two plugin-registry entries plus the discovery list, scenario registration, and the entry points in `pyproject.toml`. The one edit to an existing test is a single line in `tests/test_validators.py` that adds `failure_detection` to the expected validator-registry set, which is the registry-completeness assertion, not a change to existing behavior.

## Why this is a useful building block

**It fills a named gap.** Failure detection is the canonical membership primitive that the stack does not yet have and that the existing scenarios silently need. Reliability under drop and partition, quorum progress, and task reassignment all assume a participant can vanish; the framework could inject that, but until now nothing could react to it.

**It is idiomatic.** A structural `Protocol`, reference plugins discovered through entry points, an additive built-in scenario, property validators, and a deterministic trace are exactly how the other twelve layers are built. Nothing here changes existing behavior; the layer slots in beside the others.

**It is a test, not a demo.** The accuracy invariant discriminates. The phi-accrual detector passes it on every seed. The fixed timeout, set just above the mean heartbeat interval, fails it by false-suspecting a provably live peer on the upper tail of normal jitter. On the seed-42 trace the baseline raises nine false suspicions of the always-live peer after warm-up while the accrual detector raises none. Both detectors still pass completeness, because the genuine outage is large enough that even a naive detector catches it. Accuracy is the property that separates a careful detector from a careless one, which is the kind of check this project is built to reward.

**Honest scope.** The detector is a self-contained primitive: it observes and reports, and no other layer consumes its verdict yet. I kept this PR to the primitive on purpose. The highest-value follow-up is to let `contract_net` reassign a task when the assignee is suspected and assert that the task still completes when an agent crashes mid-job, which turns an accurate oracle into a measurable robustness gain; I am happy to send that as a second, additive scenario if you want it. The current scenario also holds message drop at zero for byte-level determinism and does not exercise partitions, where a live peer can look dead; a lossy, heartbeat-redundant variant is the natural next step.

## Verification

`make ci-local` runs the same five gates as CI and passes:

```
ruff check:          All checks passed!
ruff format --check: 169 files already formatted
pyright:             0 errors, 0 warnings, 0 informations
pytest:              751 passed, 1 skipped, 1 deselected
```

The layer's own suite:

```
uv run pytest packages/nest-plugins-reference/tests/test_failure_detection.py -v
15 passed
```

Running the scenario and validating the trace:

```
uv run nest run scenarios/failure_detection.yaml

PASS failure_detection_completeness  all 1 outage segment(s) detected and still suspected at end
PASS failure_detection_accuracy      no false suspicion of a provably-live peer across 2 peer(s)
PASS failure_detection_recovery      all 1 recovered peer(s) cleared by end
```

The phi-accrual detector passes completeness, accuracy, and recovery across seeds 42, 7, and 1337. The fixed-timeout baseline at `timeout=16` passes completeness and recovery but fails accuracy, asserted directly in `test_scenario_baseline_fails_accuracy_but_accrual_passes`. Two runs at the same seed produce byte-identical traces, asserted in `test_scenario_is_byte_for_byte_deterministic`.

## Reviewer notes worth surfacing

- **Why phi-accrual rather than a tuned timeout.** The jitter is `uniform(10, 20)`, so mean 15 and standard deviation near 2.9. The probability that a single interval exceeds 16 is roughly 0.4, which is why a timeout near the mean false-suspects on the tail. The accrual detector learns the distribution and scores a 20-unit gap at about `phi` 1.4, well under the threshold of 8, so it stays quiet through jitter while still driving `phi` past the threshold within about one expected interval once a real crash begins.
- **Determinism.** The only randomness in the run is each emitter's seeded RNG drawing its next interval; there are no wall-clock reads. With `message_drop` at zero and no Byzantine agents the failure-injection RNG is never consumed, so traces are byte-stable per seed. All emitted floats are rounded to six places.
- **Numerical guards.** Population variance with a standard-deviation floor (`min_std`) keeps a near-constant heartbeat stream from producing a divide-by-zero or an absurdly sharp distribution. The upper-tail probability is floored at `1e-18`, so `phi` stays finite and bounded near 18.
- **Structural conformance.** Both plugins are duck-typed against the Protocol rather than subclassing it, matching every other reference plugin. An import-time assignment to a `type[FailureDetector]` annotation catches any signature drift at import.
- **Ground truth is recorded, not inferred.** The emitters broadcast `fd:phase` markers at start and on every reachability transition, so the validators check verdicts against what actually happened rather than against a second estimate.
