### PR TITLE
datafacts: first-class typed parents field on DatasetMetadata (follow-up to #35)

### DIFF
--- a/packages/nest-core/nest_core/types.py
+++ b/packages/nest-core/nest_core/types.py
@@ -531,6 +531,11 @@ class DatasetMetadata(BaseModel):
     checksum: str | None = None
     access_tier: str = "public"
     metadata: dict[str, Any] = Field(default_factory=dict)
+    # First-class provenance lineage: the dataset URL(s) this one was derived
+    # from. A typed, discoverable alternative to burying parents in the free-form
+    # ``metadata`` dict. Content-addressed DataFacts plugins fold these into the
+    # child's content hash, so the lineage DAG is tamper-evident. Empty = root.
+    parents: list[DataFactsUrl] = Field(default_factory=lambda: list[DataFactsUrl]())
 
 
 class AccessGrant(BaseModel):

--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
@@ -142,12 +142,18 @@ def content_hash(dataset: DatasetMetadata) -> str:
 
 
 def parents_of(dataset: DatasetMetadata) -> list[DataFactsUrl]:
-    """Read the declared provenance parents out of ``dataset.metadata``.
+    """Read the declared provenance parents off a dataset.
+
+    Prefers the first-class, typed ``DatasetMetadata.parents`` field. Falls back
+    to the legacy ``metadata["parents"]`` dict entry for backward compatibility,
+    so datasets published either way resolve their lineage identically.
 
     Example::
 
         parents = parents_of(derived_dataset)
     """
+    if dataset.parents:
+        return list(dataset.parents)
     raw: object = dataset.metadata.get("parents", [])
     if not isinstance(raw, list):
         return []

--- a/packages/nest-plugins-reference/tests/test_cid_facts_parents_field.py
+++ b/packages/nest-plugins-reference/tests/test_cid_facts_parents_field.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the first-class ``DatasetMetadata.parents`` lineage field.
+
+``cid_facts`` originally read provenance parents only from the free-form
+``metadata["parents"]`` dict entry. These tests cover the typed ``parents``
+field added to :class:`~nest_core.types.DatasetMetadata`: it is preferred when
+present, the legacy dict entry still works (backward compatibility), and both
+spellings content-address to the *same* URL so lineage is unambiguous.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
+from nest_plugins_reference.datafacts.cid_facts import (
+    CidFacts,
+    ProvenanceError,
+    parents_of,
+)
+from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+_PHANTOM = DataFactsUrl("df://sha256-" + "0" * 64)
+
+
+def _facts(owner: str = "a1") -> CidFacts:
+    return CidFacts(DidKeyIdentity(AgentId(owner), seed=b"sim-seed"))
+
+
+def test_default_parents_is_empty() -> None:
+    """A root dataset has no lineage: the field defaults to an empty list."""
+    meta = DatasetMetadata(name="raw", owner=AgentId("a1"))
+    assert meta.parents == []
+    assert parents_of(meta) == []
+
+
+@pytest.mark.asyncio
+async def test_typed_parents_field_is_read() -> None:
+    """``parents_of`` and the ancestry walk honour the typed ``parents`` field."""
+    facts = _facts()
+    root = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+    child = DatasetMetadata(name="clean", owner=AgentId("a1"), parents=[root])
+    child_url = await facts.publish(child)
+    assert parents_of(child) == [root]
+    assert facts.ancestors(child_url) == {root}
+
+
+@pytest.mark.asyncio
+async def test_legacy_dict_parents_still_supported() -> None:
+    """The pre-existing ``metadata['parents']`` dict spelling keeps working."""
+    facts = _facts()
+    root = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+    child = DatasetMetadata(name="clean", owner=AgentId("a1"), metadata={"parents": [str(root)]})
+    child_url = await facts.publish(child)
+    assert parents_of(child) == [root]
+    assert facts.ancestors(child_url) == {root}
+
+
+@pytest.mark.asyncio
+async def test_typed_and_dict_parents_content_address_identically() -> None:
+    """Declaring the same parent via the typed field or the dict yields one URL."""
+    facts = _facts()
+    root = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+    via_field = await facts.publish(
+        DatasetMetadata(name="clean", owner=AgentId("a1"), parents=[root])
+    )
+    via_dict = await facts.publish(
+        DatasetMetadata(name="clean", owner=AgentId("a1"), metadata={"parents": [str(root)]})
+    )
+    assert str(via_field) == str(via_dict)
+
+
+@pytest.mark.asyncio
+async def test_typed_parents_take_precedence_over_dict() -> None:
+    """When both are set, the typed field wins — the stray dict parent is ignored."""
+    facts = _facts()
+    root = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+    # metadata names a never-published phantom; the typed field names the real root.
+    child = DatasetMetadata(
+        name="clean",
+        owner=AgentId("a1"),
+        parents=[root],
+        metadata={"parents": [str(_PHANTOM)]},
+    )
+    child_url = await facts.publish(child)  # must NOT raise on the phantom
+    assert facts.ancestors(child_url) == {root}
+
+
+@pytest.mark.asyncio
+async def test_typed_phantom_parent_rejected_at_publish() -> None:
+    """A typed parent that was never published is rejected, like the dict form."""
+    facts = _facts()
+    orphan = DatasetMetadata(name="laundered", owner=AgentId("a1"), parents=[_PHANTOM])
+    with pytest.raises(ProvenanceError):
+        await facts.publish(orphan)


### PR DESCRIPTION
Follow-up #1 to #35 (closed as a duplicate of #31), the typed-lineage-field piece @dhve flagged as a clean, independent improvement.

## What
Adds a first-class, statically typed provenance field to `DatasetMetadata`:

```python
parents: list[DataFactsUrl] = Field(default_factory=lambda: list[DataFactsUrl]())
```

…and updates the merged `cid_facts` plugin (#31) to read it, keeping the old dict spelling working:

```python
def parents_of(dataset: DatasetMetadata) -> list[DataFactsUrl]:
    if dataset.parents:                       # typed field wins
        return list(dataset.parents)
    raw = dataset.metadata.get("parents", []) # legacy fallback, backward compatible
    ...
```

## Why
#31 declares lineage via `metadata["parents"]` — a free-form, untyped, undiscoverable dict entry. A typed field is statically checkable, IDE-discoverable, and self-documenting. Both @Hiten0305l and I independently proposed it on our closed PRs, which @dhve noted is a strong signal it's the right design.

## Non-breaking by construction
- `content_hash()` is **untouched**. Because `publish()` still folds parents into the content hash via `metadata`, a dataset declared through the typed field and one declared through the dict **content-address to the identical URL** — verified by a new test.
- #31's entire 44-test `cid_facts` suite passes unchanged.

## Tests
`packages/nest-plugins-reference/tests/test_cid_facts_parents_field.py` (6 tests): default empty, typed field read, legacy dict still works, address parity between the two spellings, typed-takes-precedence, and phantom-parent rejection via the typed field.

## Verify
```
uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -q
# 740 passed, 1 skipped
```

## Coordination
@dhve — on #39 you asked @Hiten0305l and me to coordinate on this so it isn't submitted twice. You listed it as item #1 on my #35, and it originated in my closed PR, so I'm carrying it here. Happy to adjust if you'd prefer otherwise.
