### PR TITLE
Hackathon/a2r commerce checkout frontier

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -37,6 +37,9 @@ _BUILTINS: dict[tuple[str, str], str] = {
         f"{_REF}.negotiation.alternating_offers:AlternatingOffers"
     ),
     ("negotiation", "pareto"): f"{_REF}.negotiation.pareto:ParetoNegotiation",
+    ("negotiation", "checkout_frontier"): (
+        f"{_REF}.negotiation.checkout_frontier:CheckoutFrontier"
+    ),
     ("memory", "blackboard"): f"{_REF}.memory.blackboard:Blackboard",
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -107,6 +107,10 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("multi_attribute_market", multi_attribute_market_factory)
+    elif name == "checkout_market":
+        from nest_core.scenarios_builtin.checkout_market import checkout_market_factory
+
+        register_scenario("checkout_market", checkout_market_factory)
     elif name == "provenance_supply_chain":
         from nest_core.scenarios_builtin.provenance_supply_chain import (
             provenance_supply_chain_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/checkout_market.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/checkout_market.py
@@ -1,0 +1,416 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Checkout market scenario: buyer-side evaluation under budget caps.
+
+Ten agentic checkouts, each between a *scripted* margin-only vendor and the
+*configured* negotiation plugin in the buyer seat. This inverts the merged
+``multi_attribute_market`` evaluation (scripted buyer, configured seller):
+here the shopping agent is the artifact under test, because in agent-to-retail
+commerce the buyer is the deployed software and the vendor side is a quoting
+engine.
+
+The vendor is deliberately **margin-only** (``w_deadline = 0``): fulfillment
+slack costs an in-stock vendor nothing, so expedited shipping is free for it
+to give away. Its quote schedule concedes price monotonically toward a
+clearance target, offering the **expedited lane twice, early** (the rush
+rounds) and a slow lane otherwise. A deadline-aware, budget-disciplined buyer
+grabs the rush logroll the moment it fits both its aspiration and its wallet;
+a deadline-blind, timeout-driven buyer (the reference ``alternating_offers``,
+which never reads ``conditions['deadline_days']`` and only accepts at its
+round limit) holds out and closes late on a cheaper slow-lane bundle that the
+early rush quote Pareto-dominates for *both* sides.
+
+Why the dominance is seed-independent: the buyer's deadline weight is drawn
+from ``[0.85, 0.95]``, so the rush bundle beats any slow-lane bundle for the
+buyer by at least ``0.85 * (slow - rush) / d_span - w_p * price_gap / p_span``
+which is positive for every draw here, and the vendor is margin-only, so the
+rush round's higher price beats every later round's lower price outright.
+The rush price also sits at or below every drawn budget by construction. The
+buyer's aspiration ``patience ** t`` is 0.9 in round 2 and 0.81 in round 3;
+the rush bundle's buyer utility is at least 0.8725 for every drawn weight, so
+round 3 guarantees acceptance even when round 2's price momentarily exceeds a
+low budget draw (the cap visibly bites, then the cheaper rush re-offer lands).
+
+Every exchanged bundle, both parties' private utility parameters, and their
+hard money caps are written to the trace so the offline validators can
+reconstruct utilities, compute cap-feasible dominance, and audit budget and
+floor discipline. Frame grammar (floats to 6 dp for byte-determinism; the
+cap is the buyer's budget or the vendor's floor)::
+
+    checkoutcfg:<agent>:<side>:<w_price>:<w_deadline>:<plo>:<phi>:<dlo>:<dhi>:<reservation>:<cap>
+    quote:<sid>:<agent>:<side>:<round>:<price>:<deadline>
+    deal:<sid>:<price>:<deadline>:<accepting_agent>
+    no_deal:<sid>:<rounds>
+
+The vendor drives the whole exchange synchronously inside ``on_start`` (no
+cross-agent event interleaving to go non-deterministic), emitting authentic
+``ctx.send`` frames. All randomness is drawn in the factory, before any agent
+runs, from a generator seeded only by ``(config.seed, pair)`` with a fixed
+draw order (buyer weight, budget, floor, then the slow-lane deadlines); that
+order is load-bearing for byte-identical replays.
+
+Example::
+
+    from nest_core.runner import ScenarioRunner
+    runner = ScenarioRunner(ScenarioConfig.from_yaml("scenarios/checkout_market.yaml"))
+    await runner.run()
+"""
+
+from __future__ import annotations
+
+import inspect
+import random
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Money, NegotiationStatus, Terms
+
+N_PAIRS = 10
+"""Number of independent shopper-vendor checkouts."""
+
+PRICE_RANGE = (40, 120)
+"""Feasible price interval (credits), shared by every pair."""
+
+DEADLINE_RANGE = (1, 21)
+"""Feasible delivery-deadline interval (days), shared by every pair."""
+
+PATIENCE = 0.9
+"""Concession discount per round for the buyer plugin under test."""
+
+RESERVATION = 0.0
+"""Walk-away utility floor for every agent."""
+
+MAX_ROUNDS = 10
+"""Maximum bargaining rounds before a checkout is declared a no-deal."""
+
+VENDOR_WEIGHTS = {"price": 1.0, "deadline": 0.0}
+"""The scripted vendor: pure margin, indifferent to fulfillment slack."""
+
+BUYER_WEIGHT_LOW = 0.85
+"""Lower bound of the shopper's dominant (deadline) weight."""
+
+BUYER_WEIGHT_HIGH = 0.95
+"""Upper bound of the shopper's dominant (deadline) weight."""
+
+BUDGET_RANGE = (110, 120)
+"""Interval the shopper's hard wallet budget is drawn from.
+
+The lower bound sits between the round-2 rush price (112) and the round-3
+rush price (108), so some seeds see the budget refuse round 2's rush quote
+before round 3's cheaper re-offer lands: the cap visibly bites in-trace.
+"""
+
+FLOOR_RANGE = (60, 75)
+"""Interval the vendor's unit-cost floor is drawn from (below every quote)."""
+
+RUSH_ROUNDS = (2, 3)
+"""Rounds where the vendor offers the expedited lane, the integrative gift.
+
+Two rounds, not one: the buyer's aspiration ``patience ** (r - 1)`` is 0.9 at
+round 2, which the lowest drawn deadline weight (0.85) does not clear at the
+round-2 rush price, and 0.81 at round 3, which every drawn weight clears.
+Offering the rush lane in both rounds also covers the budget-bite case where
+round 2's price exceeds a low budget draw.
+"""
+
+CLEARANCE_PRICE = 80
+"""Price the vendor's schedule descends toward by the final round."""
+
+SLOW_LANE_SPREAD = 4
+"""Non-rush deadlines are drawn from the top of the range, this far down.
+
+Late rounds carry a slow lane, so whichever late bundle a timeout-driven
+buyer closes on is dominated by the early rush quote: strictly better for
+the margin-only vendor (higher price) and strictly better for every drawn
+deadline-sensitive shopper (rush delivery outweighs the price gap).
+"""
+
+
+def _checkoutcfg_frame(
+    agent_id: AgentId,
+    side: str,
+    w_price: float,
+    w_deadline: float,
+    plo: int,
+    phi: int,
+    dlo: int,
+    dhi: int,
+    reservation: float,
+    cap: int,
+) -> str:
+    """Build the once-per-agent frame revealing private utility parameters and cap."""
+    return (
+        f"checkoutcfg:{agent_id}:{side}:{w_price:.6f}:{w_deadline:.6f}"
+        f":{plo}:{phi}:{dlo}:{dhi}:{reservation:.6f}:{cap}"
+    )
+
+
+def _quote_frame(
+    sid: str, agent_id: AgentId, side: str, rnd: int, price: int, deadline: int
+) -> str:
+    """Build the frame recording one quoted (price, deadline) bundle."""
+    return f"quote:{sid}:{agent_id}:{side}:{rnd}:{price}:{deadline}"
+
+
+def _deal_frame(sid: str, price: int, deadline: int, accepting: AgentId) -> str:
+    """Build the frame recording an accepted checkout."""
+    return f"deal:{sid}:{price}:{deadline}:{accepting}"
+
+
+def _no_deal_frame(sid: str, rounds: int) -> str:
+    """Build the frame recording a checkout that broke down."""
+    return f"no_deal:{sid}:{rounds}"
+
+
+def _terms_pd(terms: Terms) -> tuple[int, int]:
+    """Extract the (price, deadline) integer pair carried by ``terms``."""
+    price = terms.price.amount if terms.price is not None else 0
+    deadline = int(terms.conditions.get("deadline_days", 0))
+    return price, deadline
+
+
+def _construct_negotiator(neg_cls: Any, agent_id: AgentId, candidate: dict[str, Any]) -> Any:
+    """Instantiate any Negotiation plugin, passing only the kwargs it accepts.
+
+    The Negotiation protocol does not define ``__init__``, so plugins have
+    different constructor signatures: ``CheckoutFrontier`` wants the full
+    checkout config while the reference ``AlternatingOffers`` takes only
+    ``patience``. Forwarding just the kwargs that name real parameters lets
+    the YAML swap the ``negotiation:`` layer without a ``TypeError``.
+
+    Example::
+
+        neg = _construct_negotiator(CheckoutFrontier, AgentId("shopper-0"), candidate)
+    """
+    params = inspect.signature(neg_cls.__init__).parameters
+    accepted = {key: value for key, value in candidate.items() if key in params}
+    return neg_cls(agent_id, **accepted)
+
+
+def _vendor_schedule(
+    rng: random.Random, bounds: tuple[int, int, int, int], max_rounds: int
+) -> list[tuple[int, int]]:
+    """Build the vendor's deterministic, price-monotonic quote schedule.
+
+    Price descends from the top of the range toward the clearance target (the
+    margin-only vendor conceding on the only issue it values). The deadline is
+    the expedited lane on the rush rounds and a seeded slow lane otherwise.
+    The vendor gives the rush lane away early because slack costs it nothing.
+
+    Example::
+
+        schedule = _vendor_schedule(random.Random("42:0"), (40, 120, 1, 21), 10)
+    """
+    _plo, phi, dlo, dhi = bounds
+    slow_lo = max(dlo, dhi - SLOW_LANE_SPREAD)
+    schedule: list[tuple[int, int]] = []
+    for r in range(1, max_rounds + 1):
+        price = round(phi - (phi - CLEARANCE_PRICE) * r / max_rounds)
+        deadline = dlo if r in RUSH_ROUNDS else rng.randint(slow_lo, dhi)
+        schedule.append((price, deadline))
+    return schedule
+
+
+class CheckoutShopperAgent(StateMachineAgent):
+    """Passive counterparty node: the buyer plugin is driven by the vendor's loop.
+
+    The shopper agent does no work itself; it only needs to be a real
+    addressable node so the vendor's ``ctx.send`` frames have a destination.
+
+    Example::
+
+        agent = CheckoutShopperAgent(AgentId("shopper-0"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+
+
+class CheckoutVendorAgent(StateMachineAgent):
+    """The scripted vendor that drives one checkout against the buyer plugin.
+
+    Holds the buyer's configured negotiation-plugin instance and a precomputed
+    price-monotonic quote schedule, and runs the full exchange in
+    ``on_start``: it presents each scheduled quote to the buyer's ``respond``
+    and records every bundle. The vendor never reacts to the buyer's
+    counteroffers (it follows its script), which keeps the evaluation a clean
+    test of the buyer's ``respond`` rather than an echo loop. The session is
+    closed through the plugin's own ``close`` on both the agreement and the
+    no-deal path, so the protocol surface is exercised end to end.
+
+    Example::
+
+        agent = CheckoutVendorAgent(
+            AgentId("vendor-0"), AgentId("shopper-0"), "pair-0", buyer_neg,
+            buyer_weights, (40, 120, 1, 21), 0.0, 115, 70, schedule, 10,
+        )
+    """
+
+    def __init__(
+        self,
+        vendor_id: AgentId,
+        shopper_id: AgentId,
+        sid: str,
+        buyer_neg: Any,
+        buyer_weights: dict[str, float],
+        bounds: tuple[int, int, int, int],
+        reservation: float,
+        budget: int,
+        floor: int,
+        schedule: list[tuple[int, int]],
+        max_rounds: int,
+    ) -> None:
+        self._vendor_id = vendor_id
+        self._shopper_id = shopper_id
+        self._sid = sid
+        self._buyer_neg = buyer_neg
+        self._buyer_weights = buyer_weights
+        self._bounds = bounds
+        self._reservation = reservation
+        self._budget = budget
+        self._floor = floor
+        self._schedule = schedule
+        self._max_rounds = max_rounds
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Reveal both configurations, then walk the quote schedule against the buyer.
+
+        The vendor concedes price round by round; the buyer plugin evaluates
+        each quote. The checkout ends the moment the buyer accepts (deal) or
+        the schedule is exhausted (no deal). Both endings go through the
+        plugin's ``close``.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        plo, phi, dlo, dhi = self._bounds
+
+        await ctx.send(
+            self._shopper_id,
+            _checkoutcfg_frame(
+                self._shopper_id,
+                "buyer",
+                self._buyer_weights["price"],
+                self._buyer_weights["deadline"],
+                plo,
+                phi,
+                dlo,
+                dhi,
+                self._reservation,
+                self._budget,
+            ).encode(),
+        )
+        await ctx.send(
+            self._shopper_id,
+            _checkoutcfg_frame(
+                self._vendor_id,
+                "seller",
+                VENDOR_WEIGHTS["price"],
+                VENDOR_WEIGHTS["deadline"],
+                plo,
+                phi,
+                dlo,
+                dhi,
+                self._reservation,
+                self._floor,
+            ).encode(),
+        )
+
+        # The buyer opens from its best-for-self position; the vendor's
+        # scripted quotes then drive the exchange.
+        buyer_opener = Terms(price=Money(amount=plo), conditions={"deadline_days": dlo})
+        session = await self._buyer_neg.open(self._vendor_id, buyer_opener)
+
+        for rnd, (price, deadline) in enumerate(self._schedule, start=1):
+            vendor_quote = Terms(price=Money(amount=price), conditions={"deadline_days": deadline})
+            await self._buyer_neg.offer(session, vendor_quote)
+            resp = await self._buyer_neg.respond(session)
+
+            quote = _quote_frame(self._sid, self._vendor_id, "seller", rnd, price, deadline)
+            await ctx.send(self._shopper_id, quote.encode())
+
+            if resp.accepted:
+                session.status = NegotiationStatus.AGREED
+                agreement = await self._buyer_neg.close(session)
+                terms = agreement.terms if agreement is not None else vendor_quote
+                dp, dd = _terms_pd(terms)
+                await ctx.send(
+                    self._shopper_id, _deal_frame(self._sid, dp, dd, self._shopper_id).encode()
+                )
+                return
+
+            if resp.counter_terms is not None:
+                cp, cd = _terms_pd(resp.counter_terms)
+                counter = _quote_frame(self._sid, self._shopper_id, "buyer", rnd, cp, cd)
+                await ctx.send(self._shopper_id, counter.encode())
+
+        await self._buyer_neg.close(session)
+        await ctx.send(self._shopper_id, _no_deal_frame(self._sid, self._max_rounds).encode())
+
+
+def checkout_market_factory(config: ScenarioConfig, plugins: dict[str, Any]) -> dict[AgentId, Any]:
+    """Build ten pairs: a scripted margin-only vendor against the configured buyer.
+
+    Each pair's buyer weights, money caps, and vendor schedule are derived in
+    the factory from a generator seeded only by ``(config.seed, pair_index)``
+    with a fixed draw order, before any agent runs. The buyer is the
+    configured ``negotiation`` plugin, instantiated through
+    :func:`_construct_negotiator` so swapping the layer in the YAML swaps the
+    strategy under test; its instance is also injected via ``_agent_plugins``
+    so the shopper node's ``ctx`` carries it.
+
+    Example::
+
+        agents = checkout_market_factory(config, plugins)
+    """
+    neg_cls = plugins["negotiation"]
+    plo, phi = PRICE_RANGE
+    dlo, dhi = DEADLINE_RANGE
+    bounds = (plo, phi, dlo, dhi)
+
+    agents: dict[AgentId, Any] = {}
+    overrides: dict[AgentId, dict[str, Any]] = {}
+
+    for i in range(N_PAIRS):
+        shopper_id = AgentId(f"shopper-{i}")
+        vendor_id = AgentId(f"vendor-{i}")
+        sid = f"pair-{i}"
+
+        rng = random.Random(f"{config.seed}:{i}")
+        w_deadline = round(rng.uniform(BUYER_WEIGHT_LOW, BUYER_WEIGHT_HIGH), 6)
+        buyer_weights = {"price": round(1.0 - w_deadline, 6), "deadline": w_deadline}
+        budget = rng.randint(*BUDGET_RANGE)
+        floor = rng.randint(*FLOOR_RANGE)
+        schedule = _vendor_schedule(rng, bounds, MAX_ROUNDS)
+
+        buyer_candidate: dict[str, Any] = {
+            "weights": buyer_weights,
+            "price_range": PRICE_RANGE,
+            "deadline_range": DEADLINE_RANGE,
+            "side": "buyer",
+            "patience": PATIENCE,
+            "reservation": RESERVATION,
+            "budget": budget,
+            "max_rounds": MAX_ROUNDS,
+        }
+        buyer_neg = _construct_negotiator(neg_cls, shopper_id, buyer_candidate)
+
+        agents[vendor_id] = CheckoutVendorAgent(
+            vendor_id,
+            shopper_id,
+            sid,
+            buyer_neg,
+            buyer_weights,
+            bounds,
+            RESERVATION,
+            budget,
+            floor,
+            schedule,
+            MAX_ROUNDS,
+        )
+        agents[shopper_id] = CheckoutShopperAgent(shopper_id)
+        overrides[shopper_id] = {"negotiation": buyer_neg}
+
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/checkout_market.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/checkout_market.py
@@ -177,6 +177,9 @@ def _construct_negotiator(neg_cls: Any, agent_id: AgentId, candidate: dict[str, 
     checkout config while the reference ``AlternatingOffers`` takes only
     ``patience``. Forwarding just the kwargs that name real parameters lets
     the YAML swap the ``negotiation:`` layer without a ``TypeError``.
+    Deliberately duplicated from the merged ``multi_attribute_market``
+    builder rather than imported: that module is a merged submission the
+    charter forbids modifying, and its helper is private.
 
     Example::
 
@@ -352,9 +355,12 @@ class CheckoutVendorAgent(StateMachineAgent):
 def checkout_market_factory(config: ScenarioConfig, plugins: dict[str, Any]) -> dict[AgentId, Any]:
     """Build ten pairs: a scripted margin-only vendor against the configured buyer.
 
-    Each pair's buyer weights, money caps, and vendor schedule are derived in
-    the factory from a generator seeded only by ``(config.seed, pair_index)``
-    with a fixed draw order, before any agent runs. The buyer is the
+    The population comes from :data:`N_PAIRS`; the YAML ``agents`` block is
+    descriptive documentation of the same shape (the sibling market
+    scenario's convention). Each pair's buyer weights, money caps, and
+    vendor schedule are derived in the factory from a generator seeded only
+    by ``(config.seed, pair_index)`` with a fixed draw order, before any
+    agent runs. The buyer is the
     configured ``negotiation`` plugin, instantiated through
     :func:`_construct_negotiator` so swapping the layer in the YAML swaps the
     strategy under test; its instance is also injected via ``_agent_plugins``

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -3294,6 +3294,334 @@ def validate_multi_attribute_pareto_optimal(
 
 
 # ---------------------------------------------------------------------------
+# Checkout market (budget-capped multi-attribute checkout) validators
+# ---------------------------------------------------------------------------
+
+
+class _CheckoutParty:
+    """One agent's utility and hard money cap, reconstructed from the trace.
+
+    Scoring reproduces the plugin's additive MAUT verbatim (clamp into the
+    feasible ranges, weight the normalized per-issue value functions, sum)
+    with the same directional convention, so a bundle scores identically here
+    and inside ``CheckoutFrontier``. ``cap`` is the hard money constraint the
+    agent declared: a buyer's wallet budget or a vendor's unit-cost floor.
+
+    Example::
+
+        p = _CheckoutParty("buyer", 0.1, 0.9, 40, 120, 1, 21, 0.0, 110)
+        p.utility(40, 1)  # 1.0
+    """
+
+    def __init__(
+        self,
+        side: str,
+        w_price: float,
+        w_deadline: float,
+        plo: int,
+        phi: int,
+        dlo: int,
+        dhi: int,
+        reservation: float,
+        cap: int,
+    ) -> None:
+        self.side = side
+        self.w_price = w_price
+        self.w_deadline = w_deadline
+        self.plo = plo
+        self.phi = phi
+        self.dlo = dlo
+        self.dhi = dhi
+        self.reservation = reservation
+        self.cap = cap
+
+    def utility(self, price: int, deadline: int) -> float:
+        """Return this agent's utility for a (price, deadline) bundle."""
+        p = max(self.plo, min(self.phi, price))
+        d = max(self.dlo, min(self.dhi, deadline))
+        if self.side == "buyer":
+            f_price = (self.phi - p) / (self.phi - self.plo)
+            f_deadline = (self.dhi - d) / (self.dhi - self.dlo)
+        else:
+            f_price = (p - self.plo) / (self.phi - self.plo)
+            f_deadline = (d - self.dlo) / (self.dhi - self.dlo)
+        return self.w_price * f_price + self.w_deadline * f_deadline
+
+
+class _CheckoutSession:
+    """Everything a single checkout session contributed to the trace.
+
+    ``bundles`` is the set of every (price, deadline) exchanged in the
+    session, the trace-observed evidence the dominance frontier is computed
+    from. ``quotes`` keeps per-quote attribution for cap auditing.
+
+    Example::
+
+        sess = _CheckoutSession()
+        sess.bundles.add((108, 1))
+    """
+
+    def __init__(self) -> None:
+        self.bundles: set[tuple[int, int]] = set()
+        self.quotes: list[tuple[str, str, int, int]] = []
+        self.buyer: str | None = None
+        self.seller: str | None = None
+        self.agreement: tuple[int, int, str] | None = None
+        self.no_deal: bool = False
+
+
+def _collect_checkout_parties(events: list[dict[str, Any]]) -> dict[str, _CheckoutParty]:
+    """Parse ``checkoutcfg:`` frames into per-agent utility-and-cap reconstructors.
+
+    Frames are ``checkoutcfg:<agent>:<side>:<w_price>:<w_deadline>:<plo>:<phi>:
+    <dlo>:<dhi>:<reservation>:<cap>``. Malformed frames (short split,
+    non-numeric fields, unknown side, or a degenerate range that would divide
+    by zero) are skipped.
+
+    Example::
+
+        parties = _collect_checkout_parties(events)
+    """
+    parties: dict[str, _CheckoutParty] = {}
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("checkoutcfg:"):
+            continue
+        parts = msg.split(":")
+        if len(parts) < 11:
+            continue
+        agent, side = parts[1], parts[2]
+        if side not in ("buyer", "seller"):
+            continue
+        try:
+            w_price = float(parts[3])
+            w_deadline = float(parts[4])
+            plo, phi, dlo, dhi = int(parts[5]), int(parts[6]), int(parts[7]), int(parts[8])
+            reservation = float(parts[9])
+            cap = int(parts[10])
+        except ValueError:
+            continue
+        if phi <= plo or dhi <= dlo:
+            continue
+        parties[agent] = _CheckoutParty(
+            side, w_price, w_deadline, plo, phi, dlo, dhi, reservation, cap
+        )
+    return parties
+
+
+def _collect_checkout_sessions(events: list[dict[str, Any]]) -> dict[str, _CheckoutSession]:
+    """Group ``quote:``/``deal:``/``no_deal:`` frames by session id.
+
+    Example::
+
+        sessions = _collect_checkout_sessions(events)
+    """
+    sessions: dict[str, _CheckoutSession] = defaultdict(_CheckoutSession)
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        parts = msg.split(":")
+        if msg.startswith("quote:") and len(parts) >= 7:
+            sid, agent, side = parts[1], parts[2], parts[3]
+            try:
+                price, deadline = int(parts[5]), int(parts[6])
+            except ValueError:
+                continue
+            sess = sessions[sid]
+            sess.bundles.add((price, deadline))
+            sess.quotes.append((agent, side, price, deadline))
+            if side == "buyer":
+                sess.buyer = agent
+            elif side == "seller":
+                sess.seller = agent
+        elif msg.startswith("deal:") and len(parts) >= 5:
+            sid, accepting = parts[1], parts[4]
+            try:
+                price, deadline = int(parts[2]), int(parts[3])
+            except ValueError:
+                continue
+            sess = sessions[sid]
+            sess.agreement = (price, deadline, accepting)
+            sess.bundles.add((price, deadline))
+        elif msg.startswith("no_deal:") and len(parts) >= 3:
+            sessions[parts[1]].no_deal = True
+    return dict(sessions)
+
+
+def _checkout_feasible(price: int, buyer: _CheckoutParty, seller: _CheckoutParty) -> bool:
+    """Whether a price respects both declared money caps.
+
+    A bundle no wallet can pay for, or no vendor can sell at, is not evidence
+    of a reachable better deal, so infeasible bundles are excluded from the
+    dominance frontier.
+    """
+    return price <= buyer.cap and price >= seller.cap
+
+
+def validate_checkout_pareto_efficient(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """No closed deal is Pareto-dominated by a cap-feasible bundle it exchanged.
+
+    For every session that reached a ``deal:`` outcome, this reconstructs
+    both parties' utilities and caps (from their ``checkoutcfg:`` frames) and
+    FAILS if any *other* bundle exchanged in the same session both respects
+    the two money caps and dominates the agreement under
+    :func:`_pareto_dominates`. A ``no_deal:`` session is **not** a failure: a
+    checkout can legitimately break down, and with mutually exclusive caps it
+    must.
+
+    Scope is trace-evidence-bounded, like the ``multi_attribute_market``
+    dominance check: the frontier is computed from bundles observed on the
+    wire, never from the full feasible grid. The cap filter is the checkout
+    twist: dominance is judged only over bundles both parties could actually
+    transact, exactly the eligibility rule ``CheckoutFrontier`` bargains
+    under. The adversarial power is real: the reference ``alternating_offers``
+    never reads ``conditions['deadline_days']`` and only accepts at its round
+    limit, so it closes late on a slow-lane bundle while the vendor's early
+    rush quote, feasible for every drawn budget, dominates the agreement for
+    both sides and trips this check. ``checkout_frontier`` passes because
+    every standing quote stays live: the best cap-feasible bundle the vendor
+    ever offered is accepted rather than expiring.
+
+    Guards against a vacuous pass: if no deal was scorable it FAILS with
+    ``"scenario exercised no checkout negotiation"``.
+
+    Example::
+
+        results = validate_checkout_pareto_efficient(events)
+    """
+    parties = _collect_checkout_parties(events)
+    sessions = _collect_checkout_sessions(events)
+
+    scored = 0
+    violations: list[str] = []
+    for sid in sorted(sessions):
+        sess = sessions[sid]
+        if sess.agreement is None or sess.buyer is None or sess.seller is None:
+            continue
+        buyer = parties.get(sess.buyer)
+        seller = parties.get(sess.seller)
+        if buyer is None or seller is None:
+            continue
+
+        scored += 1
+        a_price, a_deadline, _accepting = sess.agreement
+        ub_star = buyer.utility(a_price, a_deadline)
+        us_star = seller.utility(a_price, a_deadline)
+
+        for xp, xd in sorted(sess.bundles):
+            if (xp, xd) == (a_price, a_deadline):
+                continue
+            if not _checkout_feasible(xp, buyer, seller):
+                continue
+            ub_x = buyer.utility(xp, xd)
+            us_x = seller.utility(xp, xd)
+            if _pareto_dominates(ub_x, us_x, ub_star, us_star):
+                violations.append(
+                    f"session {sid}: deal ({a_price},{a_deadline}) "
+                    f"u_buyer={ub_star:.6f} u_seller={us_star:.6f} dominated by "
+                    f"({xp},{xd}) u_buyer={ub_x:.6f} u_seller={us_x:.6f}"
+                )
+                break
+
+    if scored == 0:
+        return [
+            ValidationResult(
+                "checkout_pareto_efficient",
+                False,
+                "scenario exercised no checkout negotiation",
+            )
+        ]
+    if violations:
+        return [ValidationResult("checkout_pareto_efficient", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "checkout_pareto_efficient",
+            True,
+            f"{scored} deal(s) non-dominated by any cap-feasible exchanged bundle",
+        )
+    ]
+
+
+def validate_checkout_budget_and_floor(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every quote and every deal respects the quoting agent's own money cap.
+
+    The commerce discipline check: an agent that bids beyond its wallet is
+    broken even if the final deal lands under it, and a vendor that quotes
+    below its cost floor is quoting a sale it cannot honor. FAILS if any
+    buyer ``quote:`` exceeds that buyer's declared budget, any vendor
+    ``quote:`` undercuts that vendor's declared floor, or a ``deal:`` price
+    violates either party's cap. Counterparty asks are unconstrained: a buyer
+    may open below the vendor's floor (an ask is not a transaction); only the
+    closed deal must satisfy both caps.
+
+    Guards against a vacuous pass: if no session with declared caps produced
+    a quote or a deal it FAILS with
+    ``"scenario exercised no checkout negotiation"``.
+
+    Example::
+
+        results = validate_checkout_budget_and_floor(events)
+    """
+    parties = _collect_checkout_parties(events)
+    sessions = _collect_checkout_sessions(events)
+
+    scored = 0
+    offenders: list[str] = []
+    for sid in sorted(sessions):
+        sess = sessions[sid]
+        if sess.buyer is None or sess.seller is None:
+            continue
+        buyer = parties.get(sess.buyer)
+        seller = parties.get(sess.seller)
+        if buyer is None or seller is None:
+            continue
+        if not sess.quotes and sess.agreement is None:
+            continue
+
+        scored += 1
+        for agent, side, price, _deadline in sess.quotes:
+            party = parties.get(agent)
+            if party is None:
+                continue
+            if side == "buyer" and price > party.cap:
+                offenders.append(f"session {sid}: buyer quote {price} exceeds budget {party.cap}")
+            elif side == "seller" and price < party.cap:
+                offenders.append(f"session {sid}: vendor quote {price} below floor {party.cap}")
+
+        if sess.agreement is not None:
+            a_price, _a_deadline, _accepting = sess.agreement
+            if a_price > buyer.cap:
+                offenders.append(f"session {sid}: deal price {a_price} exceeds budget {buyer.cap}")
+            if a_price < seller.cap:
+                offenders.append(f"session {sid}: deal price {a_price} below floor {seller.cap}")
+
+    if scored == 0:
+        return [
+            ValidationResult(
+                "checkout_budget_and_floor",
+                False,
+                "scenario exercised no checkout negotiation",
+            )
+        ]
+    if offenders:
+        return [ValidationResult("checkout_budget_and_floor", False, "; ".join(offenders))]
+    return [
+        ValidationResult(
+            "checkout_budget_and_floor",
+            True,
+            f"{scored} session(s) respected every declared budget and floor",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Provenance supply-chain validators
 # ---------------------------------------------------------------------------
 
@@ -3800,6 +4128,10 @@ VALIDATORS: dict[str, list[Any]] = {
     "multi_attribute_market": [
         validate_multi_attribute_pareto_optimal,
         validate_multi_attribute_individually_rational,
+    ],
+    "checkout_market": [
+        validate_checkout_pareto_efficient,
+        validate_checkout_budget_and_floor,
     ],
     "provenance_supply_chain": [
         validate_provenance_chain_integrity,

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -3488,7 +3488,9 @@ def validate_checkout_pareto_efficient(
     ever offered is accepted rather than expiring.
 
     Guards against a vacuous pass: if no deal was scorable it FAILS with
-    ``"scenario exercised no checkout negotiation"``.
+    ``"scenario exercised no checkout negotiation"``. Deals that cannot be
+    scored because a party's ``checkoutcfg`` frame is missing or malformed
+    are not dropped silently: their count is surfaced in the result detail.
 
     Example::
 
@@ -3498,14 +3500,16 @@ def validate_checkout_pareto_efficient(
     sessions = _collect_checkout_sessions(events)
 
     scored = 0
+    unscorable = 0
     violations: list[str] = []
     for sid in sorted(sessions):
         sess = sessions[sid]
-        if sess.agreement is None or sess.buyer is None or sess.seller is None:
+        if sess.agreement is None:
             continue
-        buyer = parties.get(sess.buyer)
-        seller = parties.get(sess.seller)
+        buyer = parties.get(sess.buyer) if sess.buyer is not None else None
+        seller = parties.get(sess.seller) if sess.seller is not None else None
         if buyer is None or seller is None:
+            unscorable += 1
             continue
 
         scored += 1
@@ -3528,21 +3532,24 @@ def validate_checkout_pareto_efficient(
                 )
                 break
 
+    skipped = f"; {unscorable} deal(s) unscorable (missing checkoutcfg)" if unscorable else ""
     if scored == 0:
         return [
             ValidationResult(
                 "checkout_pareto_efficient",
                 False,
-                "scenario exercised no checkout negotiation",
+                "scenario exercised no checkout negotiation" + skipped,
             )
         ]
     if violations:
-        return [ValidationResult("checkout_pareto_efficient", False, "; ".join(violations))]
+        return [
+            ValidationResult("checkout_pareto_efficient", False, "; ".join(violations) + skipped)
+        ]
     return [
         ValidationResult(
             "checkout_pareto_efficient",
             True,
-            f"{scored} deal(s) non-dominated by any cap-feasible exchanged bundle",
+            f"{scored} deal(s) non-dominated by any cap-feasible exchanged bundle" + skipped,
         )
     ]
 
@@ -3563,7 +3570,10 @@ def validate_checkout_budget_and_floor(
 
     Guards against a vacuous pass: if no session with declared caps produced
     a quote or a deal it FAILS with
-    ``"scenario exercised no checkout negotiation"``.
+    ``"scenario exercised no checkout negotiation"``. Active sessions that
+    cannot be scored because a party's ``checkoutcfg`` frame is missing or
+    malformed are not dropped silently: their count is surfaced in the
+    result detail.
 
     Example::
 
@@ -3573,16 +3583,16 @@ def validate_checkout_budget_and_floor(
     sessions = _collect_checkout_sessions(events)
 
     scored = 0
+    unscorable = 0
     offenders: list[str] = []
     for sid in sorted(sessions):
         sess = sessions[sid]
-        if sess.buyer is None or sess.seller is None:
-            continue
-        buyer = parties.get(sess.buyer)
-        seller = parties.get(sess.seller)
-        if buyer is None or seller is None:
-            continue
         if not sess.quotes and sess.agreement is None:
+            continue
+        buyer = parties.get(sess.buyer) if sess.buyer is not None else None
+        seller = parties.get(sess.seller) if sess.seller is not None else None
+        if buyer is None or seller is None:
+            unscorable += 1
             continue
 
         scored += 1
@@ -3602,21 +3612,24 @@ def validate_checkout_budget_and_floor(
             if a_price < seller.cap:
                 offenders.append(f"session {sid}: deal price {a_price} below floor {seller.cap}")
 
+    skipped = f"; {unscorable} session(s) unscorable (missing checkoutcfg)" if unscorable else ""
     if scored == 0:
         return [
             ValidationResult(
                 "checkout_budget_and_floor",
                 False,
-                "scenario exercised no checkout negotiation",
+                "scenario exercised no checkout negotiation" + skipped,
             )
         ]
     if offenders:
-        return [ValidationResult("checkout_budget_and_floor", False, "; ".join(offenders))]
+        return [
+            ValidationResult("checkout_budget_and_floor", False, "; ".join(offenders) + skipped)
+        ]
     return [
         ValidationResult(
             "checkout_budget_and_floor",
             True,
-            f"{scored} session(s) respected every declared budget and floor",
+            f"{scored} session(s) respected every declared budget and floor" + skipped,
         )
     ]
 

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -1820,6 +1820,7 @@ class TestValidatorRegistry:
             "comms_versioning",
             "receipt_reputation",
             "multi_attribute_market",
+            "checkout_market",
             "provenance_supply_chain",
             "bft_hotstuff",
             "escrow_marketplace",

--- a/packages/nest-plugins-reference/nest_plugins_reference/negotiation/checkout_frontier.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/negotiation/checkout_frontier.py
@@ -28,13 +28,26 @@ concession, and that rule changes the guarantee class:
   ``pareto`` plugin, where a good early logroll is gone by the time
   aspiration decays, cannot occur here. In self-play, no agreement is
   Pareto-dominated by any budget-feasible bundle either side exchanged.
+- **Bounded termination**: the patience horizon is a hard stop, not just an
+  aspiration freeze. At or past ``max_rounds`` responds the agent stops
+  conceding fresh ground, re-proposes a clearing standing quote at most once
+  per session, and otherwise declines to counter (``counter_terms=None``).
+  Aspiration is frozen past the horizon, so both a repeated fresh counter
+  and a repeated echo would replay the same deterministic exchange forever;
+  standing down is the only honest move. In self-play every session ends,
+  within roughly ``max_rounds`` rounds plus a small constant, in an
+  acceptance or a breakdown the plugin itself initiates, never one imposed
+  by a driver's round cap.
 
 Hard money constraints are first-class: a buyer never accepts, echoes, or
 proposes a bundle priced above ``budget``; a vendor never goes below
 ``floor``. Caps are constraints, not utility terms, so a great-looking bundle
-the wallet cannot cover is simply ineligible. With mutually exclusive caps
-the plugin declines to counter and the negotiation breaks down cleanly
-rather than closing an unaffordable deal.
+the wallet cannot cover is simply ineligible. Cap conflicts end in an honest
+breakdown on two paths: an agent whose own cap excludes every feasible bundle
+declines to counter immediately, and with mutually exclusive but individually
+feasible caps (a wallet strictly below the vendor's floor) neither side can
+ever accept, so both stand down at the patience horizon instead of haggling
+forever.
 
 Weights are rounded to six decimal places on construction. Trace validators
 compare utilities with a ``1e-9`` tolerance; on integer bundle grids,
@@ -137,6 +150,7 @@ class CheckoutFrontier:
         self._rounds: dict[str, int] = {}
         self._quotes: dict[str, list[tuple[int, int]]] = {}
         self._fresh_bar: dict[str, float] = {}
+        self._horizon_echoes: dict[str, int] = {}
         self._session_counter = 0
 
     async def open(self, partner: AgentId, terms: Terms) -> NegotiationSession:
@@ -182,16 +196,21 @@ class CheckoutFrontier:
            far, find the best by own utility (earliest offer wins exact
            ties). If it clears this round's aspiration floor, accept it when
            it is the offer currently on the table, otherwise re-propose it
-           verbatim; a counterparty running the same rule accepts its own
-           returning quote, so convergence costs at most one extra round.
-        2. Otherwise counter with a fresh bundle from the per-attribute
+           verbatim; when a mutually clearing bundle exists, a counterparty
+           running the same rule accepts its own returning quote, so
+           convergence costs at most one extra round.
+        2. At or past the patience horizon (``max_rounds`` responds), stand
+           down: re-propose a clearing standing quote at most once per
+           session, never concede fresh ground, and otherwise decline to
+           counter. Aspiration is frozen there, so repeating either move
+           would replay the same deterministic exchange forever.
+        3. Otherwise counter with a fresh bundle from the per-attribute
            allowance box: cap-eligible, at or above aspiration, never above
            the previous fresh counter's own utility, and nearest to the
            counterparty's last quote in a distance weighted toward the
            attribute they signalled they value.
-        3. If no cap-eligible bundle exists at all, decline to counter: with
-           mutually exclusive money caps the honest outcome is a breakdown,
-           not a deal someone cannot afford.
+        4. If no cap-eligible bundle exists at all, decline to counter: a
+           wallet that covers nothing has no honest bid to make.
 
         Example::
 
@@ -204,6 +223,7 @@ class CheckoutFrontier:
         round_index = self._rounds.get(session.id, 0)
         self._rounds[session.id] = round_index + 1
         alpha = self._aspiration(round_index)
+        at_horizon = round_index >= self._max_rounds
 
         quotes = self._quotes.get(session.id, [])
         eligible_quotes = [q for q in quotes if self._eligible(q[0])]
@@ -212,8 +232,14 @@ class CheckoutFrontier:
             current = self._clamp(*self._extract(opponent))
             if current == best and self._eligible(current[0]):
                 return NegotiationResponse(accepted=True)
+            if at_horizon:
+                if self._horizon_echoes.get(session.id, 0) >= 1:
+                    return NegotiationResponse(accepted=False, counter_terms=None)
+                self._horizon_echoes[session.id] = 1
             return NegotiationResponse(accepted=False, counter_terms=self._to_terms(best))
 
+        if at_horizon:
+            return NegotiationResponse(accepted=False, counter_terms=None)
         counter = self._fresh_counter(session.id, round_index, alpha)
         if counter is None:
             return NegotiationResponse(accepted=False, counter_terms=None)

--- a/packages/nest-plugins-reference/nest_plugins_reference/negotiation/checkout_frontier.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/negotiation/checkout_frontier.py
@@ -1,0 +1,454 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Buyer-side checkout negotiation that never settles below the exchanged frontier.
+
+Bilateral bargaining over *price* and *delivery deadline*, built for the
+agentic-checkout setting: a shopping agent negotiating purchase terms with a
+vendor under a hard wallet budget, or a vendor quoting under a hard unit-cost
+floor. Attributes ride in the existing ``Terms`` model (``terms.price`` plus
+``terms.conditions["deadline_days"]``), the same encoding the ``pareto``
+plugin uses, so the two interoperate in mixed fleets.
+
+The strategy layers one commerce-shaped rule on top of classical monotonic
+concession, and that rule changes the guarantee class:
+
+- Keeney & Raiffa additive multi-attribute utility with per-attribute
+  patience: the attribute an agent weights more concedes more slowly, so the
+  candidate region widens along a genuine two-dimensional frontier slice
+  rather than collapsing to a scalar.
+- Rosenschein & Zlotkin monotonic concession (Zeuthen): the own-utility
+  aspiration floor ``alpha(t)`` is non-increasing, and every *fresh* counter
+  is additionally capped by the agent's previous fresh counter, so demands
+  never rise.
+- **Best-standing-quote acceptance** (the ANAC "accept the best bid so far"
+  family): every bundle the counterparty ever put on the table stays live.
+  Once the best of them clears the aspiration floor, the agent either accepts
+  it (when it is the offer on the table) or re-proposes it verbatim. Nothing
+  generous is ever "ephemeral": the failure mode pinned by
+  ``test_fsj_tradeoff_does_not_guarantee_pareto_optimality`` for the merged
+  ``pareto`` plugin, where a good early logroll is gone by the time
+  aspiration decays, cannot occur here. In self-play, no agreement is
+  Pareto-dominated by any budget-feasible bundle either side exchanged.
+
+Hard money constraints are first-class: a buyer never accepts, echoes, or
+proposes a bundle priced above ``budget``; a vendor never goes below
+``floor``. Caps are constraints, not utility terms, so a great-looking bundle
+the wallet cannot cover is simply ineligible. With mutually exclusive caps
+the plugin declines to counter and the negotiation breaks down cleanly
+rather than closing an unaffordable deal.
+
+Weights are rounded to six decimal places on construction. Trace validators
+compare utilities with a ``1e-9`` tolerance; on integer bundle grids,
+six-decimal weights make every nonzero utility difference far larger than
+that tolerance, so "almost equal" utilities are exactly equal and tie
+handling stays consistent between the plugin and the offline validators.
+
+The plugin is Tier-1 deterministic: no wall-clock, no unseeded randomness.
+Session ids come from a per-instance counter; the only RNG is the optional
+weights-from-seed path, seeded solely from ``(agent_id, seed)``.
+
+Example::
+
+    neg = CheckoutFrontier(
+        AgentId("shopper"),
+        weights={"price": 0.15, "deadline": 0.85},
+        price_range=(40, 120),
+        deadline_range=(1, 21),
+        side="buyer",
+        budget=110,
+    )
+    session = await neg.open(AgentId("vendor"), Terms(price=Money(amount=40)))
+"""
+
+from __future__ import annotations
+
+import random
+
+from nest_core.types import (
+    AgentId,
+    Agreement,
+    Money,
+    NegotiationResponse,
+    NegotiationSession,
+    NegotiationStatus,
+    Terms,
+)
+
+_EPS = 1e-9
+"""Utility comparison tolerance, matching the offline validators' epsilon."""
+
+_UNMOVED_ATTRIBUTE_WEIGHT = 2.0
+"""Distance coefficient for the attribute the counterparty held fixed.
+
+A counterparty that concedes price while holding the deadline is signalling
+the deadline is what it values. Weighting the *unmoved* attribute more in the
+counter-selection distance pulls the reply closer to their deadline, i.e. the
+agent concedes on the attribute the opponent indicated (Faratin, Sierra &
+Jennings style trade-off, steered by the observed concession direction).
+"""
+
+
+class CheckoutFrontier:
+    """Multi-attribute checkout negotiation with best-standing-quote acceptance.
+
+    Each agent knows only its own private configuration: utility weights,
+    feasible ranges, reservation level, and its hard money cap (a buyer's
+    ``budget`` or a vendor's ``floor``). Negotiation runs over price and
+    deadline carried in ``Terms``; all private configuration enters through
+    the constructor, never through the protocol methods.
+
+    Example::
+
+        neg = CheckoutFrontier(
+            AgentId("vendor"),
+            weights={"price": 1.0, "deadline": 0.0},
+            price_range=(40, 120),
+            deadline_range=(1, 21),
+            side="seller",
+            floor=60,
+        )
+        session = await neg.open(AgentId("shopper"), Terms(price=Money(amount=120)))
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        weights: dict[str, float] | None = None,
+        seed: int | None = None,
+        price_range: tuple[int, int] = (40, 120),
+        deadline_range: tuple[int, int] = (1, 21),
+        side: str = "buyer",
+        patience: float = 0.9,
+        reservation: float = 0.0,
+        budget: int | None = None,
+        floor: int | None = None,
+        max_rounds: int = 12,
+    ) -> None:
+        self._agent_id = agent_id
+        self._price_range = price_range
+        self._deadline_range = deadline_range
+        self._side = side
+        self._patience = patience
+        self._reservation = reservation
+        self._budget = budget
+        self._floor = floor
+        self._max_rounds = max_rounds
+        self._weights = self._resolve_weights(weights, seed)
+        self._rounds: dict[str, int] = {}
+        self._quotes: dict[str, list[tuple[int, int]]] = {}
+        self._fresh_bar: dict[str, float] = {}
+        self._session_counter = 0
+
+    async def open(self, partner: AgentId, terms: Terms) -> NegotiationSession:
+        """Open a negotiation with own opening terms and a deterministic session id.
+
+        Example::
+
+            session = await neg.open(AgentId("vendor"), Terms(price=Money(amount=40)))
+        """
+        self._session_counter += 1
+        return NegotiationSession(
+            id=f"checkout-{self._agent_id}-{self._session_counter}",
+            initiator=self._agent_id,
+            partner=partner,
+            status=NegotiationStatus.OPEN,
+            current_terms=terms,
+            history=[terms],
+        )
+
+    async def offer(self, session: NegotiationSession, terms: Terms) -> None:
+        """Record a counterparty offer; it stays live as a standing quote.
+
+        Every priced bundle the counterparty puts on the table is remembered
+        for the rest of the session, so a generous early quote can still be
+        accepted (or re-proposed) after aspiration decays.
+
+        Example::
+
+            await neg.offer(session, Terms(price=Money(amount=108)))
+        """
+        session.current_terms = terms
+        session.history.append(terms)
+        if terms.price is not None:
+            bundle = self._clamp(*self._extract(terms))
+            self._quotes.setdefault(session.id, []).append(bundle)
+
+    async def respond(self, session: NegotiationSession) -> NegotiationResponse:
+        """Accept or echo the best standing quote once it clears aspiration, else concede.
+
+        The decision order is the mechanism:
+
+        1. Among every cap-eligible bundle the counterparty has offered so
+           far, find the best by own utility (earliest offer wins exact
+           ties). If it clears this round's aspiration floor, accept it when
+           it is the offer currently on the table, otherwise re-propose it
+           verbatim; a counterparty running the same rule accepts its own
+           returning quote, so convergence costs at most one extra round.
+        2. Otherwise counter with a fresh bundle from the per-attribute
+           allowance box: cap-eligible, at or above aspiration, never above
+           the previous fresh counter's own utility, and nearest to the
+           counterparty's last quote in a distance weighted toward the
+           attribute they signalled they value.
+        3. If no cap-eligible bundle exists at all, decline to counter: with
+           mutually exclusive money caps the honest outcome is a breakdown,
+           not a deal someone cannot afford.
+
+        Example::
+
+            resp = await neg.respond(session)
+        """
+        opponent = session.current_terms
+        if opponent is None or opponent.price is None:
+            return NegotiationResponse(accepted=True)
+
+        round_index = self._rounds.get(session.id, 0)
+        self._rounds[session.id] = round_index + 1
+        alpha = self._aspiration(round_index)
+
+        quotes = self._quotes.get(session.id, [])
+        eligible_quotes = [q for q in quotes if self._eligible(q[0])]
+        best = self._first_max(eligible_quotes)
+        if best is not None and self._score(*best) >= alpha - _EPS:
+            current = self._clamp(*self._extract(opponent))
+            if current == best and self._eligible(current[0]):
+                return NegotiationResponse(accepted=True)
+            return NegotiationResponse(accepted=False, counter_terms=self._to_terms(best))
+
+        counter = self._fresh_counter(session.id, round_index, alpha)
+        if counter is None:
+            return NegotiationResponse(accepted=False, counter_terms=None)
+        return NegotiationResponse(accepted=False, counter_terms=self._to_terms(counter))
+
+    async def close(self, session: NegotiationSession) -> Agreement | None:
+        """Return an agreement only for an ``AGREED`` session, else mark it rejected.
+
+        Strict by design: a checkout must not capture payment without both
+        signatures. Unlike the reference ``alternating_offers`` close, which
+        settles on any non-``None`` current terms, an unagreed session here is
+        a breakdown and returns ``None``.
+
+        Example::
+
+            agreement = await neg.close(session)
+        """
+        if session.status == NegotiationStatus.AGREED:
+            return Agreement(
+                session_id=session.id,
+                terms=session.current_terms or Terms(),
+                parties=[session.initiator, session.partner],
+            )
+        session.status = NegotiationStatus.REJECTED
+        return None
+
+    def utility(self, terms: Terms) -> float:
+        """Return this agent's additive multi-attribute utility for ``terms``.
+
+        Price and deadline value functions are normalized to ``[0, 1]`` with
+        the directional convention of ``side`` (a buyer prefers a low price
+        and a short deadline, a seller the opposite) and combined with the
+        agent's weights. Inputs are clamped into the feasible ranges.
+
+        Example::
+
+            neg = CheckoutFrontier(
+                AgentId("b"),
+                weights={"price": 0.5, "deadline": 0.5},
+                price_range=(40, 50),
+                deadline_range=(1, 5),
+                side="buyer",
+            )
+            neg.utility(Terms(price=Money(amount=40), conditions={"deadline_days": 1}))  # 1.0
+        """
+        return self._score(*self._extract(terms))
+
+    def _resolve_weights(
+        self, weights: dict[str, float] | None, seed: int | None
+    ) -> dict[str, float]:
+        """Resolve the utility weights: explicit, derived from seed, or equal.
+
+        Explicit weights win. With only a ``seed``, the price weight is drawn
+        from a generator seeded solely by ``(agent_id, seed)``, so the same
+        identity and seed always produce the same preferences. All weights
+        are rounded to six decimals to keep utility gaps on the integer
+        bundle grid far above the validators' ``1e-9`` tolerance.
+        """
+        if weights is not None:
+            w_price = round(weights["price"], 6)
+            return {"price": w_price, "deadline": round(weights["deadline"], 6)}
+        if seed is not None:
+            rng = random.Random(f"{self._agent_id}:{seed}")
+            w_price = round(rng.uniform(0.1, 0.9), 6)
+            return {"price": w_price, "deadline": round(1.0 - w_price, 6)}
+        return {"price": 0.5, "deadline": 0.5}
+
+    def _aspiration(self, round_index: int) -> float:
+        """Non-increasing own-utility floor (Zeuthen / monotonic concession).
+
+        ``alpha(t) = reservation + (1 - reservation) * patience ** t`` with
+        ``t`` capped at ``max_rounds``.
+        """
+        t = min(round_index, self._max_rounds)
+        return self._reservation + (1.0 - self._reservation) * (self._patience**t)
+
+    def _eligible(self, price: int) -> bool:
+        """Whether a price respects this agent's own hard money cap.
+
+        Caps are private: a buyer checks only its budget, a vendor only its
+        floor. Cross-party feasibility is the validators' job.
+        """
+        if self._side == "buyer":
+            return self._budget is None or price <= self._budget
+        return self._floor is None or price >= self._floor
+
+    def _first_max(self, bundles: list[tuple[int, int]]) -> tuple[int, int] | None:
+        """Best bundle by own utility; the earliest offer wins exact ties.
+
+        The earliest-tie rule is load-bearing: under the counterparty's own
+        monotonic concession, the earliest of equally-good-for-us quotes is
+        the one best for *them*, so echoing it can never trade away their
+        surplus for nothing.
+        """
+        best: tuple[int, int] | None = None
+        best_u = float("-inf")
+        for bundle in bundles:
+            u = self._score(*bundle)
+            if u > best_u + _EPS:
+                best, best_u = bundle, u
+        return best
+
+    def _fresh_counter(self, sid: str, round_index: int, alpha: float) -> tuple[int, int] | None:
+        """Pick a fresh concession bundle, or ``None`` when no eligible bundle exists.
+
+        Candidates come from the per-attribute allowance box around the
+        agent's ideal corner, filtered to the utility band between this
+        round's aspiration and the previous fresh counter (demands never
+        rise). If the box is empty the band widens to the whole grid; if the
+        band itself is unreachable the agent restates its best eligible
+        bundle. Selection is by direction-weighted distance to the
+        counterparty's last quote with explicit integer tie-breaks, so every
+        step is deterministic.
+        """
+        bar = self._fresh_bar.get(sid, 1.0)
+        eligible = [b for b in self._grid() if self._eligible(b[0])]
+        if not eligible:
+            return None
+
+        in_band = [b for b in eligible if alpha - _EPS <= self._score(*b) <= bar + _EPS]
+        box = set(self._allowance_box(round_index))
+        candidates = [b for b in in_band if b in box] or in_band
+        if not candidates:
+            candidates = [max(eligible, key=lambda b: (self._score(*b), -b[0], -b[1]))]
+
+        target = self._last_quote(sid)
+        c_price, c_deadline = self._direction_weights(sid)
+        plo, phi = self._price_range
+        dlo, dhi = self._deadline_range
+        p_span, d_span = phi - plo, dhi - dlo
+
+        def distance(b: tuple[int, int]) -> tuple[float, int, int]:
+            dp = (b[0] - target[0]) / p_span
+            dd = (b[1] - target[1]) / d_span
+            return (c_price * dp * dp + c_deadline * dd * dd, b[0], b[1])
+
+        chosen = min(candidates, key=distance)
+        self._fresh_bar[sid] = self._score(*chosen)
+        return chosen
+
+    def _allowance_box(self, round_index: int) -> list[tuple[int, int]]:
+        """Bundles within this round's per-attribute concession allowance.
+
+        Each attribute may move away from the agent's ideal corner by
+        ``span * (1 - patience_a ** t)`` where ``patience_a`` grows with the
+        attribute's weight: the agent concedes more slowly on what it values.
+        The box therefore widens at different per-attribute rates, tracing a
+        two-dimensional frontier slice instead of a scalar schedule.
+        """
+        plo, phi = self._price_range
+        dlo, dhi = self._deadline_range
+        t = min(round_index, self._max_rounds)
+        allow_p = (phi - plo) * (1.0 - self._attribute_patience("price") ** t)
+        allow_d = (dhi - dlo) * (1.0 - self._attribute_patience("deadline") ** t)
+        if self._side == "buyer":
+            prices = range(plo, min(phi, plo + int(allow_p)) + 1)
+            deadlines = range(dlo, min(dhi, dlo + int(allow_d)) + 1)
+        else:
+            prices = range(max(plo, phi - int(allow_p)), phi + 1)
+            deadlines = range(max(dlo, dhi - int(allow_d)), dhi + 1)
+        return [(p, d) for p in prices for d in deadlines]
+
+    def _attribute_patience(self, attribute: str) -> float:
+        """Per-attribute concession discount, higher for the heavier weight."""
+        return self._patience + (1.0 - self._patience) * self._weights[attribute]
+
+    def _direction_weights(self, sid: str) -> tuple[float, float]:
+        """Distance coefficients steering concession toward the opponent's signal.
+
+        Comparing the counterparty's last two quotes, the attribute they held
+        (smaller normalized move) is the one they value; it gets the heavier
+        coefficient so the fresh counter lands closer to them on it.
+        """
+        quotes = self._quotes.get(sid, [])
+        if len(quotes) < 2:
+            return 1.0, 1.0
+        plo, phi = self._price_range
+        dlo, dhi = self._deadline_range
+        (pp, pd), (lp, ld) = quotes[-2], quotes[-1]
+        moved_p = abs(lp - pp) / (phi - plo)
+        moved_d = abs(ld - pd) / (dhi - dlo)
+        if moved_p < moved_d - _EPS:
+            return _UNMOVED_ATTRIBUTE_WEIGHT, 1.0
+        if moved_d < moved_p - _EPS:
+            return 1.0, _UNMOVED_ATTRIBUTE_WEIGHT
+        return 1.0, 1.0
+
+    def _last_quote(self, sid: str) -> tuple[int, int]:
+        """The counterparty's most recent bundle, or own ideal corner before any."""
+        quotes = self._quotes.get(sid, [])
+        if quotes:
+            return quotes[-1]
+        return self._ideal()
+
+    def _ideal(self) -> tuple[int, int]:
+        """This side's utility-1.0 corner of the feasible rectangle."""
+        plo, phi = self._price_range
+        dlo, dhi = self._deadline_range
+        if self._side == "buyer":
+            return plo, dlo
+        return phi, dhi
+
+    def _grid(self) -> list[tuple[int, int]]:
+        """Deterministic enumeration of every feasible (price, deadline) bundle."""
+        plo, phi = self._price_range
+        dlo, dhi = self._deadline_range
+        return [(p, d) for p in range(plo, phi + 1) for d in range(dlo, dhi + 1)]
+
+    def _extract(self, terms: Terms) -> tuple[int, int]:
+        """Pull the raw (price, deadline) pair out of ``terms`` as ints."""
+        plo, _ = self._price_range
+        dlo, _ = self._deadline_range
+        price = terms.price.amount if terms.price is not None else plo
+        deadline = int(terms.conditions.get("deadline_days", dlo))
+        return price, deadline
+
+    def _clamp(self, price: int, deadline: int) -> tuple[int, int]:
+        """Clamp a (price, deadline) pair into the feasible ranges."""
+        plo, phi = self._price_range
+        dlo, dhi = self._deadline_range
+        return max(plo, min(phi, price)), max(dlo, min(dhi, deadline))
+
+    def _score(self, price: int, deadline: int) -> float:
+        """Additive MAUT score for a (price, deadline) pair after clamping."""
+        plo, phi = self._price_range
+        dlo, dhi = self._deadline_range
+        p, d = self._clamp(price, deadline)
+        if self._side == "buyer":
+            f_price = (phi - p) / (phi - plo)
+            f_deadline = (dhi - d) / (dhi - dlo)
+        else:
+            f_price = (p - plo) / (phi - plo)
+            f_deadline = (d - dlo) / (dhi - dlo)
+        return self._weights["price"] * f_price + self._weights["deadline"] * f_deadline
+
+    def _to_terms(self, bundle: tuple[int, int]) -> Terms:
+        """Wrap a (price, deadline) bundle in the shared ``Terms`` encoding."""
+        return Terms(price=Money(amount=bundle[0]), conditions={"deadline_days": bundle[1]})

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -42,6 +42,9 @@ hybrid_x25519 = "nest_plugins_reference.privacy.hybrid_x25519:HybridX25519Privac
 [project.entry-points."nest.plugins.datafacts"]
 cid_facts = "nest_plugins_reference.datafacts.cid_facts:CidFacts"
 
+[project.entry-points."nest.plugins.negotiation"]
+checkout_frontier = "nest_plugins_reference.negotiation.checkout_frontier:CheckoutFrontier"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/nest-plugins-reference/tests/test_checkout_frontier.py
+++ b/packages/nest-plugins-reference/tests/test_checkout_frontier.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportPrivateUsage=false
+"""Unit tests for the CheckoutFrontier negotiation plugin.
+
+The commerce risk model is the test emphasis: hard wallet budgets and vendor
+cost floors are inviolable (never accept, echo, or propose across your own
+cap), a generous early quote stays live until it can be accepted, and a
+checkout never closes without both signatures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from nest_core.types import AgentId, Money, NegotiationStatus, Terms
+from nest_plugins_reference.negotiation.checkout_frontier import CheckoutFrontier
+
+
+def _terms(price: int, deadline: int) -> Terms:
+    return Terms(price=Money(amount=price), conditions={"deadline_days": deadline})
+
+
+def _pd(terms: Terms) -> tuple[int, int]:
+    price = terms.price.amount if terms.price is not None else 0
+    return price, int(terms.conditions.get("deadline_days", 0))
+
+
+def _buyer(**overrides: object) -> CheckoutFrontier:
+    kwargs: dict[str, object] = {
+        "weights": {"price": 0.5, "deadline": 0.5},
+        "price_range": (40, 60),
+        "deadline_range": (1, 11),
+        "side": "buyer",
+        "patience": 0.8,
+    }
+    kwargs.update(overrides)
+    return CheckoutFrontier(AgentId("shopper"), **kwargs)  # type: ignore[arg-type]
+
+
+def _vendor(**overrides: object) -> CheckoutFrontier:
+    kwargs: dict[str, object] = {
+        "weights": {"price": 0.5, "deadline": 0.5},
+        "price_range": (40, 60),
+        "deadline_range": (1, 11),
+        "side": "seller",
+        "patience": 0.8,
+    }
+    kwargs.update(overrides)
+    return CheckoutFrontier(AgentId("vendor"), **kwargs)  # type: ignore[arg-type]
+
+
+async def _respond_to(
+    agent: CheckoutFrontier, offers: list[tuple[int, int]]
+) -> list[tuple[bool, tuple[int, int] | None]]:
+    """Feed a sequence of counterparty offers; collect (accepted, counter) pairs."""
+    session = await agent.open(AgentId("counterparty"), _terms(*_pd(_terms(40, 1))))
+    out: list[tuple[bool, tuple[int, int] | None]] = []
+    for price, deadline in offers:
+        await agent.offer(session, _terms(price, deadline))
+        resp = await agent.respond(session)
+        counter = _pd(resp.counter_terms) if resp.counter_terms is not None else None
+        out.append((resp.accepted, counter))
+    return out
+
+
+# Utility
+
+
+def test_utility_directional_buyer() -> None:
+    """The buyer prefers a lower price and a shorter deadline."""
+    buyer = _buyer()
+    assert buyer.utility(_terms(45, 3)) > buyer.utility(_terms(55, 3))
+    assert buyer.utility(_terms(45, 3)) > buyer.utility(_terms(45, 9))
+
+
+def test_utility_directional_vendor() -> None:
+    """The vendor prefers a higher price and a longer deadline."""
+    vendor = _vendor()
+    assert vendor.utility(_terms(55, 3)) > vendor.utility(_terms(45, 3))
+    assert vendor.utility(_terms(45, 9)) > vendor.utility(_terms(45, 3))
+
+
+def test_ideal_bundle_scores_one() -> None:
+    """Each side's ideal corner scores exactly 1.0."""
+    assert _buyer().utility(_terms(40, 1)) == 1.0
+    assert _vendor().utility(_terms(60, 11)) == 1.0
+
+
+# Weights from seed
+
+
+def test_weights_from_seed_deterministic() -> None:
+    """The same (agent_id, seed) always derives the same weights."""
+    a = CheckoutFrontier(AgentId("shopper"), seed=7)
+    b = CheckoutFrontier(AgentId("shopper"), seed=7)
+    assert a._weights == b._weights
+
+
+def test_weights_from_seed_vary_by_agent() -> None:
+    """Different agent ids draw different preferences from the same seed."""
+    a = CheckoutFrontier(AgentId("shopper-a"), seed=7)
+    b = CheckoutFrontier(AgentId("shopper-b"), seed=7)
+    assert a._weights != b._weights
+
+
+def test_weights_from_seed_well_formed() -> None:
+    """Derived weights are 6-dp rounded, in range, and sum to 1."""
+    weights = CheckoutFrontier(AgentId("shopper"), seed=42)._weights
+    for value in weights.values():
+        assert 0.0 <= value <= 1.0
+        assert value == round(value, 6)
+    assert abs(weights["price"] + weights["deadline"] - 1.0) < 1e-9
+
+
+# Acceptance and the standing-quote echo
+
+
+def test_accepts_ideal_offer_immediately() -> None:
+    """An offer at the agent's ideal corner is accepted in round one."""
+    result = asyncio.run(_respond_to(_buyer(), [(40, 1)]))
+    assert result[0][0] is True
+
+
+def test_echoes_best_standing_quote_when_aspiration_reached() -> None:
+    """A generous early quote is re-proposed verbatim once aspiration decays.
+
+    Round 1: (44, 2) is worth 0.85 to the buyer, below aspiration 1.0, so it
+    is not accepted, but it stays live. Round 2: the vendor regresses to its
+    own ideal (60, 11); aspiration is now 0.8 <= 0.85, so instead of accepting
+    the bad current offer or conceding fresh ground, the buyer re-proposes
+    the standing (44, 2). Round 3: the vendor re-offers it; the buyer accepts.
+    """
+    result = asyncio.run(_respond_to(_buyer(), [(44, 2), (60, 11), (44, 2)]))
+    assert result[0] == (False, (40, 1))
+    assert result[1] == (False, (44, 2))
+    assert result[2][0] is True
+
+
+def test_earliest_quote_wins_exact_utility_ties() -> None:
+    """Among utility-tied standing quotes the earliest is echoed.
+
+    With equal weights and matched spans, (46, 2) and (44, 4) tie exactly for
+    the buyer (0.85 each). The earlier one is the counterparty's least
+    conceded, so echoing it never trades away counterparty surplus for
+    nothing.
+    """
+    buyer = _buyer(deadline_range=(1, 21))
+
+    async def go() -> tuple[int, int] | None:
+        session = await buyer.open(AgentId("vendor"), _terms(40, 1))
+        await buyer.offer(session, _terms(46, 2))
+        await buyer.respond(session)
+        await buyer.offer(session, _terms(44, 4))
+        resp = await buyer.respond(session)
+        return _pd(resp.counter_terms) if resp.counter_terms is not None else None
+
+    # u(46,2) = 0.5*(14/20) + 0.5*(19/20) = 0.825; u(44,4) = 0.5*(16/20) + 0.5*(17/20) = 0.825
+    assert asyncio.run(go()) == (46, 2)
+
+
+# Hard money caps
+
+
+def test_buyer_never_accepts_or_counters_above_budget() -> None:
+    """Attractive but unaffordable quotes are refused; counters respect the wallet."""
+    buyer = _buyer(
+        weights={"price": 0.1, "deadline": 0.9},
+        price_range=(40, 120),
+        deadline_range=(1, 21),
+        patience=0.9,
+        budget=100,
+    )
+    result = asyncio.run(_respond_to(buyer, [(105, 1), (110, 1), (108, 1), (110, 1)]))
+    for accepted, counter in result:
+        assert accepted is False
+        assert counter is not None
+        assert counter[0] <= 100
+
+
+def test_buyer_accepts_rush_quote_within_budget() -> None:
+    """The same rush logroll is accepted the moment it fits the wallet."""
+    buyer = _buyer(
+        weights={"price": 0.1, "deadline": 0.9},
+        price_range=(40, 120),
+        deadline_range=(1, 21),
+        patience=0.9,
+        budget=100,
+    )
+    result = asyncio.run(_respond_to(buyer, [(105, 1), (100, 1)]))
+    assert result[0][0] is False
+    assert result[1][0] is True
+
+
+def test_vendor_never_goes_below_floor() -> None:
+    """A vendor with a cost floor never proposes or accepts beneath it."""
+    vendor = _vendor(
+        price_range=(40, 120),
+        deadline_range=(1, 21),
+        patience=0.9,
+        floor=80,
+    )
+    result = asyncio.run(_respond_to(vendor, [(50, 21), (60, 21), (70, 21), (75, 21)]))
+    for accepted, counter in result:
+        assert accepted is False
+        assert counter is not None
+        assert counter[0] >= 80
+
+
+def test_no_eligible_bundle_declines_to_counter() -> None:
+    """A wallet below every feasible price yields refusal, not a fantasy counter."""
+    buyer = _buyer(budget=30)
+    result = asyncio.run(_respond_to(buyer, [(40, 1)]))
+    assert result[0] == (False, None)
+
+
+# Direction reading
+
+
+def test_direction_weights_favor_held_attribute() -> None:
+    """The attribute the counterparty holds fixed gets the heavier coefficient."""
+    buyer = _buyer()
+
+    async def observe(offers: list[tuple[int, int]]) -> tuple[float, float]:
+        session = await buyer.open(AgentId("vendor"), _terms(40, 1))
+        for price, deadline in offers:
+            await buyer.offer(session, _terms(price, deadline))
+        return buyer._direction_weights(session.id)
+
+    # Price conceded, deadline held: they value the deadline.
+    assert asyncio.run(observe([(60, 11), (56, 11)])) == (1.0, 2.0)
+    # Deadline conceded, price held: they value the price.
+    assert asyncio.run(observe([(60, 11), (60, 8)])) == (2.0, 1.0)
+    # One quote only: no signal yet.
+    assert asyncio.run(observe([(60, 11)])) == (1.0, 1.0)
+
+
+# Close semantics
+
+
+def test_close_returns_none_and_rejects_unagreed_session() -> None:
+    """No agreement without both signatures: unagreed sessions break down."""
+    buyer = _buyer()
+
+    async def go() -> tuple[object, NegotiationStatus]:
+        session = await buyer.open(AgentId("vendor"), _terms(40, 1))
+        agreement = await buyer.close(session)
+        return agreement, session.status
+
+    agreement, status = asyncio.run(go())
+    assert agreement is None
+    assert status == NegotiationStatus.REJECTED
+
+
+def test_close_returns_agreement_when_agreed() -> None:
+    """An AGREED session closes into an Agreement carrying the final terms."""
+    buyer = _buyer()
+
+    async def go() -> tuple[int, int]:
+        session = await buyer.open(AgentId("vendor"), _terms(40, 1))
+        await buyer.offer(session, _terms(44, 2))
+        session.status = NegotiationStatus.AGREED
+        agreement = await buyer.close(session)
+        assert agreement is not None
+        return _pd(agreement.terms)
+
+    assert asyncio.run(go()) == (44, 2)
+
+
+def test_empty_terms_accepted_as_reference_fallback() -> None:
+    """Terms without a price fall back to acceptance, matching the reference plugins."""
+    buyer = _buyer()
+
+    async def go() -> bool:
+        session = await buyer.open(AgentId("vendor"), Terms())
+        resp = await buyer.respond(session)
+        return resp.accepted
+
+    assert asyncio.run(go()) is True

--- a/packages/nest-plugins-reference/tests/test_checkout_frontier.py
+++ b/packages/nest-plugins-reference/tests/test_checkout_frontier.py
@@ -213,6 +213,42 @@ def test_no_eligible_bundle_declines_to_counter() -> None:
     assert result[0] == (False, None)
 
 
+# Patience-horizon termination
+
+
+def test_declines_fresh_counters_past_horizon() -> None:
+    """Past max_rounds responds, the agent stops conceding and declines to counter.
+
+    Aspiration is frozen at the horizon, so a fresh counter would repeat the
+    same deterministic exchange forever; the plugin stands down instead of
+    relying on a driver's round cap to end the session.
+    """
+    buyer = _buyer(max_rounds=3)
+    result = asyncio.run(_respond_to(buyer, [(60, 11)] * 5))
+    for accepted, counter in result[:3]:
+        assert accepted is False
+        assert counter is not None
+    assert result[3] == (False, None)
+    assert result[4] == (False, None)
+
+
+def test_echoes_at_most_once_past_horizon_then_accepts_or_declines() -> None:
+    """Past the horizon a clearing standing quote is re-proposed once, then never again.
+
+    The counterparty's decision on a repeated echo under frozen aspiration is
+    deterministic, so repeating it is provably futile: the second attempt
+    declines. A clearing offer that arrives on the table is still accepted,
+    at any round.
+    """
+    buyer = _buyer(max_rounds=2)
+    result = asyncio.run(_respond_to(buyer, [(44, 2), (60, 11), (60, 11), (60, 11), (44, 2)]))
+    assert result[0] == (False, (40, 1))  # aspiration 1.0: fresh counter
+    assert result[1] == (False, (44, 2))  # pre-horizon echo of the standing quote
+    assert result[2] == (False, (44, 2))  # the one allowed past-horizon echo
+    assert result[3] == (False, None)  # repeat echo is futile: decline
+    assert result[4][0] is True  # a clearing current offer is accepted even now
+
+
 # Direction reading
 
 

--- a/packages/nest-plugins-reference/tests/test_checkout_frontier_properties.py
+++ b/packages/nest-plugins-reference/tests/test_checkout_frontier_properties.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Property tests for CheckoutFrontier (Hypothesis).
+
+Four property families:
+
+* **Determinism**: identical construction plus an identical offer sequence
+  yields an identical response transcript (no wall-clock, no unseeded RNG).
+* **Monotonic concession**: an agent's *fresh* counters (bundles that are not
+  echoes of standing counterparty quotes) have non-increasing own utility.
+* **No dominated self-play** (the flagship): two CheckoutFrontier agents never
+  settle on an agreement Pareto-dominated by any cap-feasible bundle either
+  side exchanged. This is exactly the guarantee the merged ``pareto`` plugin
+  documents as unattainable for pure trade-off concession in
+  ``test_fsj_tradeoff_does_not_guarantee_pareto_optimality`` (a generous early
+  bundle is ephemeral there; here every standing quote stays live), asserted
+  green here including on that test's pinned counterexample configuration.
+* **Hard caps and rationality**: settled deals land inside
+  ``[floor, budget]`` with both utilities at or above reservation, and
+  mutually exclusive caps always break down instead of dealing.
+
+Weights are drawn on the six-decimal lattice (``k / 1_000_000``) with bundle
+spans capped at 15, so every nonzero utility difference on the integer grid
+exceeds ``1/(10**6 * 15 * 15) ~ 4.4e-9``, comfortably above the ``1e-9``
+comparison epsilon: near-ties are exact ties and the dominance check cannot
+be gamed by float noise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import NamedTuple
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.strategies import DrawFn
+from nest_core.types import AgentId, Money, Terms
+from nest_plugins_reference.negotiation.checkout_frontier import CheckoutFrontier
+
+_EPS = 1e-9
+
+
+def _terms(price: int, deadline: int) -> Terms:
+    return Terms(price=Money(amount=price), conditions={"deadline_days": deadline})
+
+
+def _pd(terms: Terms) -> tuple[int, int]:
+    price = terms.price.amount if terms.price is not None else 0
+    return price, int(terms.conditions.get("deadline_days", 0))
+
+
+def _dominates(ub_x: float, us_x: float, ub_y: float, us_y: float) -> bool:
+    """X dominates Y: no worse for either party, strictly better for one (eps-guarded)."""
+    no_worse = ub_x >= ub_y - _EPS and us_x >= us_y - _EPS
+    strictly_better = ub_x > ub_y + _EPS or us_x > us_y + _EPS
+    return no_worse and strictly_better
+
+
+class _Cfg(NamedTuple):
+    plo: int
+    phi: int
+    dlo: int
+    dhi: int
+    patience: float
+    buyer_wp: float
+    seller_wd: float
+    reservation: float
+    budget: int | None
+    floor: int | None
+
+
+@st.composite
+def _cfgs(draw: DrawFn) -> _Cfg:
+    plo = draw(st.integers(10, 50))
+    phi = plo + draw(st.integers(5, 15))
+    dlo = draw(st.integers(1, 5))
+    dhi = dlo + draw(st.integers(5, 15))
+    patience = draw(st.floats(0.7, 0.95, allow_nan=False, allow_infinity=False))
+    # Weights on the 6-dp lattice keep utility gaps far above the epsilon.
+    buyer_wp = draw(st.integers(100_000, 900_000)) / 1_000_000
+    seller_wd = draw(st.integers(100_000, 900_000)) / 1_000_000
+    reservation = draw(st.floats(0.0, 0.3, allow_nan=False, allow_infinity=False))
+    budget = draw(st.one_of(st.none(), st.integers(plo, phi)))
+    floor = draw(st.one_of(st.none(), st.integers(plo, phi)))
+    return _Cfg(plo, phi, dlo, dhi, patience, buyer_wp, seller_wd, reservation, budget, floor)
+
+
+@st.composite
+def _cfg_and_offers(draw: DrawFn) -> tuple[_Cfg, list[tuple[int, int]]]:
+    cfg = draw(_cfgs())
+    offers = draw(
+        st.lists(
+            st.tuples(st.integers(cfg.plo, cfg.phi), st.integers(cfg.dlo, cfg.dhi)),
+            min_size=1,
+            max_size=8,
+        )
+    )
+    return cfg, offers
+
+
+def _make_buyer(cfg: _Cfg, max_rounds: int = 12) -> CheckoutFrontier:
+    return CheckoutFrontier(
+        AgentId("shopper"),
+        weights={"price": cfg.buyer_wp, "deadline": round(1.0 - cfg.buyer_wp, 6)},
+        price_range=(cfg.plo, cfg.phi),
+        deadline_range=(cfg.dlo, cfg.dhi),
+        side="buyer",
+        patience=cfg.patience,
+        reservation=cfg.reservation,
+        budget=cfg.budget,
+        max_rounds=max_rounds,
+    )
+
+
+def _make_vendor(cfg: _Cfg, max_rounds: int = 12) -> CheckoutFrontier:
+    return CheckoutFrontier(
+        AgentId("vendor"),
+        weights={"price": round(1.0 - cfg.seller_wd, 6), "deadline": cfg.seller_wd},
+        price_range=(cfg.plo, cfg.phi),
+        deadline_range=(cfg.dlo, cfg.dhi),
+        side="seller",
+        patience=cfg.patience,
+        reservation=cfg.reservation,
+        floor=cfg.floor,
+        max_rounds=max_rounds,
+    )
+
+
+async def _self_play(
+    buyer: CheckoutFrontier, vendor: CheckoutFrontier, bounds: tuple[int, int, int, int]
+) -> tuple[tuple[int, int] | None, list[tuple[int, int]]]:
+    """Run two agents to settlement; return the agreement (if any) and exchanged bundles.
+
+    Each side opens from its best-for-self position, then alternately responds
+    to the other's latest offer. An agent either accepts (the offer becomes
+    the agreement), declines without a counter (breakdown), or counters; every
+    counter is recorded and forwarded.
+    """
+    plo, phi, dlo, dhi = bounds
+    buyer_open = _terms(plo, dlo)
+    vendor_open = _terms(phi, dhi)
+    bs = await buyer.open(AgentId("vendor"), buyer_open)
+    vs = await vendor.open(AgentId("shopper"), vendor_open)
+    exchanged: list[tuple[int, int]] = [(plo, dlo), (phi, dhi)]
+    buyer_last, vendor_last = buyer_open, vendor_open
+    for _ in range(30):
+        await buyer.offer(bs, vendor_last)
+        br = await buyer.respond(bs)
+        if br.accepted:
+            return _pd(vendor_last), exchanged
+        if br.counter_terms is None:
+            return None, exchanged
+        buyer_last = br.counter_terms
+        exchanged.append(_pd(buyer_last))
+
+        await vendor.offer(vs, buyer_last)
+        vr = await vendor.respond(vs)
+        if vr.accepted:
+            return _pd(buyer_last), exchanged
+        if vr.counter_terms is None:
+            return None, exchanged
+        vendor_last = vr.counter_terms
+        exchanged.append(_pd(vendor_last))
+    return None, exchanged
+
+
+@given(payload=_cfg_and_offers())
+@settings(max_examples=200)
+def test_determinism(payload: tuple[_Cfg, list[tuple[int, int]]]) -> None:
+    """Two identically-built agents fed the same offers produce identical transcripts."""
+    cfg, offers = payload
+
+    async def drive(agent: CheckoutFrontier) -> list[tuple[bool, tuple[int, int] | None]]:
+        session = await agent.open(AgentId("opp"), _terms(cfg.plo, cfg.dlo))
+        out: list[tuple[bool, tuple[int, int] | None]] = []
+        for price, deadline in offers:
+            await agent.offer(session, _terms(price, deadline))
+            resp = await agent.respond(session)
+            counter = _pd(resp.counter_terms) if resp.counter_terms is not None else None
+            out.append((resp.accepted, counter))
+        return out
+
+    assert asyncio.run(drive(_make_vendor(cfg))) == asyncio.run(drive(_make_vendor(cfg)))
+
+
+@given(cfg=_cfgs())
+@settings(max_examples=200)
+def test_monotonic_concession_of_fresh_counters(cfg: _Cfg) -> None:
+    """A vendor's fresh counters have non-increasing own utility (MCP / Zeuthen).
+
+    Fed its worst bundle repeatedly (utility 0, always below aspiration), the
+    vendor never accepts and never echoes, so every counter is fresh and must
+    sit on a non-increasing demand schedule.
+    """
+    vendor = _make_vendor(cfg)
+    worst_for_vendor = _terms(cfg.plo, cfg.dlo)
+
+    async def collect() -> list[float]:
+        session = await vendor.open(AgentId("opp"), worst_for_vendor)
+        utils: list[float] = []
+        for _ in range(15):
+            await vendor.offer(session, worst_for_vendor)
+            resp = await vendor.respond(session)
+            if resp.accepted or resp.counter_terms is None:
+                break
+            utils.append(vendor.utility(resp.counter_terms))
+        return utils
+
+    utils = asyncio.run(collect())
+    if cfg.floor is not None and cfg.floor > cfg.phi:
+        return  # no eligible bundle at all: nothing to assert
+    assert len(utils) >= 2
+    for earlier, later in zip(utils, utils[1:], strict=False):
+        assert later <= earlier + _EPS, f"concession not monotonic: {utils}"
+
+
+@given(cfg=_cfgs())
+@settings(max_examples=200, deadline=None)
+def test_selfplay_agreement_never_dominated_by_exchanged_bundle(cfg: _Cfg) -> None:
+    """No settled deal is Pareto-dominated by a cap-feasible exchanged bundle.
+
+    The merged ``pareto`` plugin pins this exact property as out of reach for
+    pure trade-off concession (its good early bundles are ephemeral). Standing
+    quotes make it hold: an agent accepts only the best cap-feasible bundle
+    its counterpart ever offered, and echoes recover anything generous that
+    aspiration once refused. Feasibility matters: a bundle no wallet can pay
+    for is not evidence of a better deal, so dominance is judged over bundles
+    inside both parties' declared caps, exactly as the offline trace validator
+    judges it.
+    """
+    buyer = _make_buyer(cfg, max_rounds=25)
+    vendor = _make_vendor(cfg, max_rounds=25)
+    agreement, exchanged = asyncio.run(
+        _self_play(buyer, vendor, (cfg.plo, cfg.phi, cfg.dlo, cfg.dhi))
+    )
+    if agreement is None:
+        return  # breakdown: the dominance claim is about settled deals only
+
+    ap, ad = agreement
+    ub_star = buyer.utility(_terms(ap, ad))
+    us_star = vendor.utility(_terms(ap, ad))
+
+    def feasible(bundle: tuple[int, int]) -> bool:
+        price = bundle[0]
+        within_budget = cfg.budget is None or price <= cfg.budget
+        above_floor = cfg.floor is None or price >= cfg.floor
+        return within_budget and above_floor
+
+    dominators = [
+        bundle
+        for bundle in exchanged
+        if bundle != (ap, ad)
+        and feasible(bundle)
+        and _dominates(
+            buyer.utility(_terms(*bundle)),
+            vendor.utility(_terms(*bundle)),
+            ub_star,
+            us_star,
+        )
+    ]
+    assert not dominators, f"agreement {agreement} dominated by {dominators}; exchanged={exchanged}"
+
+
+@given(cfg=_cfgs())
+@settings(max_examples=100, deadline=None)
+def test_selfplay_agreement_respects_caps_and_reservation(cfg: _Cfg) -> None:
+    """Settled deals price inside [floor, budget] and clear both reservations."""
+    buyer = _make_buyer(cfg, max_rounds=25)
+    vendor = _make_vendor(cfg, max_rounds=25)
+    agreement, _exchanged = asyncio.run(
+        _self_play(buyer, vendor, (cfg.plo, cfg.phi, cfg.dlo, cfg.dhi))
+    )
+    if agreement is None:
+        return
+
+    ap, ad = agreement
+    if cfg.budget is not None:
+        assert ap <= cfg.budget
+    if cfg.floor is not None:
+        assert ap >= cfg.floor
+    assert buyer.utility(_terms(ap, ad)) >= cfg.reservation - _EPS
+    assert vendor.utility(_terms(ap, ad)) >= cfg.reservation - _EPS
+
+
+def test_disjoint_caps_always_break_down() -> None:
+    """A wallet strictly below the vendor's floor can never produce a deal."""
+    cfg = _Cfg(
+        plo=40,
+        phi=60,
+        dlo=1,
+        dhi=11,
+        patience=0.8,
+        buyer_wp=0.5,
+        seller_wd=0.5,
+        reservation=0.0,
+        budget=45,
+        floor=50,
+    )
+    buyer = _make_buyer(cfg, max_rounds=25)
+    vendor = _make_vendor(cfg, max_rounds=25)
+    agreement, _exchanged = asyncio.run(
+        _self_play(buyer, vendor, (cfg.plo, cfg.phi, cfg.dlo, cfg.dhi))
+    )
+    assert agreement is None
+
+
+def test_flagship_holds_on_the_pinned_pareto_counterexample() -> None:
+    """The exact configuration that defeats the merged plugin settles clean here.
+
+    ``test_fsj_tradeoff_does_not_guarantee_pareto_optimality`` pins a
+    configuration whose self-play agreement under ``pareto`` IS dominated by
+    an exchanged bundle. Under CheckoutFrontier the same preferences settle on
+    a deal no exchanged bundle dominates, because the dominating bundle is a
+    standing quote and gets accepted instead of expiring.
+    """
+    cfg = _Cfg(
+        plo=10,
+        phi=30,
+        dlo=1,
+        dhi=9,
+        patience=0.890625,
+        buyer_wp=0.75,
+        seller_wd=0.90625,
+        reservation=0.0,
+        budget=None,
+        floor=None,
+    )
+    buyer = _make_buyer(cfg, max_rounds=25)
+    vendor = _make_vendor(cfg, max_rounds=25)
+    agreement, exchanged = asyncio.run(
+        _self_play(buyer, vendor, (cfg.plo, cfg.phi, cfg.dlo, cfg.dhi))
+    )
+    assert agreement is not None, "expected this configuration to settle"
+
+    ap, ad = agreement
+    ub_star = buyer.utility(_terms(ap, ad))
+    us_star = vendor.utility(_terms(ap, ad))
+    dominators = [
+        bundle
+        for bundle in exchanged
+        if bundle != (ap, ad)
+        and _dominates(
+            buyer.utility(_terms(*bundle)),
+            vendor.utility(_terms(*bundle)),
+            ub_star,
+            us_star,
+        )
+    ]
+    assert not dominators, f"agreement {agreement} dominated by {dominators}"

--- a/packages/nest-plugins-reference/tests/test_checkout_frontier_properties.py
+++ b/packages/nest-plugins-reference/tests/test_checkout_frontier_properties.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Property tests for CheckoutFrontier (Hypothesis).
 
-Four property families:
+Five property families:
 
 * **Determinism**: identical construction plus an identical offer sequence
   yields an identical response transcript (no wall-clock, no unseeded RNG).
@@ -17,6 +17,9 @@ Four property families:
 * **Hard caps and rationality**: settled deals land inside
   ``[floor, budget]`` with both utilities at or above reservation, and
   mutually exclusive caps always break down instead of dealing.
+* **Internal termination**: every self-play session ends by plugin decision
+  (acceptance or a declined counter), never by the driver's loop cap —
+  including mutually exclusive caps and echo standoffs.
 
 Weights are drawn on the six-decimal lattice (``k / 1_000_000``) with bundle
 spans capped at 15, so every nonzero utility difference on the integer grid
@@ -127,13 +130,17 @@ def _make_vendor(cfg: _Cfg, max_rounds: int = 12) -> CheckoutFrontier:
 
 async def _self_play(
     buyer: CheckoutFrontier, vendor: CheckoutFrontier, bounds: tuple[int, int, int, int]
-) -> tuple[tuple[int, int] | None, list[tuple[int, int]]]:
-    """Run two agents to settlement; return the agreement (if any) and exchanged bundles.
+) -> tuple[tuple[int, int] | None, list[tuple[int, int]], bool]:
+    """Run two agents to settlement; return (agreement, exchanged bundles, terminated).
 
     Each side opens from its best-for-self position, then alternately responds
     to the other's latest offer. An agent either accepts (the offer becomes
-    the agreement), declines without a counter (breakdown), or counters; every
-    counter is recorded and forwarded.
+    the agreement), declines without a counter (plugin-initiated breakdown),
+    or counters; every counter is recorded and forwarded. ``terminated`` is
+    True when the run ended because a plugin accepted or declined, and False
+    only if the driver loop exhausted, so tests can tell plugin behavior from
+    a harness artifact. The loop bound (60) deliberately exceeds the plugin's
+    own termination bound for ``max_rounds=25``.
     """
     plo, phi, dlo, dhi = bounds
     buyer_open = _terms(plo, dlo)
@@ -142,25 +149,25 @@ async def _self_play(
     vs = await vendor.open(AgentId("shopper"), vendor_open)
     exchanged: list[tuple[int, int]] = [(plo, dlo), (phi, dhi)]
     buyer_last, vendor_last = buyer_open, vendor_open
-    for _ in range(30):
+    for _ in range(60):
         await buyer.offer(bs, vendor_last)
         br = await buyer.respond(bs)
         if br.accepted:
-            return _pd(vendor_last), exchanged
+            return _pd(vendor_last), exchanged, True
         if br.counter_terms is None:
-            return None, exchanged
+            return None, exchanged, True
         buyer_last = br.counter_terms
         exchanged.append(_pd(buyer_last))
 
         await vendor.offer(vs, buyer_last)
         vr = await vendor.respond(vs)
         if vr.accepted:
-            return _pd(buyer_last), exchanged
+            return _pd(buyer_last), exchanged, True
         if vr.counter_terms is None:
-            return None, exchanged
+            return None, exchanged, True
         vendor_last = vr.counter_terms
         exchanged.append(_pd(vendor_last))
-    return None, exchanged
+    return None, exchanged, False
 
 
 @given(payload=_cfg_and_offers())
@@ -229,7 +236,7 @@ def test_selfplay_agreement_never_dominated_by_exchanged_bundle(cfg: _Cfg) -> No
     """
     buyer = _make_buyer(cfg, max_rounds=25)
     vendor = _make_vendor(cfg, max_rounds=25)
-    agreement, exchanged = asyncio.run(
+    agreement, exchanged, _terminated = asyncio.run(
         _self_play(buyer, vendor, (cfg.plo, cfg.phi, cfg.dlo, cfg.dhi))
     )
     if agreement is None:
@@ -266,7 +273,7 @@ def test_selfplay_agreement_respects_caps_and_reservation(cfg: _Cfg) -> None:
     """Settled deals price inside [floor, budget] and clear both reservations."""
     buyer = _make_buyer(cfg, max_rounds=25)
     vendor = _make_vendor(cfg, max_rounds=25)
-    agreement, _exchanged = asyncio.run(
+    agreement, _exchanged, _terminated = asyncio.run(
         _self_play(buyer, vendor, (cfg.plo, cfg.phi, cfg.dlo, cfg.dhi))
     )
     if agreement is None:
@@ -281,8 +288,36 @@ def test_selfplay_agreement_respects_caps_and_reservation(cfg: _Cfg) -> None:
     assert vendor.utility(_terms(ap, ad)) >= cfg.reservation - _EPS
 
 
-def test_disjoint_caps_always_break_down() -> None:
-    """A wallet strictly below the vendor's floor can never produce a deal."""
+@given(cfg=_cfgs())
+@settings(max_examples=300, deadline=None)
+def test_selfplay_terminates_internally(cfg: _Cfg) -> None:
+    """Every self-play session ends by plugin decision, never by the driver's cap.
+
+    This is the termination guarantee behind the bounded-termination claim:
+    past the patience horizon an agent re-proposes a clearing standing quote
+    at most once and otherwise declines to counter, so even mutually
+    exclusive caps and echo standoffs end in an acceptance or a
+    plugin-initiated breakdown. The driver's loop bound (60) exceeds the
+    plugin's own termination bound for ``max_rounds=25``; ``terminated`` may
+    therefore never be False.
+    """
+    buyer = _make_buyer(cfg, max_rounds=25)
+    vendor = _make_vendor(cfg, max_rounds=25)
+    _agreement, _exchanged, terminated = asyncio.run(
+        _self_play(buyer, vendor, (cfg.plo, cfg.phi, cfg.dlo, cfg.dhi))
+    )
+    assert terminated, "self-play outlived the plugin's termination bound"
+
+
+def test_disjoint_caps_break_down_by_plugin_decision() -> None:
+    """A wallet strictly below the vendor's floor ends in a plugin-initiated no-deal.
+
+    Both caps are individually feasible (the buyer can afford 40-45, the
+    vendor can sell at 50-60) so neither side declines up front; neither can
+    ever accept the other, and the plugin itself must stand down at the
+    patience horizon. Asserting ``terminated`` distinguishes that decline
+    from the driver loop merely running out.
+    """
     cfg = _Cfg(
         plo=40,
         phi=60,
@@ -297,10 +332,11 @@ def test_disjoint_caps_always_break_down() -> None:
     )
     buyer = _make_buyer(cfg, max_rounds=25)
     vendor = _make_vendor(cfg, max_rounds=25)
-    agreement, _exchanged = asyncio.run(
+    agreement, _exchanged, terminated = asyncio.run(
         _self_play(buyer, vendor, (cfg.plo, cfg.phi, cfg.dlo, cfg.dhi))
     )
     assert agreement is None
+    assert terminated, "breakdown must be the plugin declining, not the loop exhausting"
 
 
 def test_flagship_holds_on_the_pinned_pareto_counterexample() -> None:
@@ -326,7 +362,7 @@ def test_flagship_holds_on_the_pinned_pareto_counterexample() -> None:
     )
     buyer = _make_buyer(cfg, max_rounds=25)
     vendor = _make_vendor(cfg, max_rounds=25)
-    agreement, exchanged = asyncio.run(
+    agreement, exchanged, _terminated = asyncio.run(
         _self_play(buyer, vendor, (cfg.plo, cfg.phi, cfg.dlo, cfg.dhi))
     )
     assert agreement is not None, "expected this configuration to settle"

--- a/packages/nest-plugins-reference/tests/test_checkout_market.py
+++ b/packages/nest-plugins-reference/tests/test_checkout_market.py
@@ -127,6 +127,26 @@ def test_pareto_validator_fails_vacuous_trace() -> None:
     assert "no checkout negotiation" in result.detail
 
 
+def test_validators_surface_unscorable_sessions() -> None:
+    """A deal whose parties lack checkoutcfg frames is counted, not silently skipped."""
+    events = [
+        *_cfg_frames(pair=1),
+        _send("quote:pair-1:vendor-1:seller:2:108:1"),
+        _send("quote:pair-1:shopper-1:buyer:2:40:1"),
+        _send("deal:pair-1:108:1:shopper-1"),
+        # A second session with no config frames at all.
+        _send("quote:pair-9:vendor-9:seller:1:100:5"),
+        _send("quote:pair-9:shopper-9:buyer:1:50:1"),
+        _send("deal:pair-9:100:5:shopper-9"),
+    ]
+    pareto = validate_checkout_pareto_efficient(events)[0]
+    assert pareto.passed, pareto.detail
+    assert "1 deal(s) unscorable" in pareto.detail
+    caps = validate_checkout_budget_and_floor(events)[0]
+    assert caps.passed, caps.detail
+    assert "1 session(s) unscorable" in caps.detail
+
+
 # Validator direct-call tests: budget and floor discipline
 
 

--- a/packages/nest-plugins-reference/tests/test_checkout_market.py
+++ b/packages/nest-plugins-reference/tests/test_checkout_market.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validator unit tests and the end-to-end discrimination gate for the checkout market.
+
+Three layers:
+
+1. **Validator direct-call**: hand-built event lists drive each branch of
+   ``validate_checkout_pareto_efficient`` (dominated deal fails, a clean
+   frontier passes, a cap-infeasible dominator does not count, a no-deal is
+   not a dominance failure, an empty trace trips the vacuous guard) and of
+   ``validate_checkout_budget_and_floor`` (over-budget quote, over-budget
+   deal, below-floor deal).
+2. **End-to-end discrimination** (the core deliverable): boot the real
+   ``checkout_market`` scenario through ``ScenarioRunner`` under seeds 42, 7,
+   1337. With ``negotiation: checkout_frontier`` every validator PASSES; with
+   ``negotiation: alternating_offers`` (deadline-blind, timeout-driven)
+   ``validate_checkout_pareto_efficient`` FAILS on a deal dominated by the
+   vendor's early rush quote. The layer is overridden in-test; the shipped
+   YAML is untouched.
+3. **Byte-determinism**: the same seed writes a byte-identical trace twice.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import (
+    ValidationResult,
+    validate_checkout_budget_and_floor,
+    validate_checkout_pareto_efficient,
+    validate_trace,
+)
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "checkout_market.yaml"
+
+
+def _send(msg: str) -> dict[str, Any]:
+    """A minimal send event carrying a colon-delimited checkout frame."""
+    return {"kind": "send", "msg": msg, "agent": "driver", "to": "peer"}
+
+
+def _cfg_frames(budget: int = 120, floor: int = 60, pair: int = 0) -> list[dict[str, Any]]:
+    """Config frames for one deadline-loving buyer and one margin-only vendor."""
+    return [
+        _send(f"checkoutcfg:shopper-{pair}:buyer:0.100000:0.900000:40:120:1:21:0.000000:{budget}"),
+        _send(f"checkoutcfg:vendor-{pair}:seller:1.000000:0.000000:40:120:1:21:0.000000:{floor}"),
+    ]
+
+
+# Validator direct-call tests: Pareto efficiency
+
+
+def test_pareto_validator_flags_dominated_deal() -> None:
+    """A deal dominated by a cap-feasible exchanged bundle is caught and named."""
+    events = [
+        *_cfg_frames(),
+        _send("quote:pair-0:vendor-0:seller:2:108:1"),  # the rush logroll, feasible
+        _send("quote:pair-0:shopper-0:buyer:2:40:1"),
+        _send("quote:pair-0:vendor-0:seller:9:84:19"),  # late, slow lane
+        _send("deal:pair-0:84:19:shopper-0"),  # ... and it is what gets agreed
+    ]
+    result = validate_checkout_pareto_efficient(events)[0]
+    assert not result.passed
+    assert "dominated by" in result.detail
+    assert "(108,1)" in result.detail
+
+
+def test_pareto_validator_passes_clean_frontier() -> None:
+    """A session whose deal is the frontier bundle passes."""
+    events = [
+        *_cfg_frames(pair=1),
+        _send("quote:pair-1:vendor-1:seller:2:108:1"),
+        _send("quote:pair-1:shopper-1:buyer:2:40:1"),
+        _send("deal:pair-1:108:1:shopper-1"),
+    ]
+    result = validate_checkout_pareto_efficient(events)[0]
+    assert result.passed, result.detail
+
+
+def test_pareto_validator_ignores_cap_infeasible_dominator() -> None:
+    """A dominating bundle nobody could transact is not evidence of a better deal.
+
+    The rush quote at 115 dominates the closed deal in utility space, but the
+    buyer's wallet is 110: no checkout could ever clear it, so the validator
+    must not fail the session over it.
+    """
+    events = [
+        *_cfg_frames(budget=110, pair=2),
+        _send("quote:pair-2:vendor-2:seller:2:115:1"),  # dominates, but over budget
+        _send("quote:pair-2:shopper-2:buyer:2:40:1"),
+        _send("quote:pair-2:vendor-2:seller:9:84:19"),
+        _send("deal:pair-2:84:19:shopper-2"),
+    ]
+    result = validate_checkout_pareto_efficient(events)[0]
+    assert result.passed, result.detail
+
+
+def test_pareto_validator_ignores_no_deal_sessions() -> None:
+    """A no-deal is a legitimate breakdown, not a dominance failure."""
+    events = [
+        *_cfg_frames(pair=1),
+        _send("quote:pair-1:vendor-1:seller:2:108:1"),
+        _send("quote:pair-1:shopper-1:buyer:2:40:1"),
+        _send("deal:pair-1:108:1:shopper-1"),
+        # A second session that simply broke down.
+        *_cfg_frames(budget=45, floor=50, pair=2),
+        _send("quote:pair-2:vendor-2:seller:1:120:21"),
+        _send("quote:pair-2:shopper-2:buyer:1:40:1"),
+        _send("no_deal:pair-2:10"),
+    ]
+    result = validate_checkout_pareto_efficient(events)[0]
+    assert result.passed, result.detail
+    assert "pair-2" not in result.detail
+
+
+def test_pareto_validator_fails_vacuous_trace() -> None:
+    """A trace with no scorable deal must fail, not silently pass."""
+    result = validate_checkout_pareto_efficient([])[0]
+    assert not result.passed
+    assert "no checkout negotiation" in result.detail
+
+
+# Validator direct-call tests: budget and floor discipline
+
+
+def test_budget_validator_flags_quote_beyond_wallet() -> None:
+    """A buyer bidding beyond its own budget is broken even if the deal lands under."""
+    events = [
+        *_cfg_frames(budget=100),
+        _send("quote:pair-0:vendor-0:seller:1:110:1"),
+        _send("quote:pair-0:shopper-0:buyer:1:105:1"),  # exceeds its own wallet
+        _send("deal:pair-0:95:1:shopper-0"),
+    ]
+    result = validate_checkout_budget_and_floor(events)[0]
+    assert not result.passed
+    assert "exceeds budget" in result.detail
+
+
+def test_budget_validator_flags_deal_outside_caps() -> None:
+    """A closed deal must satisfy both parties' caps."""
+    over_budget = [
+        *_cfg_frames(budget=100),
+        _send("quote:pair-0:vendor-0:seller:1:105:1"),
+        _send("quote:pair-0:shopper-0:buyer:1:40:1"),
+        _send("deal:pair-0:105:1:shopper-0"),
+    ]
+    result = validate_checkout_budget_and_floor(over_budget)[0]
+    assert not result.passed
+    assert "exceeds budget" in result.detail
+
+    below_floor = [
+        *_cfg_frames(floor=90, pair=1),
+        _send("quote:pair-1:vendor-1:seller:1:120:21"),
+        _send("quote:pair-1:shopper-1:buyer:1:85:1"),
+        _send("deal:pair-1:85:1:vendor-1"),
+    ]
+    result = validate_checkout_budget_and_floor(below_floor)[0]
+    assert not result.passed
+    assert "below floor" in result.detail
+
+
+def test_budget_validator_allows_asks_below_counterparty_floor() -> None:
+    """A buyer may open beneath the vendor's floor: an ask is not a transaction."""
+    events = [
+        *_cfg_frames(floor=60),
+        _send("quote:pair-0:vendor-0:seller:1:120:21"),
+        _send("quote:pair-0:shopper-0:buyer:1:40:1"),  # below the vendor's floor
+        _send("deal:pair-0:108:1:shopper-0"),
+    ]
+    result = validate_checkout_budget_and_floor(events)[0]
+    assert result.passed, result.detail
+
+
+def test_budget_validator_fails_vacuous_trace() -> None:
+    """A trace with no capped session must fail, not silently pass."""
+    result = validate_checkout_budget_and_floor([])[0]
+    assert not result.passed
+    assert "no checkout negotiation" in result.detail
+
+
+# End-to-end discrimination gate
+
+
+def _run_scenario(seed: int, negotiation: str, trace_path: Path) -> list[ValidationResult]:
+    """Run the checkout scenario with a chosen negotiation layer; validate its trace."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    config.seed = seed
+    config.layers.negotiation = negotiation
+    config.output.trace = str(trace_path)
+    runner = ScenarioRunner(config, registry=PluginRegistry())
+    asyncio.run(runner.run())
+    return validate_trace(trace_path, "checkout_market")
+
+
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_checkout_frontier_passes_all_validators(seed: int) -> None:
+    """The plugin under test reaches only non-dominated, cap-disciplined deals."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    with tempfile.TemporaryDirectory() as tmp:
+        results = _run_scenario(seed, "checkout_frontier", Path(tmp) / f"cf_{seed}.jsonl")
+    assert results, "expected validators to run"
+    assert all(r.passed for r in results), [(r.name, r.detail) for r in results]
+
+
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_alternating_offers_fails_pareto_validator(seed: int) -> None:
+    """The deadline-blind reference plugin is caught: it closes a dominated deal."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    with tempfile.TemporaryDirectory() as tmp:
+        results = _run_scenario(seed, "alternating_offers", Path(tmp) / f"ao_{seed}.jsonl")
+    pareto = next(r for r in results if r.name == "checkout_pareto_efficient")
+    assert not pareto.passed, f"seed={seed}: alternating_offers should be caught"
+    assert "dominated by" in pareto.detail
+
+
+def test_same_seed_writes_byte_identical_trace() -> None:
+    """Tier-1 determinism, end to end: one seed, two runs, identical bytes."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+
+    def digest(path: Path) -> str:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        first = Path(tmp) / "first.jsonl"
+        second = Path(tmp) / "second.jsonl"
+        _run_scenario(42, "checkout_frontier", first)
+        _run_scenario(42, "checkout_frontier", second)
+        assert digest(first) == digest(second)

--- a/scenarios/checkout_market.yaml
+++ b/scenarios/checkout_market.yaml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Checkout market scenario.
+#
+# 10 shopper-vendor pairs run an agentic checkout over BOTH price and delivery
+# deadline, with hard money caps: each shopper holds a wallet budget, each
+# vendor a unit-cost floor. Vendors are scripted margin-only quoting engines
+# that offer an expedited "rush" lane early (fulfillment slack is free for an
+# in-stock vendor); the configured negotiation plugin sits in the BUYER seat,
+# the side that is real deployed software in agent-to-retail commerce.
+#
+# A deadline-aware, budget-disciplined buyer accepts the early rush logroll; a
+# deadline-blind, timeout-driven buyer holds out and closes late on a cheaper
+# slow-lane bundle that the rush quote Pareto-dominates for both sides.
+#
+# Every exchanged bundle, both parties' private utility parameters, and their
+# money caps are written to the trace (checkoutcfg/quote/deal/no_deal frames)
+# so offline validators can reconstruct utilities, check cap-feasible
+# Pareto-efficiency, and audit budget and floor discipline.
+#
+# Deterministic: per-pair weights, caps, and vendor schedules are drawn in the
+# factory from a generator seeded only by (seed, pair_index) with a fixed draw
+# order; each bargaining loop runs synchronously in its vendor's on_start, so
+# the same seed yields a byte-identical trace.
+name: checkout_market
+description: "10 shopper-vendor checkouts negotiating price + delivery under budget caps."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 20
+  brain: state-machine
+  roles:
+    - name: shopper
+      count: 10
+    - name: vendor
+      count: 10
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: checkout_frontier
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: checkout_market
+
+duration: "ticks: 10000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/checkout_market.jsonl

--- a/scenarios/checkout_market.yaml
+++ b/scenarios/checkout_market.yaml
@@ -27,6 +27,9 @@ description: "10 shopper-vendor checkouts negotiating price + delivery under bud
 tier: 1
 seed: 42
 
+# The agents block is descriptive, matching the multi_attribute_market
+# convention: the checkout_market factory derives its population from
+# N_PAIRS in scenarios_builtin/checkout_market.py, which is authoritative.
 agents:
   count: 20
   brain: state-machine


### PR DESCRIPTION
## Motivation

Agentic checkout is multi-attribute. A shopping agent negotiating a purchase is trading price against delivery deadline ("I'll pay a premium for expedited"), under a constraint no utility weight can express: a hard wallet budget. Price-only bargaining cannot represent the premium, and unconstrained multi-attribute bargaining cannot represent the wallet. This submission evaluates the **buyer side**  in agent-to-retail commerce the shopping agent is the deployed software; the vendor side is usually a quoting engine.

## What ships

- **Plugin** `("negotiation", "checkout_frontier")` — `packages/nest-plugins-reference/nest_plugins_reference/negotiation/checkout_frontier.py`, registered in `_BUILTINS` and as a `nest.plugins.negotiation` entry point.
- **Scenario** `checkout_market` — `scenarios/checkout_market.yaml` + `packages/nest-core/nest_core/scenarios_builtin/checkout_market.py`: 10 shopper-vendor pairs, scripted margin-only vendors quoting an early expedited "rush" lane, the configured plugin in the buyer seat, hard budgets and cost floors drawn per pair from the scenario seed.
- **Adversarial validators** — `validate_checkout_pareto_efficient` (no closed deal is Pareto-dominated by a *cap-feasible* bundle exchanged in the same session) and `validate_checkout_budget_and_floor` (no quote or deal crosses the quoting agent's own declared money cap). Both fail vacuous traces.
- **Tests** — 17 unit tests; 6 property tests (Hypothesis, 200 examples on the flagship dominance property, plus the pinned-counterexample and disjoint-caps cases); 16 validator/integration tests including the end-to-end discrimination gate on seeds 42/7/1337 and a byte-identical-trace determinism test.

## The mechanism, and the guarantee it buys

`CheckoutFrontier` layers one rule on top of classical monotonic concession (Keeney–Raiffa additive MAUT, Zeuthen aspiration decay, per-attribute patience, direction-reading trade-off): **best-standing-quote acceptance**. Every bundle the counterparty ever offered stays live; once the best cap-eligible one clears the aspiration floor, the agent accepts it if it is the offer on the table, or re-proposes it verbatim (the counterparty running the same rule accepts its own returning quote — one extra round, guaranteed convergence).

That changes the guarantee class. The merged `pareto` plugin (#30) documents its own boundary in `test_fsj_tradeoff_does_not_guarantee_pareto_optimality`: a Pareto-improving bundle offered early can be rejected while aspiration is high and be *gone* by the time aspiration decays — self-play can close a dominated deal, so its self-play guarantee was deliberately downgraded to individual rationality. Standing quotes remove the ephemerality: nothing generous ever expires. The flagship Hypothesis property — **no self-play agreement is Pareto-dominated by any cap-feasible bundle either side exchanged** — runs green at 200 examples, and a dedicated test replays PR #30's pinned counterexample configuration and settles it clean.

Supporting details that make the property hold and replay byte-identically: earliest-offer tie-breaks (under the counterparty's own concession, the earliest of equally-good-for-us quotes is best for *them*), acceptance only when the best standing quote *is* the current offer, fresh counters capped by the previous fresh counter's own utility, and all weights on a six-decimal lattice so no utility gap on the integer grid can fall inside the validators' `1e-9` epsilon.

Hard caps are constraints, not utility terms: a buyer never accepts, echoes, or proposes above `budget`; a vendor never goes below `floor`; with mutually exclusive caps the plugin declines to counter and the checkout breaks down honestly (`close` → `None`) instead of closing an unaffordable deal.

## Relationship to merged PR #30 (novelty delta)

This is the same problem statement (07) solved for a different regime, not a re-issue; nothing in #30 is modified and the two plugins interoperate over the same `Terms` encoding.

| | `pareto` (#30, merged) | `checkout_frontier` (this PR) |
|---|---|---|
| Evaluated seat | scripted buyer vs configured **seller** | scripted vendor vs configured **buyer** |
| Self-play guarantee | individual rationality (dominated deals possible, pinned) | + no agreement dominated by any cap-feasible exchanged bundle |
| Money constraints | none | hard budget / floor, honored in-mechanism and audited from the trace |
| Dominance evidence | all exchanged bundles | cap-feasible exchanged bundles (an unaffordable bundle is not evidence of a better deal) |
| `close()` | never exercised by its driver | exercised on both deal and no-deal paths |
| Registration | `_BUILTINS` only | `_BUILTINS` + pyproject entry point |

## Adversarial demonstration

The scenario's vendors are margin-only (`w_deadline = 0`): fulfillment slack costs an in-stock vendor nothing, so the expedited lane is free to give away and its schedule offers rush delivery in rounds 2–3 while price descends toward clearance. `checkout_frontier` buyers (deadline weight drawn in [0.85, 0.95], budget in [110, 120]) accept the rush logroll by round 3 on every seed — round 2's price can exceed a low budget draw, so the cap visibly bites in-trace before the cheaper rush re-offer lands. `alternating_offers` never reads `conditions["deadline_days"]` and only accepts at its round limit, closing late on a cheaper slow-lane bundle that the rush quote dominates for **both** sides (strictly better for a margin-only vendor, strictly better for every drawn deadline weight). The dominance is arithmetic over the drawn ranges, not a lucky seed; the gate still runs three seeds:

- `negotiation: checkout_frontier` → both validators PASS (seeds 42, 7, 1337)
- `negotiation: alternating_offers` → `checkout_pareto_efficient` FAILS with the dominating rush bundle named in the detail (seeds 42, 7, 1337)

## Verification

```bash
uv sync
uv run ruff check . && uv run ruff format --check .
uv run pyright
uv run pytest -v
uv run nest run scenarios/checkout_market.yaml
```

```python
from pathlib import Path
from nest_core.validators import validate_trace
for r in validate_trace(Path("traces/checkout_market.jsonl"), "checkout_market"):
    print(r.name, r.passed, r.detail)
```

## Tradeoffs and scope

- Fresh-counter selection enumerates the feasible grid per respond call — fine at catalog scale here (80×20), quadratic in span.
- The shipped scenario always deals by design; the breakdown path is exercised by unit, property (disjoint caps), and validator tests.