### PR TITLE
[Hackathon] hiten: add configurable provenance_supply_chain_multi scenario

### DIFF
--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -109,6 +109,12 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("provenance_supply_chain", provenance_supply_chain_factory)
+    elif name == "provenance_supply_chain_multi":
+        from nest_core.scenarios_builtin.provenance_supply_chain_multi import (
+            provenance_supply_chain_multi_factory,
+        )
+
+        register_scenario("provenance_supply_chain_multi", provenance_supply_chain_multi_factory)
     elif name == "bft_hotstuff":
         from nest_core.scenarios_builtin.bft_hotstuff import bft_hotstuff_factory
 

--- a/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain_multi.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/provenance_supply_chain_multi.py
@@ -1,0 +1,465 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Content-addressed provenance scenario: a configurable N×M fan-in pipeline, then attacks.
+
+Topology (configurable via ``task.config`` in the YAML)::
+
+    supplier-0  supplier-1  ...  supplier-(N-1)
+         \\            |              /
+          \\           |             /
+       manufacturer-0  ...  manufacturer-(M-1)
+               \\       ...       /
+                \\               /
+               distributor-0   (join: parents = all manufacturer URLs)
+                      |
+                 retailer-0
+
+Each supplier publishes a raw dataset.  Every manufacturer waits to receive
+*all* supplier inputs (``num_suppliers`` messages), then publishes one derived
+dataset whose ``parents`` list every supplier URL, and forwards the result to
+the distributor.  The distributor waits for *all* manufacturers (``num_manufacturers``
+messages) and publishes a join dataset whose ``parents`` list every manufacturer
+URL.  The retailer acts as verifier-and-attacker: it walks the full provenance
+DAG and then runs the three canonical attacks.
+
+This gives ``validate_trace(..., "provenance_supply_chain_multi")`` a different
+graph shape from the fixed diamond in ``provenance_supply_chain``: fan-width is
+configurable from YAML, not hard-coded to 2.
+
+Example (from YAML ``task.config``)::
+
+    task:
+      type: provenance_supply_chain_multi
+      config:
+        num_suppliers: 3
+        num_manufacturers: 2
+
+Defaults to ``num_suppliers=2, num_manufacturers=2``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, DatasetMetadata
+
+_PHANTOM_PARENT = "df://sha256-" + "0" * 64
+
+# ---------------------------------------------------------------------------
+# Shared helper
+# ---------------------------------------------------------------------------
+
+
+def _parents_of(meta: DatasetMetadata) -> list[str]:
+    """Read declared provenance parents off a dataset as a plain list of URL strings.
+
+    Example::
+
+        parents = _parents_of(meta)
+    """
+    raw: object = meta.metadata.get("parents", [])
+    if not isinstance(raw, list):
+        return []
+    return [str(p) for p in cast("list[Any]", raw)]
+
+
+# ---------------------------------------------------------------------------
+# Agent classes
+# ---------------------------------------------------------------------------
+
+
+class MultiSupplierAgent(StateMachineAgent):
+    """Publishes one root dataset and fans it out to every manufacturer.
+
+    Example::
+
+        supplier = MultiSupplierAgent(
+            AgentId("supplier-0"),
+            manufacturers=[AgentId("manufacturer-0"), AgentId("manufacturer-1")],
+            name="raw_0",
+        )
+    """
+
+    def __init__(self, agent_id: AgentId, manufacturers: list[AgentId], name: str) -> None:
+        self._id = agent_id
+        self._manufacturers = manufacturers
+        self._name = name
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Publish the root dataset and notify every manufacturer.
+
+        Example::
+
+            await supplier.on_start(ctx)
+        """
+        facts = ctx.plugins.get("datafacts")
+        if facts is None:
+            return
+        dataset = DatasetMetadata(name=self._name, owner=self._id)
+        url = await facts.publish(dataset)
+        for mfg in self._manufacturers:
+            await ctx.send(mfg, f"lineage|{url}|{self._id}".encode())
+
+
+class MultiManufacturerAgent(StateMachineAgent):
+    """Collects one URL from every supplier, then publishes a derived dataset.
+
+    Waits for ``num_suppliers`` ``lineage|…`` messages.  Once all arrive,
+    publishes one dataset listing all supplier URLs as parents and forwards
+    to the distributor.
+
+    Example::
+
+        mfg = MultiManufacturerAgent(
+            AgentId("manufacturer-0"),
+            distributor=AgentId("distributor-0"),
+            name="product_0",
+            num_suppliers=3,
+        )
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        distributor: AgentId,
+        name: str,
+        num_suppliers: int,
+    ) -> None:
+        self._id = agent_id
+        self._distributor = distributor
+        self._name = name
+        self._num_suppliers = num_suppliers
+        self._parent_urls: list[str] = []
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Accumulate supplier URLs; publish + forward when all have arrived.
+
+        Example::
+
+            await mfg.on_message(ctx, AgentId("supplier-0"), b"lineage|df://sha256-x|supplier-0")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("lineage|"):
+            return
+        _, parent_url, _owner = msg.split("|", 2)
+        self._parent_urls.append(parent_url)
+        if len(self._parent_urls) == self._num_suppliers:
+            facts = ctx.plugins.get("datafacts")
+            if facts is None:
+                return
+            dataset = DatasetMetadata(
+                name=self._name,
+                owner=self._id,
+                metadata={"parents": list(self._parent_urls)},
+            )
+            url = await facts.publish(dataset)
+            await ctx.send(self._distributor, f"lineage|{url}|{self._id}".encode())
+
+
+class MultiDistributorAgent(StateMachineAgent):
+    """Joins all manufacturer outputs into one dataset and forwards to the retailer.
+
+    Example::
+
+        dist = MultiDistributorAgent(
+            AgentId("distributor-0"),
+            retailer=AgentId("retailer-0"),
+            name="aggregated",
+            num_manufacturers=2,
+        )
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        retailer: AgentId,
+        name: str,
+        num_manufacturers: int,
+    ) -> None:
+        self._id = agent_id
+        self._retailer = retailer
+        self._name = name
+        self._num_manufacturers = num_manufacturers
+        self._parent_urls: list[str] = []
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Accumulate manufacturer URLs; publish + forward when all have arrived.
+
+        Example::
+
+            await dist.on_message(ctx, AgentId("manufacturer-0"), b"lineage|df://sha256-y|manufacturer-0")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("lineage|"):
+            return
+        _, parent_url, _owner = msg.split("|", 2)
+        self._parent_urls.append(parent_url)
+        if len(self._parent_urls) == self._num_manufacturers:
+            facts = ctx.plugins.get("datafacts")
+            if facts is None:
+                return
+            dataset = DatasetMetadata(
+                name=self._name,
+                owner=self._id,
+                metadata={"parents": list(self._parent_urls)},
+            )
+            url = await facts.publish(dataset)
+            await ctx.send(self._retailer, f"lineage|{url}|{self._id}".encode())
+
+
+class MultiRetailerAgent(StateMachineAgent):
+    """Walks the provenance DAG from the distributor leaf, then runs three attacks.
+
+    Reuses the same three attack patterns as ``VerifyAndAttackAgent`` in the
+    diamond scenario, exercising identical validators via a wider graph.
+
+    Example::
+
+        retailer = MultiRetailerAgent(
+            AgentId("retailer-0"),
+            first_supplier_id=AgentId("supplier-0"),
+            first_supplier_name="raw_0",
+        )
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        first_supplier_id: AgentId,
+        first_supplier_name: str,
+    ) -> None:
+        self._id = agent_id
+        self._source_id = first_supplier_id
+        self._source_name = first_supplier_name
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Walk the lineage, then run substitution, forged-freshness, and provenance attacks.
+
+        Example::
+
+            await retailer.on_message(ctx, AgentId("distributor-0"), b"lineage|df://sha256-z|distributor-0")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("lineage|"):
+            return
+        facts = ctx.plugins.get("datafacts")
+        if facts is None:
+            return
+        _, leaf_url, _owner = msg.split("|", 2)
+        root_url = await self._verify_chain(ctx, facts, leaf_url)
+        if root_url is not None:
+            await self._attack_substitution(ctx, facts, root_url)
+            await self._attack_forged_freshness(ctx, facts)
+        await self._attack_provenance(ctx, facts)
+
+    async def _verify_chain(self, ctx: AgentContext, facts: Any, leaf_url: str) -> str | None:
+        """Full breadth-first walk of the provenance DAG from the leaf to its roots.
+
+        Visits every parent of every node, de-dupes shared ancestors, reports
+        the number of distinct datasets in the lineage, and returns the
+        lexicographically first root (a node with no parents) so the
+        substitution attack has a concrete target.
+        """
+        seen: set[str] = set()
+        roots: list[str] = []
+        stack: list[str] = [leaf_url]
+        while stack:
+            url = stack.pop()
+            if url in seen:
+                continue
+            seen.add(url)
+            try:
+                meta: DatasetMetadata = await facts.fetch(url)
+            except KeyError:
+                await ctx.send(self._id, f"chain_broken|{leaf_url}|{url}".encode())
+                return None
+            parents = _parents_of(meta)
+            if parents:
+                stack.extend(parents)
+            else:
+                roots.append(url)
+        await ctx.send(self._id, f"chain_ok|{leaf_url}|{len(seen)}".encode())
+        return sorted(roots)[0] if roots else None
+
+    async def _attack_substitution(self, ctx: AgentContext, facts: Any, source_url: str) -> None:
+        """Try to republish different content under the first supplier's exact name."""
+        forged = DatasetMetadata(
+            name=self._source_name,
+            owner=self._source_id,
+            description="tampered-by-attacker",
+        )
+        attacker_url = await facts.publish(forged)
+        collided = int(str(attacker_url) == str(source_url))
+        await ctx.send(
+            self._id,
+            f"attack_substitution|{source_url}|{attacker_url}|{collided}".encode(),
+        )
+
+    async def _attack_forged_freshness(self, ctx: AgentContext, facts: Any) -> None:
+        """Republish the supplier's content signed by the attacker, then re-check freshness."""
+        forged = DatasetMetadata(name=self._source_name, owner=self._source_id)
+        forged_url = await facts.publish(forged)
+        fresh = await facts.verify_freshness(forged_url)
+        await ctx.send(
+            self._id,
+            f"attack_forged_freshness|{forged_url}|{int(fresh)}".encode(),
+        )
+
+    async def _attack_provenance(self, ctx: AgentContext, facts: Any) -> None:
+        """Try to publish a dataset whose declared parent was never published."""
+        phantom = DatasetMetadata(
+            name="laundered",
+            owner=self._source_id,
+            metadata={"parents": [_PHANTOM_PARENT]},
+        )
+        try:
+            await facts.publish(phantom)
+            rejected = 0
+        except ValueError:
+            rejected = 1
+        await ctx.send(
+            self._id,
+            f"attack_provenance|{_PHANTOM_PARENT}|{rejected}".encode(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Shared datafacts wiring (mirrors provenance_supply_chain)
+# ---------------------------------------------------------------------------
+
+
+def _build_datafacts_handles(
+    datafacts_cls: type[Any],
+    identities: dict[AgentId, Any],
+    all_ids: list[AgentId],
+) -> dict[AgentId, Any]:
+    """Instantiate one datafacts handle per agent, sharing state where possible.
+
+    Mirrors the implementation in ``provenance_supply_chain`` exactly: plugins
+    accepting ``Identity + datasets/proofs/clock`` kwargs (e.g. ``cid_facts``)
+    get per-agent handles over shared dicts; single-instance plugins (e.g.
+    ``datafacts_v1``) are shared as-is.
+
+    Example::
+
+        handles = _build_datafacts_handles(CidFacts, identities, all_ids)
+    """
+    shared_datasets: dict[Any, Any] = {}
+    shared_proofs: dict[Any, Any] = {}
+    shared_clock: Any = None
+    shared_instance: Any = None
+    handles: dict[AgentId, Any] = {}
+
+    for aid in all_ids:
+        try:
+            kwargs: dict[str, Any] = {
+                "datasets": shared_datasets,
+                "proofs": shared_proofs,
+            }
+            if shared_clock is not None:
+                kwargs["clock"] = shared_clock
+            handle = datafacts_cls(identities[aid], **kwargs)
+            shared_clock = getattr(handle, "clock", shared_clock)
+            handles[aid] = handle
+        except TypeError:
+            if shared_instance is None:
+                shared_instance = datafacts_cls()
+            handles[aid] = shared_instance
+    return handles
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def provenance_supply_chain_multi_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create the N×M pipeline: suppliers → manufacturers → distributor → retailer.
+
+    Reads ``num_suppliers`` and ``num_manufacturers`` from ``config.task.config``,
+    defaulting to 2 and 2 respectively.  Instantiates per-agent identity
+    instances and wires the datafacts plugin class into per-agent handles via
+    :func:`_build_datafacts_handles`.
+
+    Example::
+
+        agents = provenance_supply_chain_multi_factory(config, plugins)
+    """
+    task_cfg = config.task.config
+    num_suppliers: int = int(task_cfg.get("num_suppliers", 2))
+    num_manufacturers: int = int(task_cfg.get("num_manufacturers", 2))
+
+    if num_suppliers < 1:
+        msg = "num_suppliers must be >= 1"
+        raise ValueError(msg)
+    if num_manufacturers < 1:
+        msg = "num_manufacturers must be >= 1"
+        raise ValueError(msg)
+
+    # Build agent IDs
+    supplier_ids = [AgentId(f"supplier-{i}") for i in range(num_suppliers)]
+    manufacturer_ids = [AgentId(f"manufacturer-{i}") for i in range(num_manufacturers)]
+    distributor_id = AgentId("distributor-0")
+    retailer_id = AgentId("retailer-0")
+    all_ids = supplier_ids + manufacturer_ids + [distributor_id, retailer_id]
+
+    # Build identities
+    identity_cls = plugins.get("identity")
+    identities: dict[AgentId, Any] = {}
+    if identity_cls is not None and isinstance(identity_cls, type):
+        for aid in all_ids:
+            identities[aid] = identity_cls(aid, seed=b"sim-seed")
+        for aid, ident in identities.items():
+            for peer_id, peer_ident in identities.items():
+                if peer_id != aid:
+                    ident.register_peer(peer_id, peer_ident.public_key)
+
+    # Wire datafacts handles
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+    datafacts_cls = plugins.get("datafacts")
+    if datafacts_cls is not None and isinstance(datafacts_cls, type) and identities:
+        handles = _build_datafacts_handles(datafacts_cls, identities, all_ids)
+        for aid, handle in handles.items():
+            agent_plugins.setdefault(aid, {})["datafacts"] = handle
+    plugins.pop("datafacts", None)
+    plugins.pop("identity", None)
+
+    # Build agents
+    agents: dict[AgentId, StateMachineAgent] = {}
+
+    # Suppliers — each sends to all manufacturers
+    supplier_names: list[str] = []
+    for i, sid in enumerate(supplier_ids):
+        name = f"raw_material_{i}"
+        supplier_names.append(name)
+        agents[sid] = MultiSupplierAgent(sid, manufacturers=manufacturer_ids, name=name)
+
+    # Manufacturers — each waits for all suppliers
+    for j, mid in enumerate(manufacturer_ids):
+        agents[mid] = MultiManufacturerAgent(
+            mid,
+            distributor=distributor_id,
+            name=f"product_{j}",
+            num_suppliers=num_suppliers,
+        )
+
+    # Distributor — waits for all manufacturers
+    agents[distributor_id] = MultiDistributorAgent(
+        distributor_id,
+        retailer=retailer_id,
+        name="aggregated_batch",
+        num_manufacturers=num_manufacturers,
+    )
+
+    # Retailer — verifier + attacker, targets the first supplier's root dataset
+    agents[retailer_id] = MultiRetailerAgent(
+        retailer_id,
+        first_supplier_id=supplier_ids[0],
+        first_supplier_name=supplier_names[0],
+    )
+
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -2835,6 +2835,12 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_provenance_freshness_unforgeable,
         validate_provenance_chain_unforgeable,
     ],
+    "provenance_supply_chain_multi": [
+        validate_provenance_chain_integrity,
+        validate_provenance_substitution_resistant,
+        validate_provenance_freshness_unforgeable,
+        validate_provenance_chain_unforgeable,
+    ],
     "bft_hotstuff": [
         validate_bft_no_conflicting_commits,
         validate_bft_no_equivocation,

--- a/packages/nest-core/tests/test_provenance_supply_chain_multi.py
+++ b/packages/nest-core/tests/test_provenance_supply_chain_multi.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the provenance_supply_chain_multi scenario.
+
+Verifies:
+- configurable supplier count works
+- configurable manufacturer count works
+- scenario executes successfully end-to-end
+- provenance validation passes with cid_facts
+- determinism is preserved across repeated runs with the same seed
+- the existing diamond scenario (provenance_supply_chain) is untouched
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+
+type Event = dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(
+    out: Path,
+    num_suppliers: int = 2,
+    num_manufacturers: int = 2,
+    datafacts: str = "cid_facts",
+    seed: int = 42,
+) -> None:
+    """Run the multi scenario with configurable parameters."""
+    cfg = ScenarioConfig.from_yaml("scenarios/provenance_supply_chain_multi.yaml")
+    cfg.layers.datafacts = datafacts
+    cfg.seed = seed
+    cfg.output.trace = str(out)
+    cfg.task.config = {
+        "num_suppliers": num_suppliers,
+        "num_manufacturers": num_manufacturers,
+    }
+    asyncio.run(ScenarioRunner(cfg).run())
+
+
+def _chain_ok_depth(trace: Path) -> int | None:
+    """Return the lineage depth reported by the first chain_ok message, or None."""
+    for line in trace.read_text().splitlines():
+        msg = str(json.loads(line).get("msg", ""))
+        if msg.startswith("chain_ok|"):
+            parts = msg.split("|")
+            if len(parts) >= 3:
+                return int(parts[2])
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Unit: configurable supplier / manufacturer count
+# ---------------------------------------------------------------------------
+
+
+class TestConfigurableTopology:
+    def test_factory_default_counts(self, tmp_path: Path) -> None:
+        """Default 2×2 topology completes without error."""
+        out = tmp_path / "default.jsonl"
+        _run(out, num_suppliers=2, num_manufacturers=2)
+        assert out.exists()
+
+    def test_factory_three_suppliers(self, tmp_path: Path) -> None:
+        """3 suppliers → 2 manufacturers topology executes and passes."""
+        out = tmp_path / "3s2m.jsonl"
+        _run(out, num_suppliers=3, num_manufacturers=2)
+        results = validate_trace(out, "provenance_supply_chain_multi")
+        assert results, "expected validators to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_factory_one_supplier_three_manufacturers(self, tmp_path: Path) -> None:
+        """1 supplier → 3 manufacturers topology executes and passes."""
+        out = tmp_path / "1s3m.jsonl"
+        _run(out, num_suppliers=1, num_manufacturers=3)
+        results = validate_trace(out, "provenance_supply_chain_multi")
+        assert results, "expected validators to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_factory_one_supplier_one_manufacturer(self, tmp_path: Path) -> None:
+        """Minimal 1×1 topology (degenerate, no fan) executes and passes."""
+        out = tmp_path / "1s1m.jsonl"
+        _run(out, num_suppliers=1, num_manufacturers=1)
+        results = validate_trace(out, "provenance_supply_chain_multi")
+        assert results, "expected validators to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+
+# ---------------------------------------------------------------------------
+# Unit: factory rejects invalid arguments
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryValidation:
+    def test_zero_suppliers_raises(self) -> None:
+        """num_suppliers=0 must raise ValueError before any agent is created."""
+        import pytest
+        from nest_core.scenario import ScenarioConfig
+        from nest_core.scenarios import get_scenario_factory
+
+        cfg = ScenarioConfig.from_yaml("scenarios/provenance_supply_chain_multi.yaml")
+        cfg.task.config = {"num_suppliers": 0, "num_manufacturers": 2}
+        factory = get_scenario_factory("provenance_supply_chain_multi")
+        with pytest.raises(ValueError, match="num_suppliers"):
+            factory(cfg, {})
+
+    def test_zero_manufacturers_raises(self) -> None:
+        """num_manufacturers=0 must raise ValueError before any agent is created."""
+        import pytest
+        from nest_core.scenario import ScenarioConfig
+        from nest_core.scenarios import get_scenario_factory
+
+        cfg = ScenarioConfig.from_yaml("scenarios/provenance_supply_chain_multi.yaml")
+        cfg.task.config = {"num_suppliers": 2, "num_manufacturers": 0}
+        factory = get_scenario_factory("provenance_supply_chain_multi")
+        with pytest.raises(ValueError, match="num_manufacturers"):
+            factory(cfg, {})
+
+
+class TestScenarioEndToEnd:
+    def test_cid_facts_passes_all(self, tmp_path: Path) -> None:
+        """cid_facts with default 2×2 topology passes all four provenance validators."""
+        out = tmp_path / "cid_facts.jsonl"
+        _run(out, num_suppliers=2, num_manufacturers=2)
+        results = validate_trace(out, "provenance_supply_chain_multi")
+        assert results, "expected validators to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_dag_walk_covers_full_lineage(self, tmp_path: Path) -> None:
+        """The DAG walk must visit all nodes: 2 suppliers + 2 manufacturers + 1 distributor = 5."""
+        out = tmp_path / "cid_facts.jsonl"
+        _run(out, num_suppliers=2, num_manufacturers=2)
+        depth = _chain_ok_depth(out)
+        assert depth is not None, "no chain_ok recorded in trace"
+        # 2 suppliers + 2 manufacturers + 1 distributor = 5 distinct lineage nodes
+        assert depth == 5, f"expected depth 5, got {depth}"
+
+    def test_dag_walk_three_suppliers(self, tmp_path: Path) -> None:
+        """3×2 topology: 3 suppliers + 2 manufacturers + 1 distributor = 6 nodes."""
+        out = tmp_path / "3s2m.jsonl"
+        _run(out, num_suppliers=3, num_manufacturers=2)
+        depth = _chain_ok_depth(out)
+        assert depth is not None, "no chain_ok recorded in trace"
+        # Each manufacturer lists all 3 supplier URLs as parents, but the
+        # BFS de-duplicates. Total unique nodes = 3+2+1 = 6.
+        assert depth == 6, f"expected depth 6, got {depth}"
+
+    def test_datafacts_v1_fails_adversarial_checks(self, tmp_path: Path) -> None:
+        """datafacts_v1 passes the chain walk but fails all three attack validators."""
+        out = tmp_path / "v1.jsonl"
+        _run(out, datafacts="datafacts_v1")
+        results = {r.name: r.passed for r in validate_trace(out, "provenance_supply_chain_multi")}
+        # The happy-path walk still succeeds — v1 stores parents in metadata.
+        assert results["provenance_chain_integrity"] is True
+        assert results["provenance_substitution_resistant"] is False
+        assert results["provenance_freshness_unforgeable"] is False
+        assert results["provenance_chain_unforgeable"] is False
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_deterministic_across_required_seeds(self, tmp_path: Path) -> None:
+        """Identical seeds produce byte-identical traces."""
+        for seed in (42, 7, 1337):
+            a = tmp_path / f"{seed}a.jsonl"
+            b = tmp_path / f"{seed}b.jsonl"
+            _run(a, seed=seed)
+            _run(b, seed=seed)
+            assert a.read_bytes() == b.read_bytes(), f"seed {seed} not deterministic"
+            assert all(r.passed for r in validate_trace(a, "provenance_supply_chain_multi"))
+
+
+# ---------------------------------------------------------------------------
+# Non-regression: diamond scenario untouched
+# ---------------------------------------------------------------------------
+
+
+class TestDiamondScenarioUnchanged:
+    def test_diamond_still_passes(self, tmp_path: Path) -> None:
+        """The original diamond scenario is completely unaffected by this PR."""
+        cfg = ScenarioConfig.from_yaml("scenarios/provenance_supply_chain.yaml")
+        cfg.output.trace = str(tmp_path / "diamond.jsonl")
+        asyncio.run(ScenarioRunner(cfg).run())
+        results = validate_trace(tmp_path / "diamond.jsonl", "provenance_supply_chain")
+        assert results, "expected diamond validators to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_diamond_chain_ok_depth_still_four(self, tmp_path: Path) -> None:
+        """The diamond scenario still reports a 4-node lineage (unchanged)."""
+        cfg = ScenarioConfig.from_yaml("scenarios/provenance_supply_chain.yaml")
+        out = tmp_path / "diamond.jsonl"
+        cfg.output.trace = str(out)
+        asyncio.run(ScenarioRunner(cfg).run())
+        depth = _chain_ok_depth(out)
+        assert depth == 4, f"diamond depth changed: expected 4, got {depth}"

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -926,6 +926,7 @@ class TestValidatorRegistry:
             "receipt_reputation",
             "multi_attribute_market",
             "provenance_supply_chain",
+            "provenance_supply_chain_multi",
             "bft_hotstuff",
             "escrow_marketplace",
         }

--- a/scenarios/provenance_supply_chain_multi.yaml
+++ b/scenarios/provenance_supply_chain_multi.yaml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# Provenance scenario: a configurable N×M fan-in pipeline, then four attacks.
+#
+#   supplier-0  supplier-1  ...  supplier-(N-1)
+#        \           |               /
+#         \          |              /
+#      manufacturer-0  ...  manufacturer-(M-1)
+#              \       ...       /
+#               \               /
+#              distributor-0     (join: parents = all manufacturer URLs)
+#                    |
+#               retailer-0     (verifier + attacker)
+#
+# Each supplier publishes a root dataset (no parents).
+# Each manufacturer waits for every supplier URL, then publishes a dataset
+# listing all of them as provenance parents, and forwards to the distributor.
+# The distributor waits for every manufacturer URL, publishes a join dataset,
+# and forwards to the retailer.
+# The retailer walks the full DAG and runs substitution, forged-freshness,
+# and broken-provenance attacks as an outsider.
+#
+# Configurable via task.config:
+#   num_suppliers:      number of supplier agents (default 2)
+#   num_manufacturers:  number of manufacturer agents (default 2)
+#
+# Verify::
+#
+#     nest run scenarios/provenance_supply_chain_multi.yaml
+#     python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
+#         [print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail) \
+#          for r in validate_trace(Path('traces/provenance_supply_chain_multi.jsonl'), 'provenance_supply_chain_multi')]"
+#
+name: provenance_supply_chain_multi
+description: "Configurable N×M provenance fan-in pipeline (suppliers → manufacturers → distributor → retailer) with adversarial attack checks."
+
+tier: 1
+seed: 42
+
+agents:
+  # NOTE: agents.count is NOT used by the state-machine brain path.
+  # The factory derives the actual agent set from task.config (num_suppliers,
+  # num_manufacturers). Changing this value has no runtime effect; it is kept
+  # at the default-topology total (2+2+1+1=6) for reference only.
+  count: 6
+  brain: state-machine
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: cid_facts
+
+task:
+  type: provenance_supply_chain_multi
+  config:
+    num_suppliers: 2
+    num_manufacturers: 2
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 1000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/provenance_supply_chain_multi.jsonl


### PR DESCRIPTION
## Summary

This is a focused follow-up to my previous hackathon PR (#39). Following the merge of the DataFacts implementation in #31, this PR contributes the independent scenario enhancement suggested during review by introducing a configurable provenance supply-chain scenario.

The new `provenance_supply_chain_multi` scenario exercises the existing `cid_facts` implementation over a **parameterized multi-stage provenance DAG**, supporting configurable supplier and manufacturer stages while preserving the existing `provenance_supply_chain` (diamond topology) unchanged. Together, both scenarios exercise the same provenance implementation across complementary graph structures without modifying plugin behaviour.

## What
- Add a new built-in `provenance_supply_chain_multi` scenario supporting configurable `num_suppliers` and `num_manufacturers`.
- Add a dedicated `provenance_supply_chain_multi.yaml` for configuring parameterized graph sizes.
- Register the scenario independently alongside the existing provenance scenarios.
- Register a dedicated validator entry that reuses the existing provenance validator suite without modifying validator behaviour.
- Add comprehensive test coverage for configurable topologies, deterministic execution, provenance validation, invalid configuration handling, and regression protection.

### Topology
```text
                   supplier-0
                   supplier-1
                      ...
                supplier-(N-1)
                      │
        ┌─────────────┼─────────────┐
        ▼             ▼             ▼
  manufacturer-0 manufacturer-1 ... manufacturer-(M-1)
        └─────────────┬─────────────┘
                      ▼
                distributor-0
                      ▼
                  retailer-0
```
Each manufacturer aggregates provenance from **all supplier datasets**, producing a configurable multi-stage provenance DAG. The distributor aggregates all manufacturer outputs before forwarding the resulting lineage to the retailer for provenance verification and adversarial validation.

## Why
The existing `provenance_supply_chain` scenario validates provenance using a fixed diamond-shaped dependency graph. This PR introduces a complementary configurable graph topology that exercises the same `cid_facts` implementation under a different dependency structure without changing the underlying plugin.

Supporting configurable numbers of suppliers and manufacturers allows the framework to exercise the same provenance implementation across multiple graph sizes and dependency structures, expanding scenario coverage for:

- Provenance lineage construction and traversal
- Parent aggregation across multiple upstream datasets
- Provenance verification across configurable graph topologies
- Deterministic replay for configurable scenario configurations
- Adversarial validation using the existing validator suite

This expands scenario coverage while preserving backward compatibility and leaving the existing provenance implementation unchanged.

## Scope
This PR is intentionally limited to introducing the new `provenance_supply_chain_multi` scenario, its configuration, registry integration, and associated tests.

## Verification
```bash
make ci-local

uv sync
uv run ruff check .
uv run ruff format --check .
uv run pyright
uv run pytest -v
```