### PR TITLE
[Hackathon] hiten: add typed FreshnessProof model

### DIFF
--- a/packages/nest-core/nest_core/types.py
+++ b/packages/nest-core/nest_core/types.py
@@ -547,6 +547,31 @@ class AccessGrant(BaseModel):
     expires_at: float | None = None
 
 
+class FreshnessProof(BaseModel):
+    """Signed proof that a content-addressed dataset was (re)published at a given logical tick.
+
+    The ``signature`` covers a canonical serialization of the dataset URL and
+    logical tick, and must have been produced by the agent identified by
+    ``publisher``.
+    Proofs signed by anyone other than the dataset's declared owner are rejected
+    by ``CidFacts.verify_freshness``.
+
+    Example::
+
+        proof = FreshnessProof(
+            url=DataFactsUrl("df://sha256-abc123"),
+            publisher=AgentId("supplier-0"),
+            tick=3.0,
+            signature=Signature(signer=AgentId("supplier-0"), value=b"sig"),
+        )
+    """
+
+    url: DataFactsUrl
+    publisher: AgentId
+    tick: float
+    signature: Signature
+
+
 # ---------------------------------------------------------------------------
 # Transport capabilities
 # ---------------------------------------------------------------------------

--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
@@ -42,8 +42,13 @@ import hashlib
 import json
 from typing import TYPE_CHECKING, Any, cast
 
-from nest_core.types import AccessGrant, AgentId, DataFactsUrl, DatasetMetadata, Signature
-from pydantic import BaseModel
+from nest_core.types import (
+    AccessGrant,
+    AgentId,
+    DataFactsUrl,
+    DatasetMetadata,
+    FreshnessProof,
+)
 
 if TYPE_CHECKING:
     from nest_core.layers.identity import Identity
@@ -88,23 +93,6 @@ class SharedClock:
         """
         self.tick += 1.0
         return self.tick
-
-
-class FreshnessProof(BaseModel):
-    """A publisher-signed attestation that ``url`` was (re)published at ``tick``.
-
-    The signed payload is ``canonical_json({"url": url, "tick": tick})`` --
-    binding the proof to the content hash itself (not just to a name), per the
-    anti-pattern warning that a freshness proof must bind to *content*.
-
-    Example::
-
-        proof = FreshnessProof(url=url, tick=3.0, signature=sig)
-    """
-
-    url: DataFactsUrl
-    tick: float
-    signature: Signature
 
 
 def _freshness_payload(url: DataFactsUrl, tick: float) -> bytes:
@@ -218,7 +206,9 @@ class CidFacts:
 
         tick = self._clock.advance()
         signature = self._identity.sign(_freshness_payload(url, tick))
-        self._proofs[url] = FreshnessProof(url=url, tick=tick, signature=signature)
+        self._proofs[url] = FreshnessProof(
+            url=url, publisher=dataset.owner, tick=tick, signature=signature
+        )
         return url
 
     async def fetch(self, url: DataFactsUrl) -> DatasetMetadata:

--- a/packages/nest-plugins-reference/tests/test_cid_facts.py
+++ b/packages/nest-plugins-reference/tests/test_cid_facts.py
@@ -14,10 +14,9 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 from nest_core.layers.datafacts import DataFacts
 from nest_core.plugins import PluginRegistry
-from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
+from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata, FreshnessProof
 from nest_plugins_reference.datafacts.cid_facts import (
     CidFacts,
-    FreshnessProof,
     ProvenanceError,
     SharedClock,
     content_hash,
@@ -450,3 +449,111 @@ class TestRegistry:
 
     def test_listed_for_datafacts_layer(self) -> None:
         assert ("datafacts", "cid_facts") in PluginRegistry().list_plugins("datafacts")
+
+
+# ---------------------------------------------------------------------------
+# Focused FreshnessProof typed-model tests
+# (imported from nest_core.types — the canonical shared location)
+# ---------------------------------------------------------------------------
+
+
+class TestFreshnessProofModel:
+    """Verify the typed FreshnessProof fields and fail-closed behaviour.
+
+    All imports come from ``nest_core.types`` to confirm the model is a
+    first-class shared type, not a plugin-internal detail.
+    """
+
+    @pytest.mark.asyncio
+    async def test_proof_is_typed_model_not_dict(self) -> None:
+        """freshness_proof() must return a FreshnessProof instance, never a raw dict."""
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"seed")
+        facts = CidFacts(ident)
+        url = await facts.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        proof = facts.freshness_proof(url)
+        assert isinstance(proof, FreshnessProof)
+
+    @pytest.mark.asyncio
+    async def test_proof_url_matches_published_url(self) -> None:
+        """Proof url field must equal the content-addressed URL returned by publish()."""
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"seed")
+        facts = CidFacts(ident)
+        url = await facts.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        proof = facts.freshness_proof(url)
+        assert proof is not None
+        assert proof.url == url
+
+    @pytest.mark.asyncio
+    async def test_proof_publisher_matches_dataset_owner(self) -> None:
+        """Proof publisher field must equal the dataset's declared owner."""
+        owner = AgentId("supplier-0")
+        ident = DidKeyIdentity(owner, seed=b"seed")
+        facts = CidFacts(ident)
+        url = await facts.publish(DatasetMetadata(name="ds", owner=owner))
+        proof = facts.freshness_proof(url)
+        assert proof is not None
+        assert proof.publisher == owner
+
+    @pytest.mark.asyncio
+    async def test_proof_tick_is_deterministic_logical_clock(self) -> None:
+        """Tick must be a logical counter value, not a wall-clock timestamp.
+
+        SharedClock starts at 0.0 and advances by exactly 1.0 per publish call,
+        so after the first publish the tick must be exactly 1.0.
+        """
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"seed")
+        facts = CidFacts(ident)
+        url = await facts.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        proof = facts.freshness_proof(url)
+        assert proof is not None
+        assert proof.tick == 1.0  # first advance on a fresh SharedClock
+
+    @pytest.mark.asyncio
+    async def test_proof_ticks_are_monotonically_increasing(self) -> None:
+        """Each successive publish gets a strictly larger logical tick."""
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"seed")
+        facts = CidFacts(ident)
+        ticks: list[float] = []
+        for i in range(4):
+            url = await facts.publish(
+                DatasetMetadata(name=f"ds-{i}", owner=AgentId("a1"), description=str(i))
+            )
+            proof = facts.freshness_proof(url)
+            assert proof is not None
+            ticks.append(proof.tick)
+        assert ticks == sorted(ticks)
+        assert ticks == [1.0, 2.0, 3.0, 4.0]
+
+    @pytest.mark.asyncio
+    async def test_forged_signature_bytes_fail_verification(self) -> None:
+        """Corrupted signature bytes must make verify_freshness return False."""
+        from nest_core.types import Signature
+
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"seed")
+        facts = CidFacts(ident)
+        url = await facts.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        proof = facts.freshness_proof(url)
+        assert proof is not None
+
+        bad_sig = Signature(
+            signer=proof.signature.signer,
+            value=bytes(b ^ 0xFF for b in proof.signature.value),
+            algorithm=proof.signature.algorithm,
+        )
+        bad_proof = FreshnessProof(
+            url=proof.url,
+            publisher=proof.publisher,
+            tick=proof.tick,
+            signature=bad_sig,
+        )
+        facts._proofs[url] = bad_proof  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        assert await facts.verify_freshness(url) is False
+
+    @pytest.mark.asyncio
+    async def test_missing_proof_fails_verification(self) -> None:
+        """Absence of a stored proof must make verify_freshness return False."""
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"seed")
+        facts = CidFacts(ident)
+        url = await facts.publish(DatasetMetadata(name="ds", owner=AgentId("a1")))
+        del facts._proofs[url]  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        assert await facts.verify_freshness(url) is False


### PR DESCRIPTION
## Summary
This is a focused follow-up to my previous hackathon PR (#39), implementing the reviewer-suggested `FreshnessProof` API improvement after the DataFacts work from #31 was merged.
This PR promotes `FreshnessProof` from a plugin-local implementation in `cid_facts.py` to a first-class shared type in `nest_core.types` and updates the merged `cid_facts` implementation to use the shared model.

## What
- Add `FreshnessProof` as a shared model in `nest_core.types`.
- Update the merged `cid_facts` implementation to use the shared model instead of maintaining a plugin-local definition.
- Update the existing tests to import and validate the shared model from `nest_core.types`.

## Why
Previously, `FreshnessProof` was defined only inside `cid_facts.py`, making it an implementation detail of a single plugin.
Promoting it to `nest_core.types` makes it:
- a first-class public API type,
- statically typed and IDE-discoverable,
- reusable across plugins, validators, scenarios, and future extensions, and
- simpler for verifier implementations to consume consistently.

This follows the reviewer suggestion to promote `FreshnessProof` into a shared typed model while keeping the change small and focused.

## Scope
This PR is intentionally limited to the `FreshnessProof` API improvement. 

## Verification
- ✅ `make ci-local`
```bash
uv sync
uv run ruff check .
uv run ruff format --check .
uv run pyright
uv run pytest -v