### PR TITLE
[Hackathon] distributed-systems-architect: private_commerce — four-layer cross-plugin composition with joint validators

### DIFF
--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -175,3 +175,9 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.sybil_bond import sybil_bond_factory
 
         register_scenario("sybil_bond", sybil_bond_factory)
+    elif name == "private_commerce":
+        from nest_core.scenarios_builtin.private_commerce import (
+            private_commerce_factory,
+        )
+
+        register_scenario("private_commerce", private_commerce_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/private_commerce.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/private_commerce.py
@@ -1,0 +1,778 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Private commerce scenario — a four-layer cross-plugin composition.
+
+Every hackathon plugin so far was tested in isolation: gossip registry
+against a partition, streaming payments against a drain attack, hybrid
+encryption against an eavesdropper, receipt reputation against a collusion
+ring. This scenario is the first to run four of them **together** and
+instrument the emergent, cross-layer invariants none of the single-layer
+validators can see:
+
+1. **Discovery honesty × privacy.** Buyers may only learn sellers through
+   gossip that respects the partition; every encrypted bid must be preceded
+   by an honest discovery event (``registry`` × ``privacy``).
+2. **Bid opacity.** The bid amount travels the wire only inside a hybrid
+   X25519 envelope. A ground-truth ``bidmeta:`` sidecar marker lets the
+   validator assert the plaintext never leaks (``privacy`` × transport).
+3. **Undelivered streams are penalized.** A seller that drains a payment
+   stream and never delivers must end with a low receipt-based trust score
+   — even when it wash-trades fake receipts with a shill partner
+   (``payments`` × ``trust``).
+4. **Delivery is rewarded.** Sellers that fulfil their bid end with an
+   adequate trust score, and every fulfilment is backed by an earlier
+   payment stream (``payments`` × ``trust``).
+
+Cast (12 agents):
+
+* ``buyer-0..4`` — discover sellers via per-agent gossip registries, open a
+  payment stream, send a hybrid-encrypted bid, then verify delivery. An
+  unfulfilled bid triggers a ``negative:`` report to the auditor.
+* ``seller-0..3`` — honest sellers. Register a ``sell`` card, decrypt bids,
+  acknowledge delivery, and issue an Ed25519 cross-signed purchase receipt
+  co-signed by the buyer. They also settle among themselves in a directed
+  cycle of ``payment_received`` receipts, which makes the honest guild a
+  strongly-connected anchor for the trust layer's collusion severance.
+* ``shill_seller-0`` — the adversary. Registers a ``sell`` card, decrypts
+  the bid, drains the stream, never delivers — and covers its tracks by
+  wash-trading fake ``purchase`` receipts with ``shill-0``. Under the
+  ``score_average`` reference trust plugin the fake receipts *raise* its
+  score; under ``agent_receipts`` the isolated mutual pair is severed and it
+  collapses to zero. That asymmetry is exactly what validator 3 catches.
+* ``shill-0`` — the wash-trading partner. Issues the mirror-image fake
+  receipts.
+* ``auditor-0`` — owns the single trust-plugin instance, ingests receipts
+  and negatives, and emits one ``score:`` line per roster agent at the end.
+
+Trace-marker protocol (all markers are broadcasts, so they are recorded in
+the trace at send time and cannot be lost to message drops):
+
+* ``discovered:<buyer>:<seller>`` — first gossip lookup that returned the seller.
+* ``bidmeta:<buyer>:<seller>:<ref>:<amount>`` — ground-truth sidecar for the
+  opacity validator. Would not exist in production; exists so the validator
+  can bind the invariant to a known plaintext.
+* ``stream:open:<buyer>:<seller>:<ref>:<rate>`` / ``stream:close:...:<total>``
+* ``fulfilled:<seller>:<buyer>:<ref>`` — seller acknowledged delivery.
+* ``receipt:<issuer>:<json>`` — receipt en route to the auditor.
+* ``negative:<buyer>:<seller>:<ref>`` — buyer reporting non-delivery.
+* ``score:<agent>:<score>:<confidence>`` — auditor's final trust scores.
+
+The wire bid itself is ``b"bid:" + envelope`` sent point-to-point; with
+``privacy: hybrid_x25519`` the envelope is ciphertext, with ``privacy: noop``
+it is plaintext and the opacity validator fails — the charter's adversarial
+bar, demonstrated per layer by swapping exactly one YAML line.
+
+Determinism: every agent uses the simulator's seeded RNG and logical clock;
+the privacy plugin runs in ``deterministic=True`` mode; receipt identities
+derive from ``sha256(agent_id)``. Same seed → byte-identical trace.
+
+Example::
+
+    agents = private_commerce_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, cast
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentCard, AgentId, Evidence, PaymentRef, Query
+
+GOSSIP_TICK = b"COMMERCE_GOSSIP_TICK"
+"""Self-message: run one gossip round."""
+
+DISCOVER_TICK = b"COMMERCE_DISCOVER_TICK"
+"""Self-message: attempt a registry lookup and maybe bid."""
+
+CHECK_TICK = b"COMMERCE_CHECK_TICK"
+"""Self-message: verify delivery of the outstanding bid."""
+
+FINALIZE_TICK = b"COMMERCE_FINALIZE_TICK"
+"""Self-message: auditor scores the roster."""
+
+BID_WIRE_PREFIX = b"bid:"
+"""Wire prefix for the (possibly encrypted) bid payload."""
+
+ACK_PREFIX = b"ack:"
+"""Wire prefix for the seller's delivery acknowledgement."""
+
+TICK_REDUNDANCY = 5
+"""Redundant self-wake-ups per scheduled tick.
+
+``ctx.schedule`` self-deliveries are subject to the simulator's
+``message_drop`` rate like any other delivery; five independent wake-ups
+drop the chain-death probability per tick to ``0.05 ** 5`` (~3e-7).
+"""
+
+SEND_REDUNDANCY = 3
+"""Copies of each point-to-point functional message (bid, ack).
+
+Receivers deduplicate by reference, so redundancy is invisible above the
+wire. Markers don't need it — broadcasts are traced at send time.
+"""
+
+DEFAULT_GOSSIP_INTERVAL = 200.0
+DEFAULT_DISCOVER_START = 1000.0
+DEFAULT_DISCOVER_EVERY = 500.0
+DEFAULT_BID_DEADLINE = 9000.0
+DEFAULT_CHECK_DELAY = 1000.0
+DEFAULT_FINALIZE_AT = 12000.0
+DEFAULT_BID_AMOUNT = 150
+DEFAULT_STREAM_RATE = 10
+DEFAULT_STREAM_MAX = 500
+DEFAULT_INITIAL_BALANCE = 5000
+
+TRUST_THRESHOLD = 0.3
+"""Score boundary the joint validators check against.
+
+An honest seller with one corroborated ``purchase`` receipt scores
+``1 - exp(-5/10) ≈ 0.39`` under ``agent_receipts``; a severed shill scores
+``0.0``; the reference neutral prior is ``0.5``. ``0.3`` separates the
+severed adversary from every honest outcome with margin on both sides.
+"""
+
+
+def _seed_for(agent: AgentId) -> bytes:
+    """Deterministic 32-byte Ed25519 seed for an agent (matches ``agent_receipts``).
+
+    Example::
+
+        seed = _seed_for(AgentId("seller-0"))
+    """
+    return hashlib.sha256(str(agent).encode()).digest()[:32]
+
+
+def _did_for(agent: AgentId) -> str:
+    """The receipt identity (hex pubkey) for an agent — matches the trust plugin.
+
+    Example::
+
+        did = _did_for(AgentId("seller-0"))
+    """
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+    from nest_plugins_reference.trust.agent_receipts import did_for_pubkey
+
+    sk = Ed25519PrivateKey.from_private_bytes(_seed_for(agent))
+    pub = sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    return did_for_pubkey(pub)
+
+
+def _build_receipt(
+    issuer: AgentId,
+    counterparty: AgentId,
+    *,
+    receipt_id: str,
+    category: str = "purchase",
+) -> dict[str, Any]:
+    """Build an issuer-signed, counterparty-co-signed receipt.
+
+    Both signatures are genuine — the *fraud* in the shill pair is not forged
+    crypto but wash-traded provenance, which is exactly the attack the
+    ``agent_receipts`` severance defeats and ``score_average`` rewards.
+
+    Example::
+
+        r = _build_receipt(AgentId("seller-0"), AgentId("buyer-0"), receipt_id="r0")
+    """
+    from nest_plugins_reference.trust.agent_receipts import cosign_receipt, sign_receipt
+
+    receipt: dict[str, Any] = {
+        "receipt_id": receipt_id,
+        "issuer_did": _did_for(issuer),
+        "action": {"category": category, "counterparty_did": _did_for(counterparty)},
+    }
+    receipt = sign_receipt(receipt, issuer_seed=_seed_for(issuer))
+    return cosign_receipt(receipt, counterparty_seed=_seed_for(counterparty))
+
+
+class _GossipParticipant(StateMachineAgent):
+    """Shared gossip-driving behaviour for all commerce agents.
+
+    Subclasses call :meth:`_start_gossip` in ``on_start`` and
+    :meth:`_handle_gossip_or_tick` first in ``on_message``; it returns
+    ``True`` when the payload was gossip machinery and is fully consumed.
+
+    Example::
+
+        handled = await self._handle_gossip_or_tick(ctx, sender, payload)
+    """
+
+    def __init__(self, agent_id: AgentId, gossip_interval: float) -> None:
+        self._id = agent_id
+        self._gossip_interval = gossip_interval
+        self._last_round_at: float = -1.0
+
+    async def _arm_gossip(self, ctx: AgentContext) -> None:
+        for i in range(TICK_REDUNDANCY):
+            await ctx.schedule(self._gossip_interval + float(i), GOSSIP_TICK)
+
+    async def _start_gossip(self, ctx: AgentContext, capabilities: list[str]) -> None:
+        registry = ctx.plugins.get("registry")
+        if registry is not None and hasattr(registry, "register"):
+            await registry.register(
+                AgentCard(agent_id=self._id, name=str(self._id), capabilities=capabilities)
+            )
+        await self._arm_gossip(ctx)
+
+    async def _handle_gossip_or_tick(
+        self, ctx: AgentContext, sender: AgentId, payload: bytes
+    ) -> bool:
+        if sender == ctx.agent_id and payload == GOSSIP_TICK:
+            if ctx.time - self._last_round_at >= self._gossip_interval:
+                self._last_round_at = ctx.time
+                registry = ctx.plugins.get("registry")
+                if registry is not None and hasattr(registry, "gossip_round"):
+                    await registry.gossip_round(ctx)
+                await self._arm_gossip(ctx)
+            return True
+        registry = ctx.plugins.get("registry")
+        if registry is not None and hasattr(registry, "handle_gossip"):
+            handled = await registry.handle_gossip(sender, payload, ctx)
+            if handled:
+                return True
+        return False
+
+
+class CommerceBuyer(_GossipParticipant):
+    """Discovers a seller via gossip, streams payment, sends an encrypted bid.
+
+    The buyer's target is deterministic: the ``i``-th buyer takes the ``i``-th
+    entry of the sorted list of discovered sell-capable cards, so with full
+    gossip convergence every buyer-seller pairing is stable across seeds and
+    the shill seller is guaranteed exactly one victim.
+
+    Example::
+
+        buyer = CommerceBuyer(AgentId("buyer-0"), index=0, auditor=AgentId("auditor-0"),
+                              config={})
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        index: int,
+        auditor: AgentId,
+        config: dict[str, Any],
+    ) -> None:
+        super().__init__(agent_id, float(config.get("gossip_interval", DEFAULT_GOSSIP_INTERVAL)))
+        self._index = index
+        self._auditor = auditor
+        self._discover_start = float(config.get("discover_start", DEFAULT_DISCOVER_START))
+        self._discover_every = float(config.get("discover_every", DEFAULT_DISCOVER_EVERY))
+        self._bid_deadline = float(config.get("bid_deadline", DEFAULT_BID_DEADLINE))
+        self._check_delay = float(config.get("check_delay", DEFAULT_CHECK_DELAY))
+        self._bid_amount = int(config.get("bid_amount", DEFAULT_BID_AMOUNT))
+        self._stream_rate = int(config.get("stream_rate", DEFAULT_STREAM_RATE))
+        self._stream_max = int(config.get("stream_max", DEFAULT_STREAM_MAX))
+        self._expected_sellers = int(config.get("expected_sellers", 5))
+        self._announced: set[AgentId] = set()
+        self._bid_seller: AgentId | None = None
+        self._bid_ref: PaymentRef | None = None
+        self._acked = False
+        self._closed = False
+        self._checked = False
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Register a buyer card, start gossip, arm the discovery pulses.
+
+        Example::
+
+            await buyer.on_start(ctx)
+        """
+        await self._start_gossip(ctx, capabilities=["buy"])
+        for i in range(TICK_REDUNDANCY):
+            await ctx.schedule(self._discover_start + float(i), DISCOVER_TICK)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Dispatch gossip, discovery pulses, delivery checks, and acks.
+
+        Example::
+
+            await buyer.on_message(ctx, sender, payload)
+        """
+        if sender == ctx.agent_id and payload == DISCOVER_TICK:
+            await self._discover(ctx)
+            return
+        if sender == ctx.agent_id and payload == CHECK_TICK:
+            await self._check_delivery(ctx)
+            return
+        if payload.startswith(ACK_PREFIX):
+            await self._on_ack(ctx, sender, payload)
+            return
+        await self._handle_gossip_or_tick(ctx, sender, payload)
+
+    async def _discover(self, ctx: AgentContext) -> None:
+        """Look up sellers; announce new discoveries; bid when the view is ready."""
+        if self._bid_ref is not None:
+            return
+        registry = ctx.plugins.get("registry")
+        if registry is None:
+            return
+        cards = await registry.lookup(Query(capabilities=["sell"]))
+        seller_ids = sorted({card.agent_id for card in cards}, key=str)
+        for seller in seller_ids:
+            if seller not in self._announced:
+                self._announced.add(seller)
+                await ctx.broadcast(f"discovered:{self._id}:{seller}".encode())
+        ready = len(seller_ids) >= self._expected_sellers
+        deadline_passed = ctx.time >= self._bid_deadline
+        if seller_ids and (ready or deadline_passed):
+            target = seller_ids[self._index % len(seller_ids)]
+            await self._place_bid(ctx, target)
+            return
+        for i in range(TICK_REDUNDANCY):
+            await ctx.schedule(self._discover_every + float(i), DISCOVER_TICK)
+
+    async def _place_bid(self, ctx: AgentContext, seller: AgentId) -> None:
+        """Open the payment stream and send the encrypted bid."""
+        ref = PaymentRef(f"bid-{self._id}")
+        self._bid_seller = seller
+        self._bid_ref = ref
+        payments = ctx.plugins.get("payments")
+        if payments is not None and hasattr(payments, "open_stream"):
+            await payments.open_stream(
+                to=seller, rate_per_tick=self._stream_rate, max_total=self._stream_max, ref=ref
+            )
+            await ctx.broadcast(
+                f"stream:open:{self._id}:{seller}:{ref}:{self._stream_rate}".encode()
+            )
+        plaintext = f"bidamount:{self._bid_amount}:from:{self._id}:ref:{ref}".encode()
+        privacy = ctx.plugins.get("privacy")
+        envelope = plaintext
+        if privacy is not None and hasattr(privacy, "encrypt"):
+            envelope = await privacy.encrypt(plaintext, [seller])
+        await ctx.broadcast(f"bidmeta:{self._id}:{seller}:{ref}:{self._bid_amount}".encode())
+        for _ in range(SEND_REDUNDANCY):
+            await ctx.send(seller, BID_WIRE_PREFIX + envelope)
+        for i in range(TICK_REDUNDANCY):
+            await ctx.schedule(self._check_delay + float(i), CHECK_TICK)
+
+    async def _on_ack(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Record the seller's delivery ack (deduplicated by ref)."""
+        if self._bid_ref is None or sender != self._bid_seller:
+            return
+        ref = payload[len(ACK_PREFIX) :].decode("utf-8", errors="replace")
+        if ref != str(self._bid_ref) or self._acked:
+            return
+        self._acked = True
+        await self._close_stream(ctx)
+
+    async def _check_delivery(self, ctx: AgentContext) -> None:
+        """After the check delay: close the stream; report non-delivery."""
+        if self._checked or self._bid_ref is None or self._bid_seller is None:
+            return
+        self._checked = True
+        await self._close_stream(ctx)
+        if not self._acked:
+            for _ in range(SEND_REDUNDANCY):
+                await ctx.broadcast(
+                    f"negative:{self._id}:{self._bid_seller}:{self._bid_ref}".encode()
+                )
+
+    async def _close_stream(self, ctx: AgentContext) -> None:
+        if self._closed or self._bid_ref is None or self._bid_seller is None:
+            return
+        self._closed = True
+        payments = ctx.plugins.get("payments")
+        total = 0
+        if payments is not None and hasattr(payments, "close_stream"):
+            receipt = await payments.close_stream(self._bid_ref)
+            total = int(receipt.amount.amount)
+        await ctx.broadcast(
+            f"stream:close:{self._id}:{self._bid_seller}:{self._bid_ref}:{total}".encode()
+        )
+
+
+class CommerceSeller(_GossipParticipant):
+    """Honest seller: decrypts bids, acknowledges delivery, issues receipts.
+
+    On start it also submits its pre-built guild settlement receipt (the
+    directed honest cycle) so the honest sellers form one strongly-connected
+    anchor for collusion severance.
+
+    Example::
+
+        seller = CommerceSeller(AgentId("seller-0"), auditor=AgentId("auditor-0"),
+                                cycle_receipts=[], config={})
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        auditor: AgentId,
+        cycle_receipts: list[dict[str, Any]],
+        config: dict[str, Any],
+    ) -> None:
+        super().__init__(agent_id, float(config.get("gossip_interval", DEFAULT_GOSSIP_INTERVAL)))
+        self._auditor = auditor
+        self._cycle_receipts = cycle_receipts
+        self._fulfilled_refs: set[str] = set()
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Register the sell card, start gossip, submit guild receipts.
+
+        Example::
+
+            await seller.on_start(ctx)
+        """
+        await self._start_gossip(ctx, capabilities=["sell"])
+        for receipt in self._cycle_receipts:
+            for _ in range(SEND_REDUNDANCY):
+                await ctx.broadcast(f"receipt:{self._id}:{json.dumps(receipt)}".encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Decrypt bids, fulfil them, and emit cross-signed purchase receipts.
+
+        Example::
+
+            await seller.on_message(ctx, buyer, b"bid:...")
+        """
+        if payload.startswith(BID_WIRE_PREFIX):
+            await self._on_bid(ctx, sender, payload[len(BID_WIRE_PREFIX) :])
+            return
+        await self._handle_gossip_or_tick(ctx, sender, payload)
+
+    async def _on_bid(self, ctx: AgentContext, buyer: AgentId, envelope: bytes) -> None:
+        plaintext = await self._open_envelope(ctx, envelope)
+        if plaintext is None:
+            return
+        ref = self._parse_ref(plaintext)
+        if ref is None or ref in self._fulfilled_refs:
+            return
+        self._fulfilled_refs.add(ref)
+        for _ in range(SEND_REDUNDANCY):
+            await ctx.send(buyer, ACK_PREFIX + ref.encode())
+        await ctx.broadcast(f"fulfilled:{self._id}:{buyer}:{ref}".encode())
+        receipt = _build_receipt(
+            self._id, buyer, receipt_id=f"purchase-{self._id}-{ref}", category="purchase"
+        )
+        for _ in range(SEND_REDUNDANCY):
+            await ctx.broadcast(f"receipt:{self._id}:{json.dumps(receipt)}".encode())
+
+    async def _open_envelope(self, ctx: AgentContext, envelope: bytes) -> bytes | None:
+        privacy = ctx.plugins.get("privacy")
+        if privacy is None or not hasattr(privacy, "decrypt"):
+            return envelope
+        try:
+            return await privacy.decrypt(envelope)
+        except Exception:  # noqa: BLE001 - replayed/foreign envelopes are dropped
+            return None
+
+    @staticmethod
+    def _parse_ref(plaintext: bytes) -> str | None:
+        parts = plaintext.decode("utf-8", errors="replace").split(":")
+        # bidamount:<amount>:from:<buyer>:ref:<ref>
+        if len(parts) >= 6 and parts[0] == "bidamount" and parts[4] == "ref":
+            return parts[5]
+        return None
+
+
+class ShillSeller(CommerceSeller):
+    """The adversary: drains the stream, never delivers, wash-trades cover.
+
+    Inherits the honest seller's discovery surface (it *looks* legitimate on
+    the registry) but overrides fulfilment: it decrypts the bid, keeps the
+    stream money, sends no ack and no genuine receipt. Its fake receipts —
+    mutually co-signed with ``shill-0`` — are submitted on start.
+
+    Example::
+
+        shill = ShillSeller(AgentId("shill_seller-0"), auditor=AgentId("auditor-0"),
+                            cycle_receipts=fake_receipts, config={})
+    """
+
+    async def _on_bid(self, ctx: AgentContext, buyer: AgentId, envelope: bytes) -> None:
+        plaintext = await self._open_envelope(ctx, envelope)
+        if plaintext is None:
+            return
+        # Take the money and run: no ack, no fulfilment marker, no receipt.
+        return
+
+
+class ShillAccomplice(_GossipParticipant):
+    """Wash-trading partner: submits the mirror-image fake receipts on start.
+
+    Registers a card without the ``sell`` capability so buyers never target
+    it; its only job is to complete the mutual co-signature loop that makes
+    the fake receipts individually corroborated.
+
+    Example::
+
+        accomplice = ShillAccomplice(AgentId("shill-0"), fake_receipts=[],
+                                     gossip_interval=200.0)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        fake_receipts: list[dict[str, Any]],
+        gossip_interval: float,
+    ) -> None:
+        super().__init__(agent_id, gossip_interval)
+        self._fake_receipts = fake_receipts
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Register a non-sell card and submit the fake receipts.
+
+        Example::
+
+            await accomplice.on_start(ctx)
+        """
+        await self._start_gossip(ctx, capabilities=["shill"])
+        for receipt in self._fake_receipts:
+            for _ in range(SEND_REDUNDANCY):
+                await ctx.broadcast(f"receipt:{self._id}:{json.dumps(receipt)}".encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Only gossip machinery; the accomplice ignores everything else.
+
+        Example::
+
+            await accomplice.on_message(ctx, sender, payload)
+        """
+        await self._handle_gossip_or_tick(ctx, sender, payload)
+
+
+class CommerceAuditor(StateMachineAgent):
+    """Owns the single trust instance; ingests receipts; scores the roster.
+
+    Receipt broadcasts are deduplicated by ``receipt_id`` and negatives by
+    payment ref, so the senders' drop-redundancy never double-reports.
+
+    Example::
+
+        auditor = CommerceAuditor(AgentId("auditor-0"), roster=[], config={})
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        roster: list[AgentId],
+        config: dict[str, Any],
+    ) -> None:
+        self._id = agent_id
+        self._roster = roster
+        self._finalize_at = float(config.get("finalize_at", DEFAULT_FINALIZE_AT))
+        self._trust: Any = None
+        self._seen_receipts: set[str] = set()
+        self._seen_negatives: set[str] = set()
+        self._finalized = False
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Instantiate the configured trust plugin and arm the finalize pulse.
+
+        Example::
+
+            await auditor.on_start(ctx)
+        """
+        trust_cls = ctx.plugins.get("trust")
+        self._trust = trust_cls() if isinstance(trust_cls, type) else trust_cls
+        for i in range(TICK_REDUNDANCY):
+            await ctx.schedule(self._finalize_at + float(i), FINALIZE_TICK)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Ingest receipts and negatives; score everyone on the finalize pulse.
+
+        Example::
+
+            await auditor.on_message(ctx, seller, b"receipt:seller-0:{...}")
+        """
+        if sender == ctx.agent_id and payload == FINALIZE_TICK:
+            await self._finalize(ctx)
+            return
+        msg = payload.decode("utf-8", errors="replace")
+        if msg.startswith("receipt:"):
+            await self._ingest_receipt(msg)
+            return
+        if msg.startswith("negative:"):
+            await self._ingest_negative(msg)
+
+    async def _ingest_receipt(self, msg: str) -> None:
+        if self._trust is None:
+            return
+        _, issuer, receipt_json = msg.split(":", 2)
+        try:
+            parsed: object = json.loads(receipt_json)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(parsed, dict):
+            return
+        receipt_dict = cast("dict[str, Any]", parsed)
+        receipt_id = str(receipt_dict.get("receipt_id", ""))
+        if not receipt_id or receipt_id in self._seen_receipts:
+            return
+        self._seen_receipts.add(receipt_id)
+        await self._trust.report(
+            AgentId(issuer),
+            Evidence(
+                reporter=self._id, subject=AgentId(issuer), kind="positive", detail=receipt_json
+            ),
+        )
+
+    async def _ingest_negative(self, msg: str) -> None:
+        if self._trust is None:
+            return
+        parts = msg.split(":")
+        # negative:<buyer>:<seller>:<ref>
+        if len(parts) < 4:
+            return
+        _, buyer, seller, ref = parts[:4]
+        if ref in self._seen_negatives:
+            return
+        self._seen_negatives.add(ref)
+        await self._trust.report(
+            AgentId(seller),
+            Evidence(
+                reporter=AgentId(buyer),
+                subject=AgentId(seller),
+                kind="negative",
+                detail=f"undelivered:{ref}",
+            ),
+        )
+
+    async def _finalize(self, ctx: AgentContext) -> None:
+        """Emit one ``score:`` line per roster agent (idempotent)."""
+        if self._finalized or self._trust is None:
+            return
+        self._finalized = True
+        for agent in sorted(self._roster, key=str):
+            rep = await self._trust.score(agent)
+            await ctx.broadcast(f"score:{agent}:{rep.score:.6f}:{rep.confidence:.6f}".encode())
+
+
+def _role_ids(config: ScenarioConfig, role_name: str) -> list[AgentId]:
+    """All agent ids for a role, in index order.
+
+    Example::
+
+        buyers = _role_ids(config, "buyer")
+    """
+    for role in config.agents.roles:
+        if role.name == role_name:
+            return [AgentId(f"{role_name}-{i}") for i in range(role.count)]
+    return []
+
+
+def private_commerce_factory(config: ScenarioConfig, plugins: dict[str, Any]) -> dict[AgentId, Any]:
+    """Build the twelve-agent private-commerce fleet with per-agent plugin wiring.
+
+    Per-agent instances are injected through the runner's ``_agent_plugins``
+    override channel: gossip registries share one :class:`GossipNetwork`
+    (or one shared ``InMemoryRegistry`` when the YAML says ``registry:
+    in_memory`` — the adversarial leak configuration), streaming-payment
+    ledgers are per-buyer, and hybrid-privacy keypairs are cross-registered
+    so any agent can wrap to any other.
+
+    Example::
+
+        agents = private_commerce_factory(config, plugins)
+    """
+    task_cfg: dict[str, Any] = config.task.config or {}
+    gossip_interval = float(task_cfg.get("gossip_interval", DEFAULT_GOSSIP_INTERVAL))
+    initial_balance = int(task_cfg.get("initial_balance", DEFAULT_INITIAL_BALANCE))
+
+    buyers = _role_ids(config, "buyer")
+    sellers = _role_ids(config, "seller")
+    shill_sellers = _role_ids(config, "shill_seller")
+    shills = _role_ids(config, "shill")
+    auditors = _role_ids(config, "auditor")
+    auditor = auditors[0] if auditors else AgentId("auditor-0")
+
+    gossip_ids = [*buyers, *sellers, *shill_sellers, *shills]
+    all_ids = [*gossip_ids, auditor]
+    task_cfg.setdefault("expected_sellers", len(sellers) + len(shill_sellers))
+
+    overrides: dict[AgentId, dict[str, Any]] = {aid: {} for aid in all_ids}
+
+    # -- registry: per-agent gossip views, or one shared dict (adversarial) --
+    if config.layers.registry == "gossip":
+        from nest_plugins_reference.registry.gossip import GossipNetwork, GossipRegistry
+
+        network = GossipNetwork(agent_ids=list(gossip_ids))
+        for aid in gossip_ids:
+            overrides[aid]["registry"] = GossipRegistry(aid, network)
+    else:
+        from nest_plugins_reference.registry.in_memory import InMemoryRegistry
+
+        shared_registry = InMemoryRegistry()
+        for aid in gossip_ids:
+            overrides[aid]["registry"] = shared_registry
+
+    # -- privacy: per-agent keypairs with a fully cross-registered directory --
+    if config.layers.privacy == "hybrid_x25519":
+        from nest_plugins_reference.privacy.hybrid_x25519 import HybridX25519Privacy
+
+        privacy_instances = {
+            aid: HybridX25519Privacy(aid, seed=str(aid).encode(), deterministic=True)
+            for aid in all_ids
+        }
+        for aid, instance in privacy_instances.items():
+            for peer, peer_instance in privacy_instances.items():
+                if peer != aid:
+                    instance.register_peer(peer, peer_instance.public_key)
+            overrides[aid]["privacy"] = instance
+    else:
+        from nest_plugins_reference.privacy.noop import NoopPrivacy
+
+        for aid in all_ids:
+            overrides[aid]["privacy"] = NoopPrivacy()
+
+    # -- payments: per-buyer streaming ledgers --
+    from nest_plugins_reference.payments.streaming import StreamingPayments
+
+    for aid in buyers:
+        overrides[aid]["payments"] = StreamingPayments(aid, initial_balance=initial_balance)
+
+    # -- receipts: honest guild cycle + wash-traded shill pair --
+    cycle_receipts: dict[AgentId, list[dict[str, Any]]] = {aid: [] for aid in sellers}
+    for i, seller in enumerate(sellers):
+        nxt = sellers[(i + 1) % len(sellers)]
+        cycle_receipts[seller].append(
+            _build_receipt(
+                seller, nxt, receipt_id=f"guild-{seller}-{nxt}", category="payment_received"
+            )
+        )
+
+    fake_by_shill_seller: dict[AgentId, list[dict[str, Any]]] = {}
+    fake_by_shill: dict[AgentId, list[dict[str, Any]]] = {}
+    for shill_seller, shill in zip(shill_sellers, shills, strict=False):
+        fake_by_shill_seller[shill_seller] = [
+            _build_receipt(
+                shill_seller, shill, receipt_id=f"wash-{shill_seller}-{k}", category="purchase"
+            )
+            for k in range(3)
+        ]
+        fake_by_shill[shill] = [
+            _build_receipt(shill, shill_seller, receipt_id=f"wash-{shill}-{k}", category="purchase")
+            for k in range(3)
+        ]
+
+    # -- assemble agents --
+    agents: dict[AgentId, Any] = {}
+    for i, aid in enumerate(buyers):
+        agents[aid] = CommerceBuyer(aid, index=i, auditor=auditor, config=task_cfg)
+    for aid in sellers:
+        agents[aid] = CommerceSeller(
+            aid, auditor=auditor, cycle_receipts=cycle_receipts[aid], config=task_cfg
+        )
+    for aid in shill_sellers:
+        agents[aid] = ShillSeller(
+            aid, auditor=auditor, cycle_receipts=fake_by_shill_seller.get(aid, []), config=task_cfg
+        )
+    for aid in shills:
+        agents[aid] = ShillAccomplice(
+            aid, fake_receipts=fake_by_shill.get(aid, []), gossip_interval=gossip_interval
+        )
+    agents[auditor] = CommerceAuditor(
+        auditor, roster=[*sellers, *shill_sellers, *shills], config=task_cfg
+    )
+
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/private_commerce.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/private_commerce.py
@@ -106,11 +106,16 @@ TICK_REDUNDANCY = 5
 drop the chain-death probability per tick to ``0.05 ** 5`` (~3e-7).
 """
 
-SEND_REDUNDANCY = 3
+SEND_REDUNDANCY = 5
 """Copies of each point-to-point functional message (bid, ack).
 
 Receivers deduplicate by reference, so redundancy is invisible above the
-wire. Markers don't need it — broadcasts are traced at send time.
+wire. Markers don't need it — broadcasts are traced at send time. Matches
+``TICK_REDUNDANCY``'s ``0.05 ** 5`` (~3e-7) chain-death budget per message;
+at redundancy 3 a bid died outright with p = 0.05**3 (1.25e-4), which over
+a multi-bid seed bank produced an honest seller with zero fulfilled markers
+and a trust score inside the offender band of
+``commerce_undelivered_penalized`` roughly 1 in 2000 runs.
 """
 
 DEFAULT_GOSSIP_INTERVAL = 200.0

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -4923,6 +4923,239 @@ def validate_sybil_bond_attempts_rejected(
     ]
 
 
+# ---------------------------------------------------------------------------
+# Private-commerce joint validators (cross-layer composition)
+# ---------------------------------------------------------------------------
+
+
+def _pc_marker_events(events: list[dict[str, Any]]) -> list[tuple[int, str]]:
+    """Broadcast marker bodies in trace order, deduplicated at first occurrence.
+
+    Marker broadcasts appear once as a ``broadcast`` record plus once per
+    recipient as ``receive``/``dropped`` records, and senders re-broadcast
+    functional markers for drop-redundancy. All duplicates collapse to the
+    first sighting so ordering logic sees each marker exactly once.
+    """
+    seen: set[str] = set()
+    out: list[tuple[int, str]] = []
+    for i, ev in enumerate(events):
+        if ev.get("kind") not in ("broadcast", "send"):
+            continue
+        msg = _message_body(ev)
+        if msg in seen:
+            continue
+        seen.add(msg)
+        out.append((i, msg))
+    return out
+
+
+def validate_commerce_discovery_precedes_bid(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every bid must target a seller the buyer *first* discovered via the registry.
+
+    Joint invariant over the registry and privacy layers: a ``bidmeta:`` marker
+    for pair ``(buyer, seller)`` is only legitimate after a ``discovered:``
+    marker for the same pair. A shared-dict registry that leaks cards across a
+    partition would let bids fire without honest discovery ordering.
+    """
+    discovered: set[tuple[str, str]] = set()
+    violations: list[str] = []
+    bids = 0
+
+    for _, msg in _pc_marker_events(events):
+        parts = msg.split(":")
+        if len(parts) >= 3 and parts[0] == "discovered":
+            discovered.add((parts[1], parts[2]))
+        elif len(parts) >= 5 and parts[0] == "bidmeta":
+            bids += 1
+            buyer, seller = parts[1], parts[2]
+            if (buyer, seller) not in discovered:
+                violations.append(f"{buyer} bid on {seller} without prior gossip discovery")
+
+    if bids == 0:
+        return [
+            ValidationResult(
+                "commerce_discovery_precedes_bid", False, "no bidmeta markers found in trace"
+            )
+        ]
+    if violations:
+        return [ValidationResult("commerce_discovery_precedes_bid", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "commerce_discovery_precedes_bid",
+            True,
+            f"all {bids} bids preceded by gossip discovery",
+        )
+    ]
+
+
+def validate_commerce_bid_opacity(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Bid plaintext must never ride the wire outside the privacy envelope.
+
+    Joint invariant over the privacy and transport layers. Each buyer's
+    plaintext contains the marker ``bidamount:<amount>:from:<buyer>`` before
+    encryption; the ``bidmeta:`` sidecar declares the ground truth. The
+    validator scans every ``bid:``-wire message (send/receive/dropped) and
+    fails if the plaintext marker is visible. With ``privacy: noop`` the
+    envelope IS the plaintext, so this fails — the adversarial bar.
+    """
+    expected: set[tuple[str, str]] = set()  # (buyer, amount)
+    leaks: list[str] = []
+    wire_bids = 0
+
+    for ev in events:
+        msg = _message_body(ev)
+        parts = msg.split(":")
+        if ev.get("kind") in ("broadcast", "receive") and len(parts) >= 5 and parts[0] == "bidmeta":
+            expected.add((parts[1], parts[4]))
+    for ev in events:
+        if ev.get("kind") not in ("send", "receive", "dropped"):
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("bid:"):
+            continue
+        wire_bids += 1
+        for buyer, amount in expected:
+            marker = f"bidamount:{amount}:from:{buyer}"
+            if marker in msg:
+                leaks.append(f"plaintext bid of {buyer} (amount={amount}) visible on the wire")
+                break
+
+    if wire_bids == 0:
+        return [ValidationResult("commerce_bid_opacity", False, "no bid wire messages in trace")]
+    if leaks:
+        return [ValidationResult("commerce_bid_opacity", False, "; ".join(sorted(set(leaks))))]
+    return [
+        ValidationResult(
+            "commerce_bid_opacity", True, f"all {wire_bids} wire bids opaque to observers"
+        )
+    ]
+
+
+def validate_commerce_undelivered_penalized(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """A seller that drained a stream without delivering must end with low trust.
+
+    Joint invariant over the payments and trust layers. For every stream that
+    closed with ``total > 0`` toward a seller with no ``fulfilled:`` marker for
+    that ref, the seller's final ``score:`` must be strictly below the honest
+    threshold — even when the seller wash-traded fake receipts. The
+    ``score_average`` reference plugin rewards the fake receipts and fails
+    here; ``agent_receipts`` severs the shill ring and passes.
+    """
+    threshold = 0.3
+    fulfilled_refs: set[str] = set()
+    drained: dict[str, str] = {}  # ref -> seller (streams that moved money)
+    scores: dict[str, float] = {}
+
+    for _, msg in _pc_marker_events(events):
+        parts = msg.split(":")
+        if len(parts) >= 4 and parts[0] == "fulfilled":
+            fulfilled_refs.add(parts[3])
+        elif len(parts) >= 6 and parts[0] == "stream" and parts[1] == "close":
+            _, _, _buyer, seller, ref, total = parts[:6]
+            try:
+                if int(total) > 0:
+                    drained[ref] = seller
+            except ValueError:
+                continue
+        elif len(parts) >= 3 and parts[0] == "score":
+            try:
+                scores[parts[1]] = float(parts[2])
+            except ValueError:
+                continue
+
+    offenders = {seller for ref, seller in drained.items() if ref not in fulfilled_refs}
+    if not offenders:
+        return [
+            ValidationResult(
+                "commerce_undelivered_penalized",
+                False,
+                "no undelivered drained stream found — the adversary never fired",
+            )
+        ]
+
+    violations: list[str] = []
+    for seller in sorted(offenders):
+        score = scores.get(seller)
+        if score is None:
+            violations.append(f"{seller} drained without delivering but was never scored")
+        elif score >= threshold:
+            violations.append(
+                f"{seller} drained without delivering yet scored {score:.3f} >= {threshold}"
+            )
+    if violations:
+        return [ValidationResult("commerce_undelivered_penalized", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "commerce_undelivered_penalized",
+            True,
+            f"all non-delivering sellers scored below {threshold}: {sorted(offenders)}",
+        )
+    ]
+
+
+def validate_commerce_delivery_rewarded(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Fulfilling sellers must score above threshold, and every fulfilment must be paid.
+
+    Joint invariant over the payments and trust layers, dual of the penalty
+    check: (a) each ``fulfilled:`` ref has a matching ``stream:open`` toward
+    that seller, and (b) every seller with at least one fulfilment ends with a
+    final trust score at or above the honest threshold.
+    """
+    threshold = 0.3
+    opened_refs: dict[str, str] = {}  # ref -> seller
+    fulfilled_by: dict[str, list[str]] = {}  # seller -> refs
+    scores: dict[str, float] = {}
+    violations: list[str] = []
+
+    for _, msg in _pc_marker_events(events):
+        parts = msg.split(":")
+        if len(parts) >= 6 and parts[0] == "stream" and parts[1] == "open":
+            opened_refs[parts[4]] = parts[3]
+        elif len(parts) >= 4 and parts[0] == "fulfilled":
+            fulfilled_by.setdefault(parts[1], []).append(parts[3])
+        elif len(parts) >= 3 and parts[0] == "score":
+            try:
+                scores[parts[1]] = float(parts[2])
+            except ValueError:
+                continue
+
+    if not fulfilled_by:
+        return [
+            ValidationResult(
+                "commerce_delivery_rewarded", False, "no fulfilment markers found in trace"
+            )
+        ]
+
+    for seller, refs in sorted(fulfilled_by.items()):
+        for ref in refs:
+            if opened_refs.get(ref) != seller:
+                violations.append(f"{seller} fulfilled {ref} without a matching payment stream")
+        score = scores.get(seller)
+        if score is None:
+            violations.append(f"{seller} fulfilled bids but was never scored")
+        elif score < threshold:
+            violations.append(f"{seller} fulfilled bids yet scored {score:.3f} < {threshold}")
+
+    if violations:
+        return [ValidationResult("commerce_delivery_rewarded", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "commerce_delivery_rewarded",
+            True,
+            f"all {len(fulfilled_by)} fulfilling sellers paid and scored >= {threshold}",
+        )
+    ]
+
+
+
 VALIDATORS: dict[str, list[Any]] = {
     "sybil_bond": [
         validate_sybil_bond_no_free_trust,
@@ -5022,6 +5255,12 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_escrow_role_binding,
         validate_escrow_bps_in_range,
         validate_escrow_no_payout_without_delivery,
+    ],
+    "private_commerce": [
+        validate_commerce_discovery_precedes_bid,
+        validate_commerce_bid_opacity,
+        validate_commerce_undelivered_penalized,
+        validate_commerce_delivery_rewarded,
     ],
     "failure_detection": [
         validate_failure_detection_completeness,

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -5031,6 +5031,12 @@ def validate_commerce_bid_opacity(
         parts = msg.split(":")
         if ev.get("kind") in ("broadcast", "receive") and len(parts) >= 5 and parts[0] == "bidmeta":
             expected.add((parts[1], parts[4]))
+
+    if not expected:
+        return [
+            ValidationResult("commerce_bid_opacity", False, "no bidmeta markers found in trace")
+        ]
+
     for ev in events:
         if ev.get("kind") not in ("send", "receive", "dropped"):
             continue

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -4928,16 +4928,19 @@ def validate_sybil_bond_attempts_rejected(
 # ---------------------------------------------------------------------------
 
 
-def _pc_marker_events(events: list[dict[str, Any]]) -> list[tuple[int, str]]:
-    """Broadcast marker bodies in trace order, deduplicated at first occurrence.
+def _pc_marker_events(events: list[dict[str, Any]]) -> list[tuple[int, str, str]]:
+    """Broadcast ``(index, sender, marker body)`` in trace order, deduped by body.
 
     Marker broadcasts appear once as a ``broadcast`` record plus once per
     recipient as ``receive``/``dropped`` records, and senders re-broadcast
     functional markers for drop-redundancy. All duplicates collapse to the
-    first sighting so ordering logic sees each marker exactly once.
+    first sighting so ordering logic sees each marker exactly once. The
+    sender is the event's own ``agent`` field, not a claim inside the body --
+    callers that trust a marker's content (``score:``, ``fulfilled:``) must
+    check this against the principal the marker names.
     """
     seen: set[str] = set()
-    out: list[tuple[int, str]] = []
+    out: list[tuple[int, str, str]] = []
     for i, ev in enumerate(events):
         if ev.get("kind") not in ("broadcast", "send"):
             continue
@@ -4945,8 +4948,25 @@ def _pc_marker_events(events: list[dict[str, Any]]) -> list[tuple[int, str]]:
         if msg in seen:
             continue
         seen.add(msg)
-        out.append((i, msg))
+        out.append((i, str(ev.get("agent", "")), msg))
     return out
+
+
+def _pc_canonical_auditor(events: list[dict[str, Any]]) -> str | None:
+    """The sender of the first ``score:`` marker in the trace.
+
+    ``score:`` lines carry no principal of their own, so provenance for them
+    can't be checked the way ``fulfilled:<seller>`` is (the seller names
+    itself). The single trust-plugin owner finalizes and broadcasts its
+    scores before any adversary in this scenario acts, so the first sender
+    observed is the real auditor; a byzantine agent broadcasting a forged
+    ``score:`` line afterward is a different sender and is discarded rather
+    than winning last-write-wins.
+    """
+    for _, sender, msg in _pc_marker_events(events):
+        if msg.startswith("score:"):
+            return sender
+    return None
 
 
 def validate_commerce_discovery_precedes_bid(
@@ -4963,7 +4983,7 @@ def validate_commerce_discovery_precedes_bid(
     violations: list[str] = []
     bids = 0
 
-    for _, msg in _pc_marker_events(events):
+    for _, _sender, msg in _pc_marker_events(events):
         parts = msg.split(":")
         if len(parts) >= 3 and parts[0] == "discovered":
             discovered.add((parts[1], parts[2]))
@@ -5046,15 +5066,24 @@ def validate_commerce_undelivered_penalized(
     threshold — even when the seller wash-traded fake receipts. The
     ``score_average`` reference plugin rewards the fake receipts and fails
     here; ``agent_receipts`` severs the shill ring and passes.
+
+    Both marker types are bound to their expected principal: a ``fulfilled:``
+    line only counts if its broadcaster is the named seller, and a ``score:``
+    line only counts if its broadcaster is the canonical auditor
+    (:func:`_pc_canonical_auditor`) -- otherwise a byzantine agent could
+    forge either marker to false-pass a seller it doesn't control.
     """
     threshold = 0.3
+    auditor = _pc_canonical_auditor(events)
     fulfilled_refs: set[str] = set()
     drained: dict[str, str] = {}  # ref -> seller (streams that moved money)
     scores: dict[str, float] = {}
 
-    for _, msg in _pc_marker_events(events):
+    for _, sender, msg in _pc_marker_events(events):
         parts = msg.split(":")
         if len(parts) >= 4 and parts[0] == "fulfilled":
+            if sender != parts[1]:
+                continue
             fulfilled_refs.add(parts[3])
         elif len(parts) >= 6 and parts[0] == "stream" and parts[1] == "close":
             _, _, _buyer, seller, ref, total = parts[:6]
@@ -5064,6 +5093,8 @@ def validate_commerce_undelivered_penalized(
             except ValueError:
                 continue
         elif len(parts) >= 3 and parts[0] == "score":
+            if sender != auditor:
+                continue
             try:
                 scores[parts[1]] = float(parts[2])
             except ValueError:
@@ -5108,20 +5139,30 @@ def validate_commerce_delivery_rewarded(
     check: (a) each ``fulfilled:`` ref has a matching ``stream:open`` toward
     that seller, and (b) every seller with at least one fulfilment ends with a
     final trust score at or above the honest threshold.
+
+    Both marker types are bound to their expected principal -- see
+    :func:`validate_commerce_undelivered_penalized` -- so a byzantine agent
+    can't forge a ``fulfilled:`` for a seller it isn't, or overwrite the
+    auditor's ``score:`` with a fake one of its own.
     """
     threshold = 0.3
+    auditor = _pc_canonical_auditor(events)
     opened_refs: dict[str, str] = {}  # ref -> seller
     fulfilled_by: dict[str, list[str]] = {}  # seller -> refs
     scores: dict[str, float] = {}
     violations: list[str] = []
 
-    for _, msg in _pc_marker_events(events):
+    for _, sender, msg in _pc_marker_events(events):
         parts = msg.split(":")
         if len(parts) >= 6 and parts[0] == "stream" and parts[1] == "open":
             opened_refs[parts[4]] = parts[3]
         elif len(parts) >= 4 and parts[0] == "fulfilled":
+            if sender != parts[1]:
+                continue
             fulfilled_by.setdefault(parts[1], []).append(parts[3])
         elif len(parts) >= 3 and parts[0] == "score":
+            if sender != auditor:
+                continue
             try:
                 scores[parts[1]] = float(parts[2])
             except ValueError:
@@ -5153,7 +5194,6 @@ def validate_commerce_delivery_rewarded(
             f"all {len(fulfilled_by)} fulfilling sellers paid and scored >= {threshold}",
         )
     ]
-
 
 
 VALIDATORS: dict[str, list[Any]] = {

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2013,6 +2013,7 @@ class TestValidatorRegistry:
             "parc_migration",
             "rogue_trusted_agent",
             "sybil_bond",
+            "private_commerce",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/tests/test_private_commerce.py
+++ b/packages/nest-plugins-reference/tests/test_private_commerce.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the private_commerce scenario and its joint cross-layer validators.
+
+Three layers of coverage, mirroring the repo's gossip/privacy test structure:
+
+1. **Validator unit tests** — hand-built event lists exercising pass, fail,
+   and absent-marker code paths for each of the four joint validators.
+2. **Adversarial discrimination** — the full scenario re-run with exactly one
+   YAML layer swapped: ``privacy: noop`` must fail the opacity validator and
+   ``trust: score_average`` must fail the undelivered-penalty validator,
+   while the intended composition passes all four. This is the charter's bar:
+   validators the reference plugins literally cannot satisfy.
+3. **Full simulator integration** — the ``private_commerce`` scenario booted
+   via ``ScenarioRunner``: determinism (same seed → byte-identical trace),
+   seed sensitivity, and all four validators green under two seeds.
+
+Property tests (Hypothesis) fuzz the validator parsers with arbitrary
+interleavings of well-formed and junk markers to pin the no-crash and
+order-independence properties.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from pathlib import Path
+from typing import Any
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import (
+    VALIDATORS,
+    validate_commerce_bid_opacity,
+    validate_commerce_delivery_rewarded,
+    validate_commerce_discovery_precedes_bid,
+    validate_commerce_undelivered_penalized,
+    validate_trace,
+)
+
+SCENARIO_YAML = Path(__file__).resolve().parents[3] / "scenarios" / "private_commerce.yaml"
+
+
+def _bc(msg: str) -> dict[str, Any]:
+    """A broadcast trace event with the given body."""
+    return {"kind": "broadcast", "agent": "x", "msg": msg}
+
+
+def _send(msg: str) -> dict[str, Any]:
+    """A point-to-point send trace event with the given body."""
+    return {"kind": "send", "agent": "x", "to": "y", "msg": msg}
+
+
+# ---------------------------------------------------------------------------
+# 1. Validator unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryPrecedesBid:
+    def test_passes_when_discovery_comes_first(self) -> None:
+        events = [
+            _bc("discovered:buyer-0:seller-0"),
+            _bc("bidmeta:buyer-0:seller-0:bid-buyer-0:150"),
+        ]
+        (result,) = validate_commerce_discovery_precedes_bid(events)
+        assert result.passed, result.detail
+
+    def test_fails_when_bid_has_no_discovery(self) -> None:
+        events = [_bc("bidmeta:buyer-0:seller-0:bid-buyer-0:150")]
+        (result,) = validate_commerce_discovery_precedes_bid(events)
+        assert not result.passed
+        assert "without prior gossip discovery" in result.detail
+
+    def test_fails_when_discovery_is_for_a_different_seller(self) -> None:
+        events = [
+            _bc("discovered:buyer-0:seller-1"),
+            _bc("bidmeta:buyer-0:seller-0:bid-buyer-0:150"),
+        ]
+        (result,) = validate_commerce_discovery_precedes_bid(events)
+        assert not result.passed
+
+    def test_fails_on_empty_trace(self) -> None:
+        (result,) = validate_commerce_discovery_precedes_bid([])
+        assert not result.passed
+        assert "no bidmeta markers" in result.detail
+
+
+class TestBidOpacity:
+    def test_passes_when_wire_bid_is_ciphertext(self) -> None:
+        events = [
+            _bc("bidmeta:buyer-0:seller-0:bid-buyer-0:150"),
+            _send("bid:\x8f\x02\xa1 opaque envelope bytes"),
+        ]
+        (result,) = validate_commerce_bid_opacity(events)
+        assert result.passed, result.detail
+
+    def test_fails_when_plaintext_marker_is_on_the_wire(self) -> None:
+        events = [
+            _bc("bidmeta:buyer-0:seller-0:bid-buyer-0:150"),
+            _send("bid:bidamount:150:from:buyer-0:ref:bid-buyer-0"),
+        ]
+        (result,) = validate_commerce_bid_opacity(events)
+        assert not result.passed
+        assert "visible on the wire" in result.detail
+
+    def test_checks_dropped_deliveries_too(self) -> None:
+        events = [
+            _bc("bidmeta:buyer-0:seller-0:bid-buyer-0:150"),
+            {"kind": "dropped", "agent": "e", "msg": "bid:bidamount:150:from:buyer-0:ref:r"},
+        ]
+        (result,) = validate_commerce_bid_opacity(events)
+        assert not result.passed
+
+    def test_fails_on_trace_without_wire_bids(self) -> None:
+        (result,) = validate_commerce_bid_opacity([_bc("bidmeta:buyer-0:seller-0:r:150")])
+        assert not result.passed
+        assert "no bid wire messages" in result.detail
+
+
+class TestUndeliveredPenalized:
+    def test_passes_when_offender_scores_low(self) -> None:
+        events = [
+            _bc("stream:open:buyer-0:shill_seller-0:bid-buyer-0:10"),
+            _bc("stream:close:buyer-0:shill_seller-0:bid-buyer-0:200"),
+            _bc("score:shill_seller-0:0.000000:0.000000"),
+        ]
+        (result,) = validate_commerce_undelivered_penalized(events)
+        assert result.passed, result.detail
+
+    def test_fails_when_offender_scores_high(self) -> None:
+        events = [
+            _bc("stream:open:buyer-0:shill_seller-0:bid-buyer-0:10"),
+            _bc("stream:close:buyer-0:shill_seller-0:bid-buyer-0:200"),
+            _bc("score:shill_seller-0:0.750000:0.500000"),
+        ]
+        (result,) = validate_commerce_undelivered_penalized(events)
+        assert not result.passed
+        assert "0.750" in result.detail
+
+    def test_fails_when_offender_never_scored(self) -> None:
+        events = [
+            _bc("stream:open:buyer-0:shill_seller-0:bid-buyer-0:10"),
+            _bc("stream:close:buyer-0:shill_seller-0:bid-buyer-0:200"),
+        ]
+        (result,) = validate_commerce_undelivered_penalized(events)
+        assert not result.passed
+        assert "never scored" in result.detail
+
+    def test_delivered_stream_is_not_an_offense(self) -> None:
+        events = [
+            _bc("stream:open:buyer-0:seller-0:bid-buyer-0:10"),
+            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0"),
+            _bc("stream:close:buyer-0:seller-0:bid-buyer-0:200"),
+        ]
+        (result,) = validate_commerce_undelivered_penalized(events)
+        # No offenders at all → the adversary never fired → validator fails loudly.
+        assert not result.passed
+        assert "adversary never fired" in result.detail
+
+    def test_zero_total_stream_is_not_a_drain(self) -> None:
+        events = [
+            _bc("stream:open:buyer-0:shill_seller-0:bid-buyer-0:10"),
+            _bc("stream:close:buyer-0:shill_seller-0:bid-buyer-0:0"),
+        ]
+        (result,) = validate_commerce_undelivered_penalized(events)
+        assert not result.passed
+        assert "adversary never fired" in result.detail
+
+
+class TestDeliveryRewarded:
+    def test_passes_when_fulfilment_is_paid_and_scored(self) -> None:
+        events = [
+            _bc("stream:open:buyer-0:seller-0:bid-buyer-0:10"),
+            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0"),
+            _bc("score:seller-0:0.400000:1.000000"),
+        ]
+        (result,) = validate_commerce_delivery_rewarded(events)
+        assert result.passed, result.detail
+
+    def test_fails_on_unpaid_fulfilment(self) -> None:
+        events = [
+            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0"),
+            _bc("score:seller-0:0.400000:1.000000"),
+        ]
+        (result,) = validate_commerce_delivery_rewarded(events)
+        assert not result.passed
+        assert "without a matching payment stream" in result.detail
+
+    def test_fails_when_fulfilling_seller_scores_low(self) -> None:
+        events = [
+            _bc("stream:open:buyer-0:seller-0:bid-buyer-0:10"),
+            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0"),
+            _bc("score:seller-0:0.100000:1.000000"),
+        ]
+        (result,) = validate_commerce_delivery_rewarded(events)
+        assert not result.passed
+        assert "0.100" in result.detail
+
+    def test_fails_on_trace_without_fulfilments(self) -> None:
+        (result,) = validate_commerce_delivery_rewarded([])
+        assert not result.passed
+        assert "no fulfilment markers" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# Property tests: parser robustness and duplicate-collapse
+# ---------------------------------------------------------------------------
+
+_JUNK = st.text(alphabet=st.characters(codec="utf-8"), max_size=40)
+
+
+class TestValidatorProperties:
+    @given(junk=st.lists(_JUNK, max_size=25))
+    @settings(max_examples=50, suppress_health_check=[HealthCheck.too_slow])
+    def test_junk_markers_never_crash_any_validator(self, junk: list[str]) -> None:
+        """Arbitrary garbage interleaved with valid markers must not raise."""
+        events = [_bc(m) for m in junk]
+        events.insert(0, _bc("discovered:buyer-0:seller-0"))
+        events.append(_bc("bidmeta:buyer-0:seller-0:r:150"))
+        for validator in VALIDATORS["private_commerce"]:
+            results = validator(events)
+            assert results and isinstance(results[0].passed, bool)
+
+    @given(copies=st.integers(min_value=1, max_value=6))
+    @settings(max_examples=20)
+    def test_redundant_marker_copies_do_not_change_verdicts(self, copies: int) -> None:
+        """Senders re-broadcast markers for drop-redundancy; dedup must hold."""
+        base = [
+            "discovered:buyer-0:seller-0",
+            "stream:open:buyer-0:seller-0:bid-buyer-0:10",
+            "bidmeta:buyer-0:seller-0:bid-buyer-0:150",
+            "fulfilled:seller-0:buyer-0:bid-buyer-0",
+            "stream:close:buyer-0:seller-0:bid-buyer-0:60",
+            "stream:open:buyer-1:shill_seller-0:bid-buyer-1:10",
+            "bidmeta:buyer-1:shill_seller-0:bid-buyer-1:150",
+            "discovered:buyer-1:shill_seller-0",
+            "stream:close:buyer-1:shill_seller-0:bid-buyer-1:60",
+            "score:seller-0:0.400000:1.000000",
+            "score:shill_seller-0:0.000000:0.000000",
+        ]
+        # Move the second discovery before its bid to keep ordering legal.
+        base.insert(5, base.pop(7))
+        once = [_bc(m) for m in base]
+        multi = [_bc(m) for m in base for _ in range(copies)]
+        for validator in (
+            validate_commerce_discovery_precedes_bid,
+            validate_commerce_undelivered_penalized,
+            validate_commerce_delivery_rewarded,
+        ):
+            (r_once,) = validator(once)
+            (r_multi,) = validator(multi)
+            assert r_once.passed == r_multi.passed, (validator.__name__, r_multi.detail)
+
+
+# ---------------------------------------------------------------------------
+# 2 + 3. Full-simulator integration and adversarial discrimination
+# ---------------------------------------------------------------------------
+
+
+def _run_scenario(tmp_path: Path, *, seed: int = 42, **layer_overrides: str) -> Path:
+    """Run the private_commerce scenario with optional layer swaps; return the trace path."""
+    config = ScenarioConfig.from_yaml(SCENARIO_YAML)
+    config.seed = seed
+    for layer, plugin in layer_overrides.items():
+        setattr(config.layers, layer, plugin)
+    trace = tmp_path / f"pc-{seed}-{'-'.join(layer_overrides.values()) or 'intended'}.jsonl"
+    config.output.trace = str(trace)
+    asyncio.run(ScenarioRunner(config).run())
+    return trace
+
+
+class TestPrivateCommerceIntegration:
+    def test_intended_composition_passes_all_validators(self, tmp_path: Path) -> None:
+        trace = _run_scenario(tmp_path)
+        results = validate_trace(trace, "private_commerce")
+        assert len(results) == 4
+        failures = [r for r in results if not r.passed]
+        assert not failures, [f"{r.name}: {r.detail}" for r in failures]
+
+    def test_second_seed_also_passes(self, tmp_path: Path) -> None:
+        trace = _run_scenario(tmp_path, seed=7)
+        failures = [r for r in validate_trace(trace, "private_commerce") if not r.passed]
+        assert not failures, [f"{r.name}: {r.detail}" for r in failures]
+
+    def test_same_seed_gives_byte_identical_traces(self, tmp_path: Path) -> None:
+        h = [
+            hashlib.sha256(_run_scenario(tmp_path / f"run{i}", seed=42).read_bytes()).hexdigest()
+            for i in (1, 2)
+        ]
+        assert h[0] == h[1]
+
+    def test_different_seeds_give_different_traces(self, tmp_path: Path) -> None:
+        h42 = hashlib.sha256(_run_scenario(tmp_path / "a", seed=42).read_bytes()).hexdigest()
+        h7 = hashlib.sha256(_run_scenario(tmp_path / "b", seed=7).read_bytes()).hexdigest()
+        assert h42 != h7
+
+    def test_noop_privacy_fails_exactly_the_opacity_validator(self, tmp_path: Path) -> None:
+        """Adversarial discrimination: plaintext envelopes must be caught."""
+        trace = _run_scenario(tmp_path, privacy="noop")
+        verdicts = {r.name: r.passed for r in validate_trace(trace, "private_commerce")}
+        assert verdicts["commerce_bid_opacity"] is False
+        assert verdicts["commerce_discovery_precedes_bid"] is True
+        assert verdicts["commerce_undelivered_penalized"] is True
+        assert verdicts["commerce_delivery_rewarded"] is True
+
+    def test_score_average_trust_fails_exactly_the_penalty_validator(self, tmp_path: Path) -> None:
+        """Adversarial discrimination: wash-traded receipts must inflate the
+        reference trust average past the threshold, which the joint validator
+        catches. ``agent_receipts`` severance is what makes the intended
+        composition pass instead."""
+        trace = _run_scenario(tmp_path, trust="score_average")
+        verdicts = {r.name: r.passed for r in validate_trace(trace, "private_commerce")}
+        assert verdicts["commerce_undelivered_penalized"] is False
+        assert verdicts["commerce_bid_opacity"] is True
+        assert verdicts["commerce_discovery_precedes_bid"] is True
+        assert verdicts["commerce_delivery_rewarded"] is True

--- a/packages/nest-plugins-reference/tests/test_private_commerce.py
+++ b/packages/nest-plugins-reference/tests/test_private_commerce.py
@@ -42,9 +42,15 @@ from nest_core.validators import (
 SCENARIO_YAML = Path(__file__).resolve().parents[3] / "scenarios" / "private_commerce.yaml"
 
 
-def _bc(msg: str) -> dict[str, Any]:
-    """A broadcast trace event with the given body."""
-    return {"kind": "broadcast", "agent": "x", "msg": msg}
+def _bc(msg: str, agent: str = "x") -> dict[str, Any]:
+    """A broadcast trace event with the given body, from the given sender.
+
+    ``agent`` defaults to a bystander id ("x") for markers that don't carry
+    a principal to bind against. Markers the validators bind to a principal
+    (``fulfilled:<seller>``, ``score:`` from the auditor) must pass the
+    matching real sender explicitly.
+    """
+    return {"kind": "broadcast", "agent": agent, "msg": msg}
 
 
 def _send(msg: str) -> dict[str, Any]:
@@ -150,13 +156,27 @@ class TestUndeliveredPenalized:
     def test_delivered_stream_is_not_an_offense(self) -> None:
         events = [
             _bc("stream:open:buyer-0:seller-0:bid-buyer-0:10"),
-            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0"),
+            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0", agent="seller-0"),
             _bc("stream:close:buyer-0:seller-0:bid-buyer-0:200"),
         ]
         (result,) = validate_commerce_undelivered_penalized(events)
         # No offenders at all → the adversary never fired → validator fails loudly.
         assert not result.passed
         assert "adversary never fired" in result.detail
+
+    def test_forged_fulfilled_from_wrong_sender_does_not_count(self) -> None:
+        """A ``fulfilled:seller-0`` broadcast by someone other than seller-0
+        must not clear seller-0 of the drain -- the marker names a principal
+        it didn't actually come from."""
+        events = [
+            _bc("stream:open:buyer-0:shill_seller-0:bid-buyer-0:10"),
+            _bc("fulfilled:shill_seller-0:buyer-0:bid-buyer-0", agent="attacker-0"),
+            _bc("stream:close:buyer-0:shill_seller-0:bid-buyer-0:200"),
+            _bc("score:shill_seller-0:0.750000:0.500000"),
+        ]
+        (result,) = validate_commerce_undelivered_penalized(events)
+        assert not result.passed
+        assert "0.750" in result.detail
 
     def test_zero_total_stream_is_not_a_drain(self) -> None:
         events = [
@@ -172,7 +192,7 @@ class TestDeliveryRewarded:
     def test_passes_when_fulfilment_is_paid_and_scored(self) -> None:
         events = [
             _bc("stream:open:buyer-0:seller-0:bid-buyer-0:10"),
-            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0"),
+            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0", agent="seller-0"),
             _bc("score:seller-0:0.400000:1.000000"),
         ]
         (result,) = validate_commerce_delivery_rewarded(events)
@@ -180,7 +200,7 @@ class TestDeliveryRewarded:
 
     def test_fails_on_unpaid_fulfilment(self) -> None:
         events = [
-            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0"),
+            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0", agent="seller-0"),
             _bc("score:seller-0:0.400000:1.000000"),
         ]
         (result,) = validate_commerce_delivery_rewarded(events)
@@ -190,7 +210,7 @@ class TestDeliveryRewarded:
     def test_fails_when_fulfilling_seller_scores_low(self) -> None:
         events = [
             _bc("stream:open:buyer-0:seller-0:bid-buyer-0:10"),
-            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0"),
+            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0", agent="seller-0"),
             _bc("score:seller-0:0.100000:1.000000"),
         ]
         (result,) = validate_commerce_delivery_rewarded(events)
@@ -201,6 +221,34 @@ class TestDeliveryRewarded:
         (result,) = validate_commerce_delivery_rewarded([])
         assert not result.passed
         assert "no fulfilment markers" in result.detail
+
+    def test_forged_fulfilled_from_wrong_sender_does_not_count(self) -> None:
+        """A seller can't be credited with a fulfilment someone else claimed
+        on its behalf -- the marker's principal must match its broadcaster."""
+        events = [
+            _bc("stream:open:buyer-0:seller-0:bid-buyer-0:10"),
+            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0", agent="attacker-0"),
+            _bc("score:seller-0:0.400000:1.000000"),
+        ]
+        (result,) = validate_commerce_delivery_rewarded(events)
+        assert not result.passed
+        assert "no fulfilment markers" in result.detail
+
+    def test_forged_score_after_the_auditor_does_not_override_it(self) -> None:
+        """A byzantine agent broadcasting a ``score:`` line after the real
+        auditor finalized must not win last-write-wins: the canonical
+        auditor is whoever broadcast the *first* score: marker in the trace,
+        and every later score: from a different sender is discarded."""
+        events = [
+            _bc("stream:open:buyer-0:seller-0:bid-buyer-0:10"),
+            _bc("fulfilled:seller-0:buyer-0:bid-buyer-0", agent="seller-0"),
+            _bc("score:seller-0:0.750000:1.000000", agent="auditor-0"),
+            # Forged low score from a non-auditor sender, broadcast after the
+            # real one -- must not overwrite the honest 0.75.
+            _bc("score:seller-0:0.000000:0.000000", agent="attacker-0"),
+        ]
+        (result,) = validate_commerce_delivery_rewarded(events)
+        assert result.passed, result.detail
 
 
 # ---------------------------------------------------------------------------
@@ -226,23 +274,25 @@ class TestValidatorProperties:
     @settings(max_examples=20)
     def test_redundant_marker_copies_do_not_change_verdicts(self, copies: int) -> None:
         """Senders re-broadcast markers for drop-redundancy; dedup must hold."""
+        # (message, sender) -- fulfilled: and score: need their real principal
+        # as sender now that the validators check marker provenance.
         base = [
-            "discovered:buyer-0:seller-0",
-            "stream:open:buyer-0:seller-0:bid-buyer-0:10",
-            "bidmeta:buyer-0:seller-0:bid-buyer-0:150",
-            "fulfilled:seller-0:buyer-0:bid-buyer-0",
-            "stream:close:buyer-0:seller-0:bid-buyer-0:60",
-            "stream:open:buyer-1:shill_seller-0:bid-buyer-1:10",
-            "bidmeta:buyer-1:shill_seller-0:bid-buyer-1:150",
-            "discovered:buyer-1:shill_seller-0",
-            "stream:close:buyer-1:shill_seller-0:bid-buyer-1:60",
-            "score:seller-0:0.400000:1.000000",
-            "score:shill_seller-0:0.000000:0.000000",
+            ("discovered:buyer-0:seller-0", "x"),
+            ("stream:open:buyer-0:seller-0:bid-buyer-0:10", "x"),
+            ("bidmeta:buyer-0:seller-0:bid-buyer-0:150", "x"),
+            ("fulfilled:seller-0:buyer-0:bid-buyer-0", "seller-0"),
+            ("stream:close:buyer-0:seller-0:bid-buyer-0:60", "x"),
+            ("stream:open:buyer-1:shill_seller-0:bid-buyer-1:10", "x"),
+            ("bidmeta:buyer-1:shill_seller-0:bid-buyer-1:150", "x"),
+            ("discovered:buyer-1:shill_seller-0", "x"),
+            ("stream:close:buyer-1:shill_seller-0:bid-buyer-1:60", "x"),
+            ("score:seller-0:0.400000:1.000000", "auditor-0"),
+            ("score:shill_seller-0:0.000000:0.000000", "auditor-0"),
         ]
         # Move the second discovery before its bid to keep ordering legal.
         base.insert(5, base.pop(7))
-        once = [_bc(m) for m in base]
-        multi = [_bc(m) for m in base for _ in range(copies)]
+        once = [_bc(m, agent=a) for m, a in base]
+        multi = [_bc(m, agent=a) for m, a in base for _ in range(copies)]
         for validator in (
             validate_commerce_discovery_precedes_bid,
             validate_commerce_undelivered_penalized,

--- a/scenarios/private_commerce.yaml
+++ b/scenarios/private_commerce.yaml
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Private commerce — a four-layer cross-plugin composition:
+#
+#   registry: gossip           (partition-honest discovery, per-agent views)
+#   payments: streaming        (per-tick metered payment streams)
+#   privacy:  hybrid_x25519    (X25519 + ChaCha20-Poly1305 bid envelopes)
+#   trust:    agent_receipts   (cross-signed receipts, collusion severance)
+#
+# 12 agents: 5 buyers, 4 honest sellers, 1 shill seller, 1 shill accomplice,
+# 1 auditor. Buyers discover sellers via gossip, open a payment stream, send
+# a hybrid-encrypted bid. Honest sellers deliver and issue cross-signed
+# purchase receipts; the shill seller drains the stream, never delivers, and
+# wash-trades fake receipts with its accomplice for cover.
+#
+# Four joint validators check the cross-layer invariants:
+#   commerce_discovery_precedes_bid  — registry × privacy ordering
+#   commerce_bid_opacity             — privacy × transport confidentiality
+#   commerce_undelivered_penalized   — payments × trust (adversary punished)
+#   commerce_delivery_rewarded       — payments × trust (honesty rewarded)
+#
+# Adversarial discrimination (swap exactly one line and re-run):
+#   privacy: noop           → commerce_bid_opacity FAILS (plaintext on the wire)
+#   trust: score_average    → commerce_undelivered_penalized FAILS (wash-trade
+#                             receipts inflate the shill's average score)
+#
+# A partition splits buyers {0,1} from the rest for the first 3000 ticks;
+# gossip convergence (and hence those buyers' bids) waits for the heal.
+# Deterministic under any fixed seed: every agent uses the simulator's
+# seeded RNG and logical clock; the privacy plugin runs deterministic mode.
+name: private_commerce
+description: >
+  12 agents compose gossip discovery, streaming payments, hybrid-encrypted
+  bids, and receipt-corroborated trust. A wash-trading shill seller drains a
+  payment stream without delivering; joint cross-layer validators prove it
+  is penalized while honest sellers are rewarded.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 12
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 5
+    - name: seller
+      count: 4
+    - name: shill_seller
+      count: 1
+    - name: shill
+      count: 1
+    - name: auditor
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: gossip
+  auth: jwt
+  trust: agent_receipts
+  payments: streaming
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: hybrid_x25519
+  datafacts: datafacts_v1
+
+task:
+  type: private_commerce
+  config:
+    gossip_interval: 200
+    discover_start: 1000
+    discover_every: 500
+    bid_deadline: 9000
+    check_delay: 1000
+    finalize_at: 12000
+    bid_amount: 150
+    stream_rate: 10
+    stream_max: 500
+    initial_balance: 5000
+
+failures:
+  message_drop: 0.05
+  network_partition:
+    groups:
+      - [buyer-0, buyer-1]
+      - [buyer-2, buyer-3, buyer-4, seller-0, seller-1, seller-2, seller-3, shill_seller-0, shill-0]
+  partition_heal_at_tick: 3000
+
+duration: "ticks: 40000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/private_commerce.jsonl


### PR DESCRIPTION
# [Hackathon] distributed-systems-architect: private_commerce — four-layer cross-plugin composition with joint validators

## Problem picked

None of the ten listed problems — this PR targets the gap they leave behind. Every merged hackathon plugin (gossip registry #24, streaming payments #21, hybrid_x25519 privacy #28, agent_receipts trust #26) was designed, tested, and validated **in isolation**. Nobody has asked what happens when they run **together**, and no validator in the repo can even express a cross-layer invariant. This PR is a **scenario + validator** submission per the charter ("a layer plugin *or* a scenario *or* a validator"): a `private_commerce` scenario that composes four merged plugins into one workflow, plus four joint validators that test emergent properties spanning layer boundaries.

## What it does

**Scenario (12 agents):** 5 buyers discover sellers through per-agent gossip registries (partition-honest — buyers 0-1 are partitioned away for the first 3000 ticks and must wait for the heal), open per-tick streaming payments, and send bids wrapped in hybrid X25519 + ChaCha20-Poly1305 envelopes. 4 honest sellers decrypt, deliver, and issue Ed25519 cross-signed purchase receipts; they also settle among themselves in a directed receipt cycle, forming the strongly-connected honest anchor that collusion severance needs. The adversary — `shill_seller-0` — looks legitimate on the registry, decrypts the bid, **drains the stream, never delivers**, and covers itself by wash-trading mutually co-signed fake receipts with `shill-0`. An auditor ingests receipts and negatives into the configured trust plugin and emits final scores.

**Joint validators** (registered as `VALIDATORS["private_commerce"]`):

| Validator | Layers spanned | Invariant |
|---|---|---|
| `commerce_discovery_precedes_bid` | registry × privacy | every encrypted bid is preceded by an honest gossip discovery of that seller |
| `commerce_bid_opacity` | privacy × transport | the known bid plaintext never appears in any `bid:` wire message (send / receive / **dropped**) |
| `commerce_undelivered_penalized` | payments × trust | a seller that drained a stream without delivering ends below the trust threshold — *despite* wash-traded receipts |
| `commerce_delivery_rewarded` | payments × trust | every fulfilment is backed by a payment stream, and fulfilling sellers score above threshold |

## Adversarial discrimination (one YAML line each)

The charter asks for validators the reference plugin cannot satisfy. Here each cross-layer check is pinned to the specific plugin that makes it pass:

- `privacy: hybrid_x25519 → noop`: bid envelopes become plaintext; `commerce_bid_opacity` **FAILS** (the other three still pass — the failure is surgically attributable).
- `trust: agent_receipts → score_average`: the shill's wash-traded receipts *raise* its running average to 0.75; `commerce_undelivered_penalized` **FAILS**. Under `agent_receipts` the isolated mutual co-signing pair is severed by the SCC analysis and the shill collapses to 0.0 — the composition passes.

Both discriminations are integration tests (`test_noop_privacy_fails_exactly_the_opacity_validator`, `test_score_average_trust_fails_exactly_the_penalty_validator`) that assert the *exact* verdict vector, not just "something failed."

## Design decisions & tradeoffs

- **Ground-truth sidecar (`bidmeta:`)**: opacity is unfalsifiable unless the validator knows the plaintext. Buyers broadcast a `bidmeta:` marker declaring what they encrypted; the validator then proves that string never rides the wire in a `bid:` message. In production this sidecar would not exist; in a test rig, making the invariant checkable is the point.
- **Marker broadcasts vs. functional sends**: markers (`discovered:`, `stream:*`, `fulfilled:`, `score:`) are broadcasts — recorded in the trace at *send* time, so a dropped delivery can never make the trace lie about what an agent did. Functional messages (bid, ack, receipt) get 3× send redundancy with receiver-side dedup by ref/receipt-id; self-scheduled ticks get 5× redundancy (drop-chain death probability ≈ 0.05⁵). This is the same pattern the gossip scenario (#24) uses, extended to point-to-point traffic.
- **Deterministic pairing**: buyer *i* targets the *i*-th sorted discovered seller, so with 5 buyers and 5 sell-capable cards, the shill gets exactly one victim under every seed — the adversary is guaranteed to fire, and the penalty validator fails loudly if it ever doesn't (`"the adversary never fired"`), rather than passing vacuously.
- **Trust threshold 0.3**: an honest seller with one corroborated purchase receipt scores `1 − exp(−5/10) ≈ 0.39` under `agent_receipts`; a severed shill scores exactly 0.0; the reference neutral prior is 0.5. 0.3 separates every honest outcome from the severed adversary with margin on both sides, and sits below the 0.5 prior so `score_average`'s wash-trade inflation (0.75) is caught.
- **Per-agent plugin wiring** uses the runner's existing `_agent_plugins` override channel (same as #24): per-agent gossip views, per-buyer streaming ledgers, per-agent X25519 keypairs cross-registered at build time. No runner changes needed.

## Test rigor

25 tests in `packages/nest-plugins-reference/tests/test_private_commerce.py`:

- **17 unit tests** covering pass / fail / absent-marker / vacuous-pass paths for all four validators (e.g. zero-total stream is not a drain; a delivered stream is not an offense; unpaid fulfilment is caught).
- **2 Hypothesis property tests**: arbitrary junk markers interleaved with valid ones never crash any validator; N-fold marker duplication (the drop-redundancy scenario) never changes any verdict.
- **6 integration tests** booting the full simulator: all validators green under seeds 42 and 7; byte-identical traces under a repeated seed; different traces under different seeds; and the two exact-verdict adversarial discriminations above.

## How to verify

```bash
uv run nest run scenarios/private_commerce.yaml
uv run python -c "
from pathlib import Path
from nest_core.validators import validate_trace
for r in validate_trace(Path('traces/private_commerce.jsonl'), 'private_commerce'):
    print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail)
"
# Adversarial: edit scenarios/private_commerce.yaml, set privacy: noop → opacity FAILS
# Adversarial: set trust: score_average → undelivered-penalty FAILS
uv run pytest packages/nest-plugins-reference/tests/test_private_commerce.py -v
```

Full CI (`uv sync && uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -v`) is green locally: 761 passed, 0 ruff, 0 pyright.

## Persona

`distributed-systems-architect`: the submission's whole thesis is that correctness of parts does not compose for free. The code reflects it — redundancy budgets computed from the drop rate, partition-aware pairing deadlines, an SCC-severance-aware threshold derivation, and validators that treat the trace as the only source of truth (markers recorded at send time so drops can't hide behavior). The novelty is not any one algorithm; it is the instrumented composition and the two one-line adversarial swaps that attribute each cross-layer failure to the exact layer that caused it.
