### PR TITLE
[Hackathon] stellarminds-ai: PARC — portable reputation credentials with a recomputing admission gate

### DIFF
--- a/docs/layers/trust.md
+++ b/docs/layers/trust.md
@@ -25,10 +25,54 @@ Source: [`nest_plugins_reference/trust/score_average.py`](../../packages/nest-pl
 The `reputation` scenario exercises this layer — 16 honest + 4
 malicious + 1 observer that samples cheat reports probabilistically.
 
+## `agent_receipts` — receipt-corroborated, collusion-resistant reputation
+
+Derives reputation from **cross-signed receipts** of real interactions
+instead of self-asserted feedback. A receipt builds reputation only if
+its Ed25519 issuer signature verifies, a *distinct* counterparty
+co-signed the same interaction, and the receipt does not sit inside an
+isolated collusion component (Tarjan SCC severance over the
+corroboration graph) — so a wash-trading ring collapses to score ~0
+while honest agents keep their corroborated score.
+
+Source: [`nest_plugins_reference/trust/agent_receipts.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py).
+Scenario: `receipt_reputation` (honest anchor + isolated 4-agent ring +
+byzantine co-signers).
+
+## `parc` — portable reputation credentials
+
+Reputation elsewhere in this layer dies with the run. `parc` extends
+`agent_receipts` with **portability**: it exports an agent's receipt
+ledger as a W3C-Verifiable-Credential-shaped document (a
+`behavioral_merkle_root` committing to the carried receipts plus
+`nanda-rep/0.2` scores recomputable from them), signed **through the
+identity layer** (`ed25519_rotating`), and admits presented credentials
+at the border of a new trust domain by *recomputing rather than
+trusting*:
+
+- the Merkle root and scores are re-derived from the carried receipts —
+  an issuer-inflated-then-re-signed score passes proof verification and
+  is still rejected (**a valid signature is not admission**);
+- the proof is checked against the issuer's key-rotation window *as-of*
+  the credential's `validFrom` tick, so a credential signed with a
+  rotated-out key is rejected;
+- the presenter must *be* the credential subject (stolen credentials
+  are rejected);
+- an inline single-subject ledger is a star graph and cannot show an
+  N-party ring, so the gate also re-runs whole-graph collusion
+  severance over the originating domain's **published ledger**.
+
+Source: [`nest_plugins_reference/trust/parc.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/parc.py).
+Scenario: `parc_migration` (two trust domains in one run; forged,
+replayed, stale-key, inflated, and wash-ring credentials each denied
+with a typed reason).
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under
 entry point group `nest.plugins.trust`.
 
 Good fits to test here: EigenTrust-style transitive reputation,
-proof-of-stake reputation, decaying scores, attestation graphs.
+proof-of-stake reputation, decaying scores, attestation graphs,
+selective disclosure of credential receipts (Merkle inclusion proofs),
+credential revocation registries.

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -27,6 +27,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
+    ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
     ("payments", "empic_escrow"): f"{_REF}.payments.empic_escrow:EMPICEscrowPayments",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -129,3 +129,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("failure_detection", failure_detection_factory)
+    elif name == "parc_migration":
+        from nest_core.scenarios_builtin.parc_migration import (
+            parc_migration_factory,
+        )
+
+        register_scenario("parc_migration", parc_migration_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/parc_migration.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/parc_migration.py
@@ -1,0 +1,551 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Portable-reputation migration scenario: credentials cross a trust-domain border.
+
+Two trust domains live in one deterministic run. In **domain A**, agents have
+earned cross-signed receipts (an honest anchor plus an isolated wash-trading
+ring). At a fixed logical tick the population **migrates**: domain A's auditor
+exports each agent's reputation as a signed PARC credential, publishes its
+community ledger once, and every agent presents its credential at **domain
+B**'s admission gate. The gate never saw domain A's run — it decides from the
+credential alone (plus the published ledger), by *recomputing* the committed
+Merkle root and the ``nanda-rep/0.2`` scores rather than trusting the signed
+claims.
+
+The migrating cast covers one attack per adversarial validator:
+
+* ``honest-<i>`` — genuine credentials over corroborated receipts → admitted.
+* ``ring-<i>`` — an isolated 3-agent collusion ring. Each member's *inline*
+  credential is individually corroborated (a star ledger cannot show a ring),
+  so it survives recomputation — and is then denied by whole-graph severance
+  over the published ledger (``severed_below_threshold``).
+* ``forger-0`` — presents its own credential with a tampered ``proofValue``
+  → ``proof_invalid``.
+* ``replay-0`` — presents ``honest-1``'s genuine credential as its own
+  → ``replay_presenter_mismatch``.
+* ``stale-0`` — its credential was signed with auditor A's **rotated-out**
+  key (via the identity layer's adversarial ``sign_with``) with ``validFrom``
+  after the rotation → ``stale_key``.
+* ``inflated-0`` — its credential comes from ``auditor-x``, a *trusted but
+  corrupt* issuer that inflated ``reputation_score`` and re-signed. The proof
+  verifies; recomputation over the carried receipts catches the lie
+  → ``score_mismatch``. This is the headline property: **a valid signature is
+  not admission**.
+
+Set ``task.config.naive_gate: true`` and the gate trusts the signed claims
+(``require_recomputation=False``): the inflated credential and the whole ring
+are admitted, so the corresponding validators FAIL — the differential proof of
+what recomputation buys. Under ``trust: score_average`` no credentials exist
+at all and every validator fails for want of admissions.
+
+Identity wiring (the cross-layer composition): the factory builds real
+``ed25519_rotating`` identities for both auditors and the gate, performs
+auditor A's key rotation at logical tick ``_ROTATE_AT``, and replays the
+rotation record onto the gate's identity, so admission-time proof checks run
+against genuine rotation windows — not scenario-faked ones.
+
+Trace line protocol (``:``-delimited message bodies):
+
+* ``export:<agent>:<root8>:<score6>`` — domain A exported a credential.
+* ``admit:<agent>:<granted|denied>:<reason>:<role>`` — the gate's decision;
+  the ``parc_migration`` validators read these lines.
+
+Example::
+
+    agents = parc_migration_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, cast
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+# The credential builders and receipt format live in exactly one place — the
+# plugins — so the scenario constructs receipts the same way the gate verifies
+# them (the receipt_reputation scenario sets this precedent).
+from nest_plugins_reference.trust.agent_receipts import (
+    cosign_receipt,
+    did_for_pubkey,
+    sign_receipt,
+)
+from nest_plugins_reference.trust.parc import (
+    AdmissionPolicy,
+    attach_proof,
+)
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Evidence
+
+# Logical credential timeline (independent of simulator ticks): auditor A
+# rotates its signing key at _ROTATE_AT and issues every credential at
+# _ISSUE_AT — so a credential signed with the pre-rotation key is stale by
+# construction.
+_ROTATE_AT = 5.0
+_ISSUE_AT = 6.0
+
+_AUDITOR_A = AgentId("auditor-a")
+_AUDITOR_X = AgentId("auditor-x")
+_GATE = AgentId("gate-0")
+
+
+def _seed_for(agent: AgentId) -> bytes:
+    """Deterministic 32-byte Ed25519 receipt seed for an agent (plugin-matching).
+
+    Example::
+
+        seed = _seed_for(AgentId("honest-0"))
+    """
+    return hashlib.sha256(str(agent).encode()).digest()[:32]
+
+
+def _did_for(agent: AgentId) -> str:
+    """The trust-layer receipt identity (hex pubkey) for an agent.
+
+    Example::
+
+        did = _did_for(AgentId("honest-0"))
+    """
+    sk = Ed25519PrivateKey.from_private_bytes(_seed_for(agent))
+    pub = sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    return did_for_pubkey(pub)
+
+
+def _receipt(issuer: AgentId, counterparty: AgentId, *, receipt_id: str) -> dict[str, Any]:
+    """A corroborated purchase receipt from ``issuer`` about ``counterparty``.
+
+    Example::
+
+        r = _receipt(AgentId("honest-0"), AgentId("honest-1"), receipt_id="r0")
+    """
+    receipt: dict[str, Any] = {
+        "receipt_id": receipt_id,
+        "issuer_did": _did_for(issuer),
+        "action": {"category": "purchase", "counterparty_did": _did_for(counterparty)},
+    }
+    receipt = sign_receipt(receipt, issuer_seed=_seed_for(issuer))
+    return cosign_receipt(receipt, counterparty_seed=_seed_for(counterparty))
+
+
+def _domain_a_ledger(
+    honest: list[AgentId],
+    ring: list[AgentId],
+    extras: list[AgentId],
+) -> list[dict[str, Any]]:
+    """Domain A's community ledger: honest anchor, isolated ring, honest extras.
+
+    The honest agents form a directed cycle plus chords (one SCC, the anchor,
+    strictly larger than the ring). The ring co-signs all-pairs among itself
+    only — individually corroborated, collectively isolated. Each extra
+    (forger, stale, inflated victims-to-be) issues genuine receipts with
+    honest counterparties, so their credentials are real; their attacks happen
+    at the border, not in the ledger.
+
+    Example::
+
+        ledger = _domain_a_ledger(honest, ring, extras)
+    """
+    ledger: list[dict[str, Any]] = []
+    n = len(honest)
+    for i, issuer in enumerate(honest):
+        for k in (1, 2):
+            cp = honest[(i + k) % n]
+            ledger.append(_receipt(issuer, cp, receipt_id=f"{issuer}->{cp}"))
+    for i, issuer in enumerate(ring):
+        for j, cp in enumerate(ring):
+            if i != j:
+                ledger.append(_receipt(issuer, cp, receipt_id=f"{issuer}->{cp}"))
+    for idx, issuer in enumerate(extras):
+        for k in (0, 1):
+            cp = honest[(idx + k) % n]
+            ledger.append(_receipt(issuer, cp, receipt_id=f"{issuer}->{cp}"))
+    return ledger
+
+
+class DomainAAuditor(StateMachineAgent):
+    """Domain A's honest auditor: reports the ledger, exports, publishes.
+
+    On start it instantiates the configured trust plugin, reports every ledger
+    receipt into it, exports one credential per migrant (signing with its
+    post-rotation key — except the stale migrant's, deliberately signed with
+    the rotated-out key), hands ``replay-0`` a copy of ``honest-1``'s
+    credential, and publishes the community ledger to the gate. If the
+    configured trust plugin cannot build credentials (e.g. ``score_average``),
+    it does nothing — and every admission validator fails for want of
+    admissions, which is the point.
+
+    Example::
+
+        auditor = DomainAAuditor(_AUDITOR_A, identity=ident, ledger=ledger,
+                                 migrants=migrants, stale=AgentId("stale-0"),
+                                 replayer=AgentId("replay-0"),
+                                 replay_victim=AgentId("honest-1"),
+                                 old_key_id="ab12...")
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        identity: Any,
+        ledger: list[dict[str, Any]],
+        migrants: list[AgentId],
+        stale: AgentId,
+        replayer: AgentId,
+        replay_victim: AgentId,
+        old_key_id: str,
+    ) -> None:
+        self._id = agent_id
+        self._identity = identity
+        self._ledger = ledger
+        self._migrants = migrants
+        self._stale = stale
+        self._replayer = replayer
+        self._replay_victim = replay_victim
+        self._old_key_id = old_key_id
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Report the ledger, export credentials, publish the community ledger.
+
+        Example::
+
+            await auditor.on_start(ctx)
+        """
+        trust_cls = ctx.plugins.get("trust")
+        trust: Any = trust_cls() if isinstance(trust_cls, type) else trust_cls
+        if trust is None or not hasattr(trust, "build_credential"):
+            return
+        for receipt in self._ledger:
+            await trust.report(
+                AgentId(str(receipt["issuer_did"])),
+                Evidence(
+                    reporter=self._id,
+                    subject=self._id,
+                    kind="positive",
+                    detail=json.dumps(receipt),
+                ),
+            )
+        # The plugin maps AgentId -> receipt did via the same sha256 seed
+        # derivation the ledger used, so exports find the migrants' receipts.
+        credentials: dict[AgentId, dict[str, Any]] = {}
+        for migrant in self._migrants:
+            key_id = self._old_key_id if migrant == self._stale else None
+            credentials[migrant] = await trust.build_credential(
+                migrant,
+                identity=self._identity,
+                valid_from=_ISSUE_AT,
+                key_id=key_id,
+            )
+        await ctx.send(_GATE, b"ledger:" + json.dumps(self._ledger).encode())
+        for migrant in self._migrants:
+            vc = credentials[migrant]
+            await ctx.send(migrant, b"credential:" + json.dumps(vc).encode())
+            subject = vc["credentialSubject"]
+            root8 = str(subject["behavioral_merkle_root"])[:8]
+            await ctx.broadcast(f"export:{migrant}:{root8}:{subject['reputation_score']}".encode())
+        # The replayer "stole" a genuine credential; it never earned its own.
+        await ctx.send(
+            self._replayer,
+            b"credential:" + json.dumps(credentials[self._replay_victim]).encode(),
+        )
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """The auditor receives no messages; present for Protocol completeness.
+
+        Example::
+
+            await auditor.on_message(ctx, sender, b"noop")
+        """
+        return
+
+
+class CorruptAuditor(StateMachineAgent):
+    """A *trusted but corrupt* issuer: inflates a score and genuinely re-signs.
+
+    Builds a real credential for its client over the client's real receipts,
+    then rewrites ``reputation_score`` upward and re-attaches a genuine proof
+    under its own (trusted) key. The signature verifies; only recomputation
+    over the carried receipts exposes the lie. This is the attack that
+    distinguishes a recomputing gate from a signature-checking one.
+
+    Example::
+
+        corrupt = CorruptAuditor(_AUDITOR_X, identity=ident,
+                                 client=AgentId("inflated-0"), receipts=[...])
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        identity: Any,
+        client: AgentId,
+        receipts: list[dict[str, Any]],
+    ) -> None:
+        self._id = agent_id
+        self._identity = identity
+        self._client = client
+        self._receipts = receipts
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Issue the inflated-but-genuinely-signed credential to the client.
+
+        Example::
+
+            await corrupt.on_start(ctx)
+        """
+        trust_cls = ctx.plugins.get("trust")
+        trust: Any = trust_cls() if isinstance(trust_cls, type) else trust_cls
+        if trust is None or not hasattr(trust, "build_credential"):
+            return
+        for receipt in self._receipts:
+            await trust.report(
+                AgentId(str(receipt["issuer_did"])),
+                Evidence(
+                    reporter=self._id,
+                    subject=self._id,
+                    kind="positive",
+                    detail=json.dumps(receipt),
+                ),
+            )
+        vc = await trust.build_credential(
+            self._client, identity=self._identity, valid_from=_ISSUE_AT
+        )
+        vc.pop("proof", None)
+        vc["credentialSubject"]["reputation_score"] = "0.990000"
+        vc = attach_proof(vc, identity=self._identity)
+        await ctx.send(self._client, b"credential:" + json.dumps(vc).encode())
+        subject = vc["credentialSubject"]
+        root8 = str(subject["behavioral_merkle_root"])[:8]
+        await ctx.broadcast(f"export:{self._client}:{root8}:{subject['reputation_score']}".encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """The corrupt auditor receives no messages; Protocol completeness.
+
+        Example::
+
+            await corrupt.on_message(ctx, sender, b"noop")
+        """
+        return
+
+
+class Migrant(StateMachineAgent):
+    """An agent that carries its credential across the border and presents it.
+
+    On receiving its ``credential:`` from an issuer it presents at the gate.
+    The ``forged`` role tampers its own credential's ``proofValue`` first (a
+    deterministic first-nibble flip); every other role presents what it was
+    given — including the replayer, whose theft is the credential itself.
+
+    Example::
+
+        agent = Migrant(AgentId("honest-0"), role="honest")
+    """
+
+    def __init__(self, agent_id: AgentId, *, role: str) -> None:
+        self._id = agent_id
+        self._role = role
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Migrants act only on receiving their credential.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        return
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Present the received credential at the gate (tampering if forged).
+
+        Example::
+
+            await agent.on_message(ctx, sender, b"credential:{...}")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("credential:"):
+            return
+        vc: dict[str, Any] = json.loads(msg[len("credential:") :])
+        if self._role == "forged":
+            proof = vc.get("proof")
+            if isinstance(proof, dict):
+                proof_typed = cast("dict[str, Any]", proof)
+                value = str(proof_typed.get("proofValue", ""))
+                if value:
+                    flipped = "0" if value[0] != "0" else "f"
+                    proof_typed["proofValue"] = flipped + value[1:]
+        envelope = {"role": self._role, "credential": vc}
+        await ctx.send(_GATE, b"present:" + json.dumps(envelope).encode())
+
+
+class BorderGate(StateMachineAgent):
+    """Domain B's admission gate: verifies, recomputes, and decides.
+
+    Owns its own instance of the configured trust plugin and an identity-layer
+    view of the issuers (including auditor A's replayed key rotation). Ingests
+    domain A's published ledger for whole-graph severance, then admits or
+    denies each presented credential and broadcasts one ``admit:`` line per
+    decision. Falls back to trusting the *claimed* score when the configured
+    plugin has no ``admit`` (the naive baseline the validators punish).
+
+    Example::
+
+        gate = BorderGate(_GATE, identity=gate_ident, policy=policy)
+    """
+
+    def __init__(self, agent_id: AgentId, *, identity: Any, policy: AdmissionPolicy) -> None:
+        self._id = agent_id
+        self._identity = identity
+        self._policy = policy
+        self._trust: Any = None
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Instantiate the configured trust plugin.
+
+        Example::
+
+            await gate.on_start(ctx)
+        """
+        trust_cls = ctx.plugins.get("trust")
+        self._trust = trust_cls() if isinstance(trust_cls, type) else trust_cls
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Ingest the published ledger; decide each presented credential.
+
+        Example::
+
+            await gate.on_message(ctx, migrant, b"present:{...}")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if msg.startswith("ledger:"):
+            receipts: list[dict[str, Any]] = json.loads(msg[len("ledger:") :])
+            if hasattr(self._trust, "ingest_published_ledger"):
+                self._trust.ingest_published_ledger(receipts)
+            return
+        if not msg.startswith("present:"):
+            return
+        envelope: dict[str, Any] = json.loads(msg[len("present:") :])
+        role = str(envelope.get("role", "unknown"))
+        vc: dict[str, Any] = envelope.get("credential", {})
+        if hasattr(self._trust, "admit"):
+            result = await self._trust.admit(
+                vc,
+                policy=self._policy,
+                presenter_did=_did_for(sender),
+                identity=self._identity,
+                current_tick=_ISSUE_AT,
+            )
+            admitted, reason = result.admitted, result.reason
+        else:
+            # Naive baseline: trust whatever the credential claims.
+            try:
+                claimed = float(str(vc["credentialSubject"]["reputation_score"]))
+            except (KeyError, TypeError, ValueError):
+                claimed = 0.0
+            admitted = claimed >= self._policy.min_reputation_score
+            reason = "admitted" if admitted else "below_threshold"
+        decision = "granted" if admitted else "denied"
+        await ctx.broadcast(f"admit:{sender}:{decision}:{reason}:{role}".encode())
+
+
+def parc_migration_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create the two-domain migration cast with real identity-layer wiring.
+
+    Builds ``ed25519_rotating`` identities for both auditors and the gate,
+    performs auditor A's key rotation at ``_ROTATE_AT``, replays the rotation
+    record onto the gate (so admission checks run against genuine key
+    windows), constructs domain A's ledger, and wires the migrating cast.
+    ``task.config`` keys: ``min_reputation_score`` (default ``0.2``) and
+    ``naive_gate`` (default ``false`` — set true to make the gate trust
+    signed claims, the differential baseline).
+
+    Example::
+
+        agents = parc_migration_factory(config, plugins)
+    """
+    task_config = config.task.config
+    min_score = float(task_config.get("min_reputation_score", 0.2))
+    naive_gate = bool(task_config.get("naive_gate", False))
+
+    honest = [AgentId(f"honest-{i}") for i in range(4)]
+    ring = [AgentId(f"ring-{i}") for i in range(3)]
+    forger = AgentId("forger-0")
+    replayer = AgentId("replay-0")
+    stale = AgentId("stale-0")
+    inflated = AgentId("inflated-0")
+    extras = [forger, stale, inflated]
+
+    identity_cls = plugins.get("identity")
+    if identity_cls is None or not isinstance(identity_cls, type):
+        msg = "parc_migration requires a resolvable identity plugin class"
+        raise ValueError(msg)
+    a_ident = identity_cls(_AUDITOR_A, seed=b"parc:auditor-a")
+    x_ident = identity_cls(_AUDITOR_X, seed=b"parc:auditor-x")
+    gate_ident = identity_cls(_GATE, seed=b"parc:gate-0")
+
+    # Gate learns A's key #0 at tick 0, then A rotates at _ROTATE_AT and the
+    # gate applies the (old-key-signed) rotation record — after which A's old
+    # key window is [0, _ROTATE_AT) on both sides. Credentials are issued at
+    # _ISSUE_AT, so anything signed with key #0 is stale by construction.
+    old_key_id = str(a_ident.current_key_id)
+    if hasattr(gate_ident, "register_peer"):
+        gate_ident.register_peer(_AUDITOR_A, a_ident.public_key)
+        gate_ident.register_peer(_AUDITOR_X, x_ident.public_key)
+    if hasattr(a_ident, "rotate_key") and hasattr(gate_ident, "apply_rotation"):
+        a_ident.set_clock(_ROTATE_AT)
+        rotation = a_ident.rotate_key(b"parc:auditor-a:rotated")
+        gate_ident.set_clock(_ROTATE_AT)
+        if not gate_ident.apply_rotation(rotation):  # pragma: no cover - wiring invariant
+            msg = "gate failed to apply auditor A's rotation record"
+            raise ValueError(msg)
+        a_ident.set_clock(_ISSUE_AT)
+
+    ledger = _domain_a_ledger(honest, ring, extras)
+    inflated_receipts = [r for r in ledger if str(r["issuer_did"]) == _did_for(inflated)]
+    # Auditor A exports for everyone except the corrupt auditor's client.
+    a_migrants = [*honest, *ring, forger, stale]
+
+    policy = AdmissionPolicy(
+        trusted_issuers={
+            f"did:nest:{_AUDITOR_A}",
+            f"did:nest:{_AUDITOR_X}",
+        },
+        min_reputation_score=min_score,
+        require_recomputation=not naive_gate,
+        require_published_ledger=not naive_gate,
+    )
+
+    roles: dict[AgentId, str] = {a: "honest" for a in honest}
+    roles.update({a: "ring" for a in ring})
+    roles[forger] = "forged"
+    roles[replayer] = "replay"
+    roles[stale] = "stale"
+    roles[inflated] = "inflated"
+
+    agents: dict[AgentId, StateMachineAgent] = {
+        migrant: Migrant(migrant, role=roles[migrant]) for migrant in roles
+    }
+    agents[_AUDITOR_A] = DomainAAuditor(
+        _AUDITOR_A,
+        identity=a_ident,
+        ledger=ledger,
+        migrants=a_migrants,
+        stale=stale,
+        replayer=replayer,
+        replay_victim=honest[1],
+        old_key_id=old_key_id,
+    )
+    agents[_AUDITOR_X] = CorruptAuditor(
+        _AUDITOR_X,
+        identity=x_ident,
+        client=inflated,
+        receipts=inflated_receipts,
+    )
+    agents[_GATE] = BorderGate(_GATE, identity=gate_ident, policy=policy)
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -3932,6 +3932,104 @@ def validate_failure_detection_completeness(
     ]
 
 
+# ---------------------------------------------------------------------------
+# Portable-reputation (PARC) migration validators
+#
+# The parc_migration scenario broadcasts one ``admit:<agent>:<decision>:
+# <reason>:<role>`` line per border decision. The six checks below each pin
+# one attack class the naive signature-trusting gate would miss (or one
+# retention property a degenerate deny-everything gate would break). Together
+# they prove the headline invariant: a valid signature is not admission.
+# ---------------------------------------------------------------------------
+
+
+def _collect_admissions(
+    events: list[dict[str, Any]],
+) -> dict[str, tuple[bool, str, str]]:
+    """Parse ``admit:<agent>:<granted|denied>:<reason>:<role>`` trace lines.
+
+    Returns ``agent -> (admitted, reason, role)`` using the last decision per
+    agent. Decisions come from the live gate against the configured trust
+    plugin, so this dict is what lets the validators discriminate between a
+    recomputing gate and a naive one.
+
+    Example::
+
+        admissions = _collect_admissions(events)
+    """
+    admissions: dict[str, tuple[bool, str, str]] = {}
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("admit:"):
+            continue
+        parts = msg.split(":")
+        if len(parts) < 5:
+            continue
+        agent, decision, reason, role = parts[1], parts[2], parts[3], parts[4]
+        admissions[agent] = (decision == "granted", reason, role)
+    return admissions
+
+
+def _admissions_for_role(
+    events: list[dict[str, Any]],
+    role: str,
+) -> dict[str, tuple[bool, str]]:
+    """The ``agent -> (admitted, reason)`` decisions for one population role.
+
+    Example::
+
+        ring = _admissions_for_role(events, "ring")
+    """
+    return {
+        agent: (admitted, reason)
+        for agent, (admitted, reason, r) in _collect_admissions(events).items()
+        if r == role
+    }
+
+
+def _validate_role_denied(
+    events: list[dict[str, Any]],
+    *,
+    name: str,
+    role: str,
+    expected_reason: str,
+) -> list[ValidationResult]:
+    """Shared check: every agent of ``role`` is denied with ``expected_reason``.
+
+    Fails when the population was never exercised (no decisions observed for
+    the role — a gate that crashes or stays silent must not pass), when any
+    member was admitted, or when the denial carries the wrong reason (a gate
+    that denies for an accidental reason is not demonstrating the defense the
+    validator is named for).
+
+    Example::
+
+        results = _validate_role_denied(events, name="parc_forgery_rejected",
+                                        role="forged",
+                                        expected_reason="proof_invalid")
+    """
+    decisions = _admissions_for_role(events, role)
+    if not decisions:
+        return [ValidationResult(name, False, f"no admission decisions observed for role {role!r}")]
+    problems: list[str] = []
+    for agent, (admitted, reason) in sorted(decisions.items()):
+        if admitted:
+            problems.append(f"{agent} was admitted")
+        elif reason != expected_reason:
+            problems.append(f"{agent} denied with {reason!r}, expected {expected_reason!r}")
+    if problems:
+        return [ValidationResult(name, False, "; ".join(problems))]
+    return [
+        ValidationResult(
+            name,
+            True,
+            f"{len(decisions)} {role} agent(s) denied with {expected_reason!r}",
+        )
+    ]
+
+
 def validate_failure_detection_accuracy(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
@@ -4037,6 +4135,131 @@ def validate_failure_detection_accuracy(
     return [accuracy, recovery]
 
 
+def validate_parc_honest_admitted(events: list[dict[str, Any]]) -> list[ValidationResult]:
+    """Every honest migrant is admitted — the gate retains genuine reputation.
+
+    Guards against the degenerate defense: a gate that denies everything
+    trivially "catches" every attack. Portability only holds if honest
+    credentials actually cross the border.
+
+    Example::
+
+        results = validate_parc_honest_admitted(events)
+    """
+    decisions = _admissions_for_role(events, "honest")
+    if not decisions:
+        return [
+            ValidationResult(
+                "parc_honest_admitted", False, "no admission decisions observed for role 'honest'"
+            )
+        ]
+    denied = {a: reason for a, (admitted, reason) in decisions.items() if not admitted}
+    if denied:
+        detail = ", ".join(f"{a} ({reason})" for a, reason in sorted(denied.items()))
+        return [ValidationResult("parc_honest_admitted", False, f"honest denied: {detail}")]
+    return [
+        ValidationResult("parc_honest_admitted", True, f"{len(decisions)} honest agent(s) admitted")
+    ]
+
+
+def validate_parc_forgery_rejected(events: list[dict[str, Any]]) -> list[ValidationResult]:
+    """A credential with tampered proof bytes is denied as ``proof_invalid``.
+
+    The naive gate never checks the proof against the recomputed canonical
+    payload, so the forged credential sails through it.
+
+    Example::
+
+        results = validate_parc_forgery_rejected(events)
+    """
+    return _validate_role_denied(
+        events,
+        name="parc_forgery_rejected",
+        role="forged",
+        expected_reason="proof_invalid",
+    )
+
+
+def validate_parc_inflation_rejected(events: list[dict[str, Any]]) -> list[ValidationResult]:
+    """An inflated score from a *trusted* issuer is denied as ``score_mismatch``.
+
+    The headline property: the credential's signature is genuine and its
+    issuer is trusted, yet recomputing the nanda-rep/0.2 scores from the
+    carried receipts exposes the inflated claim. A gate that trusts signed
+    claims (the naive baseline) admits it and FAILS this validator.
+
+    Example::
+
+        results = validate_parc_inflation_rejected(events)
+    """
+    return _validate_role_denied(
+        events,
+        name="parc_inflation_rejected",
+        role="inflated",
+        expected_reason="score_mismatch",
+    )
+
+
+def validate_parc_ring_severed(events: list[dict[str, Any]]) -> list[ValidationResult]:
+    """Wash-ring members are denied via whole-graph severance at the border.
+
+    Each ring member's *inline* credential is individually corroborated (a
+    single-subject ledger is a star and cannot show the ring), so inline
+    recomputation alone admits it. Only re-running collusion severance over
+    the originating domain's published ledger reveals the isolated dense
+    component — the reason must therefore be ``severed_below_threshold``.
+
+    Example::
+
+        results = validate_parc_ring_severed(events)
+    """
+    return _validate_role_denied(
+        events,
+        name="parc_ring_severed",
+        role="ring",
+        expected_reason="severed_below_threshold",
+    )
+
+
+def validate_parc_replay_rejected(events: list[dict[str, Any]]) -> list[ValidationResult]:
+    """A stolen (genuine) credential presented by a non-subject is denied.
+
+    The credential itself verifies — it was honestly issued to someone else.
+    Admission must bind the presenter to ``credentialSubject.id``
+    (``replay_presenter_mismatch``), or any bystander can borrow reputation.
+
+    Example::
+
+        results = validate_parc_replay_rejected(events)
+    """
+    return _validate_role_denied(
+        events,
+        name="parc_replay_rejected",
+        role="replay",
+        expected_reason="replay_presenter_mismatch",
+    )
+
+
+def validate_parc_stale_key_rejected(events: list[dict[str, Any]]) -> list[ValidationResult]:
+    """A credential signed with a rotated-out issuer key is denied as ``stale_key``.
+
+    The signature bytes are cryptographically valid under the old key; what
+    fails is the identity layer's key-rotation window as-of the credential's
+    ``validFrom`` tick. This is the cross-layer check a trust plugin that
+    ignores the identity layer cannot perform.
+
+    Example::
+
+        results = validate_parc_stale_key_rejected(events)
+    """
+    return _validate_role_denied(
+        events,
+        name="parc_stale_key_rejected",
+        role="stale",
+        expected_reason="stale_key",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
@@ -4132,5 +4355,13 @@ VALIDATORS: dict[str, list[Any]] = {
     "failure_detection": [
         validate_failure_detection_completeness,
         validate_failure_detection_accuracy,
+    ],
+    "parc_migration": [
+        validate_parc_honest_admitted,
+        validate_parc_forgery_rejected,
+        validate_parc_inflation_rejected,
+        validate_parc_ring_severed,
+        validate_parc_replay_rejected,
+        validate_parc_stale_key_rejected,
     ],
 }

--- a/packages/nest-core/tests/test_parc_migration.py
+++ b/packages/nest-core/tests/test_parc_migration.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end tests for the parc_migration scenario + adversarial validators.
+
+The headline assertions are the differential proof the charter requires:
+
+* all six ``parc_migration`` validators **PASS** under ``trust: parc`` with
+  the recomputing gate (default config),
+* the inflation and ring validators **FAIL** under the *naive gate*
+  (``task.config.naive_gate: true`` — proof still checked, signed claims
+  trusted), while the proof/replay/stale-key defenses keep passing, and
+* **every** validator FAILS under ``trust: score_average`` (no credentials
+  can even be built),
+
+plus a byte-level determinism check (same seed -> identical trace sha256).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+
+_SCENARIO_YAML = Path(__file__).parent.parent.parent.parent / "scenarios" / "parc_migration.yaml"
+
+_ALL_VALIDATORS = (
+    "parc_honest_admitted",
+    "parc_forgery_rejected",
+    "parc_inflation_rejected",
+    "parc_ring_severed",
+    "parc_replay_rejected",
+    "parc_stale_key_rejected",
+)
+
+
+def _config(
+    trace: Path,
+    *,
+    trust: str = "parc",
+    naive_gate: bool = False,
+    seed: int | None = None,
+) -> ScenarioConfig:
+    """Load the scenario YAML with trust/naive-gate/seed/trace overrides."""
+    config = ScenarioConfig.from_yaml(_SCENARIO_YAML)
+    config.layers.trust = trust
+    config.task.config["naive_gate"] = naive_gate
+    config.output.trace = str(trace)
+    if seed is not None:
+        config.seed = seed
+    return config
+
+
+def _results(trace: Path) -> dict[str, bool]:
+    return {r.name: r.passed for r in validate_trace(trace, "parc_migration")}
+
+
+class TestAdversarialProof:
+    # Seed-bank robustness: the leaderboard re-runs under multiple seeds, so
+    # the adversarial proof must hold across the bank, not just the default.
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("seed", [1, 7, 42, 123, 9999])
+    async def test_all_validators_pass_under_parc(self, tmp_path: Path, seed: int) -> None:
+        trace = tmp_path / f"parc_{seed}.jsonl"
+        await ScenarioRunner(_config(trace, seed=seed)).run()
+        results = _results(trace)
+        for name in _ALL_VALIDATORS:
+            assert results[name] is True, name
+
+    @pytest.mark.asyncio
+    async def test_naive_gate_fails_exactly_the_recomputation_defenses(
+        self, tmp_path: Path
+    ) -> None:
+        trace = tmp_path / "naive.jsonl"
+        await ScenarioRunner(_config(trace, naive_gate=True)).run()
+        results = _results(trace)
+        # The whole point: signature-checking alone admits the inflated
+        # credential and the wash ring...
+        assert results["parc_inflation_rejected"] is False
+        assert results["parc_ring_severed"] is False
+        # ...while the non-recomputation defenses (and honest retention) hold.
+        assert results["parc_honest_admitted"] is True
+        assert results["parc_forgery_rejected"] is True
+        assert results["parc_replay_rejected"] is True
+        assert results["parc_stale_key_rejected"] is True
+
+    @pytest.mark.asyncio
+    async def test_score_average_fails_everything(self, tmp_path: Path) -> None:
+        trace = tmp_path / "baseline.jsonl"
+        await ScenarioRunner(_config(trace, trust="score_average")).run()
+        results = _results(trace)
+        # A trust plugin with no export surface cannot even produce
+        # credentials, let alone gate them.
+        for name in _ALL_VALIDATORS:
+            assert results[name] is False, name
+
+
+class TestDeterminism:
+    @pytest.mark.asyncio
+    async def test_same_seed_identical_trace(self, tmp_path: Path) -> None:
+        t1 = tmp_path / "run1.jsonl"
+        t2 = tmp_path / "run2.jsonl"
+        await ScenarioRunner(_config(t1)).run()
+        await ScenarioRunner(_config(t2)).run()
+        h1 = hashlib.sha256(t1.read_bytes()).hexdigest()
+        h2 = hashlib.sha256(t2.read_bytes()).hexdigest()
+        assert h1 == h2
+
+
+class TestScenarioShape:
+    @pytest.mark.asyncio
+    async def test_every_role_gets_exactly_one_decision(self, tmp_path: Path) -> None:
+        trace = tmp_path / "shape.jsonl"
+        await ScenarioRunner(_config(trace)).run()
+        import json
+
+        decided: dict[str, str] = {}
+        exports = 0
+        for line in trace.read_text().splitlines():
+            event = json.loads(line)
+            if event.get("kind") != "broadcast":
+                continue
+            msg = str(event.get("msg", ""))
+            if msg.startswith("export:"):
+                exports += 1
+            if msg.startswith("admit:"):
+                agent, _decision, _reason, role = msg.split(":")[1:5]
+                decided[agent] = role
+        # 9 exports from auditor A + 1 from the corrupt auditor. The replayer
+        # never earns an export — it presents a stolen credential.
+        assert exports == 10
+        # 11 migrants decided: 4 honest, 3 ring, forger, replayer, stale,
+        # inflated.
+        assert len(decided) == 11
+        assert sorted(decided.values()).count("honest") == 4
+        assert sorted(decided.values()).count("ring") == 3
+        for role in ("forged", "replay", "stale", "inflated"):
+            assert role in decided.values()

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -1824,6 +1824,7 @@ class TestValidatorRegistry:
             "bft_hotstuff",
             "escrow_marketplace",
             "failure_detection",
+            "parc_migration",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/parc.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/parc.py
@@ -1,0 +1,630 @@
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportPrivateUsage=false
+# (PARC deliberately composes agent_receipts' module-level receipt maths —
+# _canonical/_verify_receipt/_raw_reputation/_normalize/_severed_dids/
+# _corroboration_graph — so the credential recompute path can never drift
+# from the exporter's scoring. See the module docstring.)
+"""PARC — a Portable Agent Reputation Credential trust plugin.
+
+Reputation in NEST dies with the run: every trust plugin holds an in-memory
+ledger and nothing exports it, carries it, or verifies it in another trust
+domain. This plugin makes reputation **portable**. It extends the
+``agent_receipts`` reference plugin (cross-signed receipts, corroboration
+gates, collusion-ring severance) with two new capabilities:
+
+1. **Export** — :meth:`ParcTrust.build_credential` wraps an agent's receipt
+   ledger as a W3C-Verifiable-Credential-shaped document: a
+   ``behavioral_merkle_root`` committing to the carried receipts, the
+   ``nanda-rep/0.2`` scores recomputable from them, and an Ed25519 proof
+   issued **through the identity layer** (``ed25519_rotating``), so the proof
+   carries a ``key_id`` and is checkable against the issuer's key-rotation
+   windows.
+2. **Admission** — :meth:`ParcTrust.admit` consumes a presented credential at
+   the border of a new trust domain. The gate **recomputes rather than
+   trusts**: it re-derives the Merkle root and the scores from the carried
+   receipts and rejects any divergence. *A valid signature is not admission* —
+   an issuer-inflated-then-re-signed score passes proof verification and is
+   still rejected on recompute divergence.
+
+An inline credential carries only the subject's own receipts — a star graph —
+so it cannot reveal an N-party collusion ring (each ring member's credential
+looks individually corroborated). :meth:`ParcTrust.ingest_published_ledger`
+closes that hole: the originating domain publishes its community ledger once,
+and the gate re-runs the whole-graph collusion severance from
+``agent_receipts`` over it, denying severed subjects even though their inline
+credentials verify.
+
+Identity conventions (two key namespaces, deliberately distinct):
+
+* **Subjects** are named by the trust-layer receipt identity — the lowercase
+  hex pubkey of ``agent_receipts.did_for_pubkey`` — because that is what the
+  carried receipts' ``issuer_did`` fields use and what recomputation runs on.
+* **Issuers** are named by a stable ``did:nest:<agent-id>`` URI, and the
+  proof's ``verificationMethod`` pins the actual signing key as a
+  ``did:key:z6Mk...`` (multibase/multicodec Ed25519, encoder vendored below)
+  plus the identity layer's ``key_id`` fragment. Verification resolves the
+  issuer through the identity layer and enforces the key's validity window
+  **as-of the credential's** ``validFrom`` tick, so a credential signed with
+  an already-rotated-out key is rejected (``stale_key``).
+
+Determinism: scores are embedded as fixed 6-decimal strings, receipts are
+sorted by ``receipt_id``, canonicalization is sorted-key compact JSON, Merkle
+leaves are sorted — byte-identical credentials for identical ledgers, with no
+wall-clock anywhere (``validFrom`` is a logical tick supplied by the caller).
+
+Registered under ``("trust", "parc")`` in ``nest_core.plugins`` and as the
+``parc`` entry point in the ``nest.plugins.trust`` group.
+
+Example::
+
+    trust = ParcTrust()
+    await trust.report(subject, evidence)  # receipts, as in agent_receipts
+    vc = await trust.build_credential(subject, identity=ident, valid_from=6.0)
+    result = await gate.admit(vc, policy=policy, presenter_did=did,
+                              identity=gate_ident, current_tick=6.0)
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from nest_core.types import AgentId
+
+# PARC composes the receipt maths of the merged agent_receipts plugin rather
+# than re-implementing it: receipt verification, corroboration, and the
+# whole-graph collusion severance MUST stay in exactly one place so a
+# credential's recomputed score can never drift from the exporter's.
+from nest_plugins_reference.trust import agent_receipts as ar
+
+SCORING_METHOD = "nanda-rep/0.2"
+CREDENTIAL_TYPE = "ParcReputationCredential"
+CREDENTIAL_CONTEXT = "https://www.w3.org/ns/credentials/v2"
+PROOF_TYPE = "Ed25519Signature2020"
+ISSUER_URI_PREFIX = "did:nest:"
+
+# ---------------------------------------------------------------------------
+# Vendored did:key encoding (multibase base58btc + multicodec ed25519-pub)
+# ---------------------------------------------------------------------------
+
+_B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+# Multicodec prefix for ed25519-pub (0xed) as an unsigned varint (0xed 0x01).
+_ED25519_MULTICODEC = b"\xed\x01"
+
+
+def _b58btc_encode(data: bytes) -> str:
+    """Base58btc-encode ``data`` (Bitcoin alphabet, leading zeros as ``1``).
+
+    Vendored (~15 lines) so the plugin stays stdlib+cryptography-only, matching
+    the dependency posture of the other reference plugins.
+
+    Example::
+
+        s = _b58btc_encode(b"\\x00\\x01")
+    """
+    num = int.from_bytes(data, "big")
+    out: list[str] = []
+    while num > 0:
+        num, rem = divmod(num, 58)
+        out.append(_B58_ALPHABET[rem])
+    pad = 0
+    for byte in data:
+        if byte != 0:
+            break
+        pad += 1
+    return "1" * pad + "".join(reversed(out))
+
+
+def did_key_for_pubkey(pubkey: bytes) -> str:
+    """Return the ``did:key`` DID for a raw 32-byte Ed25519 public key.
+
+    ``did:key:z`` + base58btc(multicodec ``ed25519-pub`` prefix + key). Every
+    Ed25519 ``did:key`` therefore starts with ``did:key:z6Mk``. This is the
+    interop-facing form used in ``proof.verificationMethod``; receipts keep
+    the hex namespace of :func:`agent_receipts.did_for_pubkey`.
+
+    Example::
+
+        did = did_key_for_pubkey(pubkey)  # "did:key:z6Mk..."
+    """
+    return "did:key:z" + _b58btc_encode(_ED25519_MULTICODEC + pubkey)
+
+
+# ---------------------------------------------------------------------------
+# Credential construction helpers
+# ---------------------------------------------------------------------------
+
+
+def _fmt6(value: float) -> str:
+    """Format a float as a fixed 6-decimal string for deterministic embedding.
+
+    Scores ride in the signed credential as strings, not floats, so canonical
+    JSON bytes never depend on float repr subtleties.
+
+    Example::
+
+        s = _fmt6(0.5)  # "0.500000"
+    """
+    return f"{value:.6f}"
+
+
+def merkle_root(receipts: list[dict[str, Any]]) -> str:
+    """Deterministic Merkle root (hex) committing to a set of receipts.
+
+    Leaves are ``sha256`` of each receipt's canonical bytes, sorted
+    lexicographically so the root is order-independent; odd levels duplicate
+    the last node. An empty ledger has the root ``sha256(b"")``.
+
+    Example::
+
+        root = merkle_root(receipts)
+    """
+    leaves = sorted(hashlib.sha256(ar._canonical(r)).hexdigest() for r in receipts)
+    if not leaves:
+        return hashlib.sha256(b"").hexdigest()
+    level = leaves
+    while len(level) > 1:
+        if len(level) % 2 == 1:
+            level = [*level, level[-1]]
+        level = [
+            hashlib.sha256((level[i] + level[i + 1]).encode()).hexdigest()
+            for i in range(0, len(level), 2)
+        ]
+    return level[0]
+
+
+def _inline_scores(receipts: list[dict[str, Any]]) -> tuple[float, float, float]:
+    """``(reputation_score, validity_rate, corroboration_rate)`` for a subject's ledger.
+
+    Computed over the subject's own receipts exactly as an admission gate can
+    recompute them from the carried credential: valid + corroborated receipts
+    are weighted and normalized, **without** whole-graph severance — a
+    single-subject ledger is a star graph, so severance is structurally a
+    no-op there. Ring detection is therefore the published-ledger path's job
+    (see :meth:`ParcTrust.ingest_published_ledger`), not the inline score's.
+
+    Example::
+
+        score, validity, corroboration = _inline_scores(receipts)
+    """
+    if not receipts:
+        return 0.0, 0.0, 0.0
+    valid = [r for r in receipts if ar._verify_receipt(r)]
+    corroborated = [r for r in valid if ar.is_corroborated(r)]
+    raw = ar._raw_reputation(corroborated, ar.DEFAULT_CATEGORY_WEIGHTS)
+    return (
+        ar._normalize(raw),
+        len(valid) / len(receipts),
+        len(corroborated) / len(receipts),
+    )
+
+
+def credential_payload(credential: dict[str, Any]) -> bytes:
+    """Canonical bytes a credential's proof signs: the document minus ``proof``.
+
+    Example::
+
+        payload = credential_payload(vc)
+    """
+    return ar._canonical({k: v for k, v in credential.items() if k != "proof"})
+
+
+def attach_proof(
+    credential: dict[str, Any],
+    *,
+    identity: Any,
+    key_id: str | None = None,
+) -> dict[str, Any]:
+    """Return ``credential`` with an identity-layer Ed25519 proof attached.
+
+    Signs :func:`credential_payload` through the identity plugin — ``sign()``
+    for the current key, or ``sign_with(key_id)`` to sign with a specific
+    (possibly rotated-out) key. The latter mirrors
+    ``Ed25519RotatingIdentity.sign_with``'s adversarial purpose: scenarios use
+    it to forge post-rotation credentials that the as-of window check must
+    reject. ``verificationMethod`` pins the signing key as
+    ``did:key:...#<key_id>``.
+
+    Example::
+
+        vc = attach_proof(vc, identity=ident)
+    """
+    payload = credential_payload(credential)
+    if key_id is not None and hasattr(identity, "sign_with"):
+        sig = identity.sign_with(payload, key_id)
+    else:
+        sig = identity.sign(payload)
+    pub = _own_pubkey_for_key(identity, str(sig.key_id))
+    return {
+        **credential,
+        "proof": {
+            "type": PROOF_TYPE,
+            "verificationMethod": f"{did_key_for_pubkey(pub)}#{sig.key_id}",
+            "proofValue": sig.value.hex(),
+        },
+    }
+
+
+def _own_pubkey_for_key(identity: Any, key_id: str) -> bytes:
+    """The raw public key bytes of one of ``identity``'s own keys, by ``key_id``.
+
+    Falls back to the current ``public_key`` when the plugin does not expose a
+    key history (e.g. ``did_key``), whose single key is its only key.
+
+    Example::
+
+        pub = _own_pubkey_for_key(ident, str(ident.current_key_id))
+    """
+    records = getattr(identity, "_records", None)
+    if isinstance(records, dict):
+        own = cast("dict[Any, Any]", records).get(identity.agent_id, [])
+        for record in cast("list[Any]", own):
+            if str(record.key_id) == key_id:
+                return cast("bytes", record.public_key)
+    return cast("bytes", identity.public_key)
+
+
+# ---------------------------------------------------------------------------
+# Admission policy and result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AdmissionPolicy:
+    """What an admitting trust domain requires of a presented credential.
+
+    ``require_recomputation=False`` is the *naive gate*: it trusts the signed
+    claims (proof and freshness still checked) and skips root/score
+    recomputation and published-ledger severance. It exists so scenarios can
+    demonstrate exactly which attacks recomputation stops — the adversarial
+    validators FAIL under the naive gate and PASS under the default.
+
+    Example::
+
+        policy = AdmissionPolicy(trusted_issuers={"did:nest:auditor-a"},
+                                 min_reputation_score=0.2)
+    """
+
+    trusted_issuers: set[str] = field(default_factory=set[str])
+    min_reputation_score: float = 0.0
+    max_age_ticks: float | None = None
+    max_ledger_receipts: int | None = None
+    score_tolerance: float = 1e-6
+    require_recomputation: bool = True
+    require_published_ledger: bool = False
+
+
+@dataclass
+class AdmissionResult:
+    """The outcome of one admission decision: a verdict and a typed reason.
+
+    ``reason`` is ``"admitted"`` on success, else one of the snake_case
+    rejection reasons (``schema_invalid``, ``wrong_scoring_method``,
+    ``untrusted_issuer``, ``replay_presenter_mismatch``, ``stale_credential``,
+    ``proof_invalid``, ``stale_key``, ``ledger_too_large``,
+    ``foreign_receipts``, ``root_mismatch``, ``score_mismatch``,
+    ``below_threshold``, ``published_ledger_missing``,
+    ``severed_below_threshold``). Validators key on these strings.
+
+    Example::
+
+        result = AdmissionResult(admitted=True, reason="admitted")
+    """
+
+    admitted: bool
+    reason: str
+    recomputed_score: float | None = None
+    detail: str = ""
+
+
+# ---------------------------------------------------------------------------
+# The trust plugin
+# ---------------------------------------------------------------------------
+
+
+class ParcTrust(ar.AgentReceiptsTrust):
+    """Portable-reputation trust plugin implementing the ``Trust`` Protocol.
+
+    Inherits the full receipt-reputation behavior of ``agent_receipts``
+    (``report``/``score``/``attest``/``stake``, corroboration gates, collusion
+    severance) and adds the portability surface: credential export, admission
+    with recomputation, and published-ledger severance. The constructor stays
+    no-arg-callable for the NEST runner.
+
+    Example::
+
+        trust = ParcTrust()
+        vc = await trust.build_credential(subject, identity=ident, valid_from=6.0)
+    """
+
+    def __init__(self, identity: Any = None) -> None:
+        super().__init__(identity)
+        # The originating domain's community ledger, if one was published to
+        # this gate. Whole-graph severance for admissions runs over this.
+        self._published_ledger: list[dict[str, Any]] = []
+
+    # -- export ------------------------------------------------------------
+
+    async def build_credential(
+        self,
+        subject: AgentId,
+        *,
+        identity: Any,
+        valid_from: float,
+        key_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Export ``subject``'s reputation as a signed, portable credential.
+
+        Collects the subject's receipts from this plugin's ledger (sorted by
+        ``receipt_id`` for determinism), commits to them with a Merkle root,
+        embeds the inline-recomputable ``nanda-rep/0.2`` scores as fixed
+        6-decimal strings, and signs the canonical document through the
+        identity layer. ``valid_from`` is the logical tick the credential is
+        anchored to — verifiers enforce the signing key's rotation window
+        as-of this tick. ``key_id`` selects a specific (possibly rotated-out)
+        signing key and exists for adversarial scenarios, mirroring
+        ``Ed25519RotatingIdentity.sign_with``.
+
+        Example::
+
+            vc = await trust.build_credential(AgentId("a1"), identity=ident,
+                                              valid_from=6.0)
+        """
+        did = self._did_of(subject)
+        receipts = sorted(
+            (r for r in self._ledger if str(r.get("issuer_did", "")) == did),
+            key=lambda r: str(r.get("receipt_id", "")),
+        )
+        score, validity_rate, corroboration_rate = _inline_scores(receipts)
+        credential: dict[str, Any] = {
+            "@context": [CREDENTIAL_CONTEXT],
+            "type": ["VerifiableCredential", CREDENTIAL_TYPE],
+            "issuer": f"{ISSUER_URI_PREFIX}{identity.agent_id}",
+            "validFrom": valid_from,
+            "credentialSubject": {
+                "id": did,
+                "behavioral_merkle_root": merkle_root(receipts),
+                "scoring_method": SCORING_METHOD,
+                "reputation_score": _fmt6(score),
+                "validity_rate": _fmt6(validity_rate),
+                "corroboration_rate": _fmt6(corroboration_rate),
+                "receipt_count": len(receipts),
+                "as_of": valid_from,
+                "receipts": receipts,
+            },
+        }
+        return attach_proof(credential, identity=identity, key_id=key_id)
+
+    # -- published-ledger ingestion -----------------------------------------
+
+    def ingest_published_ledger(self, receipts: list[dict[str, Any]]) -> int:
+        """Ingest an originating domain's published community ledger.
+
+        Stores the receipts for whole-graph collusion severance at admission
+        time. Only receipts that verify enter (a hostile publisher cannot
+        smuggle unverifiable edges into the severance graph). Replaces any
+        previously published ledger; returns the number retained.
+
+        Example::
+
+            kept = gate.ingest_published_ledger(ledger)
+        """
+        self._published_ledger = [r for r in receipts if ar._verify_receipt(r)]
+        return len(self._published_ledger)
+
+    # -- admission -----------------------------------------------------------
+
+    async def admit(
+        self,
+        credential: dict[str, Any],
+        *,
+        policy: AdmissionPolicy,
+        presenter_did: str,
+        identity: Any,
+        current_tick: float,
+    ) -> AdmissionResult:
+        """Decide admission for a presented credential under ``policy``.
+
+        Gates run in order, each with a typed rejection reason: schema →
+        scoring method → trusted issuer → presenter binding (the presenter
+        must *be* the credential subject — anyone else replaying a stolen
+        credential is rejected) → freshness → proof (Ed25519 under the
+        issuer's identity-layer key, with the key's rotation window enforced
+        **as-of** ``validFrom``) → ledger size → subject binding of carried
+        receipts → Merkle-root recomputation → score recomputation →
+        threshold → published-ledger severance. The proof gate distinguishes
+        ``proof_invalid`` (bad bytes/unknown key) from ``stale_key`` (genuine
+        signature, but the key's validity window does not contain
+        ``validFrom``).
+
+        Example::
+
+            result = await gate.admit(vc, policy=policy, presenter_did=did,
+                                      identity=gate_ident, current_tick=6.0)
+        """
+        parsed = _parse_credential(credential)
+        if parsed is None:
+            return AdmissionResult(False, "schema_invalid")
+        issuer, valid_from, subject = parsed
+
+        if subject.get("scoring_method") != SCORING_METHOD:
+            return AdmissionResult(
+                False,
+                "wrong_scoring_method",
+                detail=str(subject.get("scoring_method")),
+            )
+        if issuer not in policy.trusted_issuers:
+            return AdmissionResult(False, "untrusted_issuer", detail=issuer)
+        subject_did = str(subject["id"])
+        if subject_did != presenter_did:
+            return AdmissionResult(False, "replay_presenter_mismatch")
+        if policy.max_age_ticks is not None and current_tick - valid_from > policy.max_age_ticks:
+            return AdmissionResult(False, "stale_credential")
+
+        proof_reason = await self._verify_proof(credential, issuer, valid_from, identity)
+        if proof_reason is not None:
+            return AdmissionResult(False, proof_reason)
+
+        receipts = cast("list[dict[str, Any]]", subject["receipts"])
+        if policy.max_ledger_receipts is not None and len(receipts) > policy.max_ledger_receipts:
+            return AdmissionResult(False, "ledger_too_large")
+
+        claimed_score = float(str(subject["reputation_score"]))
+        score = claimed_score
+        if policy.require_recomputation:
+            if any(str(r.get("issuer_did", "")) != subject_did for r in receipts):
+                return AdmissionResult(False, "foreign_receipts")
+            if merkle_root(receipts) != subject["behavioral_merkle_root"]:
+                return AdmissionResult(False, "root_mismatch")
+            recomputed, validity_rate, corroboration_rate = _inline_scores(receipts)
+            mismatches = [
+                name
+                for name, claimed_raw, actual in (
+                    ("reputation_score", subject["reputation_score"], recomputed),
+                    ("validity_rate", subject["validity_rate"], validity_rate),
+                    ("corroboration_rate", subject["corroboration_rate"], corroboration_rate),
+                )
+                if abs(float(str(claimed_raw)) - actual) > policy.score_tolerance
+            ]
+            if int(subject["receipt_count"]) != len(receipts):
+                mismatches.append("receipt_count")
+            if mismatches:
+                return AdmissionResult(
+                    False,
+                    "score_mismatch",
+                    recomputed_score=recomputed,
+                    detail=",".join(mismatches),
+                )
+            score = recomputed
+
+        if score < policy.min_reputation_score:
+            return AdmissionResult(False, "below_threshold", recomputed_score=score)
+
+        if policy.require_recomputation and policy.require_published_ledger:
+            if not self._published_ledger:
+                return AdmissionResult(False, "published_ledger_missing")
+            severed = ar._severed_dids(ar._corroboration_graph(self._published_ledger))
+            if subject_did in severed:
+                return AdmissionResult(
+                    False,
+                    "severed_below_threshold",
+                    recomputed_score=0.0,
+                    detail="subject severed by whole-graph collusion analysis",
+                )
+
+        return AdmissionResult(True, "admitted", recomputed_score=score)
+
+    async def _verify_proof(
+        self,
+        credential: dict[str, Any],
+        issuer: str,
+        valid_from: float,
+        identity: Any,
+    ) -> str | None:
+        """Verify the credential proof; ``None`` on success, else a reason.
+
+        Resolves the issuer through the identity layer, binds the proof to the
+        exact key named by its ``verificationMethod`` fragment, cross-checks
+        the embedded ``did:key`` against that key's actual bytes, verifies the
+        Ed25519 signature, and finally enforces the key's rotation window
+        as-of ``validFrom``. Window data comes from
+        ``AgentIdentity.metadata["keys"]`` (the ``ed25519_rotating`` history);
+        an identity plugin without key history degrades to a single
+        always-valid key.
+
+        Example::
+
+            reason = await gate._verify_proof(vc, issuer, 6.0, gate_ident)
+        """
+        proof = credential.get("proof")
+        if not isinstance(proof, dict):
+            return "proof_invalid"
+        proof_typed = cast("dict[str, Any]", proof)
+        method = str(proof_typed.get("verificationMethod", ""))
+        did_part, _, key_id = method.partition("#")
+        if not did_part or not key_id:
+            return "proof_invalid"
+
+        issuer_agent = AgentId(issuer.removeprefix(ISSUER_URI_PREFIX))
+        resolved = await identity.resolve(issuer_agent)
+        keys = resolved.metadata.get("keys")
+        if not isinstance(keys, list):
+            keys = [
+                {
+                    "key_id": hashlib.sha256(resolved.public_key).hexdigest(),
+                    "public_key": resolved.public_key.hex(),
+                    "issued_at": 0.0,
+                    "rotated_out": None,
+                }
+            ]
+        record = next(
+            (
+                cast("dict[str, Any]", k)
+                for k in cast("list[Any]", keys)
+                if isinstance(k, dict) and str(cast("dict[str, Any]", k).get("key_id")) == key_id
+            ),
+            None,
+        )
+        if record is None:
+            return "proof_invalid"
+        pub = bytes.fromhex(str(record["public_key"]))
+        if did_key_for_pubkey(pub) != did_part:
+            return "proof_invalid"
+        try:
+            sig = bytes.fromhex(str(proof_typed.get("proofValue", "")))
+            Ed25519PublicKey.from_public_bytes(pub).verify(sig, credential_payload(credential))
+        except (InvalidSignature, ValueError, TypeError):
+            return "proof_invalid"
+
+        issued_at = float(record.get("issued_at", 0.0))
+        rotated_out_raw = record.get("rotated_out")
+        rotated_out = float("inf") if rotated_out_raw is None else float(str(rotated_out_raw))
+        if not (issued_at <= valid_from < rotated_out):
+            return "stale_key"
+        return None
+
+
+def _parse_credential(
+    credential: dict[str, Any],
+) -> tuple[str, float, dict[str, Any]] | None:
+    """Extract ``(issuer, validFrom, credentialSubject)``; ``None`` if malformed.
+
+    Checks the structural shape only — types of the required fields and the
+    ``ParcReputationCredential`` type marker. Cryptographic and semantic gates
+    run afterwards in :meth:`ParcTrust.admit`.
+
+    Example::
+
+        parsed = _parse_credential(vc)
+    """
+    types = credential.get("type")
+    if not isinstance(types, list) or CREDENTIAL_TYPE not in cast("list[Any]", types):
+        return None
+    issuer = credential.get("issuer")
+    valid_from = credential.get("validFrom")
+    subject = credential.get("credentialSubject")
+    if not isinstance(issuer, str) or not issuer.startswith(ISSUER_URI_PREFIX):
+        return None
+    if not isinstance(valid_from, int | float):
+        return None
+    if not isinstance(subject, dict):
+        return None
+    subject_typed = cast("dict[str, Any]", subject)
+    required = (
+        "id",
+        "behavioral_merkle_root",
+        "scoring_method",
+        "reputation_score",
+        "validity_rate",
+        "corroboration_rate",
+        "receipt_count",
+        "receipts",
+    )
+    if any(key not in subject_typed for key in required):
+        return None
+    if not isinstance(subject_typed["receipts"], list):
+        return None
+    return str(issuer), float(valid_from), subject_typed

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -46,6 +46,9 @@ cid_facts = "nest_plugins_reference.datafacts.cid_facts:CidFacts"
 heartbeat = "nest_plugins_reference.failure_detection.heartbeat:HeartbeatFailureDetector"
 phi_accrual = "nest_plugins_reference.failure_detection.phi_accrual:PhiAccrualFailureDetector"
 
+[project.entry-points."nest.plugins.trust"]
+parc = "nest_plugins_reference.trust.parc:ParcTrust"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/nest-plugins-reference/tests/test_parc.py
+++ b/packages/nest-plugins-reference/tests/test_parc.py
@@ -1,0 +1,546 @@
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportPrivateUsage=false
+"""Unit + hostile-path + property tests for the ``parc`` trust plugin.
+
+The hostile paths mirror the sm-parc threat taxonomy: tampered credential,
+untrusted issuer, replayed (stolen) credential, stale credential, stale
+(rotated-out) signing key, oversized ledger, foreign receipts, tampered
+ledger (root mismatch), issuer-inflated-and-re-signed score, below-threshold,
+missing published ledger, and wash-ring severance over the published ledger.
+Each asserts the *typed reason*, not just the denial — the reasons are the
+plugin's contract with the trace validators.
+
+Property tests (Hypothesis) assert the structural invariants:
+
+1. Merkle root is permutation-invariant and tamper-sensitive.
+2. Any single-nibble proof tamper is rejected as ``proof_invalid``.
+3. Export -> admit round-trips for arbitrary honest ledgers.
+4. Admission thresholding is exact: admitted iff recomputed score clears
+   ``min_reputation_score``.
+5. base58btc round-trips against an independent decoder.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Evidence
+from nest_plugins_reference.identity.ed25519_rotating import Ed25519RotatingIdentity
+from nest_plugins_reference.trust.agent_receipts import (
+    cosign_receipt,
+    did_for_pubkey,
+    sign_receipt,
+)
+from nest_plugins_reference.trust.parc import (
+    _B58_ALPHABET,
+    AdmissionPolicy,
+    ParcTrust,
+    _b58btc_encode,
+    attach_proof,
+    credential_payload,
+    did_key_for_pubkey,
+    merkle_root,
+)
+
+_ISSUER = AgentId("issuer-a")
+_GATE = AgentId("gate-b")
+_ROTATE_AT = 5.0
+_ISSUE_AT = 6.0
+
+
+def _seed(name: str) -> bytes:
+    """The deterministic receipt seed for an agent name (plugin-matching)."""
+    return hashlib.sha256(name.encode()).digest()[:32]
+
+
+def _did(name: str) -> str:
+    """The trust-layer receipt identity (hex pubkey) for an agent name."""
+    sk = Ed25519PrivateKey.from_private_bytes(_seed(name))
+    return did_for_pubkey(sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw))
+
+
+def _receipt(issuer: str, cp: str, *, rid: str, category: str = "purchase") -> dict[str, Any]:
+    """A corroborated receipt from ``issuer`` about counterparty ``cp``."""
+    r: dict[str, Any] = {
+        "receipt_id": rid,
+        "issuer_did": _did(issuer),
+        "action": {"category": category, "counterparty_did": _did(cp)},
+    }
+    return cosign_receipt(sign_receipt(r, issuer_seed=_seed(issuer)), counterparty_seed=_seed(cp))
+
+
+async def _trust_with(receipts: list[dict[str, Any]]) -> ParcTrust:
+    """A ParcTrust whose ledger holds ``receipts`` (reported the normal way)."""
+    trust = ParcTrust()
+    for r in receipts:
+        await trust.report(
+            AgentId("reporter"),
+            Evidence(
+                reporter=AgentId("reporter"),
+                subject=AgentId("reporter"),
+                kind="positive",
+                detail=json.dumps(r),
+            ),
+        )
+    return trust
+
+
+def _identities() -> tuple[Ed25519RotatingIdentity, Ed25519RotatingIdentity, str]:
+    """(issuer identity, gate identity, issuer's pre-rotation key id).
+
+    The gate learns the issuer's key #0, the issuer rotates at ``_ROTATE_AT``,
+    and the gate applies the rotation record — the same wiring the scenario
+    factory performs.
+    """
+    issuer = Ed25519RotatingIdentity(_ISSUER, seed=b"test:issuer-a")
+    gate = Ed25519RotatingIdentity(_GATE, seed=b"test:gate-b")
+    old_key_id = str(issuer.current_key_id)
+    gate.register_peer(_ISSUER, issuer.public_key)
+    issuer.set_clock(_ROTATE_AT)
+    rotation = issuer.rotate_key(b"test:issuer-a:rotated")
+    gate.set_clock(_ROTATE_AT)
+    assert gate.apply_rotation(rotation)
+    issuer.set_clock(_ISSUE_AT)
+    return issuer, gate, old_key_id
+
+
+def _policy(**overrides: Any) -> AdmissionPolicy:
+    """The default test policy: trusts the test issuer, threshold 0.2."""
+    defaults: dict[str, Any] = {
+        "trusted_issuers": {f"did:nest:{_ISSUER}"},
+        "min_reputation_score": 0.2,
+    }
+    defaults.update(overrides)
+    return AdmissionPolicy(**defaults)
+
+
+async def _admit(
+    gate_trust: ParcTrust,
+    vc: dict[str, Any],
+    *,
+    presenter: str = "alice",
+    policy: AdmissionPolicy | None = None,
+    current_tick: float = _ISSUE_AT,
+) -> Any:
+    """Admit ``vc`` at a fresh gate against the standard test wiring."""
+    _, gate_ident, _ = _identities()
+    return await gate_trust.admit(
+        vc,
+        policy=policy or _policy(),
+        presenter_did=_did(presenter),
+        identity=gate_ident,
+        current_tick=current_tick,
+    )
+
+
+def _alice_receipts() -> list[dict[str, Any]]:
+    """Two corroborated purchase receipts for alice (inline score ~0.63)."""
+    return [
+        _receipt("alice", "bob", rid="r1"),
+        _receipt("alice", "carol", rid="r2"),
+    ]
+
+
+async def _alice_credential() -> tuple[dict[str, Any], ParcTrust]:
+    """A genuine credential for alice plus the exporting trust instance."""
+    trust = await _trust_with(_alice_receipts())
+    issuer_ident, _, _ = _identities()
+    vc = await trust.build_credential(AgentId("alice"), identity=issuer_ident, valid_from=_ISSUE_AT)
+    return vc, trust
+
+
+# ---------------------------------------------------------------------------
+# did:key / base58btc
+# ---------------------------------------------------------------------------
+
+
+class TestDidKey:
+    def test_ed25519_did_key_prefix(self) -> None:
+        # Every multicodec-prefixed Ed25519 key encodes to did:key:z6Mk...
+        issuer, _, _ = _identities()
+        assert did_key_for_pubkey(issuer.public_key).startswith("did:key:z6Mk")
+
+    def test_distinct_keys_distinct_dids(self) -> None:
+        issuer, gate, _ = _identities()
+        assert did_key_for_pubkey(issuer.public_key) != did_key_for_pubkey(gate.public_key)
+
+    @given(st.binary(min_size=0, max_size=48))
+    @settings(deadline=None)
+    def test_b58btc_roundtrip(self, data: bytes) -> None:
+        encoded = _b58btc_encode(data)
+        # Independent decode: leading '1's are zero bytes, the rest is base-58.
+        pad = len(encoded) - len(encoded.lstrip("1"))
+        num = 0
+        for char in encoded[pad:]:
+            num = num * 58 + _B58_ALPHABET.index(char)
+        body = num.to_bytes((num.bit_length() + 7) // 8, "big") if num else b""
+        assert b"\x00" * pad + body == data
+
+
+# ---------------------------------------------------------------------------
+# Merkle root
+# ---------------------------------------------------------------------------
+
+
+class TestMerkleRoot:
+    @given(st.permutations(list(range(5))))
+    @settings(deadline=None)
+    def test_permutation_invariant(self, order: list[int]) -> None:
+        receipts = [_receipt("alice", "bob", rid=f"r{i}") for i in range(5)]
+        shuffled = [receipts[i] for i in order]
+        assert merkle_root(shuffled) == merkle_root(receipts)
+
+    def test_tamper_changes_root(self) -> None:
+        receipts = _alice_receipts()
+        root = merkle_root(receipts)
+        tampered = copy.deepcopy(receipts)
+        tampered[0]["action"]["category"] = "payment_sent"
+        assert merkle_root(tampered) != root
+
+    def test_subset_changes_root(self) -> None:
+        receipts = _alice_receipts()
+        assert merkle_root(receipts[:1]) != merkle_root(receipts)
+
+    def test_empty_ledger_root_is_defined(self) -> None:
+        assert merkle_root([]) == hashlib.sha256(b"").hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Export -> admit round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    @pytest.mark.asyncio
+    async def test_genuine_credential_admitted(self) -> None:
+        vc, trust = await _alice_credential()
+        result = await _admit(trust, vc)
+        assert result.admitted is True
+        assert result.reason == "admitted"
+        assert result.recomputed_score == pytest.approx(
+            float(vc["credentialSubject"]["reputation_score"]), abs=1e-6
+        )
+
+    @pytest.mark.asyncio
+    async def test_credential_shape(self) -> None:
+        vc, _ = await _alice_credential()
+        assert vc["type"] == ["VerifiableCredential", "ParcReputationCredential"]
+        assert vc["issuer"] == f"did:nest:{_ISSUER}"
+        subject = vc["credentialSubject"]
+        assert subject["id"] == _did("alice")
+        assert subject["scoring_method"] == "nanda-rep/0.2"
+        assert subject["receipt_count"] == 2
+        assert subject["behavioral_merkle_root"] == merkle_root(subject["receipts"])
+        assert vc["proof"]["type"] == "Ed25519Signature2020"
+        assert vc["proof"]["verificationMethod"].startswith("did:key:z6Mk")
+
+    @pytest.mark.asyncio
+    async def test_credential_bytes_deterministic(self) -> None:
+        vc1, _ = await _alice_credential()
+        vc2, _ = await _alice_credential()
+        assert credential_payload(vc1) == credential_payload(vc2)
+        assert vc1["proof"] == vc2["proof"]
+
+    @pytest.mark.asyncio
+    async def test_empty_ledger_credential_scores_zero(self) -> None:
+        trust = await _trust_with([])
+        issuer_ident, _, _ = _identities()
+        vc = await trust.build_credential(
+            AgentId("nobody"), identity=issuer_ident, valid_from=_ISSUE_AT
+        )
+        assert vc["credentialSubject"]["reputation_score"] == "0.000000"
+        result = await _admit(trust, vc, presenter="nobody")
+        assert result.admitted is False
+        assert result.reason == "below_threshold"
+
+
+# ---------------------------------------------------------------------------
+# Hostile paths — one typed reason each
+# ---------------------------------------------------------------------------
+
+
+class TestHostilePaths:
+    @pytest.mark.asyncio
+    async def test_schema_invalid(self) -> None:
+        trust = ParcTrust()
+        result = await _admit(trust, {"type": ["VerifiableCredential"]})
+        assert (result.admitted, result.reason) == (False, "schema_invalid")
+
+    @pytest.mark.asyncio
+    async def test_wrong_scoring_method(self) -> None:
+        vc, trust = await _alice_credential()
+        vc = copy.deepcopy(vc)
+        # An un-corroborated nanda-rep/0.1 facet must be rejected before any
+        # recomputation, even though its proof is now broken anyway.
+        vc["credentialSubject"]["scoring_method"] = "nanda-rep/0.1"
+        result = await _admit(trust, vc)
+        assert (result.admitted, result.reason) == (False, "wrong_scoring_method")
+
+    @pytest.mark.asyncio
+    async def test_untrusted_issuer(self) -> None:
+        vc, trust = await _alice_credential()
+        result = await _admit(trust, vc, policy=_policy(trusted_issuers={"did:nest:someone"}))
+        assert (result.admitted, result.reason) == (False, "untrusted_issuer")
+
+    @pytest.mark.asyncio
+    async def test_replayed_credential_rejected(self) -> None:
+        vc, trust = await _alice_credential()
+        result = await _admit(trust, vc, presenter="mallory")
+        assert (result.admitted, result.reason) == (False, "replay_presenter_mismatch")
+
+    @pytest.mark.asyncio
+    async def test_stale_credential_rejected(self) -> None:
+        vc, trust = await _alice_credential()
+        result = await _admit(
+            trust, vc, policy=_policy(max_age_ticks=10.0), current_tick=_ISSUE_AT + 11.0
+        )
+        assert (result.admitted, result.reason) == (False, "stale_credential")
+
+    @pytest.mark.asyncio
+    async def test_tampered_proof_rejected(self) -> None:
+        vc, trust = await _alice_credential()
+        vc = copy.deepcopy(vc)
+        value = vc["proof"]["proofValue"]
+        vc["proof"]["proofValue"] = ("0" if value[0] != "0" else "f") + value[1:]
+        result = await _admit(trust, vc)
+        assert (result.admitted, result.reason) == (False, "proof_invalid")
+
+    @pytest.mark.asyncio
+    async def test_tampered_subject_breaks_proof(self) -> None:
+        vc, trust = await _alice_credential()
+        vc = copy.deepcopy(vc)
+        # Tamper a signed field WITHOUT re-signing: the untouched (genuine)
+        # proof no longer covers the canonical bytes.
+        vc["credentialSubject"]["receipt_count"] = 99
+        result = await _admit(trust, vc)
+        assert (result.admitted, result.reason) == (False, "proof_invalid")
+
+    @pytest.mark.asyncio
+    async def test_unknown_key_id_rejected(self) -> None:
+        vc, trust = await _alice_credential()
+        vc = copy.deepcopy(vc)
+        did_part, _, _ = vc["proof"]["verificationMethod"].partition("#")
+        vc["proof"]["verificationMethod"] = f"{did_part}#{'0' * 64}"
+        result = await _admit(trust, vc)
+        assert (result.admitted, result.reason) == (False, "proof_invalid")
+
+    @pytest.mark.asyncio
+    async def test_stale_key_rejected(self) -> None:
+        # Signed with the issuer's PRE-rotation key, validFrom after rotation:
+        # cryptographically valid, but the key's window is [0, _ROTATE_AT).
+        trust = await _trust_with(_alice_receipts())
+        issuer_ident, _, old_key_id = _identities()
+        vc = await trust.build_credential(
+            AgentId("alice"), identity=issuer_ident, valid_from=_ISSUE_AT, key_id=old_key_id
+        )
+        result = await _admit(trust, vc)
+        assert (result.admitted, result.reason) == (False, "stale_key")
+
+    @pytest.mark.asyncio
+    async def test_old_key_valid_within_its_window(self) -> None:
+        # The same pre-rotation key IS acceptable for a credential anchored
+        # inside its window — rotation must not retroactively void history.
+        trust = await _trust_with(_alice_receipts())
+        issuer_ident, _, old_key_id = _identities()
+        vc = await trust.build_credential(
+            AgentId("alice"), identity=issuer_ident, valid_from=1.0, key_id=old_key_id
+        )
+        result = await _admit(trust, vc)
+        assert result.admitted is True
+
+    @pytest.mark.asyncio
+    async def test_ledger_too_large_rejected(self) -> None:
+        vc, trust = await _alice_credential()
+        result = await _admit(trust, vc, policy=_policy(max_ledger_receipts=1))
+        assert (result.admitted, result.reason) == (False, "ledger_too_large")
+
+    @pytest.mark.asyncio
+    async def test_foreign_receipts_rejected(self) -> None:
+        # Mallory pads her thin ledger with bob's genuine receipts and
+        # recommits the root + scores, re-signed by a corrupt trusted issuer:
+        # the subject-binding gate still rejects it.
+        trust = await _trust_with([_receipt("mallory", "bob", rid="m1")])
+        issuer_ident, _, _ = _identities()
+        vc = await trust.build_credential(
+            AgentId("mallory"), identity=issuer_ident, valid_from=_ISSUE_AT
+        )
+        vc.pop("proof")
+        padded = [*vc["credentialSubject"]["receipts"], _receipt("bob", "carol", rid="b1")]
+        vc["credentialSubject"]["receipts"] = padded
+        vc["credentialSubject"]["behavioral_merkle_root"] = merkle_root(padded)
+        vc = attach_proof(vc, identity=issuer_ident)
+        result = await _admit(trust, vc, presenter="mallory")
+        assert (result.admitted, result.reason) == (False, "foreign_receipts")
+
+    @pytest.mark.asyncio
+    async def test_root_mismatch_rejected(self) -> None:
+        # A receipt vanishes from the carried ledger but the committed root
+        # is left stale — re-signed so the proof itself verifies.
+        vc, trust = await _alice_credential()
+        issuer_ident, _, _ = _identities()
+        vc = copy.deepcopy(vc)
+        vc.pop("proof")
+        vc["credentialSubject"]["receipts"] = vc["credentialSubject"]["receipts"][:1]
+        vc = attach_proof(vc, identity=issuer_ident)
+        result = await _admit(trust, vc)
+        assert (result.admitted, result.reason) == (False, "root_mismatch")
+
+    @pytest.mark.asyncio
+    async def test_inflated_score_rejected_despite_valid_signature(self) -> None:
+        # The headline property: a trusted issuer inflates the score and
+        # genuinely re-signs. Proof verifies; recomputation catches the lie.
+        vc, trust = await _alice_credential()
+        issuer_ident, _, _ = _identities()
+        vc = copy.deepcopy(vc)
+        vc.pop("proof")
+        vc["credentialSubject"]["reputation_score"] = "0.990000"
+        vc = attach_proof(vc, identity=issuer_ident)
+        result = await _admit(trust, vc)
+        assert (result.admitted, result.reason) == (False, "score_mismatch")
+        assert result.recomputed_score == pytest.approx(0.6321, abs=1e-3)
+
+    @pytest.mark.asyncio
+    async def test_naive_gate_admits_inflated_score(self) -> None:
+        # The differential: with recomputation off, the same inflated
+        # credential is admitted — which is exactly what the adversarial
+        # validators punish.
+        vc, trust = await _alice_credential()
+        issuer_ident, _, _ = _identities()
+        vc = copy.deepcopy(vc)
+        vc.pop("proof")
+        vc["credentialSubject"]["reputation_score"] = "0.990000"
+        vc = attach_proof(vc, identity=issuer_ident)
+        result = await _admit(trust, vc, policy=_policy(require_recomputation=False))
+        assert result.admitted is True
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_rejected(self) -> None:
+        vc, trust = await _alice_credential()
+        result = await _admit(trust, vc, policy=_policy(min_reputation_score=0.9))
+        assert (result.admitted, result.reason) == (False, "below_threshold")
+
+    @pytest.mark.asyncio
+    async def test_published_ledger_missing_rejected(self) -> None:
+        vc, _ = await _alice_credential()
+        gate = ParcTrust()  # never ingested a published ledger
+        _, gate_ident, _ = _identities()
+        result = await gate.admit(
+            vc,
+            policy=_policy(require_published_ledger=True),
+            presenter_did=_did("alice"),
+            identity=gate_ident,
+            current_tick=_ISSUE_AT,
+        )
+        assert (result.admitted, result.reason) == (False, "published_ledger_missing")
+
+    @pytest.mark.asyncio
+    async def test_ring_severed_over_published_ledger(self) -> None:
+        # Each ring member's inline credential is individually corroborated
+        # and survives recomputation; the published-ledger severance is what
+        # denies it. Honest agents over the same published ledger stay
+        # admitted.
+        ring = ["r0", "r1", "r2"]
+        honest = ["h0", "h1", "h2", "h3"]
+        ledger: list[dict[str, Any]] = []
+        for i, a in enumerate(honest):
+            for k in (1, 2):
+                ledger.append(_receipt(a, honest[(i + k) % len(honest)], rid=f"{a}-{k}"))
+        for a in ring:
+            for b in ring:
+                if a != b:
+                    ledger.append(_receipt(a, b, rid=f"{a}->{b}"))
+        trust = await _trust_with(ledger)
+        issuer_ident, _, _ = _identities()
+        gate = ParcTrust()
+        assert gate.ingest_published_ledger(ledger) == len(ledger)
+        policy = _policy(require_published_ledger=True)
+        _, gate_ident, _ = _identities()
+
+        ring_vc = await trust.build_credential(
+            AgentId("r0"), identity=issuer_ident, valid_from=_ISSUE_AT
+        )
+        result = await gate.admit(
+            ring_vc,
+            policy=policy,
+            presenter_did=_did("r0"),
+            identity=gate_ident,
+            current_tick=_ISSUE_AT,
+        )
+        assert (result.admitted, result.reason) == (False, "severed_below_threshold")
+
+        honest_vc = await trust.build_credential(
+            AgentId("h0"), identity=issuer_ident, valid_from=_ISSUE_AT
+        )
+        result = await gate.admit(
+            honest_vc,
+            policy=policy,
+            presenter_did=_did("h0"),
+            identity=gate_ident,
+            current_tick=_ISSUE_AT,
+        )
+        assert result.admitted is True
+
+    def test_hostile_published_ledger_edges_dropped(self) -> None:
+        gate = ParcTrust()
+        forged = {"receipt_id": "x", "issuer_did": _did("a"), "signature": "00" * 64}
+        assert gate.ingest_published_ledger([forged]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+class TestProperties:
+    @given(st.integers(min_value=0, max_value=127))
+    @settings(deadline=None, max_examples=30)
+    def test_any_proof_nibble_tamper_rejected(self, position: int) -> None:
+        import asyncio
+
+        async def run() -> None:
+            vc, trust = await _alice_credential()
+            vc2 = copy.deepcopy(vc)
+            value = vc2["proof"]["proofValue"]
+            index = position % len(value)
+            original = value[index]
+            replacement = "0" if original != "0" else "f"
+            vc2["proof"]["proofValue"] = value[:index] + replacement + value[index + 1 :]
+            result = await _admit(trust, vc2)
+            assert result.admitted is False
+            assert result.reason == "proof_invalid"
+
+        asyncio.run(run())
+
+    @given(st.integers(min_value=1, max_value=5), st.integers(min_value=0, max_value=100))
+    @settings(deadline=None, max_examples=25)
+    def test_export_admit_roundtrip_and_exact_threshold(
+        self, receipt_count: int, threshold_pct: int
+    ) -> None:
+        import asyncio
+
+        async def run() -> None:
+            receipts = [_receipt("alice", f"cp{i}", rid=f"r{i}") for i in range(receipt_count)]
+            trust = await _trust_with(receipts)
+            issuer_ident, _, _ = _identities()
+            vc = await trust.build_credential(
+                AgentId("alice"), identity=issuer_ident, valid_from=_ISSUE_AT
+            )
+            threshold = threshold_pct / 100.0
+            result = await _admit(trust, vc, policy=_policy(min_reputation_score=threshold))
+            score = float(vc["credentialSubject"]["reputation_score"])
+            if result.admitted:
+                assert score >= threshold - 1e-9
+                assert result.reason == "admitted"
+            else:
+                assert result.reason == "below_threshold"
+                assert score < threshold
+
+        asyncio.run(run())

--- a/scenarios/parc_migration.yaml
+++ b/scenarios/parc_migration.yaml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Portable-reputation migration: agents earn cross-signed receipts in trust
+# domain A, then migrate to domain B carrying signed PARC credentials. B's
+# admission gate RECOMPUTES the committed Merkle root and nanda-rep/0.2 scores
+# from the carried receipts instead of trusting the signed claims, and re-runs
+# whole-graph collusion severance over domain A's published ledger.
+#
+# Under `trust: parc` all six parc_migration adversarial validators PASS:
+# honest agents are admitted while the forged, replayed, stale-key, inflated,
+# and wash-ring credentials are each denied with a typed reason. Set
+# `task.config.naive_gate: true` (the gate trusts signed claims) and the
+# inflation + ring validators FAIL -- the differential proof that a valid
+# signature is not admission. Swap `trust: score_average` and every validator
+# fails: no credentials can even be built.
+name: parc_migration
+description: "10 migrants (4 honest, 3-ring, forger, replayer, stale-key, inflated), 2 issuers, 1 gate."
+
+tier: 1
+seed: 42
+
+agents:
+  # 4 honest + 3 ring + forger + replayer + stale + inflated + 2 auditors + 1 gate = 13
+  count: 13
+  brain: state-machine
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  # The cross-layer composition: credentials are signed through the rotating
+  # identity layer and verified against genuine key-rotation windows.
+  identity: ed25519_rotating
+  registry: in_memory
+  auth: jwt
+  # The whole point: parc exports portable credentials and recomputes them at
+  # admission. Switch to `score_average` to watch every validator fail.
+  trust: parc
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: parc_migration
+  config:
+    min_reputation_score: 0.2
+    naive_gate: false
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/parc_migration.jsonl


### PR DESCRIPTION
## Motivation

Reputation in NEST dies with the run. Every trust plugin holds an in-memory ledger; nothing exports it, carries it, or verifies it in another trust domain — an agent that migrates starts from zero, and a domain that wants to admit a stranger has nothing to check. The merged `agent_receipts` plugin (#26) made reputation *evidence-based*; this PR makes it **portable**, and does it by composing two merged submissions rather than adding a parallel scheme: the receipt maths of `agent_receipts` and the rotation windows of `ed25519_rotating` (#25).

## Design

**`trust/parc.py` — `ParcTrust`** extends `AgentReceiptsTrust` (drop-in for the `Trust` Protocol) with:

- **Export** (`build_credential`): wraps the subject's receipts as a W3C-VC-shaped document — `behavioral_merkle_root` committing to the carried receipts, `nanda-rep/0.2` scores embedded as fixed 6-decimal strings, `validFrom` as a logical tick — signed **through the identity layer**, with the signing `key_id` pinned in `proof.verificationMethod` as `did:key:z6Mk...#<key_id>` (base58btc/multicodec encoder vendored, ~25 lines, stdlib-only).
- **Admission** (`admit`): ordered gates, each a typed reason: schema → scoring method → trusted issuer → presenter binding (`replay_presenter_mismatch`) → freshness → proof with **as-of key-window enforcement** (`proof_invalid` vs `stale_key`) → ledger size → subject binding (`foreign_receipts`) → **Merkle-root recomputation** → **score recomputation** (`score_mismatch`) → threshold → **published-ledger severance** (`severed_below_threshold`).
- **Published-ledger severance** (`ingest_published_ledger`): an inline single-subject ledger is a star graph and structurally cannot show an N-party collusion ring, so the originating domain publishes its community ledger once and the gate re-runs `agent_receipts`' whole-graph Tarjan severance over it. Stated openly rather than papered over.

**The headline property: a valid signature is not admission.** The scenario's `auditor-x` is a *trusted* issuer that inflates a client's score and genuinely re-signs. The proof verifies; recomputation over the carried receipts rejects it.

**Scenario** (`parc_migration`, tier 1): two trust domains in one seeded run. 4 honest agents + a 3-agent wash ring earn receipts in domain A; at the border to domain B: a forger (tampered proof), a replayer (stolen genuine credential), a stale-key credential (signed with A's rotated-out key via the identity layer's adversarial `sign_with`), and the inflated credential. The factory performs a genuine key rotation and replays the rotation record onto the gate — the proof checks run against real key windows, not scenario-faked ones.

**Adversarial validators** (6, in `VALIDATORS["parc_migration"]`): honest admitted (anti-deny-everything guard), forgery → `proof_invalid`, inflation → `score_mismatch`, ring → `severed_below_threshold`, replay → `replay_presenter_mismatch`, stale key → `stale_key`. Each asserts the *typed reason*, not just the denial.

**Differential proof:** `task.config.naive_gate: true` makes the gate trust signed claims (proof still checked) — the inflation and ring validators FAIL while the rest hold. Under `trust: score_average` no credentials can be built and every validator fails. Both asserted in tests across a 5-seed bank.

## Tradeoffs

- **Inline vs pointer ledgers.** Carrying receipts in the credential keeps verification fully offline but bloats the document and cannot reveal rings; the published-ledger path closes the ring hole at the cost of the origin domain publishing its graph. Both are shipped; the residual (a hostile publisher omitting receipts entirely) is documented in the plugin docstring.
- **Two key namespaces.** Subjects keep `agent_receipts`' hex-pubkey identity (that is what the carried receipts use — recomputation depends on it); issuers get stable `did:nest:` URIs with per-key `did:key` pins, so issuer trust survives key rotation. Unifying them would have meant rewriting the merged receipt format.
- **Scores as strings.** Fixed 6-decimal embedding sidesteps JCS float canonicalization entirely; the gate compares within `score_tolerance` (default 1e-6).
- **No revocation registry / selective disclosure** in this PR: freshness (`max_age_ticks`) + rotation windows cover staleness; Merkle inclusion proofs are the natural follow-up and listed in `docs/layers/trust.md`.

## What would invalidate this

- A corrupt issuer that *fabricates receipts wholesale* (not just inflates scores) with counterparties it controls defeats inline recomputation; only anchor-aware published-ledger analysis catches it, and a publisher that censors its ledger weakens that.
- Ring severance inherits `agent_receipts`' thresholds (dense rings ≥3 or mutual pairs, isolated from the anchor): a ring that buys one genuine corroborated edge to an honest anchor agent evades severance.
- The as-of check anchors to `validFrom` supplied by the issuer; a *compromised current key* can backdate `validFrom` into its own window. Rotation bounds the damage window but does not eliminate it.

## Verify

```bash
uv sync
uv run pytest packages/nest-plugins-reference/tests/test_parc.py packages/nest-core/tests/test_parc_migration.py -v
uv run nest run scenarios/parc_migration.yaml   # then validate:
uv run python -c "
from pathlib import Path
from nest_core.validators import validate_trace
for r in validate_trace(Path('traces/parc_migration.jsonl'), 'parc_migration'):
    print(r.passed, r.name, '-', r.detail)"
```

`make ci-local`: all 5 checks green (ruff check, ruff format, pyright strict, 777 tests).
