### PR TITLE
[Hackathon] hiten: add DidKeyIdentity helper accessors

### DIFF
--- a/packages/nest-plugins-reference/nest_plugins_reference/identity/did_key.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/identity/did_key.py
@@ -55,6 +55,25 @@ class DidKeyIdentity:
         self._known_keys[agent_id] = _decode_public_key(public_key)
 
     @property
+    def agent_id(self) -> AgentId:
+        """This agent's identifier.
+
+        Example::
+
+            aid = ident.agent_id
+        """
+        return self._agent_id
+
+    def has_peer_key(self, agent: AgentId) -> bool:
+        """Return ``True`` if the given agent's public key is registered.
+
+        Example::
+
+            ident.has_peer_key(AgentId("a2"))
+        """
+        return agent in self._known_keys
+
+    @property
     def public_key(self) -> bytes:
         """This agent's public key.
 

--- a/packages/nest-plugins-reference/tests/test_plugins.py
+++ b/packages/nest-plugins-reference/tests/test_plugins.py
@@ -140,6 +140,25 @@ class TestDidKeyIdentity:
         with pytest.raises(ValueError, match="public keys only"):
             ident.register_peer(AgentId("a2"), ident.public_key, private_key=b"secret")
 
+    def test_agent_id(self) -> None:
+        from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"seed")
+        assert ident.agent_id == AgentId("a1")
+
+    def test_has_peer_key_self_and_unknown(self) -> None:
+        from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"seed")
+        # Own key is registered at construction time.
+        assert ident.has_peer_key(AgentId("a1")) is True
+        # Peer key not yet registered → False.
+        assert ident.has_peer_key(AgentId("a2")) is False
+        # Register a peer, then True.
+        peer = DidKeyIdentity(AgentId("a2"), seed=b"seed2")
+        ident.register_peer(AgentId("a2"), peer.public_key)
+        assert ident.has_peer_key(AgentId("a2")) is True
+
     @pytest.mark.asyncio
     async def test_resolve(self) -> None:
         from nest_plugins_reference.identity.did_key import DidKeyIdentity


### PR DESCRIPTION
## Summary
This is a focused follow-up to my previous hackathon PR (#39). Following the merge of the DataFacts implementation in #31, this PR contributes an independent identity-layer API improvement by adding two small helper accessors to `DidKeyIdentity`.
The change exposes the identity's agent ID through a public property and provides a helper for checking whether a peer's public key has been registered, without changing existing identity semantics.

## What
- Add the `agent_id` property.
- Add the `has_peer_key(agent)` helper.
- Add focused unit tests covering both helper APIs.

## Why
`DidKeyIdentity` already stores the identity's agent ID and maintains a registry of known peer public keys internally. Exposing these operations through dedicated helper APIs improves usability while preserving existing identity behavior.
The `agent_id` property provides a stable public accessor instead of requiring downstream code to depend on private implementation details.
The `has_peer_key(agent)` helper provides a clear, self-documenting way to determine whether a peer's public key has been registered, avoiding direct inspection of internal state and making downstream code more readable.

These additions are intentionally lightweight, reusable, and do not modify signing, verification, key generation, or identity semantics.

## Scope
This PR is intentionally limited to the `DidKeyIdentity` helper APIs and their associated unit tests.

## Verification
- ✅ `make ci-local`
```bash
uv sync
uv run ruff check .
uv run ruff format --check .
uv run pyright
uv run pytest -v
```