### PR TITLE
[Hackathon] geick: typed CRDT memory for concurrent agent writes

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -39,6 +39,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("negotiation", "pareto"): f"{_REF}.negotiation.pareto:ParetoNegotiation",
     ("memory", "blackboard"): f"{_REF}.memory.blackboard:Blackboard",
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
+    ("memory", "typed_crdt"): f"{_REF}.memory.typed_crdt:TypedCrdtMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
     ("privacy", "hybrid_x25519"): f"{_REF}.privacy.hybrid_x25519:HybridX25519Privacy",
     ("datafacts", "datafacts_v1"): f"{_REF}.datafacts.datafacts_v1:DataFactsV1",

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/README_typed_crdt.md
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/README_typed_crdt.md
@@ -1,0 +1,190 @@
+# Typed CRDT Memory Plugin
+
+## Problem
+
+The default `blackboard` memory plugin uses last-writer-wins behavior.
+
+That means if several agents write to the same key, the final value depends on message delivery order. Earlier writes can be silently overwritten.
+
+Example:
+
+```text
+agent_1 writes fact_1
+agent_2 writes fact_2
+...
+agent_8 writes fact_8
+```
+
+With `blackboard`, the final memory only contains whichever write arrived last.
+
+This is unsafe for multi-agent coordination because NANDA Town scenarios can include concurrent writers, dropped messages, and reordered delivery.
+
+## Solution
+
+`typed_crdt` is a memory plugin that merges values according to the declared memory type.
+
+Instead of treating every key as a normal value, each write includes a `type` field. The first write establishes the type for that key. Later writes to the same key must use the same type.
+
+Supported types:
+
+| Type | Merge behavior | Use case |
+|---|---|---|
+| `set` | Union tagged items | Shared facts, catalogue entries, presence |
+| `counter` | Keep max count per writer and derive total | Vote totals, event counts, reports |
+| `vote` | Preserve one ballot per writer and derive majority result | Agent decisions, reputation labels, approvals |
+
+If two agents write different memory types to the same key, the plugin rejects the write instead of guessing.
+
+## Example: set memory
+
+First write:
+
+```json
+{"type":"set","writer":"agent_1","value":"fact_1"}
+```
+
+Second write:
+
+```json
+{"type":"set","writer":"agent_2","value":"fact_2"}
+```
+
+Final state:
+
+```json
+{
+  "type": "set",
+  "items": {
+    "agent_1:fact_1": {
+      "writer": "agent_1",
+      "value": "fact_1"
+    },
+    "agent_2:fact_2": {
+      "writer": "agent_2",
+      "value": "fact_2"
+    }
+  },
+  "values": ["fact_1", "fact_2"]
+}
+```
+
+## Example: counter memory
+
+First write:
+
+```json
+{"type":"counter","writer":"agent_1","count":1}
+```
+
+Second write:
+
+```json
+{"type":"counter","writer":"agent_2","count":1}
+```
+
+Final state:
+
+```json
+{
+  "type": "counter",
+  "counts": {
+    "agent_1": 1,
+    "agent_2": 1
+  },
+  "total": 2
+}
+```
+
+Duplicate delivery from the same writer does not double count because merging keeps the maximum count per writer.
+
+## Example: vote memory
+
+First write:
+
+```json
+{"type":"vote","writer":"agent_1","value":"approve"}
+```
+
+Second write:
+
+```json
+{"type":"vote","writer":"agent_2","value":"approve"}
+```
+
+Third write:
+
+```json
+{"type":"vote","writer":"agent_3","value":"reject"}
+```
+
+Final state:
+
+```json
+{
+  "type": "vote",
+  "ballots": {
+    "agent_1": "approve",
+    "agent_2": "approve",
+    "agent_3": "reject"
+  },
+  "result": {
+    "winner": "approve",
+    "confidence": 0.667,
+    "counts": {
+      "approve": 2,
+      "reject": 1
+    }
+  }
+}
+```
+
+The plugin shows a majority result, but it does not delete dissent.
+
+## Determinism
+
+`typed_crdt` encodes JSON with sorted keys. This makes the merged output deterministic.
+
+The same writes produce the same final bytes even when delivered in different orders.
+
+## How to run the validator
+
+From the repo root:
+
+```powershell
+$env:PYTHONPATH="packages\nest-core;packages\nest-plugins-reference"
+python3 validators\validate_typed_crdt_memory.py
+```
+
+Expected result:
+
+```text
+Blackboard expected failure:
+  result: FAILS convergence, as expected
+TypedCrdtMemory set: PASS
+TypedCrdtMemory counter: PASS
+TypedCrdtMemory vote: PASS
+All typed CRDT memory validators passed.
+```
+
+## How to run the tests
+
+From the repo root:
+
+```powershell
+$env:PYTHONPATH="packages\nest-core;packages\nest-plugins-reference"
+python3 -m pytest packages\nest-plugins-reference\tests\test_typed_crdt_memory.py -v
+```
+
+Expected result:
+
+```text
+6 passed
+```
+
+## Limits
+
+This plugin does not automatically infer the correct memory type. Agents or scenarios must write self-describing JSON values with a `type` field.
+
+The first write to a key establishes that key's type. Later writes with a different type are rejected.
+
+This is intentional: a schema conflict should be explicit instead of silently corrupting shared memory.

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -55,3 +55,15 @@ class TypedCrdtMemory:
                 await q.put(new)
             return True
         return False
+    
+    def _decode(self, value: bytes) -> dict[str, Any]:
+        """Decode JSON bytes into a Python dictionary."""
+        try:
+            decoded = json.loads(value.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError("TypedCrdtMemory values must be JSON-encoded bytes") from exc
+
+        if not isinstance(decoded, dict):
+            raise ValueError("TypedCrdtMemory value must decode to a JSON object")
+
+        return decoded

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -67,3 +67,7 @@ class TypedCrdtMemory:
             raise ValueError("TypedCrdtMemory value must decode to a JSON object")
 
         return decoded
+    
+    def _encode(self, state: dict[str, Any]) -> bytes:
+        """Encode a Python dictionary into deterministic JSON bytes."""
+        return json.dumps(state, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -93,3 +93,50 @@ class TypedCrdtMemory:
             return self._merge_set(old, new)
 
         raise ValueError(f"Unsupported typed CRDT memory type: {old_type!r}")
+    
+    def _normalize_set(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Normalize set memory into a deterministic add-only set.
+
+        Accepted simple write shape:
+            {"type": "set", "writer": "agent_1", "value": "fact A"}
+
+        Canonical stored shape:
+            {
+                "type": "set",
+                "items": {
+                    "agent_1:fact A": {"writer": "agent_1", "value": "fact A"}
+                },
+                "values": ["fact A"]
+            }
+        """
+        items = state.get("items", {})
+
+        if not items and "writer" in state and "value" in state:
+            writer = str(state["writer"])
+            value = state["value"]
+            tag = str(state.get("tag", f"{writer}:{value}"))
+            items = {
+                tag: {
+                    "writer": writer,
+                    "value": value,
+                }
+            }
+
+        if not isinstance(items, dict):
+            raise ValueError("set memory requires an 'items' object")
+
+        sorted_items = {
+            str(tag): items[tag]
+            for tag in sorted(items, key=str)
+        }
+
+        values = [
+            sorted_items[tag].get("value")
+            for tag in sorted_items
+        ]
+
+        return {
+            "type": "set",
+            "items": sorted_items,
+            "values": values,
+        }

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -31,10 +31,20 @@ class TypedCrdtMemory:
         return self._store.get(key)
 
     async def write(self, key: str, value: bytes) -> None:
-        """Write a value for a key, notifying subscribers."""
-        self._store[key] = value
+        """Merge a value into a key, notifying subscribers."""
+        current = self._store.get(key)
+
+        if current is None:
+            merged = self._encode(self._normalize_state(self._decode(value)))
+        else:
+            old_state = self._decode(current)
+            new_state = self._decode(value)
+            merged = self._encode(self._merge_state(old_state, new_state))
+
+        self._store[key] = merged
+
         for q in self._subscribers.get(key, []):
-            await q.put(value)
+            await q.put(merged)
 
     async def subscribe(self, key: str) -> AsyncIterator[bytes]:
         """Subscribe to changes for a key."""

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections import Counter
 from collections.abc import AsyncIterator
 from typing import Any
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -208,3 +208,18 @@ class TypedCrdtMemory:
             "counts": sorted_counts,
             "total": sum(sorted_counts.values()),
         }
+    
+    def _merge_counter(self, old: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]:
+        """Merge counter memory by taking the max count per writer."""
+        old_norm = self._normalize_counter(old)
+        new_norm = self._normalize_counter(new)
+
+        merged_counts = dict(old_norm["counts"])
+
+        for writer, count in new_norm["counts"].items():
+            merged_counts[writer] = max(merged_counts.get(writer, 0), count)
+
+        return self._normalize_counter({
+            "type": "counter",
+            "counts": merged_counts,
+        })

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -71,3 +71,12 @@ class TypedCrdtMemory:
     def _encode(self, state: dict[str, Any]) -> bytes:
         """Encode a Python dictionary into deterministic JSON bytes."""
         return json.dumps(state, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    
+    def _normalize_state(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Convert a user write into the canonical stored CRDT shape."""
+        memory_type = state.get("type")
+
+        if memory_type == "set":
+            return self._normalize_set(state)
+
+        raise ValueError(f"Unsupported typed CRDT memory type: {memory_type!r}")

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -169,3 +169,42 @@ class TypedCrdtMemory:
             "type": "set",
             "items": merged_items,
         })
+    
+    def _normalize_counter(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Normalize counter memory into per-writer counts.
+
+        Accepted simple write shape:
+            {"type": "counter", "writer": "agent_1", "count": 1}
+
+        Canonical stored shape:
+            {
+                "type": "counter",
+                "counts": {"agent_1": 1},
+                "total": 1
+            }
+        """
+        counts = state.get("counts", {})
+
+        if not counts and "writer" in state:
+            writer = str(state["writer"])
+            count = int(state.get("count", state.get("value", 1)))
+            counts = {writer: count}
+
+        if not isinstance(counts, dict):
+            raise ValueError("counter memory requires a 'counts' object")
+
+        clean_counts = {
+            str(writer): int(count)
+            for writer, count in counts.items()
+        }
+
+        sorted_counts = {
+            writer: clean_counts[writer]
+            for writer in sorted(clean_counts, key=str)
+        }
+
+        return {
+            "type": "counter",
+            "counts": sorted_counts,
+            "total": sum(sorted_counts.values()),
+        }

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -8,7 +8,9 @@ replace last-writer-wins writes with type-aware CRDT merge behavior.
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import AsyncIterator
+from typing import Any
 
 
 class TypedCrdtMemory:

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -88,6 +88,9 @@ class TypedCrdtMemory:
 
         if memory_type == "set":
             return self._normalize_set(state)
+        
+        if memory_type == "counter":
+            return self._normalize_counter(state)
 
         raise ValueError(f"Unsupported typed CRDT memory type: {memory_type!r}")
     

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -92,6 +92,9 @@ class TypedCrdtMemory:
         
         if memory_type == "counter":
             return self._normalize_counter(state)
+        
+        if memory_type == "vote":
+            return self._normalize_vote(state)
 
         raise ValueError(f"Unsupported typed CRDT memory type: {memory_type!r}")
     

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Typed CRDT memory plugin.
 
-This starts as a Blackboard-compatible memory plugin. Later commits will
-replace last-writer-wins writes with type-aware CRDT merge behavior.
+This plugin stores JSON-encoded bytes and merges updates according to the
+declared memory type instead of using last-writer-wins replacement.
 """
 
 from __future__ import annotations
@@ -11,16 +11,20 @@ import asyncio
 import json
 from collections import Counter
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import cast
+
+type JsonScalar = str | int | float | bool | None
+type JsonValue = JsonScalar | dict[str, JsonValue] | list[JsonValue]
+type JsonObject = dict[str, JsonValue]
 
 
 class TypedCrdtMemory:
-    """Shared key-value memory plugin.
+    """Shared key-value memory plugin with type-aware CRDT merge behavior.
 
-    For now, this intentionally behaves like Blackboard:
-    writes replace the old value.
-
-    Later, write() will merge values instead of overwriting them.
+    Supported memory types:
+    - set: union of tagged items
+    - counter: max count per writer, with total derived from counts
+    - vote: one ballot per writer, with majority result derived from ballots
     """
 
     def __init__(self) -> None:
@@ -34,14 +38,7 @@ class TypedCrdtMemory:
     async def write(self, key: str, value: bytes) -> None:
         """Merge a value into a key, notifying subscribers."""
         current = self._store.get(key)
-
-        if current is None:
-            merged = self._encode(self._normalize_state(self._decode(value)))
-        else:
-            old_state = self._decode(current)
-            new_state = self._decode(value)
-            merged = self._encode(self._merge_state(old_state, new_state))
-
+        merged = self._merge_bytes(current, value)
         self._store[key] = merged
 
         for q in self._subscribers.get(key, []):
@@ -58,16 +55,30 @@ class TypedCrdtMemory:
             self._subscribers[key].remove(q)
 
     async def cas(self, key: str, expected: bytes, new: bytes) -> bool:
-        """Compare-and-swap: update only if current value matches expected."""
+        """Compare-and-swap: merge new value only if current matches expected."""
         current = self._store.get(key)
-        if current == expected:
-            self._store[key] = new
-            for q in self._subscribers.get(key, []):
-                await q.put(new)
-            return True
-        return False
-    
-    def _decode(self, value: bytes) -> dict[str, Any]:
+        if current != expected:
+            return False
+
+        merged = self._merge_bytes(current, new)
+        self._store[key] = merged
+
+        for q in self._subscribers.get(key, []):
+            await q.put(merged)
+
+        return True
+
+    def _merge_bytes(self, old_bytes: bytes | None, new_bytes: bytes) -> bytes:
+        """Merge an optional existing encoded state with a new encoded update."""
+        new_state = self._decode(new_bytes)
+
+        if old_bytes is None:
+            return self._encode(self._normalize_state(new_state))
+
+        old_state = self._decode(old_bytes)
+        return self._encode(self._merge_state(old_state, new_state))
+
+    def _decode(self, value: bytes) -> JsonObject:
         """Decode JSON bytes into a Python dictionary."""
         try:
             decoded = json.loads(value.decode("utf-8"))
@@ -77,28 +88,41 @@ class TypedCrdtMemory:
         if not isinstance(decoded, dict):
             raise ValueError("TypedCrdtMemory value must decode to a JSON object")
 
-        return decoded
-    
-    def _encode(self, state: dict[str, Any]) -> bytes:
+        return cast("JsonObject", decoded)
+
+    def _encode(self, state: JsonObject) -> bytes:
         """Encode a Python dictionary into deterministic JSON bytes."""
         return json.dumps(state, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    
-    def _normalize_state(self, state: dict[str, Any]) -> dict[str, Any]:
+
+    def _object_field(self, state: JsonObject, field: str, error_message: str) -> JsonObject:
+        """Read a JSON object field, defaulting to an empty object."""
+        raw_value = state.get(field, {})
+        if not isinstance(raw_value, dict):
+            raise ValueError(error_message)
+        return cast("JsonObject", raw_value)
+
+    def _to_int(self, value: JsonValue) -> int:
+        """Convert a JSON scalar to int, rejecting objects and arrays."""
+        if isinstance(value, str | int | float | bool):
+            return int(value)
+        raise ValueError(f"counter values must be numeric, got {value!r}")
+
+    def _normalize_state(self, state: JsonObject) -> JsonObject:
         """Convert a user write into the canonical stored CRDT shape."""
         memory_type = state.get("type")
 
         if memory_type == "set":
             return self._normalize_set(state)
-        
+
         if memory_type == "counter":
             return self._normalize_counter(state)
-        
+
         if memory_type == "vote":
             return self._normalize_vote(state)
 
         raise ValueError(f"Unsupported typed CRDT memory type: {memory_type!r}")
-    
-    def _merge_state(self, old: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]:
+
+    def _merge_state(self, old: JsonObject, new: JsonObject) -> JsonObject:
         """Merge two decoded CRDT states."""
         old_type = old.get("type")
         new_type = new.get("type")
@@ -108,16 +132,16 @@ class TypedCrdtMemory:
 
         if old_type == "set":
             return self._merge_set(old, new)
-        
+
         if old_type == "counter":
             return self._merge_counter(old, new)
-        
+
         if old_type == "vote":
             return self._merge_vote(old, new)
 
         raise ValueError(f"Unsupported typed CRDT memory type: {old_type!r}")
-    
-    def _normalize_set(self, state: dict[str, Any]) -> dict[str, Any]:
+
+    def _normalize_set(self, state: JsonObject) -> JsonObject:
         """Normalize set memory into a deterministic add-only set.
 
         Accepted simple write shape:
@@ -132,52 +156,55 @@ class TypedCrdtMemory:
                 "values": ["fact A"]
             }
         """
-        items = state.get("items", {})
+        raw_items = state.get("items", {})
+        items: dict[str, JsonObject] = {}
 
-        if not items and "writer" in state and "value" in state:
+        if not raw_items and "writer" in state and "value" in state:
             writer = str(state["writer"])
             value = state["value"]
             tag = str(state.get("tag", f"{writer}:{value}"))
-            items = {
-                tag: {
-                    "writer": writer,
-                    "value": value,
-                }
-            }
+            items[tag] = {"writer": writer, "value": value}
+        else:
+            if not isinstance(raw_items, dict):
+                raise ValueError("set memory requires an 'items' object")
 
-        if not isinstance(items, dict):
-            raise ValueError("set memory requires an 'items' object")
+            for raw_tag, raw_item in cast("JsonObject", raw_items).items():
+                if not isinstance(raw_item, dict):
+                    raise ValueError("set memory items must be objects")
 
-        sorted_items = {
-            str(tag): items[tag]
-            for tag in sorted(items, key=str)
-        }
+                item = cast("JsonObject", raw_item)
+                writer = str(item.get("writer", ""))
+                value = item.get("value")
+                items[str(raw_tag)] = {"writer": writer, "value": value}
 
-        values = [
-            sorted_items[tag].get("value")
-            for tag in sorted_items
-        ]
+        sorted_items: dict[str, JsonObject] = {tag: items[tag] for tag in sorted(items, key=str)}
+        values: list[JsonValue] = [sorted_items[tag]["value"] for tag in sorted_items]
 
         return {
             "type": "set",
-            "items": sorted_items,
-            "values": values,
+            "items": cast("JsonValue", sorted_items),
+            "values": cast("JsonValue", values),
         }
 
-    def _merge_set(self, old: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]:
+    def _merge_set(self, old: JsonObject, new: JsonObject) -> JsonObject:
         """Merge set memory by unioning tagged items."""
         old_norm = self._normalize_set(old)
         new_norm = self._normalize_set(new)
 
-        merged_items = dict(old_norm["items"])
-        merged_items.update(new_norm["items"])
+        old_items = self._object_field(old_norm, "items", "set memory requires an 'items' object")
+        new_items = self._object_field(new_norm, "items", "set memory requires an 'items' object")
 
-        return self._normalize_set({
-            "type": "set",
-            "items": merged_items,
-        })
-    
-    def _normalize_counter(self, state: dict[str, Any]) -> dict[str, Any]:
+        merged_items: JsonObject = dict(old_items)
+        merged_items.update(new_items)
+
+        return self._normalize_set(
+            {
+                "type": "set",
+                "items": cast("JsonValue", merged_items),
+            }
+        )
+
+    def _normalize_counter(self, state: JsonObject) -> JsonObject:
         """Normalize counter memory into per-writer counts.
 
         Accepted simple write shape:
@@ -190,48 +217,58 @@ class TypedCrdtMemory:
                 "total": 1
             }
         """
-        counts = state.get("counts", {})
+        raw_counts = state.get("counts", {})
+        counts: dict[str, int] = {}
 
-        if not counts and "writer" in state:
+        if not raw_counts and "writer" in state:
             writer = str(state["writer"])
-            count = int(state.get("count", state.get("value", 1)))
-            counts = {writer: count}
+            count_source = state.get("count", state.get("value", 1))
+            counts[writer] = self._to_int(count_source)
+        else:
+            if not isinstance(raw_counts, dict):
+                raise ValueError("counter memory requires a 'counts' object")
 
-        if not isinstance(counts, dict):
-            raise ValueError("counter memory requires a 'counts' object")
+            for writer, count in cast("JsonObject", raw_counts).items():
+                counts[str(writer)] = self._to_int(count)
 
-        clean_counts = {
-            str(writer): int(count)
-            for writer, count in counts.items()
-        }
-
-        sorted_counts = {
-            writer: clean_counts[writer]
-            for writer in sorted(clean_counts, key=str)
+        sorted_counts: dict[str, int] = {
+            writer: counts[writer] for writer in sorted(counts, key=str)
         }
 
         return {
             "type": "counter",
-            "counts": sorted_counts,
+            "counts": cast("JsonValue", sorted_counts),
             "total": sum(sorted_counts.values()),
         }
-    
-    def _merge_counter(self, old: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]:
+
+    def _merge_counter(self, old: JsonObject, new: JsonObject) -> JsonObject:
         """Merge counter memory by taking the max count per writer."""
         old_norm = self._normalize_counter(old)
         new_norm = self._normalize_counter(new)
 
-        merged_counts = dict(old_norm["counts"])
+        old_counts = self._object_field(
+            old_norm, "counts", "counter memory requires a 'counts' object"
+        )
+        new_counts = self._object_field(
+            new_norm, "counts", "counter memory requires a 'counts' object"
+        )
 
-        for writer, count in new_norm["counts"].items():
-            merged_counts[writer] = max(merged_counts.get(writer, 0), count)
+        merged_counts: dict[str, int] = {
+            writer: self._to_int(count) for writer, count in old_counts.items()
+        }
 
-        return self._normalize_counter({
-            "type": "counter",
-            "counts": merged_counts,
-        })
-    
-    def _normalize_vote(self, state: dict[str, Any]) -> dict[str, Any]:
+        for writer, count in new_counts.items():
+            new_count = self._to_int(count)
+            merged_counts[writer] = max(merged_counts.get(writer, 0), new_count)
+
+        return self._normalize_counter(
+            {
+                "type": "counter",
+                "counts": cast("JsonValue", merged_counts),
+            }
+        )
+
+    def _normalize_vote(self, state: JsonObject) -> JsonObject:
         """Normalize vote memory into per-writer ballots.
 
         Accepted simple write shape:
@@ -248,26 +285,24 @@ class TypedCrdtMemory:
                 }
             }
         """
-        ballots = state.get("ballots", {})
+        raw_ballots = state.get("ballots", {})
+        ballots: dict[str, str] = {}
 
-        if not ballots and "writer" in state and "value" in state:
+        if not raw_ballots and "writer" in state and "value" in state:
             writer = str(state["writer"])
-            ballots = {writer: state["value"]}
+            ballots[writer] = str(state["value"])
+        else:
+            if not isinstance(raw_ballots, dict):
+                raise ValueError("vote memory requires a 'ballots' object")
 
-        if not isinstance(ballots, dict):
-            raise ValueError("vote memory requires a 'ballots' object")
+            for writer, value in cast("JsonObject", raw_ballots).items():
+                ballots[str(writer)] = str(value)
 
-        clean_ballots = {
-            str(writer): value
-            for writer, value in ballots.items()
+        sorted_ballots: dict[str, str] = {
+            writer: ballots[writer] for writer in sorted(ballots, key=str)
         }
 
-        sorted_ballots = {
-            writer: clean_ballots[writer]
-            for writer in sorted(clean_ballots, key=str)
-        }
-
-        counts = Counter(sorted_ballots.values())
+        counts: Counter[str] = Counter(sorted_ballots.values())
 
         if counts:
             # Deterministic tie-break:
@@ -275,29 +310,26 @@ class TypedCrdtMemory:
             # 2. if tied, lexicographically smallest value wins
             winner, winner_count = sorted(
                 counts.items(),
-                key=lambda item: (-item[1], str(item[0])),
+                key=lambda item: (-item[1], item[0]),
             )[0]
             confidence = winner_count / len(sorted_ballots)
         else:
             winner = None
             confidence = 0.0
 
-        sorted_counts = {
-            value: counts[value]
-            for value in sorted(counts, key=str)
-        }
+        sorted_counts: dict[str, int] = {value: counts[value] for value in sorted(counts, key=str)}
 
         return {
             "type": "vote",
-            "ballots": sorted_ballots,
+            "ballots": cast("JsonValue", sorted_ballots),
             "result": {
                 "winner": winner,
                 "confidence": confidence,
-                "counts": sorted_counts,
+                "counts": cast("JsonValue", sorted_counts),
             },
         }
-    
-    def _merge_vote(self, old: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]:
+
+    def _merge_vote(self, old: JsonObject, new: JsonObject) -> JsonObject:
         """Merge vote memory by keeping one ballot per writer.
 
         The majority result is derived from the preserved ballots.
@@ -305,10 +337,19 @@ class TypedCrdtMemory:
         old_norm = self._normalize_vote(old)
         new_norm = self._normalize_vote(new)
 
-        merged_ballots = dict(old_norm["ballots"])
-        merged_ballots.update(new_norm["ballots"])
+        old_ballots = self._object_field(
+            old_norm, "ballots", "vote memory requires a 'ballots' object"
+        )
+        new_ballots = self._object_field(
+            new_norm, "ballots", "vote memory requires a 'ballots' object"
+        )
 
-        return self._normalize_vote({
-            "type": "vote",
-            "ballots": merged_ballots,
-        })
+        merged_ballots: JsonObject = dict(old_ballots)
+        merged_ballots.update(new_ballots)
+
+        return self._normalize_vote(
+            {
+                "type": "vote",
+                "ballots": cast("JsonValue", merged_ballots),
+            }
+        )

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -294,4 +294,18 @@ class TypedCrdtMemory:
             },
         }
     
-    
+    def _merge_vote(self, old: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]:
+        """Merge vote memory by keeping one ballot per writer.
+
+        The majority result is derived from the preserved ballots.
+        """
+        old_norm = self._normalize_vote(old)
+        new_norm = self._normalize_vote(new)
+
+        merged_ballots = dict(old_norm["ballots"])
+        merged_ballots.update(new_norm["ballots"])
+
+        return self._normalize_vote({
+            "type": "vote",
+            "ballots": merged_ballots,
+        })

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -111,6 +111,9 @@ class TypedCrdtMemory:
         
         if old_type == "counter":
             return self._merge_counter(old, new)
+        
+        if old_type == "vote":
+            return self._merge_vote(old, new)
 
         raise ValueError(f"Unsupported typed CRDT memory type: {old_type!r}")
     

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Typed CRDT memory plugin.
+
+This starts as a Blackboard-compatible memory plugin. Later commits will
+replace last-writer-wins writes with type-aware CRDT merge behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+
+class TypedCrdtMemory:
+    """Shared key-value memory plugin.
+
+    For now, this intentionally behaves like Blackboard:
+    writes replace the old value.
+
+    Later, write() will merge values instead of overwriting them.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, bytes] = {}
+        self._subscribers: dict[str, list[asyncio.Queue[bytes]]] = {}
+
+    async def read(self, key: str) -> bytes | None:
+        """Read a value by key."""
+        return self._store.get(key)
+
+    async def write(self, key: str, value: bytes) -> None:
+        """Write a value for a key, notifying subscribers."""
+        self._store[key] = value
+        for q in self._subscribers.get(key, []):
+            await q.put(value)
+
+    async def subscribe(self, key: str) -> AsyncIterator[bytes]:
+        """Subscribe to changes for a key."""
+        q: asyncio.Queue[bytes] = asyncio.Queue()
+        self._subscribers.setdefault(key, []).append(q)
+        try:
+            while True:
+                yield await q.get()
+        finally:
+            self._subscribers[key].remove(q)
+
+    async def cas(self, key: str, expected: bytes, new: bytes) -> bool:
+        """Compare-and-swap: update only if current value matches expected."""
+        current = self._store.get(key)
+        if current == expected:
+            self._store[key] = new
+            for q in self._subscribers.get(key, []):
+                await q.put(new)
+            return True
+        return False

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -140,3 +140,16 @@ class TypedCrdtMemory:
             "items": sorted_items,
             "values": values,
         }
+
+    def _merge_set(self, old: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]:
+        """Merge set memory by unioning tagged items."""
+        old_norm = self._normalize_set(old)
+        new_norm = self._normalize_set(new)
+
+        merged_items = dict(old_norm["items"])
+        merged_items.update(new_norm["items"])
+
+        return self._normalize_set({
+            "type": "set",
+            "items": merged_items,
+        })

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -104,6 +104,9 @@ class TypedCrdtMemory:
 
         if old_type == "set":
             return self._merge_set(old, new)
+        
+        if old_type == "counter":
+            return self._merge_counter(old, new)
 
         raise ValueError(f"Unsupported typed CRDT memory type: {old_type!r}")
     

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -80,3 +80,16 @@ class TypedCrdtMemory:
             return self._normalize_set(state)
 
         raise ValueError(f"Unsupported typed CRDT memory type: {memory_type!r}")
+    
+    def _merge_state(self, old: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]:
+        """Merge two decoded CRDT states."""
+        old_type = old.get("type")
+        new_type = new.get("type")
+
+        if old_type != new_type:
+            raise ValueError(f"Cannot merge different memory types: {old_type!r} and {new_type!r}")
+
+        if old_type == "set":
+            return self._merge_set(old, new)
+
+        raise ValueError(f"Unsupported typed CRDT memory type: {old_type!r}")

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/typed_crdt.py
@@ -227,3 +227,71 @@ class TypedCrdtMemory:
             "type": "counter",
             "counts": merged_counts,
         })
+    
+    def _normalize_vote(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Normalize vote memory into per-writer ballots.
+
+        Accepted simple write shape:
+            {"type": "vote", "writer": "agent_1", "value": "approve"}
+
+        Canonical stored shape:
+            {
+                "type": "vote",
+                "ballots": {"agent_1": "approve"},
+                "result": {
+                    "winner": "approve",
+                    "confidence": 1.0,
+                    "counts": {"approve": 1}
+                }
+            }
+        """
+        ballots = state.get("ballots", {})
+
+        if not ballots and "writer" in state and "value" in state:
+            writer = str(state["writer"])
+            ballots = {writer: state["value"]}
+
+        if not isinstance(ballots, dict):
+            raise ValueError("vote memory requires a 'ballots' object")
+
+        clean_ballots = {
+            str(writer): value
+            for writer, value in ballots.items()
+        }
+
+        sorted_ballots = {
+            writer: clean_ballots[writer]
+            for writer in sorted(clean_ballots, key=str)
+        }
+
+        counts = Counter(sorted_ballots.values())
+
+        if counts:
+            # Deterministic tie-break:
+            # 1. highest vote count wins
+            # 2. if tied, lexicographically smallest value wins
+            winner, winner_count = sorted(
+                counts.items(),
+                key=lambda item: (-item[1], str(item[0])),
+            )[0]
+            confidence = winner_count / len(sorted_ballots)
+        else:
+            winner = None
+            confidence = 0.0
+
+        sorted_counts = {
+            value: counts[value]
+            for value in sorted(counts, key=str)
+        }
+
+        return {
+            "type": "vote",
+            "ballots": sorted_ballots,
+            "result": {
+                "winner": winner,
+                "confidence": confidence,
+                "counts": sorted_counts,
+            },
+        }
+    
+    

--- a/packages/nest-plugins-reference/tests/test_typed_crdt_memory.py
+++ b/packages/nest-plugins-reference/tests/test_typed_crdt_memory.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for typed CRDT memory."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from nest_core.layers.memory import Memory
+from nest_plugins_reference.memory.blackboard import Blackboard
+from nest_plugins_reference.memory.typed_crdt import TypedCrdtMemory
+
+
+def encode(obj: dict) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+async def apply_updates(memory, key: str, updates: list[bytes]) -> bytes:
+    for update in updates:
+        await memory.write(key, update)
+
+    result = await memory.read(key)
+    assert result is not None
+    return result
+
+
+def test_typed_crdt_satisfies_memory_protocol():
+    assert isinstance(TypedCrdtMemory(), Memory)
+
+
+def test_blackboard_is_order_dependent_for_concurrent_set_writes():
+    async def run_test():
+        updates = [
+            encode({"type": "set", "writer": f"agent_{i}", "value": f"fact_{i}"})
+            for i in range(1, 9)
+        ]
+
+        forward = await apply_updates(Blackboard(), "facts", updates)
+        reverse = await apply_updates(Blackboard(), "facts", list(reversed(updates)))
+
+        assert forward != reverse
+
+    asyncio.run(run_test())
+
+
+def test_set_memory_converges_across_write_orders():
+    async def run_test():
+        updates = [
+            encode({"type": "set", "writer": f"agent_{i}", "value": f"fact_{i}"})
+            for i in range(1, 9)
+        ]
+
+        forward = await apply_updates(TypedCrdtMemory(), "facts", updates)
+        reverse = await apply_updates(TypedCrdtMemory(), "facts", list(reversed(updates)))
+
+        assert forward == reverse
+
+        decoded = json.loads(forward.decode("utf-8"))
+        assert decoded["type"] == "set"
+        assert decoded["values"] == [f"fact_{i}" for i in range(1, 9)]
+        assert len(decoded["items"]) == 8
+
+    asyncio.run(run_test())
+
+
+def test_counter_memory_converges_and_avoids_duplicate_delivery():
+    async def run_test():
+        updates = [
+            encode({"type": "counter", "writer": f"agent_{i}", "count": 1})
+            for i in range(1, 9)
+        ]
+
+        duplicate = encode({"type": "counter", "writer": "agent_1", "count": 1})
+        later_higher_count = encode({"type": "counter", "writer": "agent_1", "count": 2})
+
+        forward = await apply_updates(
+            TypedCrdtMemory(),
+            "count",
+            updates + [duplicate, later_higher_count],
+        )
+        reverse = await apply_updates(
+            TypedCrdtMemory(),
+            "count",
+            list(reversed(updates)) + [duplicate, later_higher_count],
+        )
+
+        assert forward == reverse
+
+        decoded = json.loads(forward.decode("utf-8"))
+        assert decoded["type"] == "counter"
+        assert decoded["counts"]["agent_1"] == 2
+        assert decoded["total"] == 9
+
+    asyncio.run(run_test())
+
+
+def test_vote_memory_preserves_ballots_and_derives_majority():
+    async def run_test():
+        votes = [
+            "approve",
+            "approve",
+            "approve",
+            "approve",
+            "approve",
+            "approve",
+            "approve",
+            "reject",
+        ]
+
+        updates = [
+            encode({"type": "vote", "writer": f"agent_{i}", "value": votes[i - 1]})
+            for i in range(1, 9)
+        ]
+
+        forward = await apply_updates(TypedCrdtMemory(), "decision", updates)
+        reverse = await apply_updates(TypedCrdtMemory(), "decision", list(reversed(updates)))
+
+        assert forward == reverse
+
+        decoded = json.loads(forward.decode("utf-8"))
+        assert decoded["type"] == "vote"
+        assert len(decoded["ballots"]) == 8
+        assert decoded["result"]["winner"] == "approve"
+        assert decoded["result"]["counts"] == {"approve": 7, "reject": 1}
+        assert decoded["result"]["confidence"] == 0.875
+
+    asyncio.run(run_test())
+
+
+def test_type_mismatch_is_rejected():
+    async def run_test():
+        mem = TypedCrdtMemory()
+
+        await mem.write(
+            "shared",
+            encode({"type": "set", "writer": "agent_1", "value": "fact"}),
+        )
+
+        with pytest.raises(ValueError, match="Cannot merge different memory types"):
+            await mem.write(
+                "shared",
+                encode({"type": "vote", "writer": "agent_2", "value": "approve"}),
+            )
+
+    asyncio.run(run_test())

--- a/packages/nest-plugins-reference/tests/test_typed_crdt_memory.py
+++ b/packages/nest-plugins-reference/tests/test_typed_crdt_memory.py
@@ -5,19 +5,25 @@ from __future__ import annotations
 
 import asyncio
 import json
+from typing import Any, Protocol
 
 import pytest
-
 from nest_core.layers.memory import Memory
 from nest_plugins_reference.memory.blackboard import Blackboard
 from nest_plugins_reference.memory.typed_crdt import TypedCrdtMemory
 
 
-def encode(obj: dict) -> bytes:
+class ReadWriteMemory(Protocol):
+    async def read(self, key: str) -> bytes | None: ...
+
+    async def write(self, key: str, value: bytes) -> None: ...
+
+
+def encode(obj: dict[str, Any]) -> bytes:
     return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 
-async def apply_updates(memory, key: str, updates: list[bytes]) -> bytes:
+async def apply_updates(memory: ReadWriteMemory, key: str, updates: list[bytes]) -> bytes:
     for update in updates:
         await memory.write(key, update)
 
@@ -68,8 +74,7 @@ def test_set_memory_converges_across_write_orders():
 def test_counter_memory_converges_and_avoids_duplicate_delivery():
     async def run_test():
         updates = [
-            encode({"type": "counter", "writer": f"agent_{i}", "count": 1})
-            for i in range(1, 9)
+            encode({"type": "counter", "writer": f"agent_{i}", "count": 1}) for i in range(1, 9)
         ]
 
         duplicate = encode({"type": "counter", "writer": "agent_1", "count": 1})

--- a/validators/validate_typed_crdt_memory.py
+++ b/validators/validate_typed_crdt_memory.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validator for typed_crdt memory.
+
+This validator demonstrates the problem with last-writer-wins blackboard
+memory and checks that TypedCrdtMemory converges under interleaved writes.
+
+Expected behavior:
+- Blackboard does not converge because the final value depends on delivery order.
+- TypedCrdtMemory converges because it merges by memory type.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterable
+from typing import Any
+
+from nest_plugins_reference.memory.blackboard import Blackboard
+from nest_plugins_reference.memory.typed_crdt import TypedCrdtMemory
+
+
+Update = tuple[str, bytes]
+
+
+def encode(obj: dict[str, Any]) -> bytes:
+    """Encode JSON deterministically for test inputs."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+async def apply_updates(memory: Any, key: str, updates: Iterable[Update]) -> bytes:
+    """Apply writes to a memory plugin and return the final bytes."""
+    for _, value in updates:
+        await memory.write(key, value)
+
+    final = await memory.read(key)
+    if final is None:
+        raise AssertionError(f"Expected final value for key {key!r}, got None")
+
+    return final
+
+
+def make_set_updates() -> list[Update]:
+    return [
+        (
+            f"agent_{i}",
+            encode({
+                "type": "set",
+                "writer": f"agent_{i}",
+                "value": f"fact_{i}",
+            }),
+        )
+        for i in range(1, 9)
+    ]
+
+
+def make_counter_updates() -> list[Update]:
+    return [
+        (
+            f"agent_{i}",
+            encode({
+                "type": "counter",
+                "writer": f"agent_{i}",
+                "count": 1,
+            }),
+        )
+        for i in range(1, 9)
+    ]
+
+
+def make_vote_updates() -> list[Update]:
+    votes = [
+        "approve",
+        "approve",
+        "approve",
+        "approve",
+        "approve",
+        "approve",
+        "approve",
+        "reject",
+    ]
+
+    return [
+        (
+            f"agent_{i}",
+            encode({
+                "type": "vote",
+                "writer": f"agent_{i}",
+                "value": votes[i - 1],
+            }),
+        )
+        for i in range(1, 9)
+    ]
+
+
+async def validate_blackboard_fails() -> None:
+    """Show that Blackboard final state depends on write order."""
+    updates = make_set_updates()
+
+    forward = await apply_updates(Blackboard(), "shared_facts", updates)
+    reverse = await apply_updates(Blackboard(), "shared_facts", reversed(updates))
+
+    if forward == reverse:
+        raise AssertionError(
+            "Expected Blackboard to fail convergence, but forward and reverse matched"
+        )
+
+    print("Blackboard expected failure:")
+    print(f"  forward final value: {forward.decode('utf-8')}")
+    print(f"  reverse final value: {reverse.decode('utf-8')}")
+    print("  result: FAILS convergence, as expected")
+
+
+async def validate_typed_crdt_set() -> None:
+    updates = make_set_updates()
+
+    forward = await apply_updates(TypedCrdtMemory(), "shared_facts", updates)
+    reverse = await apply_updates(TypedCrdtMemory(), "shared_facts", reversed(updates))
+
+    if forward != reverse:
+        raise AssertionError("TypedCrdtMemory set did not converge")
+
+    decoded = json.loads(forward.decode("utf-8"))
+
+    expected_values = [f"fact_{i}" for i in range(1, 9)]
+    if decoded["type"] != "set":
+        raise AssertionError("Expected set memory type")
+    if decoded["values"] != expected_values:
+        raise AssertionError(f"Expected {expected_values}, got {decoded['values']}")
+    if len(decoded["items"]) != 8:
+        raise AssertionError("Expected 8 set items")
+
+    print("TypedCrdtMemory set: PASS")
+
+
+async def validate_typed_crdt_counter() -> None:
+    updates = make_counter_updates()
+
+    forward = await apply_updates(TypedCrdtMemory(), "vote_count", updates)
+    reverse = await apply_updates(TypedCrdtMemory(), "vote_count", reversed(updates))
+
+    if forward != reverse:
+        raise AssertionError("TypedCrdtMemory counter did not converge")
+
+    decoded = json.loads(forward.decode("utf-8"))
+
+    expected_counts = {f"agent_{i}": 1 for i in range(1, 9)}
+    if decoded["type"] != "counter":
+        raise AssertionError("Expected counter memory type")
+    if decoded["counts"] != expected_counts:
+        raise AssertionError(f"Expected {expected_counts}, got {decoded['counts']}")
+    if decoded["total"] != 8:
+        raise AssertionError(f"Expected total 8, got {decoded['total']}")
+
+    print("TypedCrdtMemory counter: PASS")
+
+
+async def validate_typed_crdt_vote() -> None:
+    updates = make_vote_updates()
+
+    forward = await apply_updates(TypedCrdtMemory(), "decision", updates)
+    reverse = await apply_updates(TypedCrdtMemory(), "decision", reversed(updates))
+
+    if forward != reverse:
+        raise AssertionError("TypedCrdtMemory vote did not converge")
+
+    decoded = json.loads(forward.decode("utf-8"))
+
+    if decoded["type"] != "vote":
+        raise AssertionError("Expected vote memory type")
+    if len(decoded["ballots"]) != 8:
+        raise AssertionError("Expected 8 ballots")
+    if decoded["result"]["winner"] != "approve":
+        raise AssertionError(f"Expected approve winner, got {decoded['result']['winner']}")
+    if decoded["result"]["counts"] != {"approve": 7, "reject": 1}:
+        raise AssertionError(f"Unexpected vote counts: {decoded['result']['counts']}")
+    if decoded["result"]["confidence"] != 0.875:
+        raise AssertionError(f"Expected confidence 0.875, got {decoded['result']['confidence']}")
+
+    print("TypedCrdtMemory vote: PASS")
+
+
+async def main() -> None:
+    await validate_blackboard_fails()
+    await validate_typed_crdt_set()
+    await validate_typed_crdt_counter()
+    await validate_typed_crdt_vote()
+    print("All typed CRDT memory validators passed.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/validators/validate_typed_crdt_memory.py
+++ b/validators/validate_typed_crdt_memory.py
@@ -19,7 +19,6 @@ from typing import Any
 from nest_plugins_reference.memory.blackboard import Blackboard
 from nest_plugins_reference.memory.typed_crdt import TypedCrdtMemory
 
-
 Update = tuple[str, bytes]
 
 
@@ -44,11 +43,13 @@ def make_set_updates() -> list[Update]:
     return [
         (
             f"agent_{i}",
-            encode({
-                "type": "set",
-                "writer": f"agent_{i}",
-                "value": f"fact_{i}",
-            }),
+            encode(
+                {
+                    "type": "set",
+                    "writer": f"agent_{i}",
+                    "value": f"fact_{i}",
+                }
+            ),
         )
         for i in range(1, 9)
     ]
@@ -58,11 +59,13 @@ def make_counter_updates() -> list[Update]:
     return [
         (
             f"agent_{i}",
-            encode({
-                "type": "counter",
-                "writer": f"agent_{i}",
-                "count": 1,
-            }),
+            encode(
+                {
+                    "type": "counter",
+                    "writer": f"agent_{i}",
+                    "count": 1,
+                }
+            ),
         )
         for i in range(1, 9)
     ]
@@ -83,11 +86,13 @@ def make_vote_updates() -> list[Update]:
     return [
         (
             f"agent_{i}",
-            encode({
-                "type": "vote",
-                "writer": f"agent_{i}",
-                "value": votes[i - 1],
-            }),
+            encode(
+                {
+                    "type": "vote",
+                    "writer": f"agent_{i}",
+                    "value": votes[i - 1],
+                }
+            ),
         )
         for i in range(1, 9)
     ]


### PR DESCRIPTION
## Summary

This submission adds a `typed_crdt` memory plugin for problem 02, concurrent memory under unreliable delivery.

The default `blackboard` memory plugin uses last-writer-wins behavior, so concurrent writes to the same key can overwrite each other depending on message delivery order. This plugin makes memory writes self-describing with a `type` field and merges them using deterministic CRDT-style behavior.

Supported memory types:

- `set`: unions tagged facts/items
- `counter`: keeps the maximum count per writer and derives a total
- `vote`: preserves one ballot per writer and derives a deterministic majority result

If two writes use different types for the same key, the plugin rejects the merge instead of silently corrupting memory.

## Files changed

- Added `TypedCrdtMemory`
- Registered the plugin as `memory: typed_crdt`
- Added validator showing blackboard is order-dependent while typed CRDT memory converges
- Added pytest coverage
- Added README documentation

## Validation

I ran the required local CI sequence:

```powershell
uv sync
uv run ruff check .
uv run ruff format --check .
uv run pyright
uv run pytest -v

Results:

uv sync passed
ruff check passed
ruff format --check passed
pyright passed with 0 errors
Full pytest suite passed

I also ran the typed CRDT validator:

python3 validators\validate_typed_crdt_memory.py

The validator shows:

blackboard fails convergence as expected
typed_crdt passes set convergence
typed_crdt passes counter convergence
typed_crdt passes vote convergence