### PR TITLE
[Hackathon] theritwik: delegatable capability tokens with cascading revocation

### DIFF
--- a/docs/layers/auth.md
+++ b/docs/layers/auth.md
@@ -21,6 +21,56 @@ shape (header.payload.sig), no claim validation beyond the signature.
 
 Source: [`nest_plugins_reference/auth/jwt_auth.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/jwt_auth.py).
 
+## `delegatable` — macaroon-style delegation with cascading revocation
+
+`jwt` issues flat tokens and revokes by exact token string, so it cannot
+model *delegation* (an agent minting a narrower sub-capability for another
+agent without the issuer) or *cascading revocation* (revoke a parent →
+every descendant fails automatically). `delegatable` adds both, following
+the macaroon construction (Birgisson et al., 2014).
+
+A token carries its whole chain of links; each link's HMAC is keyed on the
+previous link's signature, so **delegation needs only the parent token, not
+the root secret**:
+
+```python
+auth = DelegatableAuth(secret=b"authority-secret")
+root  = await auth.issue(AgentId("coordinator-0"), ["read", "write", "admin"])
+child = await auth.delegate(root, AgentId("worker-3"), ["read"], ttl=100)
+ctx   = await auth.verify_presented(child, AgentId("worker-3"))   # audience-bound
+await auth.revoke(root)          # cascades: child now fails to verify
+```
+
+Extra surface on top of the base `Auth` protocol:
+
+- `delegate(parent_token, audience, scopes_subset, ttl) -> Token` — child
+  scopes must be a subset of the parent's (a superset raises
+  `ScopeEscalationError`); child expiry is clamped to never outlive the
+  parent.
+- `verify_presented(token, presenter) -> AuthContext` — everything `verify`
+  checks, plus that the presenter is the tip's declared audience.
+
+Three attacks it stops at verify time — an attacker holding a token can
+always *append* a validly-signed link, so every restriction is re-checked on
+the way in — that the `jwt` plugin silently allows:
+
+| Attack | `jwt` | `delegatable` |
+|---|---|---|
+| **Scope escalation** (child grants a scope the parent lacked) | accepted | `ScopeEscalationError` |
+| **Stale ancestor** (child verifies after parent revoked/expired) | accepted | `RevokedAncestorError` / `ExpiredTokenError` |
+| **Audience confusion** (token for B presented by C) | accepted | `AudienceConfusionError` |
+
+The shipped adversarial validator
+([`validators/auth_validators.py`](../../packages/nest-plugins-reference/nest_plugins_reference/validators/auth_validators.py))
+encodes these as pure checks over observed grants: it **fails** against `jwt`
+and **passes** against `delegatable`. Determinism is preserved — token ids are
+content hashes, signatures are HMAC-SHA256, and expiry is measured against a
+logical tick clock, never wall time.
+
+Sources:
+[`auth/delegatable.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py),
+scenario [`scenarios/delegated_auth.yaml`](../../scenarios/delegated_auth.yaml).
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -25,6 +25,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
+    ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -119,3 +119,7 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("escrow_marketplace", escrow_marketplace_factory)
+    elif name == "delegated_auth":
+        from nest_core.scenarios_builtin.delegated_auth import delegated_auth_factory
+
+        register_scenario("delegated_auth", delegated_auth_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegated-auth scenario — a delegation tree with a cascading revocation.
+
+Topology (see ``scenarios/delegated_auth.yaml``):
+
+* ``coordinator-0`` holds the root capability ``{read, write, admin}``.
+* ``intermediary-0..2`` each receive a *narrowed*, time-bounded sub-capability
+  minted by the coordinator with :meth:`DelegatableAuth.delegate` — no issuer
+  round-trip.
+* ``leaf-0..11`` (four under each intermediary) receive a further-narrowed
+  ``{read}`` capability from their intermediary and verify it, bound to their
+  own identity via :meth:`DelegatableAuth.verify_presented`.
+
+The run has two phases, ordered by the simulator's logical clock:
+
+1. **Grant + verify** (tick 0): the tree is built top-down and every leaf
+   verifies its capability.  All 12 succeed.
+2. **Cascading revocation** (``revoke_at`` tick): the coordinator revokes the
+   *middle* intermediary's token and asks every leaf to re-verify.  The four
+   leaves under the revoked intermediary now fail with
+   ``RevokedAncestorError`` — by construction, because their chains embed the
+   revoked ancestor id — while the other eight still succeed.
+
+Every agent shares the one resolved ``DelegatableAuth`` instance (the auth
+authority), so a revocation is globally visible.  Verify outcomes are written
+to a shared ledger exposed on the plugins dict as ``_auth_ledger`` so tests can
+assert the cascade end-to-end.
+
+Example::
+
+    from nest_core.runner import ScenarioRunner
+    runner = ScenarioRunner(ScenarioConfig.from_yaml("scenarios/delegated_auth.yaml"))
+    await runner.run()
+    ledger = runner.resolved_plugins["_auth_ledger"]
+    assert all(ok for _, ok, _ in ledger["initial"])
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Token
+
+TAG_DELEGATE = b"DLG:"
+"""Coordinator → intermediary: carries the intermediary's sub-capability token."""
+
+TAG_VERIFY = b"VFY:"
+"""Intermediary → leaf: carries the leaf's capability token to verify + store."""
+
+TAG_REVERIFY = b"RVF"
+"""Coordinator → all: re-verify your stored token (post-revocation probe)."""
+
+TAG_REVOKE_TICK = b"RVK"
+"""Coordinator self-message: time to revoke the middle subtree."""
+
+ROOT_SCOPES = ["admin", "read", "write"]
+"""Scopes held by the root capability minted for the coordinator."""
+
+INTERMEDIARY_SCOPES = ["read", "write"]
+"""Scopes each intermediary receives — a strict narrowing of the root."""
+
+LEAF_SCOPES = ["read"]
+"""Scopes each leaf receives — a further narrowing of its intermediary's grant."""
+
+DEFAULT_CHILD_TTL = 100_000
+"""Delegation lifetime (logical ticks); large so nothing expires mid-scenario."""
+
+DEFAULT_REVOKE_AT = 100
+"""Logical tick at which the coordinator revokes the middle intermediary."""
+
+
+def _err_name(exc: Exception) -> str:
+    """Return the exception's class name, for compact ledger records.
+
+    Example::
+
+        assert _err_name(ValueError("x")) == "ValueError"
+    """
+    return type(exc).__name__
+
+
+class CoordinatorAgent(StateMachineAgent):
+    """Root-capability holder that seeds the tree and later revokes a subtree.
+
+    Example::
+
+        agent = CoordinatorAgent(AgentId("coordinator-0"), ["intermediary-0"], 1, 100, 100000)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        intermediaries: list[AgentId],
+        revoke_index: int,
+        revoke_at: int,
+        child_ttl: int,
+    ) -> None:
+        self._id = agent_id
+        self._intermediaries = intermediaries
+        self._revoke_index = revoke_index
+        self._revoke_at = revoke_at
+        self._child_ttl = child_ttl
+        self._child_tokens: dict[AgentId, Token] = {}
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Mint the root, delegate to each intermediary, and arm the revoke tick.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        auth = ctx.plugins.get("auth")
+        if auth is None:
+            return
+        root = await auth.issue(self._id, list(ROOT_SCOPES))
+        self._root: Token = root
+        for interm in self._intermediaries:
+            child = await auth.delegate(root, interm, list(INTERMEDIARY_SCOPES), self._child_ttl)
+            self._child_tokens[interm] = child
+            await ctx.send(interm, TAG_DELEGATE + str(child).encode())
+        await ctx.schedule(float(self._revoke_at), TAG_REVOKE_TICK)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """On the revoke self-tick: revoke the middle subtree, ask all to re-verify.
+
+        Example::
+
+            await agent.on_message(ctx, ctx.agent_id, TAG_REVOKE_TICK)
+        """
+        if sender != self._id or payload != TAG_REVOKE_TICK:
+            return
+        auth = ctx.plugins.get("auth")
+        if auth is None:
+            return
+        target = self._intermediaries[self._revoke_index]
+        await auth.revoke(self._child_tokens[target])
+        await ctx.broadcast(TAG_REVERIFY)
+
+
+class IntermediaryAgent(StateMachineAgent):
+    """Holds a delegated capability and sub-delegates ``{read}`` to its leaves.
+
+    Example::
+
+        agent = IntermediaryAgent(AgentId("intermediary-0"), [AgentId("leaf-0")], 100000)
+    """
+
+    def __init__(self, agent_id: AgentId, leaves: list[AgentId], child_ttl: int) -> None:
+        self._id = agent_id
+        self._leaves = leaves
+        self._child_ttl = child_ttl
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """On receiving my capability, mint and hand out each leaf's token.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("coordinator-0"), TAG_DELEGATE + b"...")
+        """
+        if not payload.startswith(TAG_DELEGATE):
+            return
+        auth = ctx.plugins.get("auth")
+        if auth is None:
+            return
+        my_token = Token(payload[len(TAG_DELEGATE) :].decode())
+        for leaf in self._leaves:
+            leaf_tok = await auth.delegate(my_token, leaf, list(LEAF_SCOPES), self._child_ttl)
+            await ctx.send(leaf, TAG_VERIFY + str(leaf_tok).encode())
+
+
+class LeafAgent(StateMachineAgent):
+    """Receives a capability, verifies it bound to itself, re-verifies on request.
+
+    Example::
+
+        agent = LeafAgent(AgentId("leaf-0"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+        self._token: Token | None = None
+
+    async def _verify_into(self, ctx: AgentContext, phase: str) -> None:
+        auth = ctx.plugins.get("auth")
+        ledger = ctx.plugins.get("_auth_ledger")
+        if auth is None or ledger is None or self._token is None:
+            return
+        try:
+            await auth.verify_presented(self._token, self._id)
+            ledger[phase].append((str(self._id), True, None))
+        except Exception as exc:  # noqa: BLE001 - record the typed failure, don't crash the sim
+            ledger[phase].append((str(self._id), False, _err_name(exc)))
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Store + verify on first grant; re-verify when the coordinator asks.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("intermediary-0"), TAG_VERIFY + b"...")
+        """
+        if payload.startswith(TAG_VERIFY):
+            self._token = Token(payload[len(TAG_VERIFY) :].decode())
+            await self._verify_into(ctx, "initial")
+        elif payload == TAG_REVERIFY:
+            await self._verify_into(ctx, "after_revoke")
+
+
+def delegated_auth_factory(config: ScenarioConfig, plugins: dict[str, Any]) -> dict[AgentId, Any]:
+    """Build the coordinator / intermediary / leaf fleet for the delegation tree.
+
+    Leaves are partitioned evenly across intermediaries by index.  A shared
+    ``_auth_ledger`` dict is stashed on ``plugins`` so the harness and tests can
+    read every verify outcome after the run.
+
+    Example::
+
+        agents = delegated_auth_factory(config, plugins)
+    """
+    task_cfg = config.task.config or {}
+    child_ttl = int(task_cfg.get("child_ttl", DEFAULT_CHILD_TTL))
+    revoke_at = int(task_cfg.get("revoke_at", DEFAULT_REVOKE_AT))
+    revoke_index = int(task_cfg.get("revoke_index", 1))
+
+    counts: dict[str, int] = {role.name: role.count for role in config.agents.roles}
+    n_coord = counts.get("coordinator", 1)
+    n_interm = counts.get("intermediary", 3)
+    n_leaf = counts.get("leaf", 12)
+
+    coordinator = AgentId("coordinator-0")
+    intermediaries = [AgentId(f"intermediary-{i}") for i in range(n_interm)]
+    leaves = [AgentId(f"leaf-{i}") for i in range(n_leaf)]
+
+    per_interm = n_leaf // n_interm if n_interm else 0
+    leaves_of: dict[AgentId, list[AgentId]] = {interm: [] for interm in intermediaries}
+    for idx, leaf in enumerate(leaves):
+        owner_idx = min(idx // per_interm, n_interm - 1) if per_interm else 0
+        leaves_of[intermediaries[owner_idx]].append(leaf)
+
+    # ``PluginRegistry.resolve`` yields the plugin *class*, so instantiate one
+    # shared authority here and inject it as the concrete ``auth`` instance for
+    # every agent — a single instance means a revocation is globally visible.
+    from nest_plugins_reference.auth.delegatable import DelegatableAuth
+
+    plugins["auth"] = DelegatableAuth(root_ttl=max(child_ttl * 2, 1_000_000))
+    plugins["_auth_ledger"] = {"initial": [], "after_revoke": []}
+
+    agents: dict[AgentId, Any] = {}
+    if n_coord:
+        agents[coordinator] = CoordinatorAgent(
+            coordinator,
+            intermediaries,
+            revoke_index=min(revoke_index, max(n_interm - 1, 0)),
+            revoke_at=revoke_at,
+            child_ttl=child_ttl,
+        )
+    for interm in intermediaries:
+        agents[interm] = IntermediaryAgent(interm, leaves_of[interm], child_ttl=child_ttl)
+    for leaf in leaves:
+        agents[leaf] = LeafAgent(leaf)
+    return agents

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
@@ -1,0 +1,503 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegatable capability tokens with cascading revocation (macaroon-style).
+
+The default auth plugin
+(:class:`~nest_plugins_reference.auth.jwt_auth.JwtAuth`) issues flat,
+HMAC-signed tokens and tracks revocation by *exact token string*
+(``JwtAuth._revoked: set[str]``).  That shape cannot express the most common
+real-world authorization pattern:
+
+* **Delegation without the issuer.**  Agent *A* holds a root capability and
+  wants to mint a *narrower*, time-bounded sub-capability for agent *B* — and
+  it must be able to do so **without going back to the issuer** for a fresh
+  signature.
+* **Cascading revocation.**  Revoking *A*'s capability must invalidate *B*'s
+  (and every further descendant's) at the next ``verify`` — automatically,
+  with no per-child revocation list.
+
+This plugin implements the macaroon construction (Birgisson et al., 2014).
+A token carries its whole *chain* of links from root to tip; the tip's HMAC
+is keyed on the **previous link's signature**, so extending a token requires
+only the parent token — never the root secret:
+
+    s0  = HMAC(root_secret,   canonical(link0))
+    s1  = HMAC(s0,            canonical(link1))     # delegation: no secret needed
+    ...
+    tip = HMAC(s_{n-1},       canonical(link_n))
+
+Three attacks the reference ``jwt`` plugin silently allows, and how this
+plugin stops each **at verify time** (an attacker who holds a token can always
+*append* a link — the signature alone never proves restriction, so every
+restriction is re-checked on the way in):
+
+* **Scope escalation** — a child asking for a scope its parent never held.
+  :meth:`delegate` refuses it, and :meth:`verify` independently rejects any
+  chain whose scopes are not monotonically narrowing, so a hand-forged token
+  cannot slip an escalation past a valid signature.
+* **Stale ancestor** — presenting a child after an ancestor was revoked or
+  expired.  Because every descendant embeds its ancestors' ``jti`` values,
+  :meth:`verify` fails the whole chain if *any* ancestor id is in the revoked
+  set (:class:`RevokedAncestorError`) or any link has lapsed
+  (:class:`ExpiredTokenError`).
+* **Audience confusion** — a token minted for *B* being presented by *C*.
+  Each link binds an audience (``sub``); :meth:`verify_presented` rejects a
+  presenter that is not the tip's declared audience
+  (:class:`AudienceConfusionError`).
+
+Determinism (Tier 1): token ids are content hashes, signatures are HMAC-SHA256
+over canonical JSON, and expiry is measured against an injected **logical
+tick** clock — never ``time.time()`` — so the same operations replay
+byte-identically under a fixed seed.
+
+Example::
+
+    auth = DelegatableAuth(secret=b"authority-secret")
+    root = await auth.issue(AgentId("coordinator-0"), ["read", "write", "admin"])
+    child = await auth.delegate(root, AgentId("worker-3"), ["read"], ttl=100)
+    ctx = await auth.verify_presented(child, AgentId("worker-3"))
+    assert ctx.scopes == ["read"]
+    await auth.revoke(root)                       # revoke the ancestor...
+    # ...and every descendant fails at the next verify, by construction:
+    # await auth.verify(child)  -> RevokedAncestorError
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypedDict, cast
+
+from nest_core.types import AgentId, AuthContext, Token
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+DEFAULT_ROOT_TTL = 1_000_000
+"""Default lifetime (in logical ticks) of a root token minted by :meth:`issue`.
+
+Large by design: root capabilities are long-lived and narrowed by delegation,
+not by a short root expiry.  Override per instance via the constructor.
+"""
+
+
+class DelegationError(ValueError):
+    """Base class for every delegation/verification failure.
+
+    Subclassing :class:`ValueError` keeps drop-in compatibility with the
+    reference ``jwt`` plugin, whose failures are all ``ValueError``.
+
+    Example::
+
+        try:
+            await auth.verify(tampered)
+        except DelegationError as exc:
+            print("rejected:", exc)
+    """
+
+
+class InvalidTokenError(DelegationError):
+    """Token is malformed, or its HMAC chain does not verify.
+
+    Example::
+
+        raise InvalidTokenError("signature mismatch at link 2")
+    """
+
+
+class ScopeEscalationError(DelegationError):
+    """A child link requests a scope its parent never held.
+
+    Example::
+
+        raise ScopeEscalationError("child asked for 'admin' not in parent scopes")
+    """
+
+
+class TokenTtlError(DelegationError):
+    """A child's lifetime is non-positive or exceeds its parent's.
+
+    Example::
+
+        raise TokenTtlError("child exp 200 > parent exp 150")
+    """
+
+
+class ExpiredTokenError(DelegationError):
+    """The token (or an ancestor) has lapsed against the logical clock.
+
+    Example::
+
+        raise ExpiredTokenError("token expired at tick 100 (now 137)")
+    """
+
+
+class RevokedAncestorError(DelegationError):
+    """Some ancestor in the chain has been revoked — the child fails too.
+
+    Example::
+
+        raise RevokedAncestorError("ancestor 9f3a... is revoked")
+    """
+
+
+class AudienceConfusionError(DelegationError):
+    """The presenter is not the audience the tip was minted for.
+
+    Example::
+
+        raise AudienceConfusionError("token for worker-3 presented by mallory-0")
+    """
+
+
+class _Link(TypedDict):
+    """One capability link in a delegation chain (wire representation)."""
+
+    jti: str
+    sub: str
+    scopes: list[str]
+    iat: int
+    exp: int
+    parent: str | None
+
+
+class _TokenBody(TypedDict):
+    """The full decoded token: an ordered chain plus its tip signature."""
+
+    chain: list[_Link]
+    sig: str
+
+
+@dataclass(frozen=True)
+class CapabilityLink:
+    """Public, read-only view of a single link — for traces and validators.
+
+    Example::
+
+        links = auth.describe(child)
+        assert links[-1].sub == "worker-3"
+        assert links[0].parent is None            # the root
+    """
+
+    jti: str
+    sub: str
+    scopes: tuple[str, ...]
+    iat: int
+    exp: int
+    parent: str | None
+
+
+def _canonical(link: _Link) -> bytes:
+    """Serialize a link to canonical bytes (sorted keys, no whitespace).
+
+    Determinism hinges on this being stable, so scopes are sorted upstream and
+    the encoding pins key order and separators.
+
+    Example::
+
+        blob = _canonical({"jti": "x", "sub": "a", "scopes": [], "iat": 0, "exp": 1})
+    """
+    return json.dumps(link, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _mint_jti(sub: str, scopes: list[str], iat: int, exp: int, parent: str | None) -> str:
+    """Derive a deterministic token id from a link's content-bearing fields.
+
+    Content addressing means two links with identical content share an id and
+    a tampered link gets a *different* id (so a forged ``parent`` pointer is
+    detectable at verify time).
+
+    Example::
+
+        jti = _mint_jti("a1", ["read"], 0, 100, None)
+    """
+    material = json.dumps(
+        {"sub": sub, "scopes": scopes, "iat": iat, "exp": exp, "parent": parent},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(material).hexdigest()[:16]
+
+
+class DelegatableAuth:
+    """Macaroon-style auth: delegatable capabilities with cascading revocation.
+
+    The instance is the authority: it holds the root ``secret`` used to anchor
+    (and verify) every chain, the shared revocation set, and a logical clock.
+    Delegation, by contrast, needs only the parent token — see :meth:`delegate`.
+
+    Example::
+
+        auth = DelegatableAuth(secret=b"secret", clock=0)
+        root = await auth.issue(AgentId("a1"), ["read", "write"])
+        ctx = await auth.verify(root)
+    """
+
+    def __init__(
+        self,
+        secret: bytes = b"nest-delegatable-secret",
+        clock: int = 0,
+        root_ttl: int = DEFAULT_ROOT_TTL,
+    ) -> None:
+        self._secret = secret
+        self._clock = clock
+        self._root_ttl = root_ttl
+        self._revoked: set[str] = set()
+
+    @property
+    def now(self) -> int:
+        """Current logical tick used for issuance and expiry checks.
+
+        Example::
+
+            assert auth.now == 0
+        """
+        return self._clock
+
+    def advance(self, ticks: int = 1) -> int:
+        """Advance the logical clock and return the new tick (for tests/drivers).
+
+        Example::
+
+            auth.advance(50)
+        """
+        if ticks < 0:
+            msg = "cannot rewind the logical clock"
+            raise ValueError(msg)
+        self._clock += ticks
+        return self._clock
+
+    # -- encoding -----------------------------------------------------------
+
+    @staticmethod
+    def _encode(chain: list[_Link], sig: str) -> Token:
+        body: _TokenBody = {"chain": chain, "sig": sig}
+        return Token(json.dumps(body, sort_keys=True, separators=(",", ":")))
+
+    @staticmethod
+    def _decode(token: Token) -> _TokenBody:
+        try:
+            raw = json.loads(str(token))
+        except json.JSONDecodeError as exc:
+            msg = f"token is not valid JSON: {exc}"
+            raise InvalidTokenError(msg) from exc
+        if not isinstance(raw, dict):
+            msg = "token is not a JSON object"
+            raise InvalidTokenError(msg)
+        data = cast("dict[str, object]", raw)
+        if "chain" not in data or "sig" not in data:
+            msg = "token missing 'chain' or 'sig'"
+            raise InvalidTokenError(msg)
+        chain = data["chain"]
+        if not isinstance(chain, list) or not chain:
+            msg = "token chain is empty or malformed"
+            raise InvalidTokenError(msg)
+        return cast("_TokenBody", data)
+
+    def _tip_signature(self, chain: Sequence[_Link]) -> str:
+        """Recompute the chain's tip signature from the root secret."""
+        sig = hmac.new(self._secret, _canonical(chain[0]), hashlib.sha256).hexdigest()
+        for link in chain[1:]:
+            sig = hmac.new(sig.encode(), _canonical(link), hashlib.sha256).hexdigest()
+        return sig
+
+    # -- Auth protocol ------------------------------------------------------
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Mint a root capability token for ``subject`` with ``scopes``.
+
+        Example::
+
+            root = await auth.issue(AgentId("coordinator-0"), ["read", "write"])
+        """
+        norm = sorted(set(scopes))
+        iat = self._clock
+        exp = self._clock + self._root_ttl
+        jti = _mint_jti(str(subject), norm, iat, exp, None)
+        link: _Link = {
+            "jti": jti,
+            "sub": str(subject),
+            "scopes": norm,
+            "iat": iat,
+            "exp": exp,
+            "parent": None,
+        }
+        return self._encode([link], self._tip_signature([link]))
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: int,
+    ) -> Token:
+        """Mint a narrower child capability for ``audience`` — no issuer needed.
+
+        The child's scopes must be a subset of the parent's (a request for any
+        scope the parent lacks raises :class:`ScopeEscalationError`) and its
+        expiry is clamped to never outlive the parent.  Only the parent token
+        is consumed; the root ``secret`` is untouched, which is what makes this
+        real delegation rather than re-issuance.
+
+        Example::
+
+            child = await auth.delegate(root, AgentId("worker-3"), ["read"], ttl=100)
+        """
+        body = self._decode(parent_token)
+        parent = body["chain"][-1]
+        parent_scopes = set(parent["scopes"])
+        requested = sorted(set(scopes_subset))
+        extra = set(requested) - parent_scopes
+        if extra:
+            msg = f"scope escalation: {sorted(extra)} not held by parent {parent['jti']}"
+            raise ScopeEscalationError(msg)
+        if ttl <= 0:
+            msg = f"child ttl must be positive, got {ttl}"
+            raise TokenTtlError(msg)
+        iat = self._clock
+        exp = min(self._clock + ttl, parent["exp"])
+        if exp <= iat:
+            msg = f"child already expired: exp {exp} <= iat {iat}"
+            raise TokenTtlError(msg)
+        jti = _mint_jti(str(audience), requested, iat, exp, parent["jti"])
+        child: _Link = {
+            "jti": jti,
+            "sub": str(audience),
+            "scopes": requested,
+            "iat": iat,
+            "exp": exp,
+            "parent": parent["jti"],
+        }
+        new_chain = [*body["chain"], child]
+        # Extend the parent's *tip* signature by one HMAC — never the root
+        # secret.  This is the macaroon property: any holder of the parent
+        # token can delegate without contacting the issuer.
+        child_sig = hmac.new(body["sig"].encode(), _canonical(child), hashlib.sha256).hexdigest()
+        return self._encode(new_chain, child_sig)
+
+    async def verify(self, token: Token) -> AuthContext:
+        """Verify a token end-to-end and return the tip's :class:`AuthContext`.
+
+        Checks, in order: HMAC chain integrity and content-addressed ids,
+        monotonic scope narrowing, monotonic (non-increasing) expiry, tip
+        expiry against the logical clock, and transitive revocation of every
+        ancestor.  Any failure raises a :class:`DelegationError` subclass.
+
+        Example::
+
+            ctx = await auth.verify(child)
+            assert ctx.subject == AgentId("worker-3")
+        """
+        body = self._decode(token)
+        chain = body["chain"]
+
+        if chain[0]["parent"] is not None:
+            msg = "root link must have no parent"
+            raise InvalidTokenError(msg)
+        for depth, link in enumerate(chain):
+            expected_jti = _mint_jti(
+                link["sub"], link["scopes"], link["iat"], link["exp"], link["parent"]
+            )
+            if not hmac.compare_digest(expected_jti, link["jti"]):
+                msg = f"tampered link at depth {depth}: id does not match content"
+                raise InvalidTokenError(msg)
+            if depth > 0 and link["parent"] != chain[depth - 1]["jti"]:
+                msg = f"broken chain at depth {depth}: parent pointer mismatch"
+                raise InvalidTokenError(msg)
+
+        if not hmac.compare_digest(self._tip_signature(chain), body["sig"]):
+            msg = "token signature does not verify"
+            raise InvalidTokenError(msg)
+
+        for depth in range(1, len(chain)):
+            if not set(chain[depth]["scopes"]) <= set(chain[depth - 1]["scopes"]):
+                widened = sorted(set(chain[depth]["scopes"]) - set(chain[depth - 1]["scopes"]))
+                msg = f"scope escalation at depth {depth}: gained {widened}"
+                raise ScopeEscalationError(msg)
+            if chain[depth]["exp"] > chain[depth - 1]["exp"]:
+                msg = f"ttl escalation at depth {depth}: child outlives parent"
+                raise TokenTtlError(msg)
+
+        tip = chain[-1]
+        if tip["exp"] < self._clock:
+            msg = f"token expired at tick {tip['exp']} (now {self._clock})"
+            raise ExpiredTokenError(msg)
+
+        for link in chain:
+            if link["jti"] in self._revoked:
+                msg = f"ancestor {link['jti']} is revoked"
+                raise RevokedAncestorError(msg)
+
+        return AuthContext(
+            subject=AgentId(tip["sub"]),
+            scopes=list(tip["scopes"]),
+            issued_at=float(tip["iat"]),
+            expires_at=float(tip["exp"]),
+        )
+
+    async def verify_presented(self, token: Token, presenter: AgentId) -> AuthContext:
+        """Verify ``token`` **and** bind it to ``presenter`` (audience check).
+
+        Everything :meth:`verify` checks, plus: the tip's audience must equal
+        the agent actually presenting the token, closing the audience-confusion
+        hole the flat ``jwt`` plugin cannot express.
+
+        Example::
+
+            ctx = await auth.verify_presented(child, AgentId("worker-3"))
+        """
+        ctx = await self.verify(token)
+        if ctx.subject != presenter:
+            msg = f"token for {ctx.subject} presented by {presenter}"
+            raise AudienceConfusionError(msg)
+        return ctx
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke a token by its tip id — cascades to every descendant.
+
+        Because each descendant embeds this id among its ancestors, revoking
+        here makes them all fail their next :meth:`verify` with
+        :class:`RevokedAncestorError`.
+
+        Example::
+
+            await auth.revoke(root)   # every child/grandchild now fails to verify
+        """
+        body = self._decode(token)
+        self._revoked.add(body["chain"][-1]["jti"])
+
+    # -- observability ------------------------------------------------------
+
+    def describe(self, token: Token) -> tuple[CapabilityLink, ...]:
+        """Return the chain as read-only :class:`CapabilityLink` records.
+
+        Useful for emitting delegation evidence into a trace or feeding an
+        adversarial validator without exposing the mutable wire dicts.
+
+        Example::
+
+            root_link, *rest = auth.describe(child)
+            assert root_link.parent is None
+        """
+        body = self._decode(token)
+        return tuple(
+            CapabilityLink(
+                jti=link["jti"],
+                sub=link["sub"],
+                scopes=tuple(link["scopes"]),
+                iat=link["iat"],
+                exp=link["exp"],
+                parent=link["parent"],
+            )
+            for link in body["chain"]
+        )
+
+    def is_revoked(self, jti: str) -> bool:
+        """Return whether a specific link id has been revoked.
+
+        Example::
+
+            assert auth.is_revoked(root_jti) is False
+        """
+        return jti in self._revoked

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -16,6 +16,14 @@ Example::
 
 from __future__ import annotations
 
+from nest_plugins_reference.validators.auth_validators import (
+    DelegationAudit,
+    GrantObservation,
+    check_delegation_safety,
+    check_no_audience_confusion,
+    check_no_scope_escalation,
+    check_no_stale_ancestor,
+)
 from nest_plugins_reference.validators.gossip_validators import (
     ConvergenceFailureError,
     PartitionLeakError,
@@ -33,12 +41,18 @@ from nest_plugins_reference.validators.privacy_validators import (
 
 __all__ = [
     "ConvergenceFailureError",
+    "DelegationAudit",
+    "GrantObservation",
     "PartitionLeakError",
     "ValidatorReport",
     "check_converged",
+    "check_delegation_safety",
     "check_eavesdropper_blocked",
     "check_field_injection_rejected",
+    "check_no_audience_confusion",
     "check_no_partition_view_leak",
+    "check_no_scope_escalation",
+    "check_no_stale_ancestor",
     "check_replay_rejected",
     "check_stale_revocation_blocked",
     "corrupt_proof",

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/auth_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/auth_validators.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for delegatable capability tokens.
+
+Three attacks the default ``jwt`` plugin silently allows — because its tokens
+are flat, unrelated strings with no parent/child relationship and no audience
+binding:
+
+1. **Scope escalation** — a "delegated" token grants a capability the delegator
+   never held.  ``jwt`` re-issues an independent token with whatever scopes are
+   asked for and ``verify`` accepts it.  ``check_no_scope_escalation`` catches
+   any *verified* grant whose scopes are not a subset of its parent's.
+2. **Stale ancestor** — a child still verifies after its parent was revoked (or
+   expired).  ``jwt._revoked`` is keyed by exact token string, so revoking the
+   parent does nothing to the child.  ``check_no_stale_ancestor`` catches any
+   *verified* grant with a revoked/expired ancestor in its chain.
+3. **Audience confusion** — a token minted for *B* is presented by *C* and
+   still verifies.  ``jwt`` has no audience binding.
+   ``check_no_audience_confusion`` catches any *verified* grant whose presenter
+   is not its declared audience.
+
+Each validator is a **pure function** over a list of :class:`GrantObservation`
+records — the same shape whether the evidence was built by driving a live auth
+plugin (unit/integration tests) or replayed from a scenario trace.  A grant is
+only a violation if the plugin actually *accepted* it (``verified=True``); a
+plugin that raises on the attack produces ``verified=False`` records and passes
+cleanly.  That is exactly the charter's bar:
+
+* against the **delegatable** plugin every attack raises, so no verified grant
+  is a violation and all three checks PASS;
+* against the **jwt** plugin every attack is accepted, so the matching check
+  FAILS — the validator literally cannot be satisfied by the reference plugin.
+
+Example::
+
+    grants = [GrantObservation(jti="c", parent_jti="r", audience=AgentId("b"),
+                               scopes=("read", "admin"), presenter=AgentId("b"),
+                               verified=True)]
+    parents = {"r": ("read",)}
+    assert not check_no_scope_escalation(grants, parent_scopes=parents).passed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from nest_plugins_reference.validators.gossip_validators import ValidatorReport
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from nest_core.types import AgentId
+
+
+@dataclass(frozen=True)
+class GrantObservation:
+    """One observed capability grant and whether the plugin accepted it.
+
+    ``verified`` records the plugin's own verdict when the (possibly malicious)
+    token was presented — the validators only ever flag grants the plugin
+    *accepted*.
+
+    Example::
+
+        obs = GrantObservation(
+            jti="child-1", parent_jti="root-0", audience=AgentId("b"),
+            scopes=("read",), presenter=AgentId("b"), verified=True,
+        )
+    """
+
+    jti: str
+    parent_jti: str | None
+    audience: AgentId
+    scopes: tuple[str, ...]
+    presenter: AgentId
+    verified: bool
+    error: str | None = None
+
+
+def check_no_scope_escalation(
+    grants: Sequence[GrantObservation],
+    *,
+    parent_scopes: Mapping[str, tuple[str, ...]],
+) -> ValidatorReport:
+    """Assert no *verified* grant holds a scope its parent never held.
+
+    ``parent_scopes`` maps a link id to the scope set that link legitimately
+    held, so the check works even when the parent link itself is not among the
+    supplied ``grants`` (e.g. a root minted separately).
+
+    Returns ``passed=False`` with ``evidence["escalations"]`` listing
+    ``(jti, gained_scopes)`` pairs when any accepted child widened its scopes.
+
+    Example::
+
+        report = check_no_scope_escalation(grants, parent_scopes={"r": ("read",)})
+        assert report.passed, report.detail
+    """
+    escalations: list[tuple[str, list[str]]] = []
+    for g in grants:
+        if not g.verified or g.parent_jti is None:
+            continue
+        allowed = set(parent_scopes.get(g.parent_jti, ()))
+        gained = sorted(set(g.scopes) - allowed)
+        if gained:
+            escalations.append((g.jti, gained))
+    if escalations:
+        return ValidatorReport(
+            passed=False,
+            detail=f"{len(escalations)} verified grant(s) escalated scope beyond parent",
+            evidence={"escalations": escalations[:20]},
+        )
+    return ValidatorReport(passed=True, detail="no verified grant escalated scope")
+
+
+def check_no_stale_ancestor(
+    grants: Sequence[GrantObservation],
+    *,
+    revoked_jtis: set[str],
+) -> ValidatorReport:
+    """Assert no *verified* grant has a revoked ancestor in its chain.
+
+    The chain is reconstructed transitively from each grant's ``parent_jti``
+    pointers across the whole ``grants`` set, so revoking a *root* is caught on
+    a deep descendant even when only the leaf was presented.
+
+    Returns ``passed=False`` with ``evidence["stale"]`` listing
+    ``(jti, revoked_ancestor)`` pairs.
+
+    Example::
+
+        report = check_no_stale_ancestor(grants, revoked_jtis={"root-0"})
+        assert report.passed, report.detail
+    """
+    parent_of: dict[str, str | None] = {g.jti: g.parent_jti for g in grants}
+    stale: list[tuple[str, str]] = []
+    for g in grants:
+        if not g.verified:
+            continue
+        seen: set[str] = set()
+        cursor: str | None = g.jti
+        while cursor is not None and cursor not in seen:
+            seen.add(cursor)
+            if cursor in revoked_jtis:
+                stale.append((g.jti, cursor))
+                break
+            cursor = parent_of.get(cursor)
+    if stale:
+        return ValidatorReport(
+            passed=False,
+            detail=f"{len(stale)} verified grant(s) survived a revoked ancestor",
+            evidence={"stale": stale[:20]},
+        )
+    return ValidatorReport(passed=True, detail="no verified grant had a revoked ancestor")
+
+
+def check_no_audience_confusion(grants: Sequence[GrantObservation]) -> ValidatorReport:
+    """Assert every *verified* grant was presented by its declared audience.
+
+    Returns ``passed=False`` with ``evidence["confused"]`` listing
+    ``(jti, audience, presenter)`` triples where an accepted token was
+    presented by someone other than its audience.
+
+    Example::
+
+        report = check_no_audience_confusion(grants)
+        assert report.passed, report.detail
+    """
+    confused: list[tuple[str, str, str]] = []
+    for g in grants:
+        if g.verified and g.presenter != g.audience:
+            confused.append((g.jti, str(g.audience), str(g.presenter)))
+    if confused:
+        return ValidatorReport(
+            passed=False,
+            detail=f"{len(confused)} verified grant(s) presented by the wrong agent",
+            evidence={"confused": confused[:20]},
+        )
+    return ValidatorReport(passed=True, detail="no verified grant confused its audience")
+
+
+@dataclass(frozen=True)
+class DelegationAudit:
+    """Aggregate result of all three delegation-safety checks.
+
+    Example::
+
+        audit = check_delegation_safety(grants, parent_scopes=ps, revoked_jtis=set())
+        assert audit.passed, audit.reports
+    """
+
+    passed: bool
+    reports: dict[str, ValidatorReport] = field(default_factory=dict[str, ValidatorReport])
+
+
+def check_delegation_safety(
+    grants: Sequence[GrantObservation],
+    *,
+    parent_scopes: Mapping[str, tuple[str, ...]],
+    revoked_jtis: set[str],
+) -> DelegationAudit:
+    """Run all three adversarial checks and report the combined verdict.
+
+    ``passed`` is ``True`` only if none of scope escalation, stale-ancestor
+    survival, or audience confusion is present among the accepted grants.
+
+    Example::
+
+        audit = check_delegation_safety(grants, parent_scopes=ps, revoked_jtis={"r"})
+        assert audit.passed, audit.reports["stale_ancestor"].detail
+    """
+    reports = {
+        "scope_escalation": check_no_scope_escalation(grants, parent_scopes=parent_scopes),
+        "stale_ancestor": check_no_stale_ancestor(grants, revoked_jtis=revoked_jtis),
+        "audience_confusion": check_no_audience_confusion(grants),
+    }
+    return DelegationAudit(
+        passed=all(r.passed for r in reports.values()),
+        reports=reports,
+    )

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -33,6 +33,9 @@ Repository = "https://github.com/projnanda/nandatown"
 # package. The PluginRegistry also keeps built-in defaults keyed by
 # (layer, name), but declaring the entry point here is the documented,
 # install-time discovery path described in CONTRIBUTING.md.
+[project.entry-points."nest.plugins.auth"]
+delegatable = "nest_plugins_reference.auth.delegatable:DelegatableAuth"
+
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
 

--- a/packages/nest-plugins-reference/tests/test_delegatable_auth.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable_auth.py
@@ -1,0 +1,544 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Conformance, adversarial, and property tests for the delegatable auth plugin.
+
+Coverage:
+
+* **Protocol conformance** — implements ``nest_core.layers.auth.Auth`` and the
+  happy-path issue/verify round-trip.
+* **Delegation semantics** — scope narrowing, ttl clamping, and the macaroon
+  property that delegation needs the parent token but *not* the root secret.
+* **Adversarial (verify-time) defenses** — hand-forged tokens that widen scope
+  or outlive their parent carry a *valid signature* (an attacker holds the
+  parent's tip signature and can append a link), yet ``verify`` rejects them.
+* **Cascading revocation** — revoking an ancestor fails every descendant;
+  revoking a child leaves the parent intact.
+* **Determinism** — identical operations produce byte-identical tokens.
+* **Property-based** — random subset delegations never widen scope; random
+  chains revoke transitively.
+* **Validator discrimination** — the shipped adversarial validator FAILS
+  against the reference ``jwt`` plugin and PASSES against this one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+from typing import Any
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.delegatable import (
+    AudienceConfusionError,
+    DelegatableAuth,
+    ExpiredTokenError,
+    InvalidTokenError,
+    RevokedAncestorError,
+    ScopeEscalationError,
+    TokenTtlError,
+)
+from nest_plugins_reference.auth.jwt_auth import JwtAuth
+from nest_plugins_reference.validators import (
+    GrantObservation,
+    check_delegation_safety,
+)
+
+COORD = AgentId("coordinator-0")
+BOB = AgentId("worker-bob")
+ALICE = AgentId("worker-alice")
+MALLORY = AgentId("mallory-0")
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance + happy path
+# ---------------------------------------------------------------------------
+
+
+def test_implements_auth_protocol() -> None:
+    """Runtime structural check against the Auth protocol."""
+    from nest_core.layers.auth import Auth
+
+    assert isinstance(DelegatableAuth(), Auth)
+
+
+def test_issue_and_verify_roundtrip() -> None:
+    auth = DelegatableAuth(secret=b"s")
+    root = _run(auth.issue(COORD, ["write", "read", "read"]))  # dupes tolerated
+    ctx = _run(auth.verify(root))
+    assert ctx.subject == COORD
+    assert ctx.scopes == ["read", "write"]  # normalized: sorted + deduped
+
+
+def test_describe_exposes_chain_root_first() -> None:
+    auth = DelegatableAuth(secret=b"s")
+    root = _run(auth.issue(COORD, ["read"]))
+    child = _run(auth.delegate(root, BOB, ["read"], ttl=100))
+    links = auth.describe(child)
+    assert len(links) == 2
+    assert links[0].parent is None
+    assert links[0].sub == str(COORD)
+    assert links[1].parent == links[0].jti
+    assert links[1].sub == str(BOB)
+
+
+# ---------------------------------------------------------------------------
+# Delegation semantics
+# ---------------------------------------------------------------------------
+
+
+def test_delegate_narrows_scopes() -> None:
+    auth = DelegatableAuth(secret=b"s")
+    root = _run(auth.issue(COORD, ["read", "write", "admin"]))
+    child = _run(auth.delegate(root, BOB, ["read"], ttl=100))
+    ctx = _run(auth.verify(child))
+    assert ctx.subject == BOB
+    assert ctx.scopes == ["read"]
+
+
+def test_delegate_rejects_scope_escalation() -> None:
+    auth = DelegatableAuth(secret=b"s")
+    root = _run(auth.issue(COORD, ["read"]))
+    try:
+        _run(auth.delegate(root, BOB, ["read", "admin"], ttl=100))
+    except ScopeEscalationError:
+        return
+    raise AssertionError("delegate should have raised ScopeEscalationError")
+
+
+def test_delegate_needs_parent_token_not_root_secret() -> None:
+    """Macaroon property: a party without the authority's secret can delegate."""
+    authority = DelegatableAuth(secret=b"the-real-secret")
+    root = _run(authority.issue(COORD, ["read", "write"]))
+
+    # A different agent holds only the parent token and a *wrong* secret.
+    delegator = DelegatableAuth(secret=b"wrong-secret")
+    child = _run(delegator.delegate(root, BOB, ["read"], ttl=100))
+
+    # The authority still verifies the child: the child's signature is anchored
+    # to the parent's tip signature, which never required the root secret.
+    ctx = _run(authority.verify(child))
+    assert ctx.subject == BOB and ctx.scopes == ["read"]
+
+
+def test_ttl_clamped_to_parent_expiry() -> None:
+    auth = DelegatableAuth(secret=b"s", clock=0, root_ttl=500)
+    root = _run(auth.issue(COORD, ["read"]))  # exp = 500
+    child = _run(auth.delegate(root, BOB, ["read"], ttl=10_000))  # asks to outlive
+    (root_link, child_link) = auth.describe(child)
+    assert child_link.exp == root_link.exp == 500  # clamped, never outlives parent
+
+
+def test_delegate_rejects_nonpositive_ttl() -> None:
+    auth = DelegatableAuth(secret=b"s")
+    root = _run(auth.issue(COORD, ["read"]))
+    try:
+        _run(auth.delegate(root, BOB, ["read"], ttl=0))
+    except TokenTtlError:
+        return
+    raise AssertionError("ttl=0 should raise TokenTtlError")
+
+
+# ---------------------------------------------------------------------------
+# Verify-time defenses against forged (validly-signed) tokens
+# ---------------------------------------------------------------------------
+
+
+def _canon(link: dict[str, Any]) -> bytes:
+    return json.dumps(link, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _jti(sub: str, scopes: list[str], iat: int, exp: int, parent: str | None) -> str:
+    material = json.dumps(
+        {"sub": sub, "scopes": scopes, "iat": iat, "exp": exp, "parent": parent},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(material).hexdigest()[:16]
+
+
+def _forge_child(parent_token: Token, audience: AgentId, scopes: list[str], exp: int) -> Token:
+    """Append a validly-signed child link to a parent token, off-protocol.
+
+    Uses only the parent's tip signature (public, in the token) — exactly what a
+    real attacker holding the parent token could compute.  The resulting token
+    has a correct HMAC chain and content-addressed ids; only ``verify``'s
+    semantic monotonicity checks can catch it.
+    """
+    body = json.loads(str(parent_token))
+    parent_link = body["chain"][-1]
+    norm = sorted(set(scopes))
+    jti = _jti(str(audience), norm, 0, exp, parent_link["jti"])
+    child = {
+        "jti": jti,
+        "sub": str(audience),
+        "scopes": norm,
+        "iat": 0,
+        "exp": exp,
+        "parent": parent_link["jti"],
+    }
+    new_chain = [*body["chain"], child]
+    sig = hmac.new(body["sig"].encode(), _canon(child), hashlib.sha256).hexdigest()
+    forged = {"chain": new_chain, "sig": sig}
+    return Token(json.dumps(forged, sort_keys=True, separators=(",", ":")))
+
+
+def test_verify_rejects_forged_scope_widening() -> None:
+    auth = DelegatableAuth(secret=b"s", root_ttl=1000)
+    root = _run(auth.issue(COORD, ["read"]))
+    forged = _forge_child(root, BOB, ["read", "admin"], exp=1000)  # widened scope
+    try:
+        _run(auth.verify(forged))
+    except ScopeEscalationError:
+        return
+    raise AssertionError("verify must reject a validly-signed but scope-widened token")
+
+
+def test_verify_rejects_forged_ttl_extension() -> None:
+    auth = DelegatableAuth(secret=b"s", root_ttl=1000)
+    root = _run(auth.issue(COORD, ["read"]))
+    forged = _forge_child(root, BOB, ["read"], exp=5000)  # outlives parent (exp 1000)
+    try:
+        _run(auth.verify(forged))
+    except TokenTtlError:
+        return
+    raise AssertionError("verify must reject a child that outlives its parent")
+
+
+def test_verify_rejects_tampered_scope_without_jti_fix() -> None:
+    auth = DelegatableAuth(secret=b"s")
+    root = _run(auth.issue(COORD, ["read"]))
+    body = json.loads(str(root))
+    body["chain"][0]["scopes"] = ["read", "admin"]  # tamper, leave jti stale
+    tampered = Token(json.dumps(body))
+    try:
+        _run(auth.verify(tampered))
+    except InvalidTokenError:
+        return
+    raise AssertionError("verify must reject a link whose id no longer matches content")
+
+
+def test_verify_rejects_malformed_token() -> None:
+    auth = DelegatableAuth(secret=b"s")
+    try:
+        _run(auth.verify(Token("not-json")))
+    except InvalidTokenError:
+        return
+    raise AssertionError("verify must reject non-JSON tokens")
+
+
+# ---------------------------------------------------------------------------
+# Audience binding
+# ---------------------------------------------------------------------------
+
+
+def test_verify_presented_accepts_declared_audience() -> None:
+    auth = DelegatableAuth(secret=b"s")
+    root = _run(auth.issue(COORD, ["read"]))
+    child = _run(auth.delegate(root, BOB, ["read"], ttl=100))
+    ctx = _run(auth.verify_presented(child, BOB))
+    assert ctx.subject == BOB
+
+
+def test_verify_presented_rejects_audience_confusion() -> None:
+    auth = DelegatableAuth(secret=b"s")
+    root = _run(auth.issue(COORD, ["read"]))
+    child = _run(auth.delegate(root, BOB, ["read"], ttl=100))
+    try:
+        _run(auth.verify_presented(child, MALLORY))
+    except AudienceConfusionError:
+        return
+    raise AssertionError("a token minted for BOB must not verify when MALLORY presents it")
+
+
+# ---------------------------------------------------------------------------
+# Cascading revocation
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_ancestor_cascades_to_descendants() -> None:
+    auth = DelegatableAuth(secret=b"s")
+    root = _run(auth.issue(COORD, ["read", "write"]))
+    child = _run(auth.delegate(root, BOB, ["read", "write"], ttl=1000))
+    grandchild = _run(auth.delegate(child, ALICE, ["read"], ttl=500))
+
+    assert _run(auth.verify(grandchild)).subject == ALICE  # ok before revoke
+    _run(auth.revoke(root))  # revoke the *root*
+
+    for tok in (root, child, grandchild):
+        try:
+            _run(auth.verify(tok))
+        except RevokedAncestorError:
+            continue
+        raise AssertionError("revoking the root must fail every descendant")
+
+
+def test_revoke_child_leaves_parent_valid() -> None:
+    auth = DelegatableAuth(secret=b"s")
+    root = _run(auth.issue(COORD, ["read", "write"]))
+    child = _run(auth.delegate(root, BOB, ["read"], ttl=1000))
+    _run(auth.revoke(child))
+
+    assert _run(auth.verify(root)).subject == COORD  # parent unaffected
+    try:
+        _run(auth.verify(child))
+    except RevokedAncestorError:
+        return
+    raise AssertionError("the revoked child itself must fail")
+
+
+def test_expired_token_rejected_against_logical_clock() -> None:
+    auth = DelegatableAuth(secret=b"s", clock=0, root_ttl=1000)
+    root = _run(auth.issue(COORD, ["read"]))
+    child = _run(auth.delegate(root, BOB, ["read"], ttl=50))  # exp = 50
+    assert _run(auth.verify(child)).subject == BOB
+    auth.advance(100)  # now = 100 > 50
+    try:
+        _run(auth.verify(child))
+    except ExpiredTokenError:
+        return
+    raise AssertionError("verify must reject a token expired against the logical clock")
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_same_ops_produce_byte_identical_tokens() -> None:
+    def build() -> tuple[str, str]:
+        auth = DelegatableAuth(secret=b"seed", clock=0)
+        root = _run(auth.issue(COORD, ["read", "write"]))
+        child = _run(auth.delegate(root, BOB, ["read"], ttl=100))
+        return str(root), str(child)
+
+    assert build() == build()
+
+
+# ---------------------------------------------------------------------------
+# Property-based
+# ---------------------------------------------------------------------------
+
+_SCOPE_POOL = ["read", "write", "admin", "delete", "list"]
+
+
+@settings(max_examples=60, deadline=None)
+@given(
+    root_scopes=st.sets(st.sampled_from(_SCOPE_POOL), min_size=1),
+    requested=st.sets(st.sampled_from(_SCOPE_POOL), min_size=1),
+)
+def test_property_delegation_never_widens(root_scopes: set[str], requested: set[str]) -> None:
+    """delegate accepts iff requested ⊆ root, and verify returns exactly it."""
+    auth = DelegatableAuth(secret=b"s")
+    root = _run(auth.issue(COORD, sorted(root_scopes)))
+    if requested <= root_scopes:
+        child = _run(auth.delegate(root, BOB, sorted(requested), ttl=100))
+        ctx = _run(auth.verify(child))
+        assert set(ctx.scopes) == requested
+    else:
+        try:
+            _run(auth.delegate(root, BOB, sorted(requested), ttl=100))
+        except ScopeEscalationError:
+            return
+        raise AssertionError("a superset request must raise ScopeEscalationError")
+
+
+@settings(max_examples=40, deadline=None)
+@given(depth=st.integers(min_value=1, max_value=6), revoke_at=st.integers(min_value=0))
+def test_property_revocation_cascades_at_any_depth(depth: int, revoke_at: int) -> None:
+    """Revoking link k fails links k..depth and leaves links 0..k-1 valid."""
+    revoke_at = revoke_at % depth if depth else 0
+    auth = DelegatableAuth(secret=b"s", root_ttl=10_000)
+    chain_tokens: list[Token] = [_run(auth.issue(COORD, ["read"]))]
+    for i in range(1, depth):
+        parent = chain_tokens[-1]
+        chain_tokens.append(_run(auth.delegate(parent, AgentId(f"a-{i}"), ["read"], ttl=1000)))
+
+    _run(auth.revoke(chain_tokens[revoke_at]))
+
+    for i, tok in enumerate(chain_tokens):
+        if i < revoke_at:
+            assert _run(auth.verify(tok)).scopes == ["read"]  # ancestors unaffected
+        else:
+            try:
+                _run(auth.verify(tok))
+            except RevokedAncestorError:
+                continue
+            raise AssertionError(f"link {i} at/under revoked {revoke_at} must fail")
+
+
+# ---------------------------------------------------------------------------
+# Adversarial validator discrimination — jwt FAILS, delegatable PASSES
+# ---------------------------------------------------------------------------
+
+
+def _fake_jti(token: Token) -> str:
+    return hashlib.sha256(str(token).encode()).hexdigest()[:16]
+
+
+def _probe_delegatable() -> tuple[list[GrantObservation], dict[str, tuple[str, ...]], set[str]]:
+    """Drive the delegatable plugin through all three attacks + one legit grant."""
+    auth = DelegatableAuth(secret=b"s", root_ttl=10_000)
+    grants: list[GrantObservation] = []
+    parent_scopes: dict[str, tuple[str, ...]] = {}
+
+    # Subtree 1 — revoked, used for the scope-escalation and stale-ancestor probes.
+    root1 = _run(auth.issue(COORD, ["read", "write"]))
+    root1_jti = auth.describe(root1)[-1].jti
+    parent_scopes[root1_jti] = ("read", "write")
+
+    # Attack: scope escalation — refused at delegate.
+    try:
+        _run(auth.delegate(root1, BOB, ["read", "write", "admin"], ttl=100))
+        esc_verified = True
+    except ScopeEscalationError:
+        esc_verified = False
+    grants.append(
+        GrantObservation(
+            jti="escalation-attempt",
+            parent_jti=root1_jti,
+            audience=BOB,
+            scopes=("read", "write", "admin"),
+            presenter=BOB,
+            verified=esc_verified,
+        )
+    )
+
+    # Attack: stale ancestor — child verifies now, then root1 is revoked.
+    child = _run(auth.delegate(root1, BOB, ["read"], ttl=100))
+    child_jti = auth.describe(child)[-1].jti
+    _run(auth.revoke(root1))
+    try:
+        _run(auth.verify_presented(child, BOB))
+        stale_verified = True
+    except RevokedAncestorError:
+        stale_verified = False
+    grants.append(
+        GrantObservation(
+            jti=child_jti,
+            parent_jti=root1_jti,
+            audience=BOB,
+            scopes=("read",),
+            presenter=BOB,
+            verified=stale_verified,
+        )
+    )
+
+    # Subtree 2 — not revoked, used for the audience-confusion + legit probes.
+    root2 = _run(auth.issue(ALICE, ["read"]))
+    root2_jti = auth.describe(root2)[-1].jti
+    parent_scopes[root2_jti] = ("read",)
+
+    # Attack: audience confusion — token for BOB presented by MALLORY.
+    child2 = _run(auth.delegate(root2, BOB, ["read"], ttl=100))
+    child2_jti = auth.describe(child2)[-1].jti
+    try:
+        _run(auth.verify_presented(child2, MALLORY))
+        conf_verified = True
+    except AudienceConfusionError:
+        conf_verified = False
+    grants.append(
+        GrantObservation(
+            jti=child2_jti,
+            parent_jti=root2_jti,
+            audience=BOB,
+            scopes=("read",),
+            presenter=MALLORY,
+            verified=conf_verified,
+        )
+    )
+
+    # A legitimate grant that must verify cleanly (so PASS is not vacuous).
+    child_ok = _run(auth.delegate(root2, ALICE, ["read"], ttl=100))
+    child_ok_jti = auth.describe(child_ok)[-1].jti
+    _run(auth.verify_presented(child_ok, ALICE))
+    grants.append(
+        GrantObservation(
+            jti=child_ok_jti,
+            parent_jti=root2_jti,
+            audience=ALICE,
+            scopes=("read",),
+            presenter=ALICE,
+            verified=True,
+        )
+    )
+    return grants, parent_scopes, {root1_jti}
+
+
+def _probe_jwt() -> tuple[list[GrantObservation], dict[str, tuple[str, ...]], set[str]]:
+    """Drive the flat jwt plugin through the same three attacks — all succeed."""
+    auth = JwtAuth(clock=0.0)
+    grants: list[GrantObservation] = []
+    parent_scopes: dict[str, tuple[str, ...]] = {}
+
+    root1 = _run(auth.issue(COORD, ["read", "write"]))
+    root1_jti = _fake_jti(root1)
+    parent_scopes[root1_jti] = ("read", "write")
+
+    # Attack: scope escalation — jwt re-issues with any scopes; verify accepts.
+    esc = _run(auth.issue(BOB, ["read", "write", "admin"]))
+    _run(auth.verify(esc))  # succeeds
+    grants.append(
+        GrantObservation(
+            jti=_fake_jti(esc),
+            parent_jti=root1_jti,
+            audience=BOB,
+            scopes=("read", "write", "admin"),
+            presenter=BOB,
+            verified=True,
+        )
+    )
+
+    # Attack: stale ancestor — revoking the "parent" string leaves the child valid.
+    child = _run(auth.issue(BOB, ["read"]))
+    _run(auth.revoke(root1))
+    _run(auth.verify(child))  # still succeeds
+    grants.append(
+        GrantObservation(
+            jti=_fake_jti(child),
+            parent_jti=root1_jti,
+            audience=BOB,
+            scopes=("read",),
+            presenter=BOB,
+            verified=True,
+        )
+    )
+
+    root2 = _run(auth.issue(ALICE, ["read"]))
+    root2_jti = _fake_jti(root2)
+    parent_scopes[root2_jti] = ("read",)
+
+    # Attack: audience confusion — no audience binding, anyone may present.
+    child2 = _run(auth.issue(BOB, ["read"]))
+    _run(auth.verify(child2))  # MALLORY presenting: jwt cannot tell
+    grants.append(
+        GrantObservation(
+            jti=_fake_jti(child2),
+            parent_jti=root2_jti,
+            audience=BOB,
+            scopes=("read",),
+            presenter=MALLORY,
+            verified=True,
+        )
+    )
+    return grants, parent_scopes, {root1_jti}
+
+
+def test_validator_passes_against_delegatable() -> None:
+    grants, parent_scopes, revoked = _probe_delegatable()
+    audit = check_delegation_safety(grants, parent_scopes=parent_scopes, revoked_jtis=revoked)
+    assert audit.passed, {k: v.detail for k, v in audit.reports.items()}
+
+
+def test_validator_fails_against_jwt() -> None:
+    grants, parent_scopes, revoked = _probe_jwt()
+    audit = check_delegation_safety(grants, parent_scopes=parent_scopes, revoked_jtis=revoked)
+    assert not audit.passed
+    assert not audit.reports["scope_escalation"].passed
+    assert not audit.reports["stale_ancestor"].passed
+    assert not audit.reports["audience_confusion"].passed

--- a/packages/nest-plugins-reference/tests/test_delegated_auth_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_delegated_auth_scenario.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end scenario test for the delegatable auth plugin.
+
+Boots ``scenarios/delegated_auth.yaml`` through the real ``ScenarioRunner`` /
+``Simulator`` — no mocking past the plugin boundary — and asserts the two
+phases of the cascading-revocation story:
+
+1. **Grant + verify**: all 12 leaves verify their delegated ``{read}``
+   capability, bound to their own identity.
+2. **Cascading revocation**: after the coordinator revokes ``intermediary-1``'s
+   token, exactly its four leaves (``leaf-4..7``) fail with
+   ``RevokedAncestorError`` while the other eight still verify.
+
+Also asserts determinism: the same seed yields the same ledger, across seeds
+42, 7, and 1337.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "delegated_auth.yaml"
+
+REVOKED_LEAVES = {f"leaf-{i}" for i in range(4, 8)}  # the four under intermediary-1
+ALL_LEAVES = {f"leaf-{i}" for i in range(12)}
+
+
+def _run_scenario(seed: int) -> dict[str, list[tuple[str, bool, str | None]]]:
+    """Run the scenario at ``seed`` and return the shared auth ledger."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    config = config.model_copy(update={"seed": seed})
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"delegated_auth_{seed}.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        asyncio.run(runner.run())
+        ledger: dict[str, list[Any]] = runner.resolved_plugins["_auth_ledger"]
+        return ledger
+
+
+def test_scenario_file_exists() -> None:
+    assert SCENARIO_PATH.exists(), f"missing scenario at {SCENARIO_PATH}"
+
+
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_all_leaves_verify_before_revocation(seed: int) -> None:
+    """Phase 1: every leaf successfully verifies its delegated capability."""
+    ledger = _run_scenario(seed)
+    initial = ledger["initial"]
+    verified = {aid for aid, ok, _ in initial if ok}
+    assert verified == ALL_LEAVES, f"seed={seed}: not all leaves verified: {verified}"
+    assert all(ok for _, ok, _ in initial)
+
+
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_revocation_cascades_to_only_the_revoked_subtree(seed: int) -> None:
+    """Phase 2: revoking intermediary-1 fails exactly leaf-4..7, others survive."""
+    ledger = _run_scenario(seed)
+    after = ledger["after_revoke"]
+    assert after, f"seed={seed}: no post-revocation verifications recorded"
+
+    failed = {aid for aid, ok, _ in after if not ok}
+    passed = {aid for aid, ok, _ in after if ok}
+
+    assert failed == REVOKED_LEAVES, f"seed={seed}: wrong failed set {failed}"
+    assert passed == (ALL_LEAVES - REVOKED_LEAVES), f"seed={seed}: wrong passed set {passed}"
+
+    # The failures are specifically the cascading-revocation error, not something else.
+    errors = {err for _, ok, err in after if not ok}
+    assert errors == {"RevokedAncestorError"}, f"seed={seed}: unexpected errors {errors}"
+
+
+def test_scenario_deterministic_under_replay() -> None:
+    """Same seed → identical ledger (sorted for order-independence)."""
+
+    def normalized(seed: int) -> dict[str, list[tuple[str, bool, str | None]]]:
+        led = _run_scenario(seed)
+        return {phase: sorted(rows) for phase, rows in led.items()}
+
+    assert normalized(42) == normalized(42)

--- a/scenarios/delegated_auth.yaml
+++ b/scenarios/delegated_auth.yaml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegated-auth scenario.
+#
+# A capability delegation tree exercised end-to-end against the `delegatable`
+# auth plugin:
+#   * coordinator-0        — holds the root capability {read, write, admin}
+#   * intermediary-0..2    — each delegated a narrowed {read, write} sub-token
+#   * leaf-0..11           — four under each intermediary, each delegated {read}
+#
+# Phase 1 (tick 0): the tree is built top-down and all 12 leaves verify their
+# capability, bound to their own identity (audience check).
+# Phase 2 (revoke_at): the coordinator revokes intermediary-1's token; its four
+# leaves (leaf-4..7) then fail to verify with RevokedAncestorError, while the
+# other eight still succeed — cascading revocation by construction.
+#
+# Fully deterministic: no message drop, no partition; the delegatable plugin
+# uses content-hash ids + HMAC over a logical tick clock (never wall time), so
+# the run replays byte-identically under seeds 42, 7, and 1337.
+name: delegated_auth
+description: "16 agents in a 3-level delegation tree with a cascading revocation."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 16
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+    - name: intermediary
+      count: 3
+    - name: leaf
+      count: 12
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: delegatable
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: delegated_auth
+  config:
+    child_ttl: 100000
+    revoke_at: 100
+    revoke_index: 1
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/delegated_auth.jsonl


### PR DESCRIPTION
## Problem

Implements hackathon problem #04 (docs/hackathon/problems/04-auth-capability-delegation.md):
delegatable capability tokens with cascading revocation for the auth layer.

## What this adds

- **Plugin** `auth/delegatable.py` — macaroon-style HMAC chaining (Birgisson et al., 2014).
  `delegate(parent_token, audience, scopes_subset, ttl)` mints a narrower, time-bounded
  sub-token **without the issuer's secret**; child scopes must be a subset of the parent's
  (else `ScopeEscalationError`), child expiry is clamped to the parent's.
  `verify_presented(token, presenter)` adds audience binding. Revoking any ancestor fails
  every descendant at the next verify (`RevokedAncestorError`) — cascading by construction.
- **Adversarial validator** `validators/auth_validators.py` — three pure checks: scope
  escalation, stale/revoked ancestor, audience confusion. **FAILS against the reference
  `jwt` plugin, PASSES against `delegatable`** (proven in tests).
- **Scenario** `scenarios/delegated_auth.yaml` — 16-agent delegation tree (1 coordinator,
  3 intermediaries, 12 leaves). Mid-run one intermediary is revoked; exactly its 4 leaves
  fail with `RevokedAncestorError`, the other 8 keep verifying. Deterministic under seeds
  42, 7, 1337.
- **Tests** — 30 new: unit, Hypothesis property tests, forged-token defenses (validly-signed
  scope-widening and ttl-extension rejected at verify), validator discrimination, and
  full-simulator integration.
- Registered as `("auth", "delegatable")` builtin + `nest.plugins.auth` entry point;
  docs in `docs/layers/auth.md`.

## Determinism

Token ids are content hashes, signatures are HMAC-SHA256 over canonical JSON, expiry uses
a logical tick clock — no wall time, no unseeded RNG.

## Verify

    make ci-local
    # or just the new tests:
    uv run pytest packages/nest-plugins-reference/tests/test_delegatable_auth.py \
                  packages/nest-plugins-reference/tests/test_delegated_auth_scenario.py -v

All five CI commands exit 0 locally (ruff check, ruff format --check, pyright strict,
pytest: 766 passed).
