### PR TITLE
[Hackathon] capsec-engineer: offline-attenuating capability tokens with epoch-fenced cascading revocation

### DIFF
--- a/docs/layers/auth.md
+++ b/docs/layers/auth.md
@@ -42,6 +42,35 @@ Source: [`nest_plugins_reference/auth/delegatable.py`](../../packages/nest-plugi
 Validators: [`nest_plugins_reference/validators/delegation_validators.py`](../../packages/nest-plugins-reference/nest_plugins_reference/validators/delegation_validators.py).
 Scenario: [`scenarios/delegated_auth.yaml`](../../scenarios/delegated_auth.yaml).
 
+## Capability delegation plugin: `capability_tokens`
+
+`capability_tokens` is an HMAC-chained, macaroon-style capability-token
+plugin for offline attenuation. A root token is signed by the issuer. Each
+holder can delegate a child token without an issuer round-trip by signing the
+child caveats with the parent link signature as the HMAC key. Verification
+replays the entire chain from the root secret, so scope widening, TTL
+extension, signature tampering, and parent-hash substitution fail closed.
+
+The plugin satisfies the base `Auth` protocol and adds explicit audience and
+resource guards:
+
+```python
+auth = CapabilityTokens(secret=b"root", clock=0.0)
+root = await auth.issue(AgentId("coordinator"), ["read", "write"])
+child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=60)
+ctx = await auth.verify_for_audience(child, AgentId("worker"))
+ctx = await auth.authorize(child, AgentId("worker"), "read")
+```
+
+Revocation is by chain hash. Revoking any ancestor causes every descendant
+to fail verification with `RevokedAncestorError` once the verifier has a
+fresh revocation view. Revocation views also carry a monotonic epoch: a
+verifier configured with `stale_after=0` and cut off from the latest epoch
+raises `RevocationViewStaleError` instead of accepting with stale knowledge.
+
+Source: [`nest_plugins_reference/auth/capability_tokens.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/capability_tokens.py).
+Scenario: [`scenarios/capability_tokens_delegated_auth.yaml`](../../scenarios/capability_tokens_delegated_auth.yaml).
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/docs/superpowers/specs/2026-07-10-pr-73-review-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-10-pr-73-review-fixes-design.md
@@ -1,0 +1,53 @@
+# PR #73 Review Fixes Design
+
+## Goal
+
+Make the capability-token submission mergeable and satisfy every actionable maintainer request without changing its security model or the public `Auth.verify(token)` protocol.
+
+## Rebase and Conflict Resolution
+
+Rebase `hackathon/capsec-engineer-offline-attenuation` onto the latest upstream `main`. Resolve shared-registry conflicts additively in `plugins.py`, `scenarios.py`, and `validators.py`: retain all registrations already present on `main` and restore the capability-token plugin, delegated-auth scenario, and delegated-auth validator registrations exactly once. If upstream has merged another `delegated_auth` scenario, preserve it unchanged and register this submission's scenario under the unique `capability_tokens_delegated_auth` name.
+
+The existing untracked `PR_BODY.md` and `report.html` files are user-owned and must remain untouched.
+
+## Trace Evidence Format
+
+Replace the ambiguous `auth:<kind>:key=value:key=value` encoding with:
+
+```text
+auth:<kind>|key=value|key=value
+```
+
+The colon remains only between the `auth` namespace and event kind. A pipe separates fields, so scope values such as `admin:all`, `alpha:read`, and `payments:read` survive parsing unchanged. The emitter and parser change together; no capability-token cryptography or runtime authorization behavior changes.
+
+## Validator Coverage
+
+Strengthen `validate_delegated_auth_scope_escalation_blocked` so a passing result requires trace evidence with all three facts on the same row:
+
+- `requested == "admin:all"`
+- `rejected == "1"`
+- `error == "ScopeEscalationError"`
+
+This makes the separator fix load-bearing: truncating the scope value causes the validator to fail. Existing end-to-end scenario tests exercise the assertion with the capability-token plugin and continue proving that the baseline JWT plugin fails the adversarial validators.
+
+## PR Differentiation
+
+Add a concise PR-body paragraph distinguishing the submission from a plain HMAC-chained macaroon. It will name:
+
+- the fail-closed `stale_after` / `RevocationViewStaleError` epoch fence;
+- the `authorize()` resource guard for confused-deputy prevention; and
+- the scenario's partition group split and `partition_heal_at_tick: 80`, which keep the epoch fence load-bearing.
+
+## Verification and Delivery
+
+Run the maintainer's complete gate on the rebased branch:
+
+```bash
+uv sync
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest -v
+```
+
+After all stages pass, commit the implementation, force-push the rebased branch using `--force-with-lease`, update the PR body, and verify that PR #73 is mergeable and that CI checks are reported. Do not resolve threads or post a re-review request unless explicitly authorized.

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -27,6 +27,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
+    ("auth", "capability_tokens"): f"{_REF}.auth.capability_tokens:CapabilityTokens",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -131,6 +131,15 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.delegated_auth import delegated_auth_factory
 
         register_scenario("delegated_auth", delegated_auth_factory)
+    elif name == "capability_tokens_delegated_auth":
+        from nest_core.scenarios_builtin.capability_tokens_delegated_auth import (
+            capability_tokens_delegated_auth_factory,
+        )
+
+        register_scenario(
+            "capability_tokens_delegated_auth",
+            capability_tokens_delegated_auth_factory,
+        )
     elif name == "multi_attribute_market":
         from nest_core.scenarios_builtin.multi_attribute_market import (
             multi_attribute_market_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/capability_tokens_delegated_auth.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/capability_tokens_delegated_auth.py
@@ -1,0 +1,471 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Capability-token delegated auth under adversarial checks.
+
+The scenario builds a strict delegation tree: one coordinator, three
+intermediaries, and twelve leaves. It emits structured
+``auth:<kind>|k=v|k=v`` broadcasts consumed by the
+``capability_tokens_delegated_auth`` validators:
+
+* scope escalation is rejected at delegation time;
+* revoking an intermediary invalidates its four leaf descendants;
+* audience confusion is rejected;
+* a confused deputy cannot use its own token for an unscoped third-party action;
+* a partitioned verifier with a stale revocation epoch fails closed.
+
+Example::
+
+    agents = capability_tokens_delegated_auth_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from nest_plugins_reference.auth.capability_tokens import (
+    CapabilityTokens,
+    RevocationStore,
+)
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Token
+
+_COORDINATOR = AgentId("coordinator-0")
+_INTERMEDIARIES = [AgentId(f"intermediary-{i}") for i in range(3)]
+_LEAVES = [AgentId(f"leaf-{i}") for i in range(12)]
+_LEAF_GROUPS = {
+    _INTERMEDIARIES[0]: _LEAVES[0:4],
+    _INTERMEDIARIES[1]: _LEAVES[4:8],
+    _INTERMEDIARIES[2]: _LEAVES[8:12],
+}
+_INTERMEDIARY_SCOPES: dict[AgentId, list[str]] = {
+    _INTERMEDIARIES[0]: ["alpha:read", "alpha:write"],
+    _INTERMEDIARIES[1]: ["beta:read"],
+    _INTERMEDIARIES[2]: ["payments:read"],
+}
+_LEAF_SCOPES: dict[AgentId, list[str]] = {
+    **{leaf: ["alpha:read"] for leaf in _LEAVES[0:2]},
+    **{leaf: ["alpha:write"] for leaf in _LEAVES[2:4]},
+    **{leaf: ["beta:read"] for leaf in _LEAVES[4:8]},
+    **{leaf: ["payments:read"] for leaf in _LEAVES[8:12]},
+}
+_ROOT_SCOPES = ["alpha:read", "alpha:write", "beta:read", "payments:read"]
+
+_OP_DELEGATE = b"op:delegate"
+_OP_VERIFY = b"op:verify"
+_OP_REVOKE = b"op:revoke"
+_OP_POST_REVOKE = b"op:post-revoke"
+_OP_PARTITION_CHECK = b"op:partition-check"
+
+
+def _emit(kind: str, fields: Mapping[str, str | int | float]) -> bytes:
+    body = "|".join(f"{k}={v}" for k, v in fields.items())
+    return f"auth:{kind}|{body}".encode()
+
+
+def _error_name(exc: BaseException) -> str:
+    return type(exc).__name__
+
+
+def _set_clock(ctx: AgentContext, clock_state: dict[str, float]) -> None:
+    clock_state["now"] = ctx.time
+
+
+class DelegatedAuthCoordinator(StateMachineAgent):
+    """Issues the root token and runs coordinator-side attack probes.
+
+    Example::
+
+        agent = DelegatedAuthCoordinator(tokens={}, clock_state={"now": 0.0})
+    """
+
+    def __init__(
+        self,
+        tokens: dict[str, Token],
+        clock_state: dict[str, float],
+        partitioned_auth: CapabilityTokens | None,
+    ) -> None:
+        self._tokens = tokens
+        self._clock_state = clock_state
+        self._partitioned_auth = partitioned_auth
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Create the root token and scheduled adversarial checks.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        _set_clock(ctx, self._clock_state)
+        auth = ctx.plugins["auth"]
+        if not hasattr(auth, "delegate"):
+            await self._emit_default_failures(ctx)
+            return
+
+        root = await auth.issue(_COORDINATOR, _ROOT_SCOPES)
+        self._tokens[str(_COORDINATOR)] = root
+        for intermediary in _INTERMEDIARIES:
+            child = await auth.delegate(
+                root,
+                intermediary,
+                _INTERMEDIARY_SCOPES[intermediary],
+                ttl=80.0,
+            )
+            self._tokens[str(intermediary)] = child
+            await ctx.broadcast(
+                _emit(
+                    "delegated",
+                    {
+                        "parent": str(_COORDINATOR),
+                        "child": str(intermediary),
+                        "scope_count": len(_INTERMEDIARY_SCOPES[intermediary]),
+                        "ttl": 80,
+                    },
+                )
+            )
+
+        await self._probe_scope_escalation(ctx)
+        await self._probe_audience_confusion(ctx)
+        await self._probe_confused_deputy(ctx)
+        await ctx.schedule(3.0, _OP_REVOKE)
+        await ctx.schedule(4.0, _OP_PARTITION_CHECK)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Handle scheduled revoke and partition-fence checks.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("coordinator-0"), b"op:revoke")
+        """
+        _set_clock(ctx, self._clock_state)
+        auth = ctx.plugins["auth"]
+        if payload == _OP_REVOKE:
+            token = self._tokens.get(str(_INTERMEDIARIES[1]))
+            if token is None or not hasattr(auth, "revoke"):
+                return
+            await auth.revoke(token)
+            epoch = getattr(auth, "current_epoch", 0)
+            await ctx.broadcast(
+                _emit(
+                    "revoked",
+                    {
+                        "target": str(_INTERMEDIARIES[1]),
+                        "epoch": int(epoch),
+                    },
+                )
+            )
+            return
+        if payload == _OP_PARTITION_CHECK:
+            await self._probe_partition_epoch(ctx)
+
+    async def _emit_default_failures(self, ctx: AgentContext) -> None:
+        for kind in (
+            "attack_scope_escalation",
+            "attack_audience_confusion",
+            "attack_confused_deputy",
+            "attack_partition_stale_epoch",
+        ):
+            await ctx.broadcast(_emit(kind, {"rejected": 0, "error": "NoDelegationApi"}))
+
+    async def _probe_scope_escalation(self, ctx: AgentContext) -> None:
+        auth = ctx.plugins["auth"]
+        rejected = 0
+        error = "accepted"
+        try:
+            await auth.delegate(
+                self._tokens[str(_COORDINATOR)],
+                _INTERMEDIARIES[0],
+                ["admin:all"],
+                ttl=10.0,
+            )
+        except Exception as exc:  # noqa: BLE001 - trace needs the exact defensive verdict
+            rejected = 1
+            error = _error_name(exc)
+        await ctx.broadcast(
+            _emit(
+                "attack_scope_escalation",
+                {"requested": "admin:all", "rejected": rejected, "error": error},
+            )
+        )
+
+    async def _probe_audience_confusion(self, ctx: AgentContext) -> None:
+        auth = ctx.plugins["auth"]
+        rejected = 0
+        error = "accepted"
+        try:
+            await auth.verify_for_audience(self._tokens[str(_INTERMEDIARIES[0])], _LEAVES[0])
+        except Exception as exc:  # noqa: BLE001 - trace needs the exact defensive verdict
+            rejected = 1
+            error = _error_name(exc)
+        await ctx.broadcast(
+            _emit(
+                "attack_audience_confusion",
+                {
+                    "token_audience": str(_INTERMEDIARIES[0]),
+                    "presenter": str(_LEAVES[0]),
+                    "rejected": rejected,
+                    "error": error,
+                },
+            )
+        )
+
+    async def _probe_confused_deputy(self, ctx: AgentContext) -> None:
+        auth = ctx.plugins["auth"]
+        rejected = 0
+        error = "accepted"
+        try:
+            await auth.authorize(
+                self._tokens[str(_INTERMEDIARIES[2])],
+                _INTERMEDIARIES[2],
+                "payments:write",
+            )
+        except Exception as exc:  # noqa: BLE001 - trace needs the exact defensive verdict
+            rejected = 1
+            error = _error_name(exc)
+        await ctx.broadcast(
+            _emit(
+                "attack_confused_deputy",
+                {
+                    "deputy": str(_INTERMEDIARIES[2]),
+                    "on_behalf": str(_LEAVES[8]),
+                    "resource": "payments:write",
+                    "rejected": rejected,
+                    "error": error,
+                },
+            )
+        )
+
+    async def _probe_partition_epoch(self, ctx: AgentContext) -> None:
+        verifier = self._partitioned_auth
+        token = self._tokens.get(str(_INTERMEDIARIES[0]))
+        rejected = 0
+        error = "accepted"
+        if verifier is None or token is None:
+            rejected = 0
+            error = "NoPartitionedVerifier"
+        else:
+            try:
+                await verifier.verify_for_audience(token, _INTERMEDIARIES[0])
+            except Exception as exc:  # noqa: BLE001 - trace needs the exact defensive verdict
+                rejected = 1
+                error = _error_name(exc)
+        await ctx.broadcast(
+            _emit(
+                "attack_partition_stale_epoch",
+                {"rejected": rejected, "error": error},
+            )
+        )
+
+
+class DelegatedAuthIntermediary(StateMachineAgent):
+    """Attenuates one intermediary token into four leaf tokens.
+
+    Example::
+
+        agent = DelegatedAuthIntermediary(AgentId("intermediary-0"), leaves, tokens, clock)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        leaves: list[AgentId],
+        tokens: dict[str, Token],
+        clock_state: dict[str, float],
+    ) -> None:
+        self._id = agent_id
+        self._leaves = leaves
+        self._tokens = tokens
+        self._clock_state = clock_state
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Schedule offline leaf attenuation after the coordinator issues parents.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        await ctx.schedule(1.0, _OP_DELEGATE)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Delegate this intermediary's token to its four leaves.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("intermediary-0"), b"op:delegate")
+        """
+        if payload != _OP_DELEGATE:
+            return
+        _set_clock(ctx, self._clock_state)
+        auth = ctx.plugins["auth"]
+        if not hasattr(auth, "delegate"):
+            return
+        parent = self._tokens.get(str(self._id))
+        if parent is None:
+            return
+        for leaf in self._leaves:
+            scopes = _LEAF_SCOPES[leaf]
+            child = await auth.delegate(parent, leaf, scopes, ttl=30.0)
+            self._tokens[str(leaf)] = child
+            await ctx.broadcast(
+                _emit(
+                    "delegated",
+                    {
+                        "parent": str(self._id),
+                        "child": str(leaf),
+                        "scope_count": len(scopes),
+                        "ttl": 30,
+                    },
+                )
+            )
+
+
+class DelegatedAuthLeaf(StateMachineAgent):
+    """Verifies a leaf token before and, for one subtree, after revocation.
+
+    Example::
+
+        agent = DelegatedAuthLeaf(AgentId("leaf-4"), tokens, clock, post_revoke=True)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        tokens: dict[str, Token],
+        clock_state: dict[str, float],
+        *,
+        post_revoke: bool,
+    ) -> None:
+        self._id = agent_id
+        self._tokens = tokens
+        self._clock_state = clock_state
+        self._post_revoke = post_revoke
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Schedule initial and optional post-revocation verification.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        await ctx.schedule(2.0, _OP_VERIFY)
+        if self._post_revoke:
+            await ctx.schedule(5.0, _OP_POST_REVOKE)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Verify this leaf's token and emit a validator-readable verdict.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("leaf-4"), b"op:post-revoke")
+        """
+        if payload not in (_OP_VERIFY, _OP_POST_REVOKE):
+            return
+        _set_clock(ctx, self._clock_state)
+        auth = ctx.plugins["auth"]
+        token = self._tokens.get(str(self._id))
+        if token is None:
+            return
+        try:
+            await auth.verify(token)
+            rejected = 0
+            error = "accepted"
+        except Exception as exc:  # noqa: BLE001 - trace needs the exact defensive verdict
+            rejected = 1
+            error = _error_name(exc)
+
+        if payload == _OP_VERIFY:
+            await ctx.broadcast(
+                _emit(
+                    "leaf_verified",
+                    {
+                        "leaf": str(self._id),
+                        "verified": int(not rejected),
+                        "error": error,
+                    },
+                )
+            )
+        else:
+            await ctx.broadcast(
+                _emit(
+                    "attack_stale_parent",
+                    {
+                        "leaf": str(self._id),
+                        "rejected": rejected,
+                        "error": error,
+                    },
+                )
+            )
+
+
+def capability_tokens_delegated_auth_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Build the 16-agent delegated-auth tree and shared auth state.
+
+    The factory installs per-agent auth instances with a shared revocation
+    store.  Under ``auth: capability_tokens`` this yields real delegation;
+    under ``auth: jwt`` the coordinator emits negative attack rows so validators
+    prove the default plugin lacks the capability.
+
+    Example::
+
+        agents = capability_tokens_delegated_auth_factory(config, plugins)
+    """
+    auth_cls = plugins["auth"]
+    clock_state = {"now": 0.0}
+    tokens: dict[str, Token] = {}
+    store = RevocationStore()
+    partitioned_auth: CapabilityTokens | None = None
+    overrides: dict[AgentId, dict[str, Any]] = {}
+
+    if isinstance(auth_cls, type) and issubclass(auth_cls, CapabilityTokens):
+        partitioned_auth = auth_cls(
+            secret=b"delegated-auth-scenario",
+            clock=lambda: clock_state["now"],
+            agent_id=_INTERMEDIARIES[0],
+            revocation_store=store,
+            stale_after=0,
+            auto_sync=False,
+        )
+
+    def _auth_instance(agent_id: AgentId) -> Any:
+        if isinstance(auth_cls, type) and issubclass(auth_cls, CapabilityTokens):
+            return auth_cls(
+                secret=b"delegated-auth-scenario",
+                clock=lambda: clock_state["now"],
+                agent_id=agent_id,
+                revocation_store=store,
+                stale_after=0,
+                auto_sync=True,
+            )
+        try:
+            return auth_cls(secret=b"delegated-auth-scenario", clock=0.0)
+        except TypeError:
+            return auth_cls()
+
+    agents: dict[AgentId, StateMachineAgent] = {
+        _COORDINATOR: DelegatedAuthCoordinator(tokens, clock_state, partitioned_auth),
+    }
+    for intermediary, leaves in _LEAF_GROUPS.items():
+        agents[intermediary] = DelegatedAuthIntermediary(
+            intermediary,
+            leaves,
+            tokens,
+            clock_state,
+        )
+    for leaf in _LEAVES:
+        agents[leaf] = DelegatedAuthLeaf(
+            leaf,
+            tokens,
+            clock_state,
+            post_revoke=leaf in _LEAF_GROUPS[_INTERMEDIARIES[1]],
+        )
+
+    for agent_id in agents:
+        overrides[agent_id] = {"auth": _auth_instance(agent_id)}
+
+    plugins["_agent_plugins"] = overrides
+    plugins["_delegated_auth_revocation_store"] = store
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -4793,6 +4793,277 @@ def validate_attested_sybil_quarantined(
 
 
 # ---------------------------------------------------------------------------
+# Capability-token delegated auth validators
+# ---------------------------------------------------------------------------
+
+
+def _parse_auth_events(events: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Parse ``auth:<kind>|k=v|k=v`` trace broadcasts.
+
+    Example::
+
+        rows = _parse_auth_events(events)
+    """
+    rows: list[dict[str, str]] = []
+    for ev in events:
+        if ev.get("kind") != "broadcast":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("auth:"):
+            continue
+        prefix, separator, field_blob = msg.partition("|")
+        kind = prefix.removeprefix("auth:")
+        if not separator or not kind:
+            continue
+        parsed: dict[str, str] = {"kind": kind, "agent": str(ev.get("agent", ""))}
+        for piece in field_blob.split("|"):
+            if "=" in piece:
+                key, _, value = piece.partition("=")
+                parsed[key] = value
+        rows.append(parsed)
+    return rows
+
+
+def _auth_rows(events: list[dict[str, Any]], kind: str) -> list[dict[str, str]]:
+    return [row for row in _parse_auth_events(events) if row.get("kind") == kind]
+
+
+def _rejected_with(rows: list[dict[str, str]], expected_error: str) -> bool:
+    return any(row.get("rejected") == "1" and row.get("error") == expected_error for row in rows)
+
+
+def validate_delegated_auth_tree_exercised(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """The scenario must build the requested 1 -> 3 -> 12 delegation tree.
+
+    This prevents a vacuous pass where attack rows are emitted but no real leaf
+    token ever verifies. It reads only trace evidence: three coordinator
+    delegations, twelve leaf delegations, and twelve successful leaf
+    verifications.
+
+    Example::
+
+        results = validate_delegated_auth_tree_exercised(events)
+    """
+    delegated = _auth_rows(events, "delegated")
+    parent_edges = {
+        row.get("child", "") for row in delegated if row.get("parent") == "coordinator-0"
+    }
+    leaf_edges = {
+        row.get("child", "") for row in delegated if row.get("child", "").startswith("leaf-")
+    }
+    verified = {
+        row.get("leaf", "")
+        for row in _auth_rows(events, "leaf_verified")
+        if row.get("verified") == "1"
+    }
+    problems: list[str] = []
+    if len(parent_edges) != 3:
+        problems.append(f"expected 3 intermediary delegations, saw {len(parent_edges)}")
+    if len(leaf_edges) != 12:
+        problems.append(f"expected 12 leaf delegations, saw {len(leaf_edges)}")
+    if len(verified) != 12:
+        problems.append(f"expected 12 verified leaves, saw {len(verified)}")
+    if problems:
+        return [ValidationResult("delegated_auth_tree_exercised", False, "; ".join(problems))]
+    return [
+        ValidationResult(
+            "delegated_auth_tree_exercised",
+            True,
+            "coordinator delegated to 3 intermediaries and 12 leaves verified",
+        )
+    ]
+
+
+def validate_delegated_auth_scope_escalation_blocked(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Attack: a child cannot request a scope outside the parent grant.
+
+    Example::
+
+        results = validate_delegated_auth_scope_escalation_blocked(events)
+    """
+    rows = _auth_rows(events, "attack_scope_escalation")
+    if not rows:
+        return [
+            ValidationResult(
+                "delegated_auth_scope_escalation_blocked",
+                False,
+                "no scope-escalation attack recorded",
+            )
+        ]
+    matching_scope = [row for row in rows if row.get("requested") == "admin:all"]
+    if matching_scope and _rejected_with(matching_scope, "ScopeEscalationError"):
+        return [
+            ValidationResult(
+                "delegated_auth_scope_escalation_blocked",
+                True,
+                "admin:all escalation rejected with ScopeEscalationError",
+            )
+        ]
+    return [
+        ValidationResult(
+            "delegated_auth_scope_escalation_blocked",
+            False,
+            f"admin:all escalation was not rejected correctly: {rows}",
+        )
+    ]
+
+
+def validate_delegated_auth_cascading_revocation(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Attack: a child must not verify after any ancestor is revoked.
+
+    The scenario revokes ``intermediary-1`` and then has its four leaves verify
+    their already-issued children. Every one must fail with
+    ``RevokedAncestorError``.
+
+    Example::
+
+        results = validate_delegated_auth_cascading_revocation(events)
+    """
+    rows = _auth_rows(events, "attack_stale_parent")
+    if len(rows) != 4:
+        return [
+            ValidationResult(
+                "delegated_auth_cascading_revocation",
+                False,
+                f"expected 4 revoked-descendant checks, saw {len(rows)}",
+            )
+        ]
+    accepted = [row for row in rows if row.get("rejected") != "1"]
+    wrong_error = [row for row in rows if row.get("error") != "RevokedAncestorError"]
+    if accepted or wrong_error:
+        return [
+            ValidationResult(
+                "delegated_auth_cascading_revocation",
+                False,
+                f"accepted={accepted}; wrong_error={wrong_error}",
+            )
+        ]
+    return [
+        ValidationResult(
+            "delegated_auth_cascading_revocation",
+            True,
+            "revoked intermediary invalidated all 4 descendants",
+        )
+    ]
+
+
+def validate_delegated_auth_audience_confusion_blocked(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Attack: a token for one audience cannot be presented by another agent.
+
+    Example::
+
+        results = validate_delegated_auth_audience_confusion_blocked(events)
+    """
+    rows = _auth_rows(events, "attack_audience_confusion")
+    if not rows:
+        return [
+            ValidationResult(
+                "delegated_auth_audience_confusion_blocked",
+                False,
+                "no audience-confusion attack recorded",
+            )
+        ]
+    if _rejected_with(rows, "AudienceMismatchError"):
+        return [
+            ValidationResult(
+                "delegated_auth_audience_confusion_blocked",
+                True,
+                "wrong presenter rejected with AudienceMismatchError",
+            )
+        ]
+    return [
+        ValidationResult(
+            "delegated_auth_audience_confusion_blocked",
+            False,
+            f"audience confusion was not rejected correctly: {rows}",
+        )
+    ]
+
+
+def validate_delegated_auth_confused_deputy_blocked(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Attack: a deputy cannot spend its token on an unscoped third-party action.
+
+    The trace records a deputy attempting ``payments:write`` on behalf of a leaf
+    with a token scoped only for ``payments:read``. The expected fail-closed
+    verdict is ``ScopeEscalationError``.
+
+    Example::
+
+        results = validate_delegated_auth_confused_deputy_blocked(events)
+    """
+    rows = _auth_rows(events, "attack_confused_deputy")
+    if not rows:
+        return [
+            ValidationResult(
+                "delegated_auth_confused_deputy_blocked",
+                False,
+                "no confused-deputy attack recorded",
+            )
+        ]
+    matching_resource = [row for row in rows if row.get("resource") == "payments:write"]
+    if matching_resource and _rejected_with(matching_resource, "ScopeEscalationError"):
+        return [
+            ValidationResult(
+                "delegated_auth_confused_deputy_blocked",
+                True,
+                "deputy payments:write action rejected as an escalation",
+            )
+        ]
+    return [
+        ValidationResult(
+            "delegated_auth_confused_deputy_blocked",
+            False,
+            f"confused deputy was not rejected correctly: {rows}",
+        )
+    ]
+
+
+def validate_delegated_auth_epoch_fence_fail_closed(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Partition semantics: a stale revocation view must fail closed.
+
+    Example::
+
+        results = validate_delegated_auth_epoch_fence_fail_closed(events)
+    """
+    rows = _auth_rows(events, "attack_partition_stale_epoch")
+    if not rows:
+        return [
+            ValidationResult(
+                "delegated_auth_epoch_fence_fail_closed",
+                False,
+                "no stale-epoch partition attack recorded",
+            )
+        ]
+    if _rejected_with(rows, "RevocationViewStaleError"):
+        return [
+            ValidationResult(
+                "delegated_auth_epoch_fence_fail_closed",
+                True,
+                "partitioned verifier failed closed on stale revocation epoch",
+            )
+        ]
+    return [
+        ValidationResult(
+            "delegated_auth_epoch_fence_fail_closed",
+            False,
+            f"stale epoch was not rejected correctly: {rows}",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -5016,6 +5287,14 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_bft_no_equivocation,
         validate_bft_forged_quorum,
         validate_bft_no_stuck_view,
+    ],
+    "capability_tokens_delegated_auth": [
+        validate_delegated_auth_tree_exercised,
+        validate_delegated_auth_scope_escalation_blocked,
+        validate_delegated_auth_cascading_revocation,
+        validate_delegated_auth_audience_confusion_blocked,
+        validate_delegated_auth_confused_deputy_blocked,
+        validate_delegated_auth_epoch_fence_fail_closed,
     ],
     "escrow_marketplace": [
         validate_escrow_state_machine,

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2008,6 +2008,7 @@ class TestValidatorRegistry:
             "multi_attribute_market",
             "provenance_supply_chain",
             "bft_hotstuff",
+            "capability_tokens_delegated_auth",
             "escrow_marketplace",
             "failure_detection",
             "parc_migration",

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/capability_tokens.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/capability_tokens.py
@@ -1,0 +1,654 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegatable capability tokens with offline attenuation and cascading revocation.
+
+This plugin models macaroon/Biscuit-style delegation for the auth layer.  A
+root issuer signs the first caveat set with a root HMAC secret.  Each holder can
+mint a child token offline by signing the child's narrower caveats with the
+parent link signature as the HMAC key.  Verifiers replay the whole chain from
+the root secret and reject if any ancestor is expired, revoked, stale, or
+structurally widened.
+
+Example::
+
+    auth = CapabilityTokens(secret=b"demo", clock=0.0)
+    root = await auth.issue(AgentId("coordinator"), ["read", "write"])
+    child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=60)
+    ctx = await auth.verify_for_audience(child, AgentId("worker"))
+    assert ctx.scopes == ["read"]
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import cast
+
+from nest_core.types import AgentId, AuthContext, Token
+
+_PREFIX = "cap1."
+_ROOT_PARENT_HASH = "0" * 64
+_DEFAULT_ROOT_TTL = 3600.0
+
+_Clock = float | Callable[[], float]
+
+
+class CapabilityTokenError(ValueError):
+    """Base class for capability-token verification and delegation failures.
+
+    Example::
+
+        try:
+            await auth.verify(token)
+        except CapabilityTokenError:
+            pass
+    """
+
+
+class ScopeEscalationError(CapabilityTokenError):
+    """Raised when a delegate asks for scopes the parent never possessed.
+
+    Example::
+
+        with pytest.raises(ScopeEscalationError):
+            await auth.delegate(parent, AgentId("worker"), ["admin"], ttl=5)
+    """
+
+
+class TtlEscalationError(CapabilityTokenError):
+    """Raised when a child TTL would outlive the parent token.
+
+    Example::
+
+        with pytest.raises(TtlEscalationError):
+            await auth.delegate(parent, AgentId("worker"), ["read"], ttl=9999)
+    """
+
+
+class RevokedAncestorError(CapabilityTokenError):
+    """Raised when any link in the token's ancestor chain has been revoked.
+
+    Example::
+
+        await auth.revoke(parent)
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify(child)
+    """
+
+
+class ExpiredAncestorError(CapabilityTokenError):
+    """Raised when any ancestor in the delegation chain has expired.
+
+    Example::
+
+        expired = CapabilityTokens(clock=7200.0)
+        with pytest.raises(ExpiredAncestorError):
+            await expired.verify(token)
+    """
+
+
+class AudienceMismatchError(CapabilityTokenError):
+    """Raised when a token is presented by the wrong audience.
+
+    Example::
+
+        with pytest.raises(AudienceMismatchError):
+            await auth.verify_for_audience(token, AgentId("wrong-agent"))
+    """
+
+
+class InvalidChainError(CapabilityTokenError):
+    """Raised when a token cannot be parsed or its HMAC chain does not replay.
+
+    Example::
+
+        with pytest.raises(InvalidChainError):
+            await auth.verify(Token("cap1.not-valid"))
+    """
+
+
+class RevocationViewStaleError(CapabilityTokenError):
+    """Raised when a verifier's revocation epoch is too stale to trust.
+
+    Example::
+
+        stale = CapabilityTokens(revocation_store=store, stale_after=0, auto_sync=False)
+        await issuer.revoke(parent)
+        with pytest.raises(RevocationViewStaleError):
+            await stale.verify(child)
+    """
+
+
+@dataclass
+class RevocationStore:
+    """Shared, monotonic revocation log for partition-aware verifiers.
+
+    The store is deliberately tiny: every revoke event increments ``epoch`` and
+    stores the revoked chain hash.  A verifier can snapshot this store and later
+    fail closed if ``store.epoch - visible_epoch > stale_after``.
+
+    Example::
+
+        store = RevocationStore()
+        epoch = store.revoke("a" * 64)
+        assert epoch == 1
+    """
+
+    epoch: int = 0
+    revoked_hashes: set[str] = field(default_factory=lambda: set[str]())
+
+    def revoke(self, chain_hash: str) -> int:
+        """Record a revoked chain hash and return the new epoch.
+
+        Example::
+
+            store = RevocationStore()
+            assert store.revoke("f" * 64) == 1
+        """
+        self.epoch += 1
+        self.revoked_hashes.add(chain_hash)
+        return self.epoch
+
+    def snapshot(self) -> tuple[int, frozenset[str]]:
+        """Return an immutable ``(epoch, revoked_hashes)`` view.
+
+        Example::
+
+            epoch, hashes = store.snapshot()
+            assert epoch >= 0 and isinstance(hashes, frozenset)
+        """
+        return self.epoch, frozenset(self.revoked_hashes)
+
+
+@dataclass(frozen=True)
+class _Link:
+    body: dict[str, object]
+    sig: str
+
+
+@dataclass(frozen=True)
+class _ReplayResult:
+    links: list[_Link]
+    chain_hashes: list[str]
+    subject: AgentId
+    scopes: list[str]
+    issued_at: float
+    expires_at: float
+
+    @property
+    def chain_hash(self) -> str:
+        return self.chain_hashes[-1]
+
+
+def _canonical(data: Mapping[str, object]) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":"))
+
+
+def _b64encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64decode(raw: str) -> bytes:
+    padding = "=" * (-len(raw) % 4)
+    return base64.urlsafe_b64decode((raw + padding).encode("ascii"))
+
+
+def _normalize_scopes(scopes: Iterable[str]) -> list[str]:
+    unique: set[str] = set()
+    for scope in scopes:
+        unique.add(scope)
+    normalized = sorted(unique)
+    if not normalized:
+        msg = "capability tokens must carry at least one scope"
+        raise InvalidChainError(msg)
+    return normalized
+
+
+def _require_str(body: Mapping[str, object], field_name: str) -> str:
+    value = body.get(field_name)
+    if not isinstance(value, str):
+        msg = f"capability link missing string field {field_name!r}"
+        raise InvalidChainError(msg)
+    return value
+
+
+def _require_float(body: Mapping[str, object], field_name: str) -> float:
+    value = body.get(field_name)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        msg = f"capability link missing numeric field {field_name!r}"
+        raise InvalidChainError(msg)
+    return float(value)
+
+
+def _require_scopes(body: Mapping[str, object]) -> list[str]:
+    value = body.get("scopes")
+    if not isinstance(value, list):
+        msg = "capability link missing string-list field 'scopes'"
+        raise InvalidChainError(msg)
+    raw_scopes = cast("list[object]", value)
+    if not all(isinstance(scope, str) for scope in raw_scopes):
+        msg = "capability link missing string-list field 'scopes'"
+        raise InvalidChainError(msg)
+    return [cast("str", scope) for scope in raw_scopes]
+
+
+def _hmac_hex(key: bytes, purpose: str, body: Mapping[str, object]) -> str:
+    payload = f"{purpose}:{_canonical(body)}".encode()
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()
+
+
+def _chain_hash(previous_hash: str, body: Mapping[str, object], sig: str) -> str:
+    payload = f"{previous_hash}.{_canonical(body)}.{sig}".encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sig_key(sig: str) -> bytes:
+    try:
+        return bytes.fromhex(sig)
+    except ValueError as exc:
+        msg = "capability link signature is not hex"
+        raise InvalidChainError(msg) from exc
+
+
+class CapabilityTokens:
+    """Macaroon-style auth plugin with offline attenuation and revocation epochs.
+
+    The class satisfies the base ``Auth`` protocol via ``issue``, ``verify``,
+    and ``revoke``.  It adds ``delegate`` for holder-side attenuation and
+    ``verify_for_audience`` for explicit confused-deputy protection.
+
+    Example::
+
+        auth = CapabilityTokens(secret=b"root", clock=0.0)
+        root = await auth.issue(AgentId("a"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("b"), ["read"], ttl=10)
+        assert (await auth.verify_for_audience(child, AgentId("b"))).subject == AgentId("b")
+    """
+
+    def __init__(
+        self,
+        secret: bytes = b"nest-capability-secret",
+        *,
+        root_ttl: float = _DEFAULT_ROOT_TTL,
+        clock: _Clock = 0.0,
+        agent_id: AgentId | None = None,
+        revocation_store: RevocationStore | None = None,
+        stale_after: int = 0,
+        auto_sync: bool = True,
+    ) -> None:
+        if root_ttl <= 0:
+            msg = "root_ttl must be positive"
+            raise ValueError(msg)
+        if stale_after < 0:
+            msg = "stale_after must be non-negative"
+            raise ValueError(msg)
+        self._secret = secret
+        self._root_ttl = float(root_ttl)
+        self._clock = clock
+        self._agent_id = agent_id
+        self._store = revocation_store if revocation_store is not None else RevocationStore()
+        self._stale_after = stale_after
+        self._auto_sync = auto_sync
+        self._counter = 0
+        self._visible_epoch = 0
+        self._visible_revoked: frozenset[str] = frozenset()
+        self.sync_revocations()
+
+    def sync_revocations(self) -> None:
+        """Refresh this verifier's local revocation view from the shared store.
+
+        Example::
+
+            verifier.sync_revocations()
+            await verifier.verify(token)
+        """
+        self._visible_epoch, self._visible_revoked = self._store.snapshot()
+
+    @property
+    def visible_epoch(self) -> int:
+        """Return the epoch this verifier currently trusts.
+
+        Example::
+
+            assert auth.visible_epoch >= 0
+        """
+        return self._visible_epoch
+
+    @property
+    def current_epoch(self) -> int:
+        """Return the latest epoch known to the shared revocation store.
+
+        Example::
+
+            assert auth.current_epoch >= auth.visible_epoch
+        """
+        return self._store.epoch
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Issue a root capability token for ``subject`` and ``scopes``.
+
+        Example::
+
+            token = await auth.issue(AgentId("coordinator"), ["read", "write"])
+        """
+        now = self._now()
+        self._counter += 1
+        body: dict[str, object] = {
+            "aud": str(subject),
+            "exp": now + self._root_ttl,
+            "iat": now,
+            "jti": f"root-{self._counter}",
+            "kind": "root",
+            "scopes": _normalize_scopes(scopes),
+            "sub": str(subject),
+            "v": 1,
+        }
+        sig = _hmac_hex(self._secret, "root", body)
+        return self._encode([_Link(body=body, sig=sig)])
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token:
+        """Mint a child token from ``parent_token`` without issuer re-issuance.
+
+        The child signature is ``HMAC(parent_signature, child_caveats)``.  The
+        root secret is not used to mint the child, which is the offline
+        attenuation property the capability layer needs.
+
+        Example::
+
+            child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=30)
+        """
+        if ttl < 0:
+            msg = "child ttl must be non-negative"
+            raise TtlEscalationError(msg)
+
+        links, parent_hashes = self._unsafe_replay(parent_token)
+        parent = links[-1]
+        parent_body = parent.body
+        parent_audience = _require_str(parent_body, "aud")
+        if self._agent_id is not None and parent_audience != str(self._agent_id):
+            msg = f"token audience {parent_audience!r} cannot be delegated by {self._agent_id!r}"
+            raise AudienceMismatchError(msg)
+
+        now = self._now()
+        parent_exp = _require_float(parent_body, "exp")
+        if parent_exp < now:
+            msg = f"parent token expired at {parent_exp}"
+            raise ExpiredAncestorError(msg)
+        if now + ttl > parent_exp:
+            msg = f"child expiry {now + ttl} would outlive parent expiry {parent_exp}"
+            raise TtlEscalationError(msg)
+
+        parent_scopes = set(_require_scopes(parent_body))
+        child_scopes = _normalize_scopes(scopes_subset)
+        if not set(child_scopes) <= parent_scopes:
+            requested = sorted(set(child_scopes) - parent_scopes)
+            msg = f"scope escalation denied: {requested}"
+            raise ScopeEscalationError(msg)
+
+        self._counter += 1
+        parent_hash = parent_hashes[-1]
+        child_body: dict[str, object] = {
+            "aud": str(audience),
+            "delegator": parent_audience,
+            "exp": now + ttl,
+            "iat": now,
+            "jti": f"{parent_hash[:12]}-{self._counter}",
+            "kind": "child",
+            "parent": parent_hash,
+            "scopes": child_scopes,
+            "sub": str(audience),
+            "v": 1,
+        }
+        child_sig = _hmac_hex(_sig_key(parent.sig), "child", child_body)
+        return self._encode([*links, _Link(body=child_body, sig=child_sig)])
+
+    async def verify(self, token: Token) -> AuthContext:
+        """Verify ``token`` and return its effective auth context.
+
+        If this instance was constructed with ``agent_id``, the final token
+        audience must match that agent.  Use ``verify_for_audience`` to bind an
+        audience explicitly on a shared verifier.
+
+        Example::
+
+            ctx = await auth.verify(token)
+            assert "read" in ctx.scopes
+        """
+        result = self._replay(token, audience=self._agent_id)
+        return AuthContext(
+            subject=result.subject,
+            scopes=result.scopes,
+            issued_at=result.issued_at,
+            expires_at=result.expires_at,
+        )
+
+    async def verify_for_audience(self, token: Token, audience: AgentId) -> AuthContext:
+        """Verify ``token`` as presented by ``audience``.
+
+        Example::
+
+            ctx = await auth.verify_for_audience(token, AgentId("worker"))
+            assert ctx.subject == AgentId("worker")
+        """
+        result = self._replay(token, audience=audience)
+        return AuthContext(
+            subject=result.subject,
+            scopes=result.scopes,
+            issued_at=result.issued_at,
+            expires_at=result.expires_at,
+        )
+
+    async def authorize(
+        self,
+        token: Token,
+        presenter: AgentId,
+        required_scope: str,
+    ) -> AuthContext:
+        """Verify ``token`` as presented by ``presenter`` and gate one action scope.
+
+        This is the resource-guard primitive that stops a confused deputy: the
+        deputy may hold a perfectly valid token, but the action it performs on
+        behalf of a third party must be covered by the token's own scopes.
+        Missing scope raises ``ScopeEscalationError`` — fail closed.
+
+        Example::
+
+            with pytest.raises(ScopeEscalationError):
+                await auth.authorize(deputy_token, AgentId("deputy"), "payments:write")
+        """
+        ctx = await self.verify_for_audience(token, presenter)
+        if required_scope not in ctx.scopes:
+            msg = f"action requires scope {required_scope!r} not granted by this token"
+            raise ScopeEscalationError(msg)
+        return ctx
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke ``token`` by its terminal chain hash.
+
+        Because every descendant embeds the revoked ancestor's chain hash in its
+        HMAC replay path, revoking an ancestor invalidates all descendants on
+        the next fresh verification.
+
+        Example::
+
+            await auth.revoke(parent)
+            with pytest.raises(RevokedAncestorError):
+                await auth.verify(child)
+        """
+        result = self._replay(
+            token,
+            audience=None,
+            check_expiry=False,
+            check_revocation=False,
+        )
+        self._store.revoke(result.chain_hash)
+        self.sync_revocations()
+
+    def _now(self) -> float:
+        if callable(self._clock):
+            return float(self._clock())
+        return float(self._clock)
+
+    def _encode(self, links: list[_Link]) -> Token:
+        payload = {
+            "links": [{"body": link.body, "sig": link.sig} for link in links],
+        }
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        return Token(f"{_PREFIX}{_b64encode(raw)}")
+
+    def _decode(self, token: Token) -> list[_Link]:
+        raw = str(token)
+        if not raw.startswith(_PREFIX):
+            msg = "capability token has an unknown prefix"
+            raise InvalidChainError(msg)
+        try:
+            decoded = _b64decode(raw[len(_PREFIX) :])
+            loaded: object = json.loads(decoded)
+        except (ValueError, json.JSONDecodeError) as exc:
+            msg = "capability token is not decodable JSON"
+            raise InvalidChainError(msg) from exc
+
+        if not isinstance(loaded, dict):
+            msg = "capability token envelope must be a JSON object"
+            raise InvalidChainError(msg)
+        envelope = cast("dict[str, object]", loaded)
+        links_value = envelope.get("links")
+        if not isinstance(links_value, list) or not links_value:
+            msg = "capability token must contain at least one link"
+            raise InvalidChainError(msg)
+        links_raw = cast("list[object]", links_value)
+
+        links: list[_Link] = []
+        for item_value in links_raw:
+            if not isinstance(item_value, dict):
+                msg = "capability token link must be a JSON object"
+                raise InvalidChainError(msg)
+            item = cast("dict[str, object]", item_value)
+            body_value = item.get("body")
+            sig_value = item.get("sig")
+            if not isinstance(body_value, dict) or not isinstance(sig_value, str):
+                msg = "capability token link must carry body and sig"
+                raise InvalidChainError(msg)
+            links.append(_Link(body=cast("dict[str, object]", body_value), sig=sig_value))
+        return links
+
+    def _unsafe_replay(self, token: Token) -> tuple[list[_Link], list[str]]:
+        links = self._decode(token)
+        previous_hash = _ROOT_PARENT_HASH
+        chain_hashes: list[str] = []
+        for index, link in enumerate(links):
+            if index == 0 and _require_str(link.body, "kind") != "root":
+                msg = "first capability link must be a root"
+                raise InvalidChainError(msg)
+            if index > 0:
+                if _require_str(link.body, "kind") != "child":
+                    msg = "non-root capability links must be children"
+                    raise InvalidChainError(msg)
+                parent_hash = _require_str(link.body, "parent")
+                if parent_hash != previous_hash:
+                    msg = "child parent hash does not match previous link"
+                    raise InvalidChainError(msg)
+            previous_hash = _chain_hash(previous_hash, link.body, link.sig)
+            chain_hashes.append(previous_hash)
+        return links, chain_hashes
+
+    def _replay(
+        self,
+        token: Token,
+        *,
+        audience: AgentId | None,
+        check_expiry: bool = True,
+        check_revocation: bool = True,
+    ) -> _ReplayResult:
+        if check_revocation:
+            self._ensure_revocation_fresh()
+
+        links, _ = self._unsafe_replay(token)
+        previous_hash = _ROOT_PARENT_HASH
+        parent_sig: str | None = None
+        parent_scopes: set[str] | None = None
+        parent_exp: float | None = None
+        chain_hashes: list[str] = []
+        now = self._now()
+
+        for index, link in enumerate(links):
+            kind = _require_str(link.body, "kind")
+            if index == 0:
+                expected = _hmac_hex(self._secret, "root", link.body)
+                if kind != "root":
+                    msg = "first capability link must be a root"
+                    raise InvalidChainError(msg)
+            else:
+                if parent_sig is None:
+                    msg = "child link has no parent signature"
+                    raise InvalidChainError(msg)
+                expected = _hmac_hex(_sig_key(parent_sig), "child", link.body)
+                if kind != "child":
+                    msg = "non-root capability links must be children"
+                    raise InvalidChainError(msg)
+                parent_hash = _require_str(link.body, "parent")
+                if parent_hash != previous_hash:
+                    msg = "child parent hash does not match previous link"
+                    raise InvalidChainError(msg)
+
+            if not hmac.compare_digest(link.sig, expected):
+                msg = f"capability link {index} has an invalid HMAC"
+                raise InvalidChainError(msg)
+
+            scopes = _require_scopes(link.body)
+            exp = _require_float(link.body, "exp")
+            if parent_scopes is not None and not set(scopes) <= parent_scopes:
+                msg = f"capability link {index} widens parent scopes"
+                raise InvalidChainError(msg)
+            if parent_exp is not None and exp > parent_exp:
+                msg = f"capability link {index} outlives its parent"
+                raise InvalidChainError(msg)
+            if check_expiry and exp < now:
+                msg = f"capability link {index} expired at {exp}"
+                raise ExpiredAncestorError(msg)
+
+            current_hash = _chain_hash(previous_hash, link.body, link.sig)
+            if check_revocation and current_hash in self._visible_revoked:
+                msg = f"capability ancestor link {index} has been revoked"
+                raise RevokedAncestorError(msg)
+
+            chain_hashes.append(current_hash)
+            previous_hash = current_hash
+            parent_sig = link.sig
+            parent_scopes = set(scopes)
+            parent_exp = exp
+
+        tail = links[-1].body
+        tail_audience = _require_str(tail, "aud")
+        if audience is not None and tail_audience != str(audience):
+            msg = f"token audience {tail_audience!r} does not match presenter {audience!r}"
+            raise AudienceMismatchError(msg)
+
+        return _ReplayResult(
+            links=links,
+            chain_hashes=chain_hashes,
+            subject=AgentId(_require_str(tail, "sub")),
+            scopes=_require_scopes(tail),
+            issued_at=_require_float(tail, "iat"),
+            expires_at=_require_float(tail, "exp"),
+        )
+
+    def _ensure_revocation_fresh(self) -> None:
+        if self._auto_sync:
+            self.sync_revocations()
+        lag = self._store.epoch - self._visible_epoch
+        if lag > self._stale_after:
+            msg = (
+                f"revocation view stale by {lag} epoch(s); "
+                f"configured fail-closed bound is {self._stale_after}"
+            )
+            raise RevocationViewStaleError(msg)

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -36,6 +36,9 @@ Repository = "https://github.com/projnanda/nandatown"
 [project.entry-points."nest.plugins.comms"]
 authenticated = "nest_plugins_reference.comms.authenticated:AuthenticatedComms"
 
+[project.entry-points."nest.plugins.auth"]
+capability_tokens = "nest_plugins_reference.auth.capability_tokens:CapabilityTokens"
+
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
 

--- a/packages/nest-plugins-reference/tests/test_capability_tokens.py
+++ b/packages/nest-plugins-reference/tests/test_capability_tokens.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit, attack, and scenario tests for capability-token auth."""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.types import AgentId
+from nest_core.validators import validate_trace
+from nest_plugins_reference.auth.capability_tokens import (
+    AudienceMismatchError,
+    CapabilityTokens,
+    RevocationStore,
+    RevocationViewStaleError,
+    RevokedAncestorError,
+    ScopeEscalationError,
+    TtlEscalationError,
+)
+
+SCENARIO_PATH = (
+    Path(__file__).resolve().parents[3] / "scenarios" / "capability_tokens_delegated_auth.yaml"
+)
+VALIDATOR_KEY = "capability_tokens_delegated_auth"
+
+
+@dataclass
+class _Clock:
+    now: float = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+@pytest.mark.asyncio
+async def test_issue_verify_root_subject_and_scopes() -> None:
+    """Root tokens satisfy the base Auth protocol."""
+    auth = CapabilityTokens(secret=b"test-secret", clock=0.0)
+    token = await auth.issue(AgentId("coordinator"), ["write", "read", "read"])
+    ctx = await auth.verify_for_audience(token, AgentId("coordinator"))
+    assert ctx.subject == AgentId("coordinator")
+    assert ctx.scopes == ["read", "write"]
+
+
+@pytest.mark.asyncio
+async def test_offline_holder_attenuates_without_reissuance() -> None:
+    """A holder mints a child from the parent token, and the verifier replays it."""
+    auth = CapabilityTokens(secret=b"test-secret", clock=0.0)
+    root = await auth.issue(AgentId("coordinator"), ["alpha:read", "alpha:write"])
+    child = await auth.delegate(root, AgentId("worker"), ["alpha:read"], ttl=30)
+    ctx = await auth.verify_for_audience(child, AgentId("worker"))
+    assert ctx.subject == AgentId("worker")
+    assert ctx.scopes == ["alpha:read"]
+    assert ctx.expires_at == 30
+
+
+@pytest.mark.asyncio
+async def test_attack_scope_escalation_denied_before_child_exists() -> None:
+    """Attack: child asks for admin when parent only has read."""
+    auth = CapabilityTokens(secret=b"test-secret", clock=0.0)
+    root = await auth.issue(AgentId("coordinator"), ["read"])
+    with pytest.raises(ScopeEscalationError):
+        await auth.delegate(root, AgentId("worker"), ["read", "admin"], ttl=10)
+
+
+@pytest.mark.asyncio
+async def test_attack_ttl_extension_denied_at_delegation_boundary() -> None:
+    """Attack: child tries to outlive the parent."""
+    clock = _Clock(0.0)
+    auth = CapabilityTokens(secret=b"test-secret", root_ttl=10, clock=clock)
+    root = await auth.issue(AgentId("coordinator"), ["read"])
+    clock.now = 4
+    with pytest.raises(TtlEscalationError):
+        await auth.delegate(root, AgentId("worker"), ["read"], ttl=7)
+
+
+@pytest.mark.asyncio
+async def test_attack_revoked_ancestor_cascades_to_child() -> None:
+    """Attack: child replay after parent revocation must die by construction."""
+    auth = CapabilityTokens(secret=b"test-secret", clock=0.0)
+    root = await auth.issue(AgentId("coordinator"), ["read", "write"])
+    parent = await auth.delegate(root, AgentId("intermediary"), ["read"], ttl=100)
+    child = await auth.delegate(parent, AgentId("leaf"), ["read"], ttl=20)
+    await auth.revoke(parent)
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify_for_audience(child, AgentId("leaf"))
+
+
+@pytest.mark.asyncio
+async def test_attack_audience_confusion_rejected() -> None:
+    """Attack: stolen child token is presented by the wrong agent."""
+    auth = CapabilityTokens(secret=b"test-secret", clock=0.0)
+    root = await auth.issue(AgentId("coordinator"), ["read"])
+    child = await auth.delegate(root, AgentId("intended-worker"), ["read"], ttl=10)
+    with pytest.raises(AudienceMismatchError):
+        await auth.verify_for_audience(child, AgentId("wrong-worker"))
+
+
+@pytest.mark.asyncio
+async def test_attack_confused_deputy_unscoped_resource_rejected() -> None:
+    """Attack: deputy presents its own token to act for a third party on write."""
+    auth = CapabilityTokens(secret=b"test-secret", clock=0.0)
+    root = await auth.issue(AgentId("coordinator"), ["payments:read"])
+    deputy = await auth.delegate(root, AgentId("deputy"), ["payments:read"], ttl=10)
+    ctx = await auth.authorize(deputy, AgentId("deputy"), "payments:read")
+    assert ctx.scopes == ["payments:read"]
+    with pytest.raises(ScopeEscalationError):
+        await auth.authorize(deputy, AgentId("deputy"), "payments:write")
+
+
+@pytest.mark.asyncio
+async def test_attack_partitioned_revocation_view_fails_closed() -> None:
+    """Attack: verifier cut off from revocation epoch must reject, not guess."""
+    store = RevocationStore()
+    issuer = CapabilityTokens(secret=b"test-secret", clock=0.0, revocation_store=store)
+    stale = CapabilityTokens(
+        secret=b"test-secret",
+        clock=0.0,
+        revocation_store=store,
+        stale_after=0,
+        auto_sync=False,
+    )
+    root = await issuer.issue(AgentId("coordinator"), ["read"])
+    child = await issuer.delegate(root, AgentId("worker"), ["read"], ttl=10)
+    await issuer.revoke(root)
+    with pytest.raises(RevocationViewStaleError):
+        await stale.verify_for_audience(child, AgentId("worker"))
+
+
+def _swap_auth(config: ScenarioConfig, plugin_name: str) -> ScenarioConfig:
+    new_layers = config.layers.model_copy(update={"auth": plugin_name})
+    return config.model_copy(update={"layers": new_layers})
+
+
+def _run_scenario(plugin_name: str, seed: int = 42) -> Path:
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    config = _swap_auth(config, plugin_name)
+    config = config.model_copy(update={"seed": seed})
+    tmp = Path(tempfile.mkdtemp())
+    trace_path = tmp / f"capability_tokens_delegated_auth_{plugin_name}_{seed}.jsonl"
+    config = config.model_copy(
+        update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+    )
+    runner = ScenarioRunner(config, registry=PluginRegistry())
+    asyncio.run(runner.run())
+    return trace_path
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_capability_tokens_pass_delegated_auth_validators() -> None:
+    """The capability plugin passes every adversarial delegated-auth validator."""
+    trace_path = _run_scenario("capability_tokens")
+    results = validate_trace(trace_path, VALIDATOR_KEY)
+    assert all(r.passed for r in results), [
+        f"{r.name}: {r.detail}" for r in results if not r.passed
+    ]
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_default_jwt_fails_delegated_auth_validators() -> None:
+    """The default JWT plugin lacks offline delegation and must fail the validator suite."""
+    trace_path = _run_scenario("jwt")
+    results = validate_trace(trace_path, VALIDATOR_KEY)
+    by_name = {r.name: r for r in results}
+    assert not by_name["delegated_auth_tree_exercised"].passed
+    assert not by_name["delegated_auth_scope_escalation_blocked"].passed
+    assert not by_name["delegated_auth_audience_confusion_blocked"].passed
+    assert not by_name["delegated_auth_confused_deputy_blocked"].passed
+    assert not by_name["delegated_auth_epoch_fence_fail_closed"].passed
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_delegated_auth_scenario_deterministic_under_seed_bank(seed: int) -> None:
+    """Each seed replays to byte-identical traces and passes validators."""
+    first = _run_scenario("capability_tokens", seed=seed).read_bytes()
+    second = _run_scenario("capability_tokens", seed=seed).read_bytes()
+    assert first == second
+
+    trace_path = _run_scenario("capability_tokens", seed=seed)
+    results = validate_trace(trace_path, VALIDATOR_KEY)
+    assert all(r.passed for r in results), [
+        f"{r.name}: {r.detail}" for r in results if not r.passed
+    ]
+
+
+def test_plugin_registry_resolves_capability_tokens_builtin() -> None:
+    """Registry wiring exposes the plugin under the requested auth name."""
+    cls = PluginRegistry().resolve("auth", "capability_tokens")
+    assert cls is CapabilityTokens

--- a/packages/nest-plugins-reference/tests/test_capability_tokens_properties.py
+++ b/packages/nest-plugins-reference/tests/test_capability_tokens_properties.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hypothesis properties for capability-token attenuation and revocation."""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.capability_tokens import (
+    CapabilityTokens,
+    InvalidChainError,
+    RevokedAncestorError,
+)
+
+_SCOPE_POOL = [
+    "alpha:read",
+    "alpha:write",
+    "beta:read",
+    "payments:read",
+    "registry:lookup",
+    "memory:append",
+]
+
+
+def _flip_one_character(raw: str, index: int) -> str:
+    replacement = "A" if raw[index] != "A" else "B"
+    return raw[:index] + replacement + raw[index + 1 :]
+
+
+@given(
+    root_scopes=st.lists(st.sampled_from(_SCOPE_POOL), min_size=1, unique=True),
+    selectors=st.lists(st.integers(min_value=0, max_value=1000), min_size=1, max_size=6),
+)
+@settings(max_examples=150, deadline=None)
+@pytest.mark.asyncio
+async def test_property_attenuation_monotonicity_never_widens_scope_or_ttl(
+    root_scopes: list[str],
+    selectors: list[int],
+) -> None:
+    """Any generated delegation chain only shrinks scopes and expiry."""
+    auth = CapabilityTokens(secret=b"property-secret", root_ttl=100.0, clock=0.0)
+    token = await auth.issue(AgentId("root"), root_scopes)
+    parent_ctx = await auth.verify_for_audience(token, AgentId("root"))
+    parent_scopes = set(parent_ctx.scopes)
+    parent_exp = float(parent_ctx.expires_at or 0.0)
+
+    for depth, selector in enumerate(selectors):
+        ordered_scopes = sorted(parent_scopes)
+        child_scope_count = 1 + selector % len(ordered_scopes)
+        child_scopes = ordered_scopes[:child_scope_count]
+        ttl = float(selector % (int(parent_exp) + 1)) if parent_exp > 0 else 0.0
+        audience = AgentId(f"node-{depth}")
+        token = await auth.delegate(token, audience, child_scopes, ttl=ttl)
+        child_ctx = await auth.verify_for_audience(token, audience)
+
+        assert set(child_ctx.scopes) <= parent_scopes
+        assert float(child_ctx.expires_at or 0.0) <= parent_exp
+        parent_scopes = set(child_ctx.scopes)
+        parent_exp = float(child_ctx.expires_at or 0.0)
+
+
+@given(
+    depth=st.integers(min_value=2, max_value=6),
+    revoke_selector=st.integers(min_value=0, max_value=100),
+)
+@settings(max_examples=100, deadline=None)
+@pytest.mark.asyncio
+async def test_property_revocation_completeness_kills_every_descendant(
+    depth: int,
+    revoke_selector: int,
+) -> None:
+    """Revoking any generated ancestor kills it and all descendants."""
+    auth = CapabilityTokens(secret=b"property-secret", root_ttl=100.0, clock=0.0)
+    tokens: list[tuple[AgentId, Token]] = []
+    token = await auth.issue(AgentId("root"), ["alpha:read", "alpha:write"])
+    tokens.append((AgentId("root"), token))
+    for index in range(1, depth):
+        audience = AgentId(f"node-{index}")
+        token = await auth.delegate(token, audience, ["alpha:read"], ttl=float(100 - index))
+        tokens.append((audience, token))
+
+    revoke_index = revoke_selector % (depth - 1)
+    await auth.revoke(tokens[revoke_index][1])
+
+    for audience, descendant in tokens[revoke_index:]:
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify_for_audience(descendant, audience)
+
+
+@given(
+    depth=st.integers(min_value=1, max_value=5),
+    flip_selector=st.integers(min_value=0, max_value=10_000),
+)
+@settings(max_examples=120, deadline=None)
+@pytest.mark.asyncio
+async def test_property_chain_tamper_detection_flipping_any_selected_byte_fails_verify(
+    depth: int,
+    flip_selector: int,
+) -> None:
+    """A one-character mutation anywhere selected in the token kills verification."""
+    auth = CapabilityTokens(secret=b"property-secret", root_ttl=100.0, clock=0.0)
+    token = await auth.issue(AgentId("root"), ["alpha:read", "alpha:write"])
+    audience = AgentId("root")
+    for index in range(1, depth):
+        audience = AgentId(f"node-{index}")
+        token = await auth.delegate(token, audience, ["alpha:read"], ttl=float(100 - index))
+
+    raw = str(token)
+    tampered = Token(_flip_one_character(raw, flip_selector % len(raw)))
+    with pytest.raises(InvalidChainError):
+        await auth.verify_for_audience(tampered, audience)

--- a/scenarios/capability_tokens_delegated_auth.yaml
+++ b/scenarios/capability_tokens_delegated_auth.yaml
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegated auth: a 1 -> 3 -> 12 capability-token tree with offline
+# attenuation, mid-run cascading revocation, and fail-closed revocation epoch
+# semantics for a partitioned verifier.
+
+name: capability_tokens_delegated_auth
+description: |
+  One coordinator issues a root capability token, attenuates it to three
+  intermediaries, and each intermediary attenuates offline to four leaves.
+  The scenario records adversarial auth probes for scope escalation, revoked
+  ancestor replay, audience confusion, confused deputy use, and a stale
+  revocation epoch under partition.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 16
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+      config: {}
+    - name: intermediary
+      count: 3
+      config: {}
+    - name: leaf
+      count: 12
+      config: {}
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: capability_tokens
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: capability_tokens_delegated_auth
+  config: {}
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+  network_partition:
+    groups:
+      - [coordinator-0, intermediary-0, intermediary-1, intermediary-2, leaf-0, leaf-1, leaf-2, leaf-3]
+      - [leaf-4, leaf-5, leaf-6, leaf-7, leaf-8, leaf-9, leaf-10, leaf-11]
+  partition_heal_at_tick: 80
+
+duration: "ticks: 1200"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/capability_tokens_delegated_auth.jsonl


### PR DESCRIPTION
# NandaHack Step 1: capsec-engineer offline attenuation for auth

## Motivation

The reference `jwt` auth plugin signs exact tokens and revokes exact token strings. That is useful scaffolding, but it is not a capability system: a holder cannot attenuate authority offline, and revoking a parent does not invalidate children because there is no parent-child cryptographic relation to inspect.

This PR adds `auth: capability_tokens`, a Biscuit/macaroon-style auth plugin for Nanda Town's capability-delegation problem. The security objective is deliberately narrow and testable: authority only shrinks as it moves down a strict delegation tree, and stale revocation knowledge fails closed.

## Design

`CapabilityTokens.issue(subject, scopes)` creates a root link signed with `HMAC(root_secret, canonical_root_caveats)`. `delegate(parent_token, audience, scopes_subset, ttl)` parses the parent token and mints a child link by signing canonical child caveats with the parent link signature as the HMAC key. The root secret is not used for child minting, so a holder can attenuate offline without issuer re-issuance.

Verification is a full replay from the root secret. For each link, the verifier checks the expected HMAC, the embedded parent chain hash, scope monotonicity, TTL monotonicity, expiry, audience binding, and revocation. Every link's chain hash is derived from the previous chain hash, canonical caveats, and signature. Revocation stores the chain hash of the revoked link, so revoking an ancestor invalidates descendants by construction: a descendant verify necessarily replays and encounters the revoked ancestor hash.

Revocations carry a monotonic epoch in `RevocationStore`. A verifier tracks a local visible epoch and is configured with `stale_after`. If `store.epoch - visible_epoch > stale_after`, verification raises `RevocationViewStaleError` rather than accepting on stale knowledge. That is the explicit partition semantics: availability loses to fail-closed authorization.

## Differentiation

What sets this apart from a plain HMAC-chained macaroon is that two additional guards are load-bearing in the adversarial scenario: the `stale_after` / `RevocationViewStaleError` epoch fence treats a stale revocation view as an attack surface and fails closed, while `authorize()` binds presenter verification and a required resource scope in one confused-deputy guard. The scenario makes the epoch fence observable with a real partition-group split and `partition_heal_at_tick: 80`, rather than proving it only in an isolated unit test.

## Threat Model

| Attack | Mechanism that stops it | Test/validator proving it |
|---|---|---|
| Scope escalation by requesting `admin:all` from a `read` parent | `delegate` rejects scopes not subset of parent; verifier also rejects widened links as invalid chains | `test_attack_scope_escalation_denied_before_child_exists`; `delegated_auth_scope_escalation_blocked` |
| TTL extension beyond parent lifetime | `delegate` rejects child expiry later than parent expiry; verifier rejects outliving child links | `test_attack_ttl_extension_denied_at_delegation_boundary`; property attenuation monotonicity |
| Stale parent / revoked ancestor with child replay | Verify checks every replayed ancestor chain hash against the revocation view | `test_attack_revoked_ancestor_cascades_to_child`; `delegated_auth_cascading_revocation`; revocation completeness property |
| Audience confusion / stolen token presentation | `verify_for_audience` and per-agent `verify` bind final token audience to presenter | `test_attack_audience_confusion_rejected`; `delegated_auth_audience_confusion_blocked` |
| Confused deputy using its own token for a third-party unscoped action | `authorize(token, presenter, required_scope)` rejects actions outside the token's verified scopes; scenario records `payments:write` rejection for a `payments:read` deputy token | `test_attack_confused_deputy_unscoped_resource_rejected`; `delegated_auth_confused_deputy_blocked` |
| Partitioned verifier with stale revocation view | Monotonic epoch fence raises `RevocationViewStaleError` when the local view is older than `stale_after` | `test_attack_partitioned_revocation_view_fails_closed`; `delegated_auth_epoch_fence_fail_closed` |
| Byte-level chain tampering | Canonical JSON plus HMAC replay detects any selected token mutation | `test_property_chain_tamper_detection_flipping_any_selected_byte_fails_verify` |

## Scenario

`scenarios/capability_tokens_delegated_auth.yaml` builds one coordinator, three intermediaries, and twelve leaves. The coordinator issues the root token and delegates to intermediaries; intermediaries attenuate offline to their leaves. The run records pipe-delimited `auth:<kind>|key=value` broadcasts for validator evidence, performs a mid-run revocation of `intermediary-1`, and exercises the stale-epoch partition fence.

The unique `capability_tokens_delegated_auth` scenario name preserves the `delegated_auth` implementation already merged on `main`; both auth submissions and their registries coexist after the rebase. These validators are intentionally adversarial and fail on missing evidence, so `auth: jwt` fails the suite instead of getting a vacuous pass.

## Tradeoffs

Strict tree, not DAG: each token has one parent. That keeps replay, revocation, and evidence simple enough for deterministic scenario validation. DAG delegation would need multi-parent caveat semantics and a more complex revocation proof surface.

Fail-closed epoch fence, not best-effort availability: a partitioned verifier may reject a valid token if its revocation view is too old. That is intentional for a capability-security posture; stale authorization is treated as an attack surface, not a convenience problem.

Stdlib HMAC, not production crypto packaging: the implementation uses only `hmac`, `hashlib`, `json`, and `base64`, matching the hackathon constraint. It is a deterministic simulation plugin, not a production token format.

## Verification

```bash
uv sync
uv run pytest -q packages/nest-plugins-reference/tests/test_capability_tokens.py
uv run python -m nest_core.cli run scenarios/capability_tokens_delegated_auth.yaml --seed 42
uv run python - <<'PY'
from pathlib import Path
from nest_core.validators import validate_trace
print([
    f"{r.name}:{r.passed}"
    for r in validate_trace(
        Path("traces/capability_tokens_delegated_auth.jsonl"),
        "capability_tokens_delegated_auth",
    )
])
PY
```

Full local gate used after rebasing onto `main`:

```bash
uv sync && uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -v
```

Result: `1167 passed, 1 skipped, 1 deselected` (`ruff` clean, format clean, Pyright `0 errors`).
