### PR TITLE
trust: parc — selective disclosure via Merkle inclusion proofs (stacked on #63)

### DIFF
--- a/docs/layers/trust.md
+++ b/docs/layers/trust.md
@@ -62,6 +62,19 @@ trusting*:
   N-party ring, so the gate also re-runs whole-graph collusion
   severance over the originating domain's **published ledger**.
 
+**Selective disclosure.** A holder need not show a verifier the whole
+ledger: `build_presentation` packages chosen receipts, each with a
+Merkle inclusion proof against the credential's signed
+`behavioral_merkle_root`, and `verify_presentation` confirms every
+disclosed receipt is committed under that root — and that each proof's
+`leaf_count` equals the signed `receipt_count`, the bound on the
+undisclosed remainder — without needing the rest of the ledger. Scores
+are **not** recomputed from a disclosed subset: the reputation
+aggregate is a whole-graph property (collusion severance needs every
+edge), so the signed score stands — re-deriving it from a hand-picked
+subset is exactly the cherry-picking this split forbids. Full-ledger
+recomputation remains `admit`'s job.
+
 Source: [`nest_plugins_reference/trust/parc.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/parc.py).
 Scenario: `parc_migration` (two trust domains in one run; forged,
 replayed, stale-key, inflated, and wash-ring credentials each denied
@@ -74,5 +87,4 @@ entry point group `nest.plugins.trust`.
 
 Good fits to test here: EigenTrust-style transitive reputation,
 proof-of-stake reputation, decaying scores, attestation graphs,
-selective disclosure of credential receipts (Merkle inclusion proofs),
 credential revocation registries.

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/parc.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/parc.py
@@ -10,7 +10,7 @@ Reputation in NEST dies with the run: every trust plugin holds an in-memory
 ledger and nothing exports it, carries it, or verifies it in another trust
 domain. This plugin makes reputation **portable**. It extends the
 ``agent_receipts`` reference plugin (cross-signed receipts, corroboration
-gates, collusion-ring severance) with two new capabilities:
+gates, collusion-ring severance) with three new capabilities:
 
 1. **Export** — :meth:`ParcTrust.build_credential` wraps an agent's receipt
    ledger as a W3C-Verifiable-Credential-shaped document: a
@@ -25,6 +25,17 @@ gates, collusion-ring severance) with two new capabilities:
    receipts and rejects any divergence. *A valid signature is not admission* —
    an issuer-inflated-then-re-signed score passes proof verification and is
    still rejected on recompute divergence.
+3. **Selective disclosure** — :meth:`ParcTrust.build_presentation` reveals a
+   chosen subset of receipts, each with a **Merkle inclusion proof** against
+   the credential's signed ``behavioral_merkle_root``, and
+   :meth:`ParcTrust.verify_presentation` confirms every disclosed receipt is
+   committed under that root — plus the signed ``receipt_count`` bound on the
+   undisclosed remainder — without seeing the rest of the ledger. Disclosure
+   proves *which receipts happened*; it never recomputes scores. The
+   reputation aggregate is a whole-graph property (collusion severance needs
+   every edge), so the signed score stands — recomputing it from a
+   hand-picked subset is exactly the cherry-picking attack this split
+   forbids. Full-ledger recomputation remains :meth:`ParcTrust.admit`'s job.
 
 An inline credential carries only the subject's own receipts — a star graph —
 so it cannot reveal an N-party collusion ring (each ring member's credential
@@ -67,6 +78,7 @@ Example::
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -174,6 +186,89 @@ def merkle_root(receipts: list[dict[str, Any]]) -> str:
             for i in range(0, len(level), 2)
         ]
     return level[0]
+
+
+def inclusion_proof(
+    receipts: list[dict[str, Any]],
+    *,
+    receipt: dict[str, Any],
+) -> dict[str, Any]:
+    """Merkle inclusion proof that ``receipt`` is committed by ``merkle_root(receipts)``.
+
+    Built over the exact tree :func:`merkle_root` computes — hex leaf digests
+    sorted lexicographically, parents hashing the *concatenated hex strings*,
+    odd levels duplicating the last node — so it verifies against the
+    ``behavioral_merkle_root`` a credential signs. Shape::
+
+        {"leaf_index": int, "leaf_count": int,
+         "path": [{"sibling": <hex>, "position": "left" | "right"}, ...]}
+
+    ``leaf_count`` is the total number of committed leaves: a verifier checks
+    it against the credential's signed ``receipt_count``, so a holder cannot
+    misrepresent how much ledger stays undisclosed. Raises ``ValueError`` if
+    ``receipt`` is not in ``receipts`` — a proof for an absent leaf does not
+    exist.
+
+    Example::
+
+        proof = inclusion_proof(receipts, receipt=receipts[0])
+    """
+    leaves = sorted(hashlib.sha256(ar._canonical(r)).hexdigest() for r in receipts)
+    target = hashlib.sha256(ar._canonical(receipt)).hexdigest()
+    try:
+        index = leaves.index(target)
+    except ValueError as exc:
+        raise ValueError("receipt is not present in the ledger") from exc
+
+    path: list[dict[str, str]] = []
+    level = leaves
+    node_index = index
+    while len(level) > 1:
+        if len(level) % 2 == 1:
+            level = [*level, level[-1]]
+        # An even node is the left input of its pair, so its sibling sits on
+        # the right — and vice versa.
+        position = "right" if node_index % 2 == 0 else "left"
+        path.append({"sibling": level[node_index ^ 1], "position": position})
+        level = [
+            hashlib.sha256((level[i] + level[i + 1]).encode()).hexdigest()
+            for i in range(0, len(level), 2)
+        ]
+        node_index //= 2
+    return {"leaf_index": index, "leaf_count": len(leaves), "path": path}
+
+
+def verify_inclusion(receipt: dict[str, Any], proof: dict[str, Any], root: str) -> bool:
+    """True iff ``receipt`` folds up ``proof``'s path to ``root``.
+
+    The dual of :meth:`ParcTrust.admit`'s recomputation: instead of rebuilding
+    the whole tree from every carried receipt, the verifier recomputes ONE
+    leaf and folds it up the authentication path — it never needs the rest of
+    the ledger. ``root`` is the bare hex :func:`merkle_root` returns (what
+    credentials sign as ``behavioral_merkle_root``). A tampered receipt, a
+    tampered sibling, or a foreign root all fold to a different hex and yield
+    ``False``; a structurally malformed proof is also ``False``, never an
+    exception — proofs arrive from the presenting (adversarial) side.
+
+    Example::
+
+        ok = verify_inclusion(receipt, proof, root)
+    """
+    steps = proof.get("path")
+    if not isinstance(steps, list):
+        return False
+    node = hashlib.sha256(ar._canonical(receipt)).hexdigest()
+    for step in cast("list[Any]", steps):
+        if not isinstance(step, dict):
+            return False
+        step_typed = cast("dict[str, Any]", step)
+        sibling = step_typed.get("sibling")
+        position = step_typed.get("position")
+        if not isinstance(sibling, str) or position not in ("left", "right"):
+            return False
+        pair = sibling + node if position == "left" else node + sibling
+        node = hashlib.sha256(pair.encode()).hexdigest()
+    return node == root
 
 
 def _inline_scores(receipts: list[dict[str, Any]]) -> tuple[float, float, float]:
@@ -318,6 +413,64 @@ class AdmissionResult:
     reason: str
     recomputed_score: float | None = None
     detail: str = ""
+
+
+@dataclass(frozen=True)
+class DisclosureResult:
+    """The outcome of verifying one selective-disclosure presentation.
+
+    ``ok`` is True iff the credential's proof verified and every disclosed
+    receipt checked out. ``reasons`` is empty on success, else the ordered,
+    de-duplicated snake_case failures (``malformed_presentation``,
+    ``issuer_mismatch``, ``bad_credential_proof``, ``malformed_proof``,
+    ``count_mismatch``, ``not_included``). Frozen — a verification verdict is
+    evidence, not a scratchpad.
+
+    Example::
+
+        result = DisclosureResult(ok=True)
+    """
+
+    ok: bool
+    reasons: tuple[str, ...] = ()
+    detail: str = ""
+
+
+def _disclosed_entry_reasons(entry: Any, *, root: str, receipt_count: int) -> list[str]:
+    """The typed failures of one disclosed ``{"receipt", "proof"}`` entry.
+
+    The two substantive checks are evaluated independently rather than
+    short-circuited, so a receipt from a foreign ledger still reports
+    ``not_included`` even when its ``leaf_count`` also lies.
+
+    Example::
+
+        reasons = _disclosed_entry_reasons(entry, root=root, receipt_count=2)
+    """
+    if not isinstance(entry, dict):
+        return ["malformed_presentation"]
+    entry_typed = cast("dict[str, Any]", entry)
+    receipt = entry_typed.get("receipt")
+    proof = entry_typed.get("proof")
+    if not isinstance(receipt, dict) or not isinstance(proof, dict):
+        return ["malformed_presentation"]
+    receipt_typed = cast("dict[str, Any]", receipt)
+    proof_typed = cast("dict[str, Any]", proof)
+    leaf_index = proof_typed.get("leaf_index")
+    leaf_count = proof_typed.get("leaf_count")
+    if (
+        not isinstance(leaf_index, int)
+        or not isinstance(leaf_count, int)
+        or not isinstance(proof_typed.get("path"), list)
+        or not 0 <= leaf_index < leaf_count
+    ):
+        return ["malformed_proof"]
+    reasons: list[str] = []
+    if leaf_count != receipt_count:
+        reasons.append("count_mismatch")
+    if not verify_inclusion(receipt_typed, proof_typed, root):
+        reasons.append("not_included")
+    return reasons
 
 
 # ---------------------------------------------------------------------------
@@ -585,6 +738,106 @@ class ParcTrust(ar.AgentReceiptsTrust):
         if not (issued_at <= valid_from < rotated_out):
             return "stale_key"
         return None
+
+    # -- selective disclosure -------------------------------------------------
+
+    def build_presentation(
+        self,
+        credential: dict[str, Any],
+        receipts: list[dict[str, Any]],
+        *,
+        disclose: Iterable[str],
+    ) -> dict[str, Any]:
+        """Package ``credential`` plus inclusion proofs for the chosen receipts.
+
+        ``disclose`` names receipts by ``receipt_id``; ``receipts`` is the
+        holder's full ledger — the one the credential's
+        ``behavioral_merkle_root`` commits to. The prover needs every leaf to
+        build a path; the verifier needs none of them. Disclosed entries are
+        sorted by ``receipt_id``, so identical inputs yield a byte-identical
+        presentation. Raises ``ValueError`` for a ``receipt_id`` not in
+        ``receipts`` (see :func:`inclusion_proof`).
+
+        Example::
+
+            pres = trust.build_presentation(vc, receipts, disclose=["r1", "r7"])
+        """
+        by_id = {str(r.get("receipt_id", "")): r for r in receipts}
+        disclosed: list[dict[str, Any]] = []
+        for receipt_id in sorted(set(disclose)):
+            receipt = by_id.get(receipt_id)
+            if receipt is None:
+                raise ValueError(f"receipt {receipt_id!r} is not present in the ledger")
+            disclosed.append(
+                {"receipt": receipt, "proof": inclusion_proof(receipts, receipt=receipt)}
+            )
+        return {"credential": credential, "disclosed": disclosed}
+
+    async def verify_presentation(
+        self,
+        presentation: dict[str, Any],
+        *,
+        identity: Any,
+        expected_issuer: str | None = None,
+    ) -> DisclosureResult:
+        """Verify a selective-disclosure presentation; no score is recomputed.
+
+        Gates, each with a typed reason: the presentation and its credential
+        parse (``malformed_presentation``) → the issuer matches
+        ``expected_issuer`` when one is required (``issuer_mismatch``) → the
+        credential's Ed25519 proof verifies through the SAME identity-layer
+        path as :meth:`admit`, key-rotation window enforced as-of
+        ``validFrom`` — a forged signature or a rotated-out signing key fails
+        here exactly as it would at admission (``bad_credential_proof``, the
+        underlying ``proof_invalid``/``stale_key`` in ``detail``). Then, per
+        disclosed receipt (failures accumulated across entries): the proof is
+        well-formed (``malformed_proof``), its ``leaf_count`` equals the
+        signed ``receipt_count`` — the signed bound on the undisclosed
+        remainder (``count_mismatch``) — and the receipt folds to the signed
+        ``behavioral_merkle_root`` (``not_included``).
+
+        Deliberately absent: score recomputation. Disclosure proves *which
+        receipts happened* under the signed commitment; the reputation
+        aggregate is a whole-graph property, so the signed score stands and a
+        disclosed subset is never grounds to re-derive or adjust it. That is
+        :meth:`admit`'s job, with the full ledger.
+
+        Example::
+
+            result = await gate.verify_presentation(pres, identity=gate_ident)
+        """
+        credential = presentation.get("credential")
+        disclosed = presentation.get("disclosed")
+        if not isinstance(credential, dict) or not isinstance(disclosed, list):
+            return DisclosureResult(False, ("malformed_presentation",))
+        credential_typed = cast("dict[str, Any]", credential)
+        parsed = _parse_credential(credential_typed)
+        if parsed is None:
+            return DisclosureResult(
+                False, ("malformed_presentation",), detail="credential failed to parse"
+            )
+        issuer, valid_from, subject = parsed
+        if expected_issuer is not None and issuer != expected_issuer:
+            return DisclosureResult(False, ("issuer_mismatch",), detail=issuer)
+        if not isinstance(subject["receipt_count"], int):
+            return DisclosureResult(
+                False, ("malformed_presentation",), detail="receipt_count not an int"
+            )
+
+        proof_reason = await self._verify_proof(credential_typed, issuer, valid_from, identity)
+        if proof_reason is not None:
+            return DisclosureResult(False, ("bad_credential_proof",), detail=proof_reason)
+
+        root = str(subject["behavioral_merkle_root"])
+        receipt_count = int(subject["receipt_count"])
+        reasons: list[str] = []
+        for entry in cast("list[Any]", disclosed):
+            for reason in _disclosed_entry_reasons(entry, root=root, receipt_count=receipt_count):
+                if reason not in reasons:
+                    reasons.append(reason)
+        if reasons:
+            return DisclosureResult(False, tuple(reasons))
+        return DisclosureResult(True)
 
 
 def _parse_credential(

--- a/packages/nest-plugins-reference/tests/test_parc.py
+++ b/packages/nest-plugins-reference/tests/test_parc.py
@@ -18,6 +18,10 @@ Property tests (Hypothesis) assert the structural invariants:
 4. Admission thresholding is exact: admitted iff recomputed score clears
    ``min_reputation_score``.
 5. base58btc round-trips against an independent decoder.
+6. Every leaf of every ledger yields an inclusion proof that verifies
+   against ``merkle_root``; disclosure verification is tamper-sensitive
+   (wrong receipt / sibling / root / leaf count / credential proof) and
+   byte-deterministic.
 """
 
 from __future__ import annotations
@@ -47,7 +51,9 @@ from nest_plugins_reference.trust.parc import (
     attach_proof,
     credential_payload,
     did_key_for_pubkey,
+    inclusion_proof,
     merkle_root,
+    verify_inclusion,
 )
 
 _ISSUER = AgentId("issuer-a")
@@ -544,3 +550,223 @@ class TestProperties:
                 assert score < threshold
 
         asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Selective disclosure — inclusion proofs
+# ---------------------------------------------------------------------------
+
+
+def _ledger(count: int, *, issuer: str = "alice") -> list[dict[str, Any]]:
+    """``count`` deterministic corroborated receipts issued by ``issuer``."""
+    return [_receipt(issuer, f"cp{i}", rid=f"r{i:02d}") for i in range(count)]
+
+
+class TestInclusionProofs:
+    def test_round_trip_all_sizes(self) -> None:
+        # Every leaf of 1-, 2-, 3- (odd duplication), 8- and 50-leaf trees
+        # proves and verifies against the plugin's own merkle_root.
+        for count in (1, 2, 3, 8, 50):
+            receipts = _ledger(count)
+            root = merkle_root(receipts)
+            for r in receipts:
+                proof = inclusion_proof(receipts, receipt=r)
+                assert proof["leaf_count"] == count
+                assert verify_inclusion(r, proof, root)
+
+    @given(st.integers(min_value=1, max_value=10))
+    @settings(deadline=None, max_examples=15)
+    def test_every_leaf_proves_membership(self, count: int) -> None:
+        receipts = _ledger(count)
+        root = merkle_root(receipts)
+        for r in receipts:
+            assert verify_inclusion(r, inclusion_proof(receipts, receipt=r), root)
+
+    def test_single_receipt_path_is_empty(self) -> None:
+        # A one-leaf tree IS its root: the authentication path has no steps.
+        receipts = _ledger(1)
+        proof = inclusion_proof(receipts, receipt=receipts[0])
+        assert proof == {"leaf_index": 0, "leaf_count": 1, "path": []}
+        assert (
+            merkle_root(receipts)
+            == hashlib.sha256(
+                json.dumps(receipts[0], sort_keys=True, separators=(",", ":")).encode()
+            ).hexdigest()
+        )
+
+    def test_absent_receipt_raises(self) -> None:
+        receipts = _ledger(3)
+        stranger = _receipt("alice", "zed", rid="zz")
+        with pytest.raises(ValueError, match="not present"):
+            inclusion_proof(receipts, receipt=stranger)
+
+    def test_tampered_receipt_rejected(self) -> None:
+        receipts = _ledger(4)
+        root = merkle_root(receipts)
+        proof = inclusion_proof(receipts, receipt=receipts[0])
+        tampered = copy.deepcopy(receipts[0])
+        tampered["action"]["category"] = "payment_sent"
+        assert not verify_inclusion(tampered, proof, root)
+
+    def test_tampered_sibling_rejected(self) -> None:
+        receipts = _ledger(4)
+        root = merkle_root(receipts)
+        proof = copy.deepcopy(inclusion_proof(receipts, receipt=receipts[0]))
+        sibling = proof["path"][0]["sibling"]
+        proof["path"][0]["sibling"] = ("0" if sibling[0] != "0" else "f") + sibling[1:]
+        assert not verify_inclusion(receipts[0], proof, root)
+
+    def test_wrong_root_rejected(self) -> None:
+        receipts = _ledger(4)
+        proof = inclusion_proof(receipts, receipt=receipts[0])
+        assert not verify_inclusion(receipts[0], proof, merkle_root(receipts[:3]))
+
+    def test_malformed_proof_rejected(self) -> None:
+        receipts = _ledger(2)
+        root = merkle_root(receipts)
+        assert not verify_inclusion(receipts[0], {}, root)
+        assert not verify_inclusion(receipts[0], {"path": [{"sibling": 7}]}, root)
+        assert not verify_inclusion(
+            receipts[0], {"path": [{"sibling": "ab", "position": "up"}]}, root
+        )
+
+    def test_proof_deterministic(self) -> None:
+        # Two independent builds of the same ledger produce byte-identical
+        # proofs — the disclosure surface inherits the plugin's determinism.
+        one = inclusion_proof(_ledger(7), receipt=_ledger(7)[3])
+        two = inclusion_proof(_ledger(7), receipt=_ledger(7)[3])
+        assert json.dumps(one, sort_keys=True) == json.dumps(two, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# Selective disclosure — presentations
+# ---------------------------------------------------------------------------
+
+
+async def _presentation(
+    count: int = 20, disclose: tuple[str, ...] = ("r03", "r07", "r11")
+) -> tuple[dict[str, Any], ParcTrust, list[dict[str, Any]]]:
+    """A genuine presentation over a ``count``-receipt ledger + its trust."""
+    receipts = _ledger(count)
+    trust = await _trust_with(receipts)
+    issuer_ident, _, _ = _identities()
+    vc = await trust.build_credential(AgentId("alice"), identity=issuer_ident, valid_from=_ISSUE_AT)
+    return trust.build_presentation(vc, receipts, disclose=disclose), trust, receipts
+
+
+async def _verify_pres(trust: ParcTrust, presentation: dict[str, Any], **kwargs: Any) -> Any:
+    """Verify ``presentation`` against the standard gate identity wiring."""
+    _, gate_ident, _ = _identities()
+    return await trust.verify_presentation(presentation, identity=gate_ident, **kwargs)
+
+
+class TestPresentation:
+    @pytest.mark.asyncio
+    async def test_round_trip_ok(self) -> None:
+        pres, trust, _ = await _presentation()
+        assert [e["receipt"]["receipt_id"] for e in pres["disclosed"]] == ["r03", "r07", "r11"]
+        assert all(e["proof"]["leaf_count"] == 20 for e in pres["disclosed"])
+        result = await _verify_pres(trust, pres)
+        assert (result.ok, result.reasons) == (True, ())
+
+    @pytest.mark.asyncio
+    async def test_expected_issuer_enforced(self) -> None:
+        pres, trust, _ = await _presentation()
+        ok = await _verify_pres(trust, pres, expected_issuer=f"did:nest:{_ISSUER}")
+        assert ok.ok is True
+        bad = await _verify_pres(trust, pres, expected_issuer="did:nest:someone")
+        assert (bad.ok, bad.reasons) == (False, ("issuer_mismatch",))
+
+    @pytest.mark.asyncio
+    async def test_tampered_disclosed_receipt_not_included(self) -> None:
+        pres, trust, _ = await _presentation()
+        pres = copy.deepcopy(pres)
+        pres["disclosed"][0]["receipt"]["action"]["category"] = "payment_sent"
+        result = await _verify_pres(trust, pres)
+        assert (result.ok, result.reasons) == (False, ("not_included",))
+
+    @pytest.mark.asyncio
+    async def test_receipt_from_different_ledger_not_included(self) -> None:
+        # Mallory splices a receipt (plus a genuine proof) from her OWN
+        # 20-receipt ledger into alice's presentation: leaf_count matches the
+        # signed receipt_count, but the leaf folds to mallory's root.
+        pres, trust, _ = await _presentation()
+        other = _ledger(20, issuer="mallory")
+        pres = copy.deepcopy(pres)
+        pres["disclosed"][0] = {
+            "receipt": other[0],
+            "proof": inclusion_proof(other, receipt=other[0]),
+        }
+        result = await _verify_pres(trust, pres)
+        assert (result.ok, result.reasons) == (False, ("not_included",))
+
+    @pytest.mark.asyncio
+    async def test_leaf_count_lie_count_mismatch(self) -> None:
+        # The path still folds to the root; only the claimed scope bound lies.
+        pres, trust, _ = await _presentation()
+        pres = copy.deepcopy(pres)
+        pres["disclosed"][1]["proof"]["leaf_count"] = 3
+        result = await _verify_pres(trust, pres)
+        assert (result.ok, result.reasons) == (False, ("count_mismatch",))
+
+    @pytest.mark.asyncio
+    async def test_forged_credential_proof_rejected(self) -> None:
+        pres, trust, _ = await _presentation()
+        pres = copy.deepcopy(pres)
+        value = pres["credential"]["proof"]["proofValue"]
+        pres["credential"]["proof"]["proofValue"] = ("0" if value[0] != "0" else "f") + value[1:]
+        result = await _verify_pres(trust, pres)
+        assert (result.ok, result.reasons) == (False, ("bad_credential_proof",))
+        assert result.detail == "proof_invalid"
+
+    @pytest.mark.asyncio
+    async def test_inflated_resigned_stale_key_fails_like_admit(self) -> None:
+        # An issuer inflates the score and genuinely re-signs — with a
+        # rotated-out key. admit() rejects it as stale_key; the disclosure
+        # path rejects the SAME credential as bad_credential_proof, carrying
+        # the same underlying reason. No score is recomputed on either path.
+        receipts = _ledger(20)
+        trust = await _trust_with(receipts)
+        issuer_ident, _, old_key_id = _identities()
+        vc = await trust.build_credential(
+            AgentId("alice"), identity=issuer_ident, valid_from=_ISSUE_AT
+        )
+        vc.pop("proof")
+        vc["credentialSubject"]["reputation_score"] = "0.990000"
+        vc = attach_proof(vc, identity=issuer_ident, key_id=old_key_id)
+
+        admit_result = await _admit(trust, vc)
+        assert (admit_result.admitted, admit_result.reason) == (False, "stale_key")
+
+        pres = trust.build_presentation(vc, receipts, disclose=("r00",))
+        result = await _verify_pres(trust, pres)
+        assert (result.ok, result.reasons) == (False, ("bad_credential_proof",))
+        assert result.detail == "stale_key"
+
+    @pytest.mark.asyncio
+    async def test_malformed_disclosed_proof(self) -> None:
+        pres, trust, _ = await _presentation()
+        pres = copy.deepcopy(pres)
+        del pres["disclosed"][0]["proof"]["leaf_count"]
+        result = await _verify_pres(trust, pres)
+        assert (result.ok, result.reasons) == (False, ("malformed_proof",))
+
+    @pytest.mark.asyncio
+    async def test_malformed_presentation(self) -> None:
+        trust = ParcTrust()
+        result = await _verify_pres(trust, {})
+        assert (result.ok, result.reasons) == (False, ("malformed_presentation",))
+        result = await _verify_pres(trust, {"credential": {"type": []}, "disclosed": []})
+        assert (result.ok, result.reasons) == (False, ("malformed_presentation",))
+
+    @pytest.mark.asyncio
+    async def test_unknown_disclose_id_raises(self) -> None:
+        pres, trust, receipts = await _presentation()
+        with pytest.raises(ValueError, match="not present"):
+            trust.build_presentation(pres["credential"], receipts, disclose=("nope",))
+
+    @pytest.mark.asyncio
+    async def test_presentation_deterministic(self) -> None:
+        pres1, _, _ = await _presentation()
+        pres2, _, _ = await _presentation()
+        assert json.dumps(pres1, sort_keys=True) == json.dumps(pres2, sort_keys=True)


### PR DESCRIPTION
> **Stacked on #63 — review the top commit only** (`123c8d9`). The base commit here is #63's `trust: parc` unchanged; this PR will be rebased to a single commit once #63 merges.

## What this adds

Selective disclosure for `trust: parc` credentials: a holder reveals only chosen receipts from their ledger, each with a **Merkle inclusion proof** against the credential's signed `behavioral_merkle_root` — a verifier confirms every revealed receipt is genuinely part of the committed history **without seeing the rest of the ledger**.

- `inclusion_proof(receipts, *, receipt)` / `verify_inclusion(receipt, proof, root)` — proofs over the exact tree `merkle_root` already builds (lexicographically sorted leaf digests, odd-node duplication). Stdlib-only, no new dependencies.
- `ParcTrust.build_presentation(credential, receipts, *, disclose)` — `{credential, disclosed: [{receipt, proof}]}`, byte-deterministic.
- `ParcTrust.verify_presentation(presentation, *, identity, expected_issuer=None)` — verifies the credential's Ed25519 proof (same as-of key-window path as `admit()`), each inclusion proof, and that every proof's `leaf_count` equals the signed `receipt_count` (the credential's own bound on undisclosed scope). Typed failure reasons: `malformed_presentation`, `issuer_mismatch`, `bad_credential_proof`, `malformed_proof`, `count_mismatch`, `not_included`.

## What it deliberately does NOT do

Disclosure proves *which receipts happened*. It does **not** recompute reputation scores — score aggregation needs the whole receipt graph (collusion-ring severance requires every edge), so the signed aggregate from issuance stands. The two layers stay separate, matching the recomputing-gate philosophy of #63: membership is provable piecewise; standing is not.

## Scope note / roadmap

The #63 credential embeds the full receipts list in the signed document (the recomputing `admit()` gate consumes it), so presentations are not receipts-private until a receipts-free credential variant exists. `verify_presentation` deliberately never reads the embedded list — it verifies from root + signed count only — so such a variant (a small `build_credential` option, left out here to avoid touching #63's signed format) will verify unchanged. Happy to send that as a follow-up if there's interest.

## Tests

`make ci-local` green: **777 → 797** (+20: tree/proof round-trips incl. a Hypothesis property over random ledgers, tamper/forgery/wrong-ledger/count-lie adversarial cases, byte-determinism). Demo:

```
ledger receipts:        20
disclosed:              ['r03', 'r07', 'r11']
verify (genuine):       ok=True reasons=()
verify (tampered):      ok=False reasons=('not_included',)
```

Doc: `docs/layers/trust.md` §parc gains a "Selective disclosure" subsection.
