### PR TITLE
RoboAgent Guard for Safety and Privacy Validation

### DIFF
--- a/docs/hackathon/roboagent-guard.md
+++ b/docs/hackathon/roboagent-guard.md
@@ -1,0 +1,441 @@
+# RoboAgent Guard
+
+RoboAgent Guard is a NANDA Town Phase 1 contribution targeting
+`docs/hackathon/problems/09-privacy-hybrid-encryption-with-selective-disclosure.md`.
+It adds a narrow privacy-layer differentiator for robot sensor traces:
+`privacy: noop` leaks raw sensor payloads, while `privacy: sensor_redaction`
+filters those payloads before they are shared.
+
+The goal is not to duplicate the already-merged `hybrid_x25519` work. This
+contribution is deliberately narrower: deterministic redaction of camera,
+person-detection, private-zone, lidar, and mapping tokens, plus trace validators
+that prove the reference `noop` privacy plugin fails this sensitive workflow.
+
+## What This Adds
+
+This contribution adds five pieces:
+
+- A scenario type named `roboagent_guard`.
+- A runnable YAML scenario at `scenarios/roboagent_guard.yaml`.
+- A privacy plugin named `sensor_redaction`.
+- Two validators registered under `roboagent_guard`.
+- Unit and end-to-end tests for safe and unsafe traces.
+
+The plugin and validators are deterministic. They do not call external services,
+require secrets, or use nondeterministic behavior.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `packages/nest-core/nest_core/scenarios_builtin/roboagent_guard.py` | Built-in scenario factory and simple state-machine agents. |
+| `scenarios/roboagent_guard.yaml` | Runnable scenario configuration. |
+| `packages/nest-core/nest_core/scenarios.py` | Registers the scenario factory loader. |
+| `packages/nest-core/nest_core/validators.py` | Adds RoboAgent Guard validators and registry entry. |
+| `packages/nest-plugins-reference/nest_plugins_reference/privacy/sensor_redaction.py` | Privacy plugin that redacts sensitive sensor payloads. |
+| `packages/nest-plugins-reference/tests/test_sensor_redaction.py` | Unit tests for the privacy plugin and registry wiring. |
+| `packages/nest-core/tests/test_validators.py` | Unit tests for validator pass/fail cases. |
+| `packages/nest-core/tests/test_scenarios.py` | End-to-end scenario tests. |
+| `docs/hackathon/roboagent-guard.md` | This guide. |
+
+## Architecture
+
+The flow is:
+
+1. `ScenarioConfig.from_yaml("scenarios/roboagent_guard.yaml")` loads the YAML.
+2. `ScenarioRunner` reads `task.type: roboagent_guard`.
+3. `get_scenario_factory("roboagent_guard")` loads the built-in factory from
+   `nest_core.scenarios_builtin.roboagent_guard`.
+4. The factory creates four deterministic state-machine agents:
+   - `planner-0`
+   - `vision-0`
+   - `robot-0`
+   - `mapper-0`
+5. The supervisor sends prior approval for the planner's action.
+6. The planner sends a robot-motion command to the robot.
+7. The vision agent passes raw sensor data through `ctx.plugins["privacy"]`.
+8. With `privacy: sensor_redaction`, the trace contains redacted sensor data.
+   With `privacy: noop`, the trace leaks raw sensor data.
+9. `validate_trace(..., "roboagent_guard")` runs both RoboAgent Guard validators
+   against that trace.
+
+## Scenario Agents
+
+The scenario is intentionally small so it is easy to audit.
+
+| Agent | Role |
+| --- | --- |
+| `supervisor-0` | Sends prior approval for robot action `nav-1`. |
+| `planner-0` | Sends a robot autonomy command such as `cmd_vel` and `navigation_goal`. |
+| `vision-0` | Sends privacy-sensitive sensor data through the configured privacy plugin. |
+| `robot-0` | Receives robot commands and acknowledges them. |
+| `mapper-0` | Receives sensor/mapping data and acknowledges it. |
+
+The safe scenario sends messages that include explicit markers:
+
+```text
+supervisor_approved=nav-1 action_id=nav-1
+cmd_vel:0.10 navigation_goal:kitchen action_id=nav-1 risk_checked=nav-1 safe_action
+redacted_raw_camera redacted_camera_frame redacted_private_zone redacted_person_detected action_id=vision-1 privacy_filtered=vision-1 no_raw_storage redacted
+```
+
+The adversarial reference path is enabled by changing the YAML to
+`privacy: noop`. The raw payload leaks unchanged:
+
+```text
+raw_camera person_detected private_zone action_id=vision-1
+```
+
+The unsafe scenario is enabled by setting `task.config.unsafe: true`. It omits
+the supervisor approval and still emits risky robot commands, so the safety
+validator fails.
+
+## Privacy Plugin
+
+`SensorRedactionPrivacy` implements the existing Privacy protocol:
+
+- `encrypt(data, audience)` returns a deterministic redacted payload.
+- `decrypt(data)` returns the already-filtered payload.
+- `prove(...)` and `verify_proof(...)` provide a simple deterministic proof
+  marker so the plugin remains protocol-compatible.
+
+Sensitive tokens are replaced with `redacted_<token>`:
+
+```text
+raw_camera -> redacted_raw_camera
+person_detected -> redacted_person_detected
+private_zone -> redacted_private_zone
+```
+
+When redaction occurs, the plugin appends:
+
+```text
+privacy_filtered=<action_id> no_raw_storage redacted
+```
+
+This makes the privacy behavior visible in the trace and gives the adversarial
+validator something concrete to verify.
+
+## Validator Rules
+
+RoboAgent Guard has two validators.
+
+### `validate_roboagent_guard_safety_markers`
+
+This validator checks robot autonomy and robot-risk messages.
+
+Risk terms include:
+
+```text
+cmd_vel
+velocity
+navigation_goal
+slam
+map_save
+raw_camera
+camera_frame
+lidar_scan
+person_detected
+private_zone
+```
+
+Safety markers include:
+
+```text
+safety_approved
+supervisor_approved
+risk_checked
+privacy_filtered
+human_approved
+safe_action
+```
+
+The validator fails when:
+
+- A `send` or `broadcast` event contains a risk term but no safety marker.
+- A message has `action_id=<id>` but the marker refers to a different ID.
+- A robot command has no prior approval from a different agent.
+- The trace has no robot-risk messages at all.
+
+The "no robot-risk messages" failure is intentional. It prevents a no-op trace
+from passing without exercising the guard.
+
+### `validate_roboagent_guard_privacy_markers`
+
+This validator checks privacy-sensitive robot sensor data.
+
+Privacy terms include:
+
+```text
+private_zone
+person_detected
+raw_camera
+camera_frame
+map_save
+```
+
+Privacy markers include:
+
+```text
+privacy_filtered
+redacted
+anonymized
+no_raw_storage
+human_approved
+supervisor_approved
+```
+
+The validator fails when:
+
+- A `send` or `broadcast` event contains a privacy term but no privacy marker.
+- A message has `action_id=<id>` but the marker refers to a different ID.
+- The trace has no privacy-sensitive robot messages at all.
+
+## Marker And `action_id` Matching
+
+Markers can be plain words or key/value fields. Robot commands with an
+`action_id` also require an earlier approval message from a different agent.
+
+This passes because the supervisor approved the action before execution and the
+planner's marker matches the same action:
+
+```text
+supervisor-0 -> planner-0: supervisor_approved=nav-1 action_id=nav-1
+cmd_vel action_id=nav-1 risk_checked=nav-1
+```
+
+This fails because the marker points to a different action:
+
+```text
+cmd_vel action_id=nav-1 risk_checked=nav-2
+```
+
+This also fails because marker matching is token-based, not substring-based:
+
+```text
+cmd_vel:0.9 unsafe_action
+cmd_vel:0.9 not_supervisor_approved
+cmd_vel:0.9 risk_checked_skipped
+```
+
+This gives the validator a little more structure than keyword matching while
+staying simple enough for deterministic trace validation.
+
+## How To Run
+
+From the repository root:
+
+```bash
+uv run nest run scenarios/roboagent_guard.yaml
+```
+
+Expected output:
+
+```text
+Running scenario: roboagent_guard
+  agents: 5  seed: 42  ticks: 1000
+Trace written to: traces/roboagent_guard.jsonl
+```
+
+Then validate the trace:
+
+```bash
+uv run python - <<'PY'
+from pathlib import Path
+from nest_core.validators import validate_trace
+
+for result in validate_trace(Path("traces/roboagent_guard.jsonl"), "roboagent_guard"):
+    print(result)
+PY
+```
+
+Expected validator result with `privacy: sensor_redaction`:
+
+```text
+ValidationResult(PASS: 'roboagent_guard_safety_markers', 'checked 2 robot-agent messages')
+ValidationResult(PASS: 'roboagent_guard_privacy_markers', 'checked 1 privacy-sensitive robot messages')
+```
+
+## How To Run The Reference Failure Path
+
+To prove the adversarial validator catches the reference plugin, edit
+`scenarios/roboagent_guard.yaml`:
+
+```yaml
+layers:
+  privacy: noop
+```
+
+Run the scenario and validation again. Expected result: both validators fail
+because the trace leaks raw sensor payloads from the `noop` privacy plugin.
+
+## How To Run The Unsafe Path
+
+To see the supervisor-ordering check fail, edit `scenarios/roboagent_guard.yaml`:
+
+```yaml
+task:
+  type: roboagent_guard
+  config:
+    unsafe: true
+```
+
+Run the scenario and validation again:
+
+```bash
+uv run nest run scenarios/roboagent_guard.yaml
+uv run python - <<'PY'
+from pathlib import Path
+from nest_core.validators import validate_trace
+
+for result in validate_trace(Path("traces/roboagent_guard.jsonl"), "roboagent_guard"):
+    print(result)
+PY
+```
+
+Expected result: both validators fail because the trace contains risky robot
+messages without the required approval and privacy markers.
+
+Remember to change `unsafe` back to `false` before committing normal scenario
+changes.
+
+## How To Run Tests
+
+Run the focused validator and scenario tests:
+
+```bash
+uv run pytest packages/nest-core/tests/test_validators.py packages/nest-core/tests/test_scenarios.py -q
+```
+
+Run the full project test suite:
+
+```bash
+uv run pytest -q
+```
+
+Run the quality checks used for this PR:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+```
+
+## Test Coverage
+
+The unit tests cover:
+
+- Safe robot and privacy messages pass.
+- Missing safety markers fail.
+- Missing privacy markers fail.
+- A marker with the wrong `action_id` fails.
+- Substring spoofing markers fail.
+- Robot commands without prior approval fail.
+- A no-op trace without robot-risk messages fails.
+- Broadcast robot messages are checked.
+- `privacy: noop` fails the scenario validators.
+- `privacy: sensor_redaction` passes the scenario validators.
+
+The end-to-end scenario tests cover:
+
+- The YAML scenario runs and passes validators in safe mode.
+- The same scenario fails privacy validators under `privacy: noop`.
+- The same scenario fails safety validators when constructed with
+  `task.config.unsafe: true`.
+
+## Trace Shape
+
+The simulator writes JSONL events. RoboAgent Guard reads the `kind`, `agent`,
+`to`, and `msg` fields.
+
+Example event:
+
+```json
+{
+  "ts": 0.0,
+  "agent": "planner-0",
+  "kind": "send",
+  "to": "robot-0",
+  "size": 102,
+  "msg": "cmd_vel:0.10 navigation_goal:kitchen action_id=nav-1 risk_checked=nav-1 supervisor_approved=nav-1 safe_action",
+  "corr": "corr-1"
+}
+```
+
+Only `send` and `broadcast` events are checked. Other event kinds are ignored.
+
+## Design Choices
+
+The validators are intentionally trace-level checks. That means they can be run
+after any simulation and do not require changing the transport, comms, identity,
+or privacy plugins.
+
+The scenario is intentionally deterministic. It uses fixed messages and the
+existing simulator trace writer, so the behavior is stable across runs.
+
+The marker contract is intentionally explicit. The trace must show evidence of
+safety or privacy handling in the message itself. This is useful for audit-style
+agent evaluation because judges and tools can inspect the trace directly.
+
+## Limitations
+
+RoboAgent Guard does not prove that a real robot action is safe. It checks that
+risky robot trace messages include explicit review/filtering markers.
+
+Known limitations:
+
+- It does not verify cryptographic signatures on approvals.
+- It does not verify that a human or supervisor actually exists.
+- It does not model physical robot constraints.
+- It uses trace text conventions rather than a typed robot message schema.
+
+These are acceptable for this problem-09 scope because the contribution is a
+deterministic NANDA Town privacy plugin, scenario, and validator, not a
+production robotics runtime.
+
+## Future Improvements
+
+Possible next steps:
+
+- Add a typed robot action schema instead of plain trace text.
+- Add signed approval receipts using the identity layer.
+- Add role checks so only supervisor agents can approve commands.
+- Add timing checks so approval must happen before execution.
+- Add a richer privacy policy for raw camera, lidar, and map data.
+- Add a multi-agent robotics scenario with planner, operator, robot, mapper, and
+  auditor roles.
+
+## Quick Reference
+
+Run scenario:
+
+```bash
+uv run nest run scenarios/roboagent_guard.yaml
+```
+
+Validate trace:
+
+```bash
+uv run python - <<'PY'
+from pathlib import Path
+from nest_core.validators import validate_trace
+
+for result in validate_trace(Path("traces/roboagent_guard.jsonl"), "roboagent_guard"):
+    print(result)
+PY
+```
+
+Run tests:
+
+```bash
+uv run pytest packages/nest-core/tests/test_validators.py packages/nest-core/tests/test_scenarios.py -q
+```
+
+Run full checks:
+
+```bash
+uv run pytest -q
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+```

--- a/docs/layers/privacy.md
+++ b/docs/layers/privacy.md
@@ -55,6 +55,20 @@ Source: [`nest_plugins_reference/privacy/trust_gated.py`](../../packages/nest-pl
 Full write-up: [`trust_gated_privacy.md`](trust_gated_privacy.md).
 See `scenarios/trust_gated_exchange.yaml` for a wired example.
 
+## Sensor-redaction plugin
+
+`sensor_redaction` — **deterministic robot-sensor filtering.** A narrower
+problem-09 plugin for traces that carry camera, lidar, mapping, person-detection,
+or private-zone payloads. It redacts sensitive sensor tokens before they are
+shared and stamps the payload with `privacy_filtered=<action_id>`,
+`no_raw_storage`, and `redacted` markers so trace validators can verify that raw
+sensor data did not leak. The paired `roboagent_guard` scenario demonstrates the
+adversarial path: `privacy: noop` leaks and fails, while
+`privacy: sensor_redaction` passes.
+
+Source: [`nest_plugins_reference/privacy/sensor_redaction.py`](../../packages/nest-plugins-reference/nest_plugins_reference/privacy/sensor_redaction.py).
+See `scenarios/roboagent_guard.yaml` for a wired example.
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -52,6 +52,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
     ("privacy", "hybrid_x25519"): f"{_REF}.privacy.hybrid_x25519:HybridX25519Privacy",
+    ("privacy", "sensor_redaction"): f"{_REF}.privacy.sensor_redaction:SensorRedactionPrivacy",
     ("privacy", "trust_gated"): f"{_REF}.privacy.trust_gated:TrustGatedPrivacy",
     ("datafacts", "datafacts_v1"): f"{_REF}.datafacts.datafacts_v1:DataFactsV1",
     ("datafacts", "cid_facts"): f"{_REF}.datafacts.cid_facts:CidFacts",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -197,3 +197,7 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("capability_spoofing", capability_spoofing_factory)
+    elif name == "roboagent_guard":
+        from nest_core.scenarios_builtin.roboagent_guard import roboagent_guard_factory
+
+        register_scenario("roboagent_guard", roboagent_guard_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/roboagent_guard.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/roboagent_guard.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Problem 09 robot-sensor privacy guard scenario.
+
+The scenario emits robot autonomy and sensor-sharing messages into the trace.
+It targets hackathon problem 09 by showing that ``privacy: noop`` leaks raw
+sensor payloads while ``privacy: sensor_redaction`` filters them before sharing.
+The same validators also require robot commands to have prior approval from a
+separate supervisor agent.
+
+Set ``task.config.unsafe: true`` to omit the supervisor approval. The safety
+validator then fails, proving the scenario exercises the guard instead of only
+checking that a trace exists.
+
+Trace line protocol:
+
+* ``supervisor_approved=<id> action_id=<id>`` -- prior approval from a separate
+  supervisor agent.
+* ``cmd_vel ... navigation_goal ... action_id=<id> risk_checked=<id>
+  safe_action`` -- a guarded robot-motion command after prior approval.
+* ``camera_frame ... private_zone ... action_id=<id> privacy_filtered=<id>
+  no_raw_storage redacted`` -- filtered privacy-sensitive sensor data.
+
+Example::
+
+    agents = roboagent_guard_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId
+
+
+class _ScriptedSender(StateMachineAgent):
+    """Sends a fixed set of trace messages when the simulation starts.
+
+    Example::
+
+        agent = _ScriptedSender([(AgentId("robot-0"), b"cmd_vel ...")])
+    """
+
+    def __init__(self, messages: list[tuple[AgentId, bytes]]) -> None:
+        self._messages = messages
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Emit every configured message.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        for target, payload in self._messages:
+            await ctx.send(target, payload)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Scripted senders do not react to messages.
+
+        Example::
+
+            await agent.on_message(ctx, sender, b"ack")
+        """
+        return
+
+
+class _SupervisorAgent(StateMachineAgent):
+    """Emits prior approval for a robot action.
+
+    Example::
+
+        agent = _SupervisorAgent(AgentId("planner-0"), "nav-1")
+    """
+
+    def __init__(self, target: AgentId, action_id: str) -> None:
+        self._target = target
+        self._action_id = action_id
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Approve the action before the planner sends the command."""
+        await ctx.send(
+            self._target,
+            f"supervisor_approved={self._action_id} action_id={self._action_id}".encode(),
+        )
+
+
+class _VisionSender(StateMachineAgent):
+    """Filters raw sensor data through the configured privacy plugin before send.
+
+    Example::
+
+        agent = _VisionSender(AgentId("mapper-0"), b"raw_camera action_id=v1")
+    """
+
+    def __init__(self, target: AgentId, raw_payload: bytes) -> None:
+        self._target = target
+        self._raw_payload = raw_payload
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Apply ``ctx.plugins["privacy"]`` before sharing sensor data."""
+        privacy_impl = ctx.plugins.get("privacy")
+        privacy = privacy_impl() if isinstance(privacy_impl, type) else privacy_impl
+        payload = self._raw_payload
+        if privacy is not None:
+            payload = await privacy.encrypt(payload, [self._target])
+        await ctx.send(self._target, payload)
+
+
+class _AckSink(StateMachineAgent):
+    """Receives guarded messages and sends a small acknowledgement.
+
+    Example::
+
+        agent = _AckSink()
+    """
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Acknowledge delivery without adding robot-risk terms to the trace."""
+        await ctx.send(sender, b"ack:received")
+
+
+def _safe_messages() -> list[tuple[AgentId, bytes]]:
+    """Messages that satisfy the RoboAgent Guard validators.
+
+    Example::
+
+        messages = _safe_messages()
+    """
+    return [
+        (
+            AgentId("robot-0"),
+            (
+                b"cmd_vel:0.10 navigation_goal:kitchen action_id=nav-1 "
+                b"risk_checked=nav-1 safe_action"
+            ),
+        ),
+        (
+            AgentId("mapper-0"),
+            (b"raw_camera camera_frame private_zone person_detected action_id=vision-1"),
+        ),
+    ]
+
+
+def _unsafe_messages() -> list[tuple[AgentId, bytes]]:
+    """Messages that intentionally violate the guard validators.
+
+    Example::
+
+        messages = _unsafe_messages()
+    """
+    return [
+        (AgentId("robot-0"), b"cmd_vel:0.30 navigation_goal:kitchen action_id=nav-1"),
+        (
+            AgentId("mapper-0"),
+            b"raw_camera person_detected private_zone action_id=vision-1",
+        ),
+    ]
+
+
+def roboagent_guard_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create planner, vision, robot, and mapper agents for guard validation.
+
+    Example::
+
+        agents = roboagent_guard_factory(config, plugins)
+    """
+    unsafe = bool(config.task.config.get("unsafe", False))
+    messages = _unsafe_messages() if unsafe else _safe_messages()
+    agents: dict[AgentId, StateMachineAgent] = {}
+    if not unsafe:
+        agents[AgentId("supervisor-0")] = _SupervisorAgent(AgentId("planner-0"), "nav-1")
+    agents.update(
+        {
+            AgentId("planner-0"): _ScriptedSender([messages[0]]),
+            AgentId("vision-0"): _VisionSender(messages[1][0], messages[1][1]),
+            AgentId("robot-0"): _AckSink(),
+            AgentId("mapper-0"): _AckSink(),
+        }
+    )
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -5280,11 +5280,242 @@ def validate_sybil_bond_attempts_rejected(
     ]
 
 
+# ---------------------------------------------------------------------------
+# RoboAgent Guard validators
+# ---------------------------------------------------------------------------
+
+_ROBOAGENT_RISK_TERMS = (
+    "cmd_vel",
+    "velocity",
+    "navigation_goal",
+    "slam",
+    "map_save",
+    "raw_camera",
+    "camera_frame",
+    "lidar_scan",
+    "person_detected",
+    "private_zone",
+)
+
+_ROBOAGENT_SAFETY_TERMS = (
+    "safety_approved",
+    "supervisor_approved",
+    "risk_checked",
+    "privacy_filtered",
+    "human_approved",
+    "safe_action",
+)
+
+_ROBOAGENT_COMMAND_TERMS = (
+    "cmd_vel",
+    "velocity",
+    "navigation_goal",
+)
+
+_ROBOAGENT_SUPERVISOR_MARKERS = (
+    "supervisor_approved",
+    "safety_approved",
+    "human_approved",
+)
+
+
+def _roboagent_endpoint(ev: dict[str, Any]) -> str:
+    agent = ev.get("agent", "")
+    target = ev.get("to", "*")
+    return f"{agent}->{target}"
+
+
+def _roboagent_field_value(msg: str, key: str) -> str | None:
+    prefix = f"{key}="
+    for token in msg.replace(":", " ").split():
+        if token.startswith(prefix):
+            return token[len(prefix) :]
+    return None
+
+
+def _roboagent_tokens(msg: str) -> list[str]:
+    return msg.replace(":", " ").split()
+
+
+def _roboagent_marker_matches_action(msg: str, marker: str) -> bool:
+    """Return whether a marker is present and, when action_id exists, matches it."""
+    action_id = _roboagent_field_value(msg, "action_id")
+    marker_value = _roboagent_field_value(msg, marker)
+    if marker_value is not None:
+        return action_id is None or marker_value == action_id
+    return marker in _roboagent_tokens(msg) and action_id is None
+
+
+def _roboagent_approval_action(msg: str) -> str | None:
+    for marker in _ROBOAGENT_SUPERVISOR_MARKERS:
+        value = _roboagent_field_value(msg, marker)
+        if value is not None:
+            return value
+    return None
+
+
+def _roboagent_has_prior_approval(
+    approvals: dict[str, set[str]],
+    action_id: str | None,
+    actor: str,
+) -> bool:
+    if action_id is None:
+        return False
+    return any(agent != actor for agent in approvals.get(action_id, set()))
+
+
+def validate_roboagent_guard_safety_markers(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Robot-agent autonomy messages should include a safety/privacy marker.
+
+    RoboAgent Guard is a lightweight validator for traces where agents exchange
+    robot navigation, SLAM, mapping, sensor, or privacy-sensitive commands. If a
+    send event contains robot-risk terms, the message should also carry an
+    explicit marker showing that risk, privacy, or supervisor approval was
+    considered before action.
+    """
+    violations: list[str] = []
+
+    checked = 0
+    approvals: dict[str, set[str]] = {}
+
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+
+        msg = _message_body(ev).lower()
+        has_robot_risk = any(term in msg for term in _ROBOAGENT_RISK_TERMS)
+        actor = str(ev.get("agent", ""))
+        if not has_robot_risk:
+            approval_action = _roboagent_approval_action(msg)
+            if approval_action is not None:
+                approvals.setdefault(approval_action, set()).add(actor)
+            continue
+
+        checked += 1
+        has_safety_marker = any(
+            _roboagent_marker_matches_action(msg, marker) for marker in _ROBOAGENT_SAFETY_TERMS
+        )
+        action_id = _roboagent_field_value(msg, "action_id")
+        needs_prior_approval = any(term in msg for term in _ROBOAGENT_COMMAND_TERMS)
+        has_prior_approval = _roboagent_has_prior_approval(approvals, action_id, actor)
+
+        if not has_safety_marker:
+            preview = msg[:80]
+            violations.append(f"{_roboagent_endpoint(ev)}: {preview}")
+        elif needs_prior_approval and not has_prior_approval:
+            preview = msg[:80]
+            violations.append(f"{_roboagent_endpoint(ev)}: missing prior approval for {preview}")
+
+        approval_action = _roboagent_approval_action(msg)
+        if approval_action is not None:
+            approvals.setdefault(approval_action, set()).add(actor)
+
+    if violations:
+        detail = "; ".join(violations[:5])
+        if len(violations) > 5:
+            detail += f"; +{len(violations) - 5} more"
+        return [ValidationResult("roboagent_guard_safety_markers", False, detail)]
+
+    if checked == 0:
+        return [
+            ValidationResult(
+                "roboagent_guard_safety_markers",
+                False,
+                "no robot-agent risk messages observed",
+            )
+        ]
+
+    return [
+        ValidationResult(
+            "roboagent_guard_safety_markers",
+            True,
+            f"checked {checked} robot-agent messages",
+        )
+    ]
+
+
+def validate_roboagent_guard_privacy_markers(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Privacy-sensitive robot sensor messages should include privacy filtering.
+
+    This catches traces where an agent sends private-zone, person-detection,
+    camera, or mapping data without explicitly marking that privacy filtering
+    was applied before sharing or saving the data.
+    """
+    privacy_terms = (
+        "private_zone",
+        "person_detected",
+        "raw_camera",
+        "camera_frame",
+        "map_save",
+    )
+    privacy_markers = (
+        "privacy_filtered",
+        "redacted",
+        "anonymized",
+        "no_raw_storage",
+        "human_approved",
+        "supervisor_approved",
+    )
+
+    violations: list[str] = []
+
+    checked = 0
+
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+
+        msg = _message_body(ev).lower()
+        has_privacy_risk = any(term in msg for term in privacy_terms)
+        if not has_privacy_risk:
+            continue
+
+        checked += 1
+        has_privacy_marker = any(
+            _roboagent_marker_matches_action(msg, marker) for marker in privacy_markers
+        )
+
+        if not has_privacy_marker:
+            preview = msg[:80]
+            violations.append(f"{_roboagent_endpoint(ev)}: {preview}")
+
+    if violations:
+        detail = "; ".join(violations[:5])
+        if len(violations) > 5:
+            detail += f"; +{len(violations) - 5} more"
+        return [ValidationResult("roboagent_guard_privacy_markers", False, detail)]
+
+    if checked == 0:
+        return [
+            ValidationResult(
+                "roboagent_guard_privacy_markers",
+                False,
+                "no privacy-sensitive robot messages observed",
+            )
+        ]
+
+    return [
+        ValidationResult(
+            "roboagent_guard_privacy_markers",
+            True,
+            f"checked {checked} privacy-sensitive robot messages",
+        )
+    ]
+
+
 VALIDATORS: dict[str, list[Any]] = {
     "sybil_bond": [
         validate_sybil_bond_no_free_trust,
         validate_sybil_bond_honest_trusted,
         validate_sybil_bond_attempts_rejected,
+    ],
+    "roboagent_guard": [
+        validate_roboagent_guard_safety_markers,
+        validate_roboagent_guard_privacy_markers,
     ],
     "comms_versioning": [
         validate_comms_reject_unknown_major,

--- a/packages/nest-core/tests/test_scenarios.py
+++ b/packages/nest-core/tests/test_scenarios.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 from nest_core.runner import ScenarioRunner
 from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
 
 
 class TestAuctionScenario:
@@ -152,6 +153,69 @@ class TestVotingScenario:
 
         assert traces[0] == traces[1]
         assert len(traces[0]) > 0
+
+
+class TestRoboAgentGuardScenario:
+    @pytest.mark.asyncio
+    async def test_roboagent_guard_yaml_passes_validators(self, tmp_path: Path) -> None:
+        yaml_path = (
+            Path(__file__).parent.parent.parent.parent / "scenarios" / "roboagent_guard.yaml"
+        )
+        config = ScenarioConfig.from_yaml(yaml_path)
+        config.output.trace = str(tmp_path / "roboagent_guard.jsonl")
+
+        runner = ScenarioRunner(config)
+        trace_path = await runner.run()
+
+        results = validate_trace(trace_path, "roboagent_guard")
+        assert all(result.passed for result in results), results
+
+    @pytest.mark.asyncio
+    async def test_roboagent_guard_noop_privacy_fails_validators(self, tmp_path: Path) -> None:
+        yaml_path = (
+            Path(__file__).parent.parent.parent.parent / "scenarios" / "roboagent_guard.yaml"
+        )
+        config = ScenarioConfig.from_yaml(yaml_path)
+        config.layers.privacy = "noop"
+        config.output.trace = str(tmp_path / "roboagent_guard_noop.jsonl")
+
+        runner = ScenarioRunner(config)
+        trace_path = await runner.run()
+
+        results = validate_trace(trace_path, "roboagent_guard")
+        assert [result.passed for result in results] == [False, False]
+
+    @pytest.mark.asyncio
+    async def test_roboagent_guard_unsafe_config_fails_validators(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        trace_file = tmp_path / "roboagent_guard_unsafe.jsonl"
+        config = ScenarioConfig.from_dict(
+            {
+                "name": "test-roboagent-unsafe",
+                "seed": 42,
+                "agents": {
+                    "count": 4,
+                    "roles": [
+                        {"name": "planner", "count": 1},
+                        {"name": "vision", "count": 1},
+                        {"name": "robot", "count": 1},
+                        {"name": "mapper", "count": 1},
+                    ],
+                },
+                "layers": {"privacy": "sensor_redaction"},
+                "task": {"type": "roboagent_guard", "config": {"unsafe": True}},
+                "duration": "ticks: 1000",
+                "output": {"trace": str(trace_file)},
+            }
+        )
+
+        runner = ScenarioRunner(config)
+        trace_path = await runner.run()
+
+        results = validate_trace(trace_path, "roboagent_guard")
+        assert [result.passed for result in results] == [False, True]
 
 
 class TestConsensusScenario:

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2146,9 +2146,164 @@ class TestValidatorRegistry:
             "parc_migration",
             "rogue_trusted_agent",
             "sybil_bond",
+            "roboagent_guard",
         }
         assert set(VALIDATORS.keys()) == expected
 
     def test_each_scenario_has_validators(self) -> None:
         for scenario, validators in VALIDATORS.items():
             assert len(validators) >= 2, f"{scenario} needs at least 2 validators"
+
+
+# ---------------------------------------------------------------------------
+# RoboAgent Guard validators
+# ---------------------------------------------------------------------------
+
+
+class TestRoboAgentGuard:
+    def test_passes_when_robot_and_privacy_messages_have_markers(self) -> None:
+        events = [
+            {
+                "kind": "send",
+                "agent": "supervisor_agent",
+                "to": "planner_agent",
+                "msg": "supervisor_approved=nav-1 action_id=nav-1",
+            },
+            {
+                "kind": "send",
+                "agent": "planner_agent",
+                "to": "robot_agent",
+                "msg": (
+                    "cmd_vel:0.10 navigation_goal:kitchen action_id=nav-1 "
+                    "risk_checked=nav-1 supervisor_approved=nav-1"
+                ),
+            },
+            {
+                "kind": "send",
+                "agent": "vision_agent",
+                "to": "mapping_agent",
+                "msg": (
+                    "camera_frame private_zone person_detected action_id=vision-1 "
+                    "privacy_filtered=vision-1 no_raw_storage"
+                ),
+            },
+        ]
+
+        results = validate_events(events, "roboagent_guard")
+
+        assert results[0].name == "roboagent_guard_safety_markers"
+        assert results[0].passed is True
+        assert results[1].name == "roboagent_guard_privacy_markers"
+        assert results[1].passed is True
+
+    def test_fails_when_robot_message_has_no_safety_marker(self) -> None:
+        events = [
+            {
+                "kind": "send",
+                "agent": "planner_agent",
+                "to": "robot_agent",
+                "msg": "cmd_vel:0.30 navigation_goal:kitchen action_id=nav-1",
+            }
+        ]
+
+        results = validate_events(events, "roboagent_guard")
+
+        assert results[0].name == "roboagent_guard_safety_markers"
+        assert results[0].passed is False
+        assert "planner_agent->robot_agent" in results[0].detail
+
+    def test_fails_when_robot_command_has_only_self_approval(self) -> None:
+        events = [
+            {
+                "kind": "send",
+                "agent": "planner_agent",
+                "to": "robot_agent",
+                "msg": (
+                    "cmd_vel:0.30 navigation_goal:kitchen action_id=nav-1 "
+                    "risk_checked=nav-1 supervisor_approved=nav-1"
+                ),
+            }
+        ]
+
+        results = validate_events(events, "roboagent_guard")
+
+        assert results[0].passed is False
+        assert "missing prior approval" in results[0].detail
+
+    def test_fails_when_marker_does_not_match_action_id(self) -> None:
+        events = [
+            {
+                "kind": "send",
+                "agent": "planner_agent",
+                "to": "robot_agent",
+                "msg": "cmd_vel action_id=nav-1 risk_checked=nav-2",
+            }
+        ]
+
+        results = validate_events(events, "roboagent_guard")
+
+        assert results[0].passed is False
+
+    def test_fails_marker_substring_spoofing(self) -> None:
+        for spoof in (
+            "cmd_vel:0.9 unsafe_action",
+            "cmd_vel:0.9 not_supervisor_approved",
+            "cmd_vel:0.9 risk_checked_skipped",
+        ):
+            results = validate_events(
+                [
+                    {
+                        "kind": "send",
+                        "agent": "planner_agent",
+                        "to": "robot_agent",
+                        "msg": spoof,
+                    }
+                ],
+                "roboagent_guard",
+            )
+            assert results[0].passed is False, spoof
+
+    def test_fails_when_no_robot_messages_exercise_guard(self) -> None:
+        events = [
+            {
+                "kind": "send",
+                "agent": "buyer",
+                "to": "seller",
+                "msg": "buy:book:10",
+            }
+        ]
+
+        results = validate_events(events, "roboagent_guard")
+
+        assert results[0].passed is False
+        assert "no robot-agent risk messages" in results[0].detail
+
+    def test_fails_when_privacy_message_has_no_privacy_marker(self) -> None:
+        events = [
+            {
+                "kind": "send",
+                "agent": "vision_agent",
+                "to": "mapping_agent",
+                "msg": "raw_camera person_detected private_zone",
+            }
+        ]
+
+        results = validate_events(events, "roboagent_guard")
+
+        assert results[1].name == "roboagent_guard_privacy_markers"
+        assert results[1].passed is False
+        assert "vision_agent->mapping_agent" in results[1].detail
+
+    def test_broadcast_robot_messages_are_checked(self) -> None:
+        events = [
+            {
+                "kind": "broadcast",
+                "agent": "planner_agent",
+                "msg": "cmd_vel action_id=nav-1",
+            }
+        ]
+
+        results = validate_events(events, "roboagent_guard")
+
+        assert results[0].passed is False
+        assert "planner_agent->*" in results[0].detail

--- a/packages/nest-plugins-reference/nest_plugins_reference/privacy/sensor_redaction.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/privacy/sensor_redaction.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Sensor-redaction privacy plugin for robot-agent traces.
+
+``SensorRedactionPrivacy`` targets problem 09's reference-plugin failure mode:
+``noop`` privacy returns sensitive payloads unchanged. This plugin is narrower
+than ``hybrid_x25519``: it does not claim general encryption. It deterministically
+filters robot sensor text before the message reaches the trace, replacing raw
+camera/person/private-zone tokens with auditable redaction markers.
+
+Example::
+
+    priv = SensorRedactionPrivacy()
+    safe = await priv.encrypt(b"raw_camera person_detected action_id=vision-1", [])
+    assert b"privacy_filtered=vision-1" in safe
+"""
+
+from __future__ import annotations
+
+from nest_core.types import AgentId, Proof, Statement, Witness
+
+_SENSITIVE_TOKENS = {
+    "raw_camera",
+    "camera_frame",
+    "person_detected",
+    "private_zone",
+    "lidar_scan",
+    "map_save",
+}
+
+
+def _field_value(msg: str, key: str) -> str | None:
+    """Return a whitespace/colon-delimited ``key=value`` field from *msg*.
+
+    Example::
+
+        assert _field_value("action_id=vision-1 raw_camera", "action_id") == "vision-1"
+    """
+    prefix = f"{key}="
+    for token in msg.replace(":", " ").split():
+        if token.startswith(prefix):
+            return token[len(prefix) :]
+    return None
+
+
+class SensorRedactionPrivacy:
+    """Deterministic privacy filter for sensitive robot sensor payloads.
+
+    The plugin preserves non-sensitive fields and replaces sensitive tokens with
+    ``redacted_<token>`` fields. When any redaction occurs it appends
+    ``privacy_filtered=<action_id> no_raw_storage redacted`` so trace validators
+    can distinguish protected payloads from raw leaks.
+
+    Example::
+
+        priv = SensorRedactionPrivacy()
+        out = await priv.encrypt(b"raw_camera action_id=v1", [])
+    """
+
+    async def encrypt(self, data: bytes, audience: list[AgentId]) -> bytes:
+        """Return a redacted sensor payload.
+
+        ``audience`` is accepted for Privacy protocol compatibility; this plugin
+        is a deterministic filter, not audience-specific encryption.
+
+        Example::
+
+            out = await priv.encrypt(b"person_detected action_id=v1", [])
+        """
+        text = data.decode("utf-8", errors="replace")
+        action_id = _field_value(text, "action_id") or "unscoped"
+        changed = False
+        redacted: list[str] = []
+        for token in text.split():
+            key = token.split(":", 1)[0].split("=", 1)[0]
+            if key in _SENSITIVE_TOKENS:
+                redacted.append(f"redacted_{key}")
+                changed = True
+            else:
+                redacted.append(token)
+
+        if changed:
+            redacted.extend(
+                [
+                    f"privacy_filtered={action_id}",
+                    "no_raw_storage",
+                    "redacted",
+                ]
+            )
+        return " ".join(redacted).encode("utf-8")
+
+    async def decrypt(self, data: bytes) -> bytes:
+        """Return the already-filtered payload.
+
+        Example::
+
+            assert await priv.decrypt(b"redacted") == b"redacted"
+        """
+        return data
+
+    async def prove(self, statement: Statement, witness: Witness) -> Proof:
+        """Produce a deterministic redaction proof marker.
+
+        Example::
+
+            proof = await priv.prove(stmt, witness)
+        """
+        return Proof(statement=statement, data=b"sensor-redaction-proof", scheme="sensor_redaction")
+
+    async def verify_proof(self, statement: Statement, proof: Proof) -> bool:
+        """Verify this plugin's redaction proof marker.
+
+        Example::
+
+            ok = await priv.verify_proof(stmt, proof)
+        """
+        return proof.scheme == "sensor_redaction" and proof.statement == statement

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -47,6 +47,7 @@ byzantine_gossip = "nest_plugins_reference.registry.byzantine_gossip:ByzantineGo
 
 [project.entry-points."nest.plugins.privacy"]
 hybrid_x25519 = "nest_plugins_reference.privacy.hybrid_x25519:HybridX25519Privacy"
+sensor_redaction = "nest_plugins_reference.privacy.sensor_redaction:SensorRedactionPrivacy"
 trust_gated = "nest_plugins_reference.privacy.trust_gated:TrustGatedPrivacy"
 
 [project.entry-points."nest.plugins.datafacts"]

--- a/packages/nest-plugins-reference/tests/test_sensor_redaction.py
+++ b/packages/nest-plugins-reference/tests/test_sensor_redaction.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the sensor-redaction privacy plugin."""
+
+from __future__ import annotations
+
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, Statement, Witness
+from nest_plugins_reference.privacy.noop import NoopPrivacy
+from nest_plugins_reference.privacy.sensor_redaction import SensorRedactionPrivacy
+
+
+class TestSensorRedactionPrivacy:
+    async def test_redacts_sensitive_sensor_tokens(self) -> None:
+        priv = SensorRedactionPrivacy()
+        payload = b"raw_camera person_detected private_zone action_id=vision-1"
+
+        out = await priv.encrypt(payload, [AgentId("mapper-0")])
+        tokens = set(out.decode().split())
+
+        assert "raw_camera" not in tokens
+        assert "person_detected" not in tokens
+        assert "private_zone" not in tokens
+        assert b"privacy_filtered=vision-1" in out
+        assert b"no_raw_storage" in out
+        assert b"redacted" in out
+
+    async def test_noop_leaks_same_payload(self) -> None:
+        priv = NoopPrivacy()
+        payload = b"raw_camera person_detected private_zone action_id=vision-1"
+
+        out = await priv.encrypt(payload, [AgentId("mapper-0")])
+
+        assert out == payload
+
+    async def test_non_sensitive_payload_passes_through(self) -> None:
+        priv = SensorRedactionPrivacy()
+        payload = b"status ok action_id=vision-1"
+
+        out = await priv.encrypt(payload, [AgentId("mapper-0")])
+
+        assert out == payload
+
+    async def test_proof_round_trip(self) -> None:
+        priv = SensorRedactionPrivacy()
+        statement = Statement(predicate="redacted", public_inputs={"action_id": "vision-1"})
+        witness = Witness(private_inputs={"raw": "camera"})
+
+        proof = await priv.prove(statement, witness)
+
+        assert await priv.verify_proof(statement, proof)
+
+    def test_registry_resolves_sensor_redaction(self) -> None:
+        cls = PluginRegistry().resolve("privacy", "sensor_redaction")
+
+        assert cls is SensorRedactionPrivacy

--- a/scenarios/roboagent_guard.yaml
+++ b/scenarios/roboagent_guard.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Problem 09 privacy scenario: a planner sends a robot-motion command and a
+# vision agent shares privacy-sensitive sensor data. The validators require
+# prior supervisor approval and privacy-layer redaction of raw sensor payloads.
+#
+# Change layers.privacy to noop to watch the privacy validator fail: raw_camera,
+# person_detected, and private_zone leak into the trace unchanged.
+name: roboagent_guard
+description: "Problem 09 privacy: robot sensor redaction plus supervisor-approved autonomy."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 5
+  brain: state-machine
+  roles:
+    - name: supervisor
+      count: 1
+    - name: planner
+      count: 1
+    - name: vision
+      count: 1
+    - name: robot
+      count: 1
+    - name: mapper
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: sensor_redaction
+  datafacts: datafacts_v1
+
+task:
+  type: roboagent_guard
+  config:
+    unsafe: false
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 1000"
+
+metrics:
+  - message_count
+  - delivery_rate
+  - agent_count
+
+output:
+  trace: ./traces/roboagent_guard.jsonl


### PR DESCRIPTION
## Summary [Updated]

RoboAgent Guard targets **NandaHack Phase 1 Problem 09: privacy**.

It adds a deterministic `privacy: sensor_redaction` plugin for robot-agent sensor traces, plus a `roboagent_guard` scenario and adversarial validators. The scenario demonstrates that the reference `privacy: noop` plugin leaks raw sensor payloads and fails validation, while `privacy: sensor_redaction` redacts sensitive sensor terms and passes.

## Motivation

Robot-agent traces may contain privacy-sensitive observations such as `raw_camera`, `camera_frame`, `lidar_scan`, `person_detected`, `private_zone`, and `map_save`.

A privacy layer should prevent those raw sensor terms from being shared directly in the trace. This PR adds a narrow, deterministic sensor-redaction privacy plugin that is different from the already merged hybrid encryption work: it focuses on auditable robot-sensor redaction policy, not general-purpose encryption.

## Changes

  - Adds `SensorRedactionPrivacy` as `privacy: sensor_redaction`.
  - Registers the plugin in the built-in plugin registry and entry points.
  - Adds the `roboagent_guard` scenario factory.
  - Adds runnable scenario YAML at `scenarios/roboagent_guard.yaml`.
  - Adds adversarial validators for:
    - robot command safety markers
    - prior supervisor approval before robot commands
    - privacy filtering on sensitive sensor messages
  - Updates validator matching to use exact tokens instead of substring matching.
  - Adds adversarial tests for:
    - `unsafe_action`
    - `not_supervisor_approved`
    - `risk_checked_skipped`
    - self-attested supervisor approval
    - `privacy: noop` leaking raw sensor payloads
  - Adds documentation at `docs/hackathon/roboagent-guard.md`.
  - Updates privacy-layer docs with `sensor_redaction`.

## Adversarial Path

The reference plugin fails:

  ```yaml
  privacy: noop

With noop, raw sensor terms such as raw_camera, person_detected, and private_zone remain in the trace without privacy markers, so the RoboAgent Guard privacy validator fails.

The new plugin passes:

  privacy: sensor_redaction

With sensor_redaction, sensitive sensor tokens are replaced with redaction markers and stamped with privacy_filtered=<action_id>, no_raw_storage, and redacted.

## Verification

Branch is cleanly based on latest upstream/main with one RoboAgent Guard commit.

  make ci-local

Result:

1298 passed, 1 skipped, 1 deselected, 1 warning
ci-local: all 5 checks passed

Focused checks also pass:

uv run pytest packages/nest-core/tests/test_validators.py::TestRoboAgentGuard packages/nest-core/tests/test_scenarios.py::TestRoboAgentGuardScenario packages/nest-plugins-reference/tests/test_sensor_redaction.py -q

Result:

  16 passed

## Scope

This PR is limited to Problem 09 privacy: deterministic robot-sensor redaction, the paired scenario, adversarial validators, docs, and tests.

