### PR TITLE
scenarios: provenance_supply_chain_linear — deep linear provenance chain (follow-up to #35)

### DIFF
--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -109,6 +109,12 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("provenance_supply_chain", provenance_supply_chain_factory)
+    elif name == "provenance_supply_chain_linear":
+        from nest_core.scenarios_builtin.provenance_supply_chain_linear import (
+            provenance_supply_chain_linear_factory,
+        )
+
+        register_scenario("provenance_supply_chain_linear", provenance_supply_chain_linear_factory)
     elif name == "bft_hotstuff":
         from nest_core.scenarios_builtin.bft_hotstuff import bft_hotstuff_factory
 

--- a/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain_linear.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain_linear.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Content-addressed provenance scenario: a deep *linear* supply chain, then attacks.
+
+Where ``provenance_supply_chain`` (#31) is a **diamond** that stresses lineage
+*fan-out* (a join whose ancestry forks back to a shared root), this scenario is a
+**linear spine** that stresses lineage *depth* -- the canonical physical
+supply-chain shape::
+
+    supplier-0 -> manufacturer-0 -> distributor-0 -> retailer-0 -> auditor-0
+
+Each producer hop publishes a *dataset* through ``plugins["datafacts"]`` and
+declares exactly the previous hop's dataset as its single provenance parent, so
+the lineage is one unbranched chain four hops long. ``auditor-0``:
+
+1. **Verifies** -- walks the whole parent chain from the retailer's dataset back
+   to the supplier's root and reports how many distinct datasets it found. A
+   single broken hop anywhere along a deep chain must surface as a break.
+2. **Attacks** -- as an *outsider* (signing with its own identity, never the
+   supplier's), it runs the three provenance attacks against the root:
+
+   * *Substitution*: republish different content under the supplier's exact
+     ``name`` -- does it land on the supplier's URL?
+   * *Forged freshness*: republish identical content claiming the supplier as
+     ``owner`` -- does the supplier then read as freshly attested under an
+     outsider's signature?
+   * *Broken provenance*: publish a dataset whose declared parent was never
+     published -- is it rejected?
+
+Every step is reported as a ``|``-delimited trace message (``:`` collides with
+the ``df://`` URL scheme) using the *same* wire protocol as the diamond
+scenario, so the two share one validator set: point ``layers.datafacts`` at
+``cid_facts`` and every adversarial validator passes; point it at
+``datafacts_v1`` and they fail, because that reference plugin has no
+content-addressing, no signed freshness, and no provenance concept at all.
+
+Example::
+
+    agents = provenance_supply_chain_linear_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, DatasetMetadata
+
+# The producer hops of the linear chain, upstream-to-downstream. Kept as data so
+# the spine is easy to read and to lengthen; the auditor is appended separately.
+_CHAIN: tuple[str, ...] = ("supplier", "manufacturer", "distributor", "retailer")
+_PHANTOM_PARENT = "df://sha256-" + "0" * 64
+
+
+def _parents_of(meta: DatasetMetadata) -> list[str]:
+    """Read declared provenance parents off a dataset as plain URL strings.
+
+    Example::
+
+        parents = _parents_of(meta)
+    """
+    raw: object = meta.metadata.get("parents", [])
+    if not isinstance(raw, list):
+        return []
+    return [str(p) for p in cast("list[Any]", raw)]
+
+
+class SupplierAgent(StateMachineAgent):
+    """Publishes the root dataset (no parents) and hands it to the next hop.
+
+    Example::
+
+        supplier = SupplierAgent(AgentId("supplier-0"), downstream=AgentId("manufacturer-0"),
+                                 name="raw_materials", description="lot-A")
+    """
+
+    def __init__(self, agent_id: AgentId, downstream: AgentId, name: str, description: str) -> None:
+        self._id = agent_id
+        self._downstream = downstream
+        self._name = name
+        self._description = description
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Publish the root dataset and send its URL to the next hop.
+
+        Example::
+
+            await supplier.on_start(ctx)
+        """
+        facts = ctx.plugins.get("datafacts")
+        if facts is None:
+            return
+        dataset = DatasetMetadata(name=self._name, owner=self._id, description=self._description)
+        url = await facts.publish(dataset)
+        await ctx.send(self._downstream, f"lineage|{url}|{self._id}".encode())
+
+
+class ChainHopAgent(StateMachineAgent):
+    """A middle hop: publishes a dataset parented on the one it received, forwards it.
+
+    Manufacturer, distributor, and retailer are all this same hop with different
+    ids -- each declares exactly one parent, keeping the lineage an unbranched
+    spine.
+
+    Example::
+
+        hop = ChainHopAgent(AgentId("manufacturer-0"), downstream=AgentId("distributor-0"),
+                            name="assembled_goods")
+    """
+
+    def __init__(self, agent_id: AgentId, downstream: AgentId, name: str) -> None:
+        self._id = agent_id
+        self._downstream = downstream
+        self._name = name
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Publish a dataset parented on the received URL and forward it downstream.
+
+        Example::
+
+            await hop.on_message(ctx, AgentId("supplier-0"), b"lineage|df://sha256-x|supplier-0")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("lineage|"):
+            return
+        facts = ctx.plugins.get("datafacts")
+        if facts is None:
+            return
+        _, parent_url, _owner = msg.split("|", 2)
+        dataset = DatasetMetadata(
+            name=self._name, owner=self._id, metadata={"parents": [parent_url]}
+        )
+        url = await facts.publish(dataset)
+        await ctx.send(self._downstream, f"lineage|{url}|{self._id}".encode())
+
+
+class AuditorAgent(StateMachineAgent):
+    """Walks the deep linear lineage, then runs three attacks as an outsider.
+
+    Example::
+
+        auditor = AuditorAgent(AgentId("auditor-0"), source_id=AgentId("supplier-0"),
+                               source_name="raw_materials")
+    """
+
+    def __init__(self, agent_id: AgentId, source_id: AgentId, source_name: str) -> None:
+        self._id = agent_id
+        self._source_id = source_id
+        self._source_name = source_name
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Walk the lineage from the received leaf, then attempt the three attacks.
+
+        Example::
+
+            await auditor.on_message(ctx, AgentId("retailer-0"), b"lineage|df://sha256-x|retailer-0")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("lineage|"):
+            return
+        facts = ctx.plugins.get("datafacts")
+        if facts is None:
+            return
+        _, leaf_url, _owner = msg.split("|", 2)
+        root_url = await self._verify_chain(ctx, facts, leaf_url)
+        if root_url is not None:
+            await self._attack_substitution(ctx, facts, root_url)
+            await self._attack_forged_freshness(ctx, facts)
+        await self._attack_provenance(ctx, facts)
+
+    async def _verify_chain(self, ctx: AgentContext, facts: Any, leaf_url: str) -> str | None:
+        """Walk the parent chain from the leaf to its root, reporting depth.
+
+        Follows every declared parent (so a mis-wired fork would still be caught)
+        and de-dupes, though a correct linear chain visits each hop exactly once.
+        Returns the single root (a node with no parents) so the substitution
+        attack can target the true supplier. A parent that does not resolve is a
+        broken chain.
+        """
+        seen: set[str] = set()
+        roots: list[str] = []
+        stack: list[str] = [leaf_url]
+        while stack:
+            url = stack.pop()
+            if url in seen:
+                continue
+            seen.add(url)
+            try:
+                meta: DatasetMetadata = await facts.fetch(url)
+            except KeyError:
+                await ctx.send(self._id, f"chain_broken|{leaf_url}|{url}".encode())
+                return None
+            parents = _parents_of(meta)
+            if parents:
+                stack.extend(parents)
+            else:
+                roots.append(url)
+        await ctx.send(self._id, f"chain_ok|{leaf_url}|{len(seen)}".encode())
+        return sorted(roots)[0] if roots else None
+
+    async def _attack_substitution(self, ctx: AgentContext, facts: Any, source_url: str) -> None:
+        """Try to republish different content under the supplier's exact name."""
+        forged = DatasetMetadata(
+            name=self._source_name, owner=self._source_id, description="tampered-by-attacker"
+        )
+        attacker_url = await facts.publish(forged)
+        collided = int(str(attacker_url) == str(source_url))
+        await ctx.send(
+            self._id, f"attack_substitution|{source_url}|{attacker_url}|{collided}".encode()
+        )
+
+    async def _attack_forged_freshness(self, ctx: AgentContext, facts: Any) -> None:
+        """Republish the supplier's content signed by the attacker, then re-check freshness."""
+        forged = DatasetMetadata(name=self._source_name, owner=self._source_id)
+        forged_url = await facts.publish(forged)
+        fresh = await facts.verify_freshness(forged_url)
+        await ctx.send(self._id, f"attack_forged_freshness|{forged_url}|{int(fresh)}".encode())
+
+    async def _attack_provenance(self, ctx: AgentContext, facts: Any) -> None:
+        """Try to publish a dataset whose declared parent was never published."""
+        phantom = DatasetMetadata(
+            name="laundered", owner=self._source_id, metadata={"parents": [_PHANTOM_PARENT]}
+        )
+        try:
+            await facts.publish(phantom)
+            rejected = 0
+        except ValueError:
+            rejected = 1
+        await ctx.send(self._id, f"attack_provenance|{_PHANTOM_PARENT}|{rejected}".encode())
+
+
+def _build_datafacts_handles(
+    datafacts_cls: type[Any],
+    identities: dict[AgentId, Any],
+    all_ids: list[AgentId],
+) -> dict[AgentId, Any]:
+    """Instantiate one datafacts handle per agent, sharing state where possible.
+
+    Plugins taking an ``Identity`` plus ``datasets``/``proofs``/``clock`` keyword
+    arguments (e.g. ``cid_facts``) get one handle per agent over the same shared
+    dicts and logical clock -- so substitution resistance is meaningful
+    swarm-wide while each agent still signs as itself. Plugins with a no-argument
+    constructor (e.g. ``datafacts_v1``) get a single shared instance, already
+    correct for them since their storage is one dict.
+
+    Example::
+
+        handles = _build_datafacts_handles(CidFacts, identities, all_ids)
+    """
+    shared_datasets: dict[Any, Any] = {}
+    shared_proofs: dict[Any, Any] = {}
+    shared_clock: Any = None
+    shared_instance: Any = None
+    handles: dict[AgentId, Any] = {}
+
+    for aid in all_ids:
+        try:
+            kwargs: dict[str, Any] = {"datasets": shared_datasets, "proofs": shared_proofs}
+            if shared_clock is not None:
+                kwargs["clock"] = shared_clock
+            handle = datafacts_cls(identities[aid], **kwargs)
+            shared_clock = getattr(handle, "clock", shared_clock)
+            handles[aid] = handle
+        except TypeError:
+            if shared_instance is None:
+                shared_instance = datafacts_cls()
+            handles[aid] = shared_instance
+    return handles
+
+
+def provenance_supply_chain_linear_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create the linear chain: supplier -> manufacturer -> distributor -> retailer -> auditor.
+
+    Instantiates per-agent identity instances (so each hop signs as itself) and
+    wires the resolved ``datafacts`` plugin class into per-agent handles via
+    :func:`_build_datafacts_handles`.
+
+    Example::
+
+        agents = provenance_supply_chain_linear_factory(config, plugins)
+    """
+    producer_ids = [AgentId(f"{role}-0") for role in _CHAIN]
+    auditor_id = AgentId("auditor-0")
+    all_ids = [*producer_ids, auditor_id]
+
+    identity_cls = plugins.get("identity")
+    identities: dict[AgentId, Any] = {}
+    if identity_cls is not None and isinstance(identity_cls, type):
+        for aid in all_ids:
+            identities[aid] = identity_cls(aid, seed=b"sim-seed")
+        for aid, ident in identities.items():
+            for peer_id, peer_ident in identities.items():
+                if peer_id != aid:
+                    ident.register_peer(peer_id, peer_ident.public_key)
+
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+    datafacts_cls = plugins.get("datafacts")
+    if datafacts_cls is not None and isinstance(datafacts_cls, type) and identities:
+        handles = _build_datafacts_handles(datafacts_cls, identities, all_ids)
+        for aid, handle in handles.items():
+            agent_plugins.setdefault(aid, {})["datafacts"] = handle
+    plugins.pop("datafacts", None)
+    plugins.pop("identity", None)
+
+    source_id = producer_ids[0]
+    source_name = "raw_materials"
+    # Each producer's downstream is the next id in the spine; the last forwards
+    # to the auditor.
+    downstream = {**{producer_ids[i]: producer_ids[i + 1] for i in range(len(producer_ids) - 1)}}
+    downstream[producer_ids[-1]] = auditor_id
+
+    agents: dict[AgentId, StateMachineAgent] = {
+        source_id: SupplierAgent(
+            source_id, downstream=downstream[source_id], name=source_name, description="lot-A"
+        )
+    }
+    for aid in producer_ids[1:]:
+        agents[aid] = ChainHopAgent(aid, downstream=downstream[aid], name=f"{aid}_dataset")
+    agents[auditor_id] = AuditorAgent(auditor_id, source_id=source_id, source_name=source_name)
+    return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain_linear.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain_linear.py
@@ -10,28 +10,33 @@ supply-chain shape::
 
 Each producer hop publishes a *dataset* through ``plugins["datafacts"]`` and
 declares exactly the previous hop's dataset as its single provenance parent, so
-the lineage is one unbranched chain four hops long. ``auditor-0``:
+the lineage is one unbranched chain four hops long. A linear chain is just a
+diamond with the fan-out removed, so the producer hops and the shared datafacts
+wiring are **reused directly** from ``provenance_supply_chain``: the supplier is
+a ``SourceAgent`` fanning out to a single downstream, and each middle hop is a
+``RefineAgent``. Only ``AuditorAgent`` is defined here, because it does something
+the diamond's verifier does not -- it measures the lineage *depth*.
+
+``auditor-0``:
 
 1. **Verifies** -- walks the whole parent chain from the retailer's dataset back
-   to the supplier's root and reports how many distinct datasets it found. A
-   single broken hop anywhere along a deep chain must surface as a break.
+   to the supplier's root, reporting both the number of distinct datasets
+   (``chain_ok``) *and* the longest root-path length (``chain_depth``). The depth
+   is what distinguishes this scenario from the diamond: a four-hop spine is
+   depth 4, whereas the diamond's longest path is only 3, even though both have
+   four distinct nodes. A single broken hop anywhere along a deep chain must
+   still surface as a break.
 2. **Attacks** -- as an *outsider* (signing with its own identity, never the
    supplier's), it runs the three provenance attacks against the root:
-
-   * *Substitution*: republish different content under the supplier's exact
-     ``name`` -- does it land on the supplier's URL?
-   * *Forged freshness*: republish identical content claiming the supplier as
-     ``owner`` -- does the supplier then read as freshly attested under an
-     outsider's signature?
-   * *Broken provenance*: publish a dataset whose declared parent was never
-     published -- is it rejected?
+   substitution, forged freshness, and broken provenance.
 
 Every step is reported as a ``|``-delimited trace message (``:`` collides with
 the ``df://`` URL scheme) using the *same* wire protocol as the diamond
 scenario, so the two share one validator set: point ``layers.datafacts`` at
 ``cid_facts`` and every adversarial validator passes; point it at
-``datafacts_v1`` and they fail, because that reference plugin has no
-content-addressing, no signed freshness, and no provenance concept at all.
+``datafacts_v1`` and they fail. The extra ``chain_depth`` message is ignored by
+the shared validators (which match exact prefixes), so validator reuse is
+unaffected.
 
 Example::
 
@@ -40,102 +45,37 @@ Example::
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 from nest_core.scenario import ScenarioConfig
+
+# Reuse the diamond scenario's producer agents and datafacts wiring rather than
+# copying them: the two scenarios are twins that share one validator set, so a
+# second copy of the emitters could silently drift. These package-internal
+# helpers are deliberately reused (see PR #51 review); the ignores keep
+# provenance_supply_chain itself untouched instead of widening its public API.
+from nest_core.scenarios_builtin.provenance_supply_chain import (
+    _PHANTOM_PARENT,  # pyright: ignore[reportPrivateUsage]
+    RefineAgent,
+    SourceAgent,
+    _build_datafacts_handles,  # pyright: ignore[reportPrivateUsage]
+    _parents_of,  # pyright: ignore[reportPrivateUsage]
+)
 from nest_core.sim.agent import AgentContext, StateMachineAgent
 from nest_core.types import AgentId, DatasetMetadata
 
 # The producer hops of the linear chain, upstream-to-downstream. Kept as data so
 # the spine is easy to read and to lengthen; the auditor is appended separately.
 _CHAIN: tuple[str, ...] = ("supplier", "manufacturer", "distributor", "retailer")
-_PHANTOM_PARENT = "df://sha256-" + "0" * 64
-
-
-def _parents_of(meta: DatasetMetadata) -> list[str]:
-    """Read declared provenance parents off a dataset as plain URL strings.
-
-    Example::
-
-        parents = _parents_of(meta)
-    """
-    raw: object = meta.metadata.get("parents", [])
-    if not isinstance(raw, list):
-        return []
-    return [str(p) for p in cast("list[Any]", raw)]
-
-
-class SupplierAgent(StateMachineAgent):
-    """Publishes the root dataset (no parents) and hands it to the next hop.
-
-    Example::
-
-        supplier = SupplierAgent(AgentId("supplier-0"), downstream=AgentId("manufacturer-0"),
-                                 name="raw_materials", description="lot-A")
-    """
-
-    def __init__(self, agent_id: AgentId, downstream: AgentId, name: str, description: str) -> None:
-        self._id = agent_id
-        self._downstream = downstream
-        self._name = name
-        self._description = description
-
-    async def on_start(self, ctx: AgentContext) -> None:
-        """Publish the root dataset and send its URL to the next hop.
-
-        Example::
-
-            await supplier.on_start(ctx)
-        """
-        facts = ctx.plugins.get("datafacts")
-        if facts is None:
-            return
-        dataset = DatasetMetadata(name=self._name, owner=self._id, description=self._description)
-        url = await facts.publish(dataset)
-        await ctx.send(self._downstream, f"lineage|{url}|{self._id}".encode())
-
-
-class ChainHopAgent(StateMachineAgent):
-    """A middle hop: publishes a dataset parented on the one it received, forwards it.
-
-    Manufacturer, distributor, and retailer are all this same hop with different
-    ids -- each declares exactly one parent, keeping the lineage an unbranched
-    spine.
-
-    Example::
-
-        hop = ChainHopAgent(AgentId("manufacturer-0"), downstream=AgentId("distributor-0"),
-                            name="assembled_goods")
-    """
-
-    def __init__(self, agent_id: AgentId, downstream: AgentId, name: str) -> None:
-        self._id = agent_id
-        self._downstream = downstream
-        self._name = name
-
-    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
-        """Publish a dataset parented on the received URL and forward it downstream.
-
-        Example::
-
-            await hop.on_message(ctx, AgentId("supplier-0"), b"lineage|df://sha256-x|supplier-0")
-        """
-        msg = payload.decode("utf-8", errors="replace")
-        if not msg.startswith("lineage|"):
-            return
-        facts = ctx.plugins.get("datafacts")
-        if facts is None:
-            return
-        _, parent_url, _owner = msg.split("|", 2)
-        dataset = DatasetMetadata(
-            name=self._name, owner=self._id, metadata={"parents": [parent_url]}
-        )
-        url = await facts.publish(dataset)
-        await ctx.send(self._downstream, f"lineage|{url}|{self._id}".encode())
 
 
 class AuditorAgent(StateMachineAgent):
-    """Walks the deep linear lineage, then runs three attacks as an outsider.
+    """Walks the deep linear lineage measuring its depth, then attacks as an outsider.
+
+    Unlike the diamond's verifier, this reports the longest root-path length
+    (``chain_depth``) alongside the distinct-node count, so the trace makes the
+    scenario's defining property -- lineage *depth* -- verifiable rather than
+    indistinguishable from a shallow fan-out.
 
     Example::
 
@@ -169,22 +109,28 @@ class AuditorAgent(StateMachineAgent):
         await self._attack_provenance(ctx, facts)
 
     async def _verify_chain(self, ctx: AgentContext, facts: Any, leaf_url: str) -> str | None:
-        """Walk the parent chain from the leaf to its root, reporting depth.
+        """Walk the parent chain from the leaf to its root, reporting size and depth.
 
         Follows every declared parent (so a mis-wired fork would still be caught)
-        and de-dupes, though a correct linear chain visits each hop exactly once.
+        and de-dupes. Each node is pushed with its distance from the leaf, so the
+        longest root-path length can be emitted as ``chain_depth`` -- for an
+        unbranched chain this is simply the number of hops (4 here), which is the
+        one property that distinguishes this scenario from the diamond (whose
+        longest path is 3). Also emits ``chain_ok`` with the distinct-node count.
         Returns the single root (a node with no parents) so the substitution
         attack can target the true supplier. A parent that does not resolve is a
         broken chain.
         """
         seen: set[str] = set()
         roots: list[str] = []
-        stack: list[str] = [leaf_url]
+        max_depth = 0
+        stack: list[tuple[str, int]] = [(leaf_url, 1)]
         while stack:
-            url = stack.pop()
+            url, dist = stack.pop()
             if url in seen:
                 continue
             seen.add(url)
+            max_depth = max(max_depth, dist)
             try:
                 meta: DatasetMetadata = await facts.fetch(url)
             except KeyError:
@@ -192,10 +138,11 @@ class AuditorAgent(StateMachineAgent):
                 return None
             parents = _parents_of(meta)
             if parents:
-                stack.extend(parents)
+                stack.extend((parent, dist + 1) for parent in parents)
             else:
                 roots.append(url)
         await ctx.send(self._id, f"chain_ok|{leaf_url}|{len(seen)}".encode())
+        await ctx.send(self._id, f"chain_depth|{leaf_url}|{max_depth}".encode())
         return sorted(roots)[0] if roots else None
 
     async def _attack_substitution(self, ctx: AgentContext, facts: Any, source_url: str) -> None:
@@ -229,54 +176,17 @@ class AuditorAgent(StateMachineAgent):
         await ctx.send(self._id, f"attack_provenance|{_PHANTOM_PARENT}|{rejected}".encode())
 
 
-def _build_datafacts_handles(
-    datafacts_cls: type[Any],
-    identities: dict[AgentId, Any],
-    all_ids: list[AgentId],
-) -> dict[AgentId, Any]:
-    """Instantiate one datafacts handle per agent, sharing state where possible.
-
-    Plugins taking an ``Identity`` plus ``datasets``/``proofs``/``clock`` keyword
-    arguments (e.g. ``cid_facts``) get one handle per agent over the same shared
-    dicts and logical clock -- so substitution resistance is meaningful
-    swarm-wide while each agent still signs as itself. Plugins with a no-argument
-    constructor (e.g. ``datafacts_v1``) get a single shared instance, already
-    correct for them since their storage is one dict.
-
-    Example::
-
-        handles = _build_datafacts_handles(CidFacts, identities, all_ids)
-    """
-    shared_datasets: dict[Any, Any] = {}
-    shared_proofs: dict[Any, Any] = {}
-    shared_clock: Any = None
-    shared_instance: Any = None
-    handles: dict[AgentId, Any] = {}
-
-    for aid in all_ids:
-        try:
-            kwargs: dict[str, Any] = {"datasets": shared_datasets, "proofs": shared_proofs}
-            if shared_clock is not None:
-                kwargs["clock"] = shared_clock
-            handle = datafacts_cls(identities[aid], **kwargs)
-            shared_clock = getattr(handle, "clock", shared_clock)
-            handles[aid] = handle
-        except TypeError:
-            if shared_instance is None:
-                shared_instance = datafacts_cls()
-            handles[aid] = shared_instance
-    return handles
-
-
 def provenance_supply_chain_linear_factory(
     config: ScenarioConfig,
     plugins: dict[str, Any],
 ) -> dict[AgentId, StateMachineAgent]:
     """Create the linear chain: supplier -> manufacturer -> distributor -> retailer -> auditor.
 
-    Instantiates per-agent identity instances (so each hop signs as itself) and
-    wires the resolved ``datafacts`` plugin class into per-agent handles via
-    :func:`_build_datafacts_handles`.
+    Reuses ``SourceAgent`` (as the supplier, fanning out to a single downstream)
+    and ``RefineAgent`` (as each middle hop) from ``provenance_supply_chain``;
+    only the depth-measuring ``AuditorAgent`` is local. Instantiates per-agent
+    identity instances so each hop signs as itself, and wires the resolved
+    ``datafacts`` plugin class into per-agent handles.
 
     Example::
 
@@ -309,15 +219,17 @@ def provenance_supply_chain_linear_factory(
     source_name = "raw_materials"
     # Each producer's downstream is the next id in the spine; the last forwards
     # to the auditor.
-    downstream = {**{producer_ids[i]: producer_ids[i + 1] for i in range(len(producer_ids) - 1)}}
+    downstream = {producer_ids[i]: producer_ids[i + 1] for i in range(len(producer_ids) - 1)}
     downstream[producer_ids[-1]] = auditor_id
 
     agents: dict[AgentId, StateMachineAgent] = {
-        source_id: SupplierAgent(
-            source_id, downstream=downstream[source_id], name=source_name, description="lot-A"
+        # A linear supplier is just a SourceAgent that fans out to one downstream.
+        source_id: SourceAgent(
+            source_id, refiners=[downstream[source_id]], name=source_name, description="lot-A"
         )
     }
+    # Middle hops are RefineAgents forwarding to the next id in the spine.
     for aid in producer_ids[1:]:
-        agents[aid] = ChainHopAgent(aid, downstream=downstream[aid], name=f"{aid}_dataset")
+        agents[aid] = RefineAgent(aid, aggregator=downstream[aid], name=f"{aid}_dataset")
     agents[auditor_id] = AuditorAgent(auditor_id, source_id=source_id, source_name=source_name)
     return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -2835,6 +2835,16 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_provenance_freshness_unforgeable,
         validate_provenance_chain_unforgeable,
     ],
+    # The linear supply-chain scenario emits the same ``|``-delimited provenance
+    # wire protocol as the diamond, so it reuses the exact same validator set --
+    # the guarantees under test (substitution resistance, unforgeable freshness,
+    # unforgeable lineage) are plugin properties, independent of graph shape.
+    "provenance_supply_chain_linear": [
+        validate_provenance_chain_integrity,
+        validate_provenance_substitution_resistant,
+        validate_provenance_freshness_unforgeable,
+        validate_provenance_chain_unforgeable,
+    ],
     "bft_hotstuff": [
         validate_bft_no_conflicting_commits,
         validate_bft_no_equivocation,

--- a/packages/nest-core/tests/test_provenance_supply_chain_linear.py
+++ b/packages/nest-core/tests/test_provenance_supply_chain_linear.py
@@ -39,16 +39,24 @@ class TestScenarioEndToEnd:
         assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
 
     def test_linear_walk_visits_all_four_hops(self, tmp_path: Path) -> None:
-        """The chain walk must resolve the full depth: supplier..retailer = 4 nodes."""
+        """The defining property is depth, not node count.
+
+        ``chain_ok`` reports the distinct-node count, which is 4 for *both* the
+        diamond and this linear chain -- so on its own it cannot tell them apart
+        (a diamond trace would satisfy it verbatim). What makes this scenario
+        worth having is the lineage *depth*: ``chain_depth`` is the longest
+        root-path length, 4 here (supplier -> manufacturer -> distributor ->
+        retailer), whereas the diamond's longest path is only 3.
+        """
         out = tmp_path / "cid_facts.jsonl"
         _run("cid_facts", out)
-        chain_ok = [
-            msg
-            for line in out.read_text().splitlines()
-            if (msg := str(json.loads(line).get("msg", ""))).startswith("chain_ok|")
-        ]
+        msgs = [str(json.loads(line).get("msg", "")) for line in out.read_text().splitlines()]
+        chain_ok = [m for m in msgs if m.startswith("chain_ok|")]
+        chain_depth = [m for m in msgs if m.startswith("chain_depth|")]
         assert chain_ok, "no chain_ok recorded"
-        assert chain_ok[0].rsplit("|", 1)[-1] == "4"
+        assert chain_ok[0].rsplit("|", 1)[-1] == "4"  # 4 distinct datasets
+        assert chain_depth, "no chain_depth recorded"
+        assert chain_depth[0].rsplit("|", 1)[-1] == "4"  # longest path = 4 (diamond's is 3)
 
     def test_datafacts_v1_fails_all_adversarial_checks(self, tmp_path: Path) -> None:
         out = tmp_path / "v1.jsonl"

--- a/packages/nest-core/tests/test_provenance_supply_chain_linear.py
+++ b/packages/nest-core/tests/test_provenance_supply_chain_linear.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the provenance_supply_chain_linear scenario.
+
+Same core claim as the diamond scenario, on a deep linear spine: the three
+adversarial validators FAIL against the default ``datafacts_v1`` layer
+(name-addressed, unauthenticated freshness, no provenance) and PASS against
+``cid_facts``, driven by a real simulator run over a four-hop single-parent
+chain. Also pins the lineage depth and byte-identical determinism.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+
+_SCENARIO = "provenance_supply_chain_linear"
+_YAML = "scenarios/provenance_supply_chain_linear.yaml"
+
+
+def _run(datafacts: str, out: Path, seed: int = 42) -> None:
+    cfg = ScenarioConfig.from_yaml(_YAML)
+    cfg.layers.datafacts = datafacts
+    cfg.seed = seed
+    cfg.output.trace = str(out)
+    asyncio.run(ScenarioRunner(cfg).run())
+
+
+class TestScenarioEndToEnd:
+    def test_cid_facts_passes_all(self, tmp_path: Path) -> None:
+        out = tmp_path / "cid_facts.jsonl"
+        _run("cid_facts", out)
+        results = validate_trace(out, _SCENARIO)
+        assert results, "expected validators to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_linear_walk_visits_all_four_hops(self, tmp_path: Path) -> None:
+        """The chain walk must resolve the full depth: supplier..retailer = 4 nodes."""
+        out = tmp_path / "cid_facts.jsonl"
+        _run("cid_facts", out)
+        chain_ok = [
+            msg
+            for line in out.read_text().splitlines()
+            if (msg := str(json.loads(line).get("msg", ""))).startswith("chain_ok|")
+        ]
+        assert chain_ok, "no chain_ok recorded"
+        assert chain_ok[0].rsplit("|", 1)[-1] == "4"
+
+    def test_datafacts_v1_fails_all_adversarial_checks(self, tmp_path: Path) -> None:
+        out = tmp_path / "v1.jsonl"
+        _run("datafacts_v1", out)
+        results = {r.name: r.passed for r in validate_trace(out, _SCENARIO)}
+        # The happy-path lineage walk still works -- v1 stores parents in its
+        # metadata dict even though it never validates them.
+        assert results["provenance_chain_integrity"] is True
+        assert results["provenance_substitution_resistant"] is False
+        assert results["provenance_freshness_unforgeable"] is False
+        assert results["provenance_chain_unforgeable"] is False
+
+    def test_deterministic_across_required_seeds(self, tmp_path: Path) -> None:
+        for seed in (42, 7, 1337):
+            a, b = tmp_path / f"{seed}a.jsonl", tmp_path / f"{seed}b.jsonl"
+            _run("cid_facts", a, seed=seed)
+            _run("cid_facts", b, seed=seed)
+            assert a.read_bytes() == b.read_bytes(), f"seed {seed} not deterministic"
+            assert all(r.passed for r in validate_trace(a, _SCENARIO))

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -926,6 +926,7 @@ class TestValidatorRegistry:
             "receipt_reputation",
             "multi_attribute_market",
             "provenance_supply_chain",
+            "provenance_supply_chain_linear",
             "bft_hotstuff",
             "escrow_marketplace",
         }

--- a/scenarios/provenance_supply_chain_linear.yaml
+++ b/scenarios/provenance_supply_chain_linear.yaml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Provenance scenario: a deep LINEAR supply chain, then three attacks.
+#
+#   supplier-0 -> manufacturer-0 -> distributor-0 -> retailer-0 -> auditor-0
+#
+# Each producer publishes a dataset declaring exactly the previous hop's dataset
+# as its single provenance parent, so the lineage is one unbranched chain four
+# hops deep. auditor-0 walks the whole chain back to the supplier's root, then
+# runs substitution, forged-freshness, and broken-provenance attacks as an
+# outsider.
+#
+# Complements provenance_supply_chain (a diamond): that one stresses lineage
+# fan-out (a join), this one stresses lineage depth (a long single-parent spine).
+# Both share one validator set because both emit the same provenance wire
+# protocol -- the guarantees under test are plugin properties, not graph shape.
+#
+# Verify::
+#
+#     nest run scenarios/provenance_supply_chain_linear.yaml
+#     python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
+#         [print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail) \
+#          for r in validate_trace(Path('traces/provenance_supply_chain_linear.jsonl'), 'provenance_supply_chain_linear')]"
+#
+# Swap `layers.datafacts` to `datafacts_v1` to see the adversarial validators
+# flip to FAIL -- that plugin has no content-addressing, signed freshness, or
+# provenance concept at all.
+name: provenance_supply_chain_linear
+description: "Deep linear dataset supply chain with provenance; an outsider then attempts substitution, forged-freshness, and broken-provenance attacks."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 5
+  brain: state-machine
+  roles:
+    - name: supplier
+      count: 1
+    - name: manufacturer
+      count: 1
+    - name: distributor
+      count: 1
+    - name: retailer
+      count: 1
+    - name: auditor
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: cid_facts
+
+task:
+  type: provenance_supply_chain_linear
+  config: {}
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 1000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/provenance_supply_chain_linear.jsonl


### PR DESCRIPTION
Follow-up #2 to #35 (closed as a duplicate of #31), the distinct-topology scenario @dhve flagged as worth landing independently.

## What
A new `provenance_supply_chain_linear` scenario — a deep **linear** dataset chain:

```
supplier-0 -> manufacturer-0 -> distributor-0 -> retailer-0 -> auditor-0
```

Each producer declares exactly the previous hop's dataset as its single provenance parent, so the lineage is one unbranched spine four hops deep. The auditor walks the whole chain back to the supplier's root, then runs the three attacks (substitution, forged freshness, broken provenance) as an outsider.

## Why it complements #31
#31's `provenance_supply_chain` is a **diamond** — it stresses lineage *fan-out* (a join whose ancestry forks back to a shared root). This one stresses lineage *depth* (a long single-parent chain). Notably #31's own history shows the scenario started linear and moved to a diamond; this restores the linear angle as a first-class, separate scenario rather than losing it.

## Minimal and #31-safe
- Exercises the **merged `cid_facts` plugin** as-is — no plugin changes.
- Emits the **same `|`-delimited provenance wire protocol** as the diamond, so it reuses #31's four validators under a new registry key `provenance_supply_chain_linear` — **zero new validator code**, and `provenance_supply_chain` is left completely untouched.
- Touch points: new scenario module + YAML, one `scenarios.py` dispatch branch, one `VALIDATORS` key, one line in the registry test.

## Adversarial discrimination (same YAML, two plugins)
```
uv run nest run scenarios/provenance_supply_chain_linear.yaml
# cid_facts  -> 4x PASS (chain resolved to depth 4)
# datafacts_v1 -> chain_integrity PASS, substitution/freshness/provenance FAIL
```

## Determinism & tests
Tier 1, seeded only, logical-tick clock. `test_provenance_supply_chain_linear.py` asserts all-pass on `cid_facts`, the three adversarial FAILs on `datafacts_v1`, lineage depth == 4, and **byte-identical replay under seeds 42 / 7 / 1337**.

## Verify
```
uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -q
# 740 passed, 1 skipped
```

Persona — provenance-engineer: content addressing as substitution resistance, lineage folded into the content hash so a deep chain is tamper-evident end to end, freshness bound under a signature, and a verifier anchored to externally observed ticks.
