### PR TITLE
[Hackathon] payments-risk-eng: BudgetLimitedPayments — cross-source spend-cap guard

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -42,6 +42,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
     ("payments", "empic_escrow"): f"{_REF}.payments.empic_escrow:EMPICEscrowPayments",
     ("payments", "escrow"): f"{_REF}.payments.escrow:EscrowPayments",
+    ("payments", "budget_limited"): (f"{_REF}.payments.budget_limited:BudgetLimitedPayments"),
     ("coordination", "contract_net"): f"{_REF}.coordination.contract_net:ContractNet",
     ("coordination", "hotstuff"): f"{_REF}.coordination.hotstuff:HotStuff",
     ("negotiation", "alternating_offers"): (

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -197,3 +197,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("capability_spoofing", capability_spoofing_factory)
+    elif name == "budget_enforcement":
+        from nest_core.scenarios_builtin.budget_enforcement import (
+            budget_enforcement_factory,
+        )
+
+        register_scenario("budget_enforcement", budget_enforcement_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/budget_enforcement.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/budget_enforcement.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Budget-enforcement scenario — one shared budget across many spending sources.
+
+Persona: payments-risk engineer. A household authorizes a single monthly
+restaurant budget, but the spending comes from several independent sources that
+cannot see each other:
+
+* ``human-card``     — a person paying on a credit card.
+* ``meal-planner``   — an autonomous agent ordering weeknight dinners (card rail).
+* ``travel-agent``   — a booking agent placing a reservation deposit (crypto rail).
+* ``lunch-app``      — a subscription topping up a school lunch account (bank rail).
+
+Each source has its **own money** (its own balance on its own rail) but they all
+draw down **one shared budget** — modelled by passing every source's wallet the
+same ``spent`` holder. Each files its purchase against the shared cap; a source
+is refused once the *combined* spend would breach the cap, even though that
+source spent little or nothing itself. That cross-source refusal is the whole
+point: no single per-rail wallet can enforce it, because none sees the others.
+
+This is a discriminating scenario, exactly like ``escrow_marketplace``:
+
+* Under ``payments: budget_limited`` (with a shared budget) the source that tips
+  the combined total over the cap is refused, and total confirmed spend stays
+  within the cap. Both budget validators **pass**.
+* Under ``payments: prepaid_credits`` (no budget, per-rail balances) every source
+  pays from its own funds with nothing watching the total, so combined spend
+  blows past the cap and no refusal is ever emitted. Both validators **fail** —
+  the baseline lets an overspend through that only a shared ledger catches.
+
+Trace line protocol (colon-delimited ``k=v``, matching
+:func:`nest_core.validators._parse_budget_events`)::
+
+    budget:cap:pool=<id>:cap=<int>
+    budget:paid:pool=<id>:payer=<id>:payee=<id>:amount=<int>
+    budget:refused:pool=<id>:payer=<id>:amount=<int>
+
+Example::
+
+    agents = budget_enforcement_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Money, PaymentRef
+
+# The shared budget pool id carried in the trace.
+_POOL_ID = "household-restaurant"
+_DEFAULT_CAP = 1000
+# The four spending sources and the purchase each makes this month. Combined
+# they total 1050 (> 1000), so the last source to spend is refused — because of
+# spend the others made, on rails it cannot see. Ticks are staggered so the
+# order (and therefore who gets refused) is deterministic.
+_DEFAULT_SOURCES: tuple[tuple[str, int], ...] = (
+    ("human-card", 340),
+    ("meal-planner", 280),
+    ("travel-agent", 250),
+    ("lunch-app", 180),
+)
+# Each source has ample balance on its own rail — only the shared budget can
+# refuse a payment, never an empty wallet.
+_SOURCE_BALANCE = 100_000
+
+
+def _emit(fields: dict[str, str | int]) -> str:
+    """Build a ``budget:<kind>:k=v:...`` broadcast payload.
+
+    The colon-separated ``k=v`` form matches the parser in
+    :func:`nest_core.validators._parse_budget_events`.
+
+    Example::
+
+        line = _emit({"kind": "paid", "pool": "p", "payer": "human-card", "amount": 340})
+    """
+    kind = str(fields.pop("kind"))
+    body = ":".join(f"{k}={v}" for k, v in fields.items())
+    return f"budget:{kind}:{body}" if body else f"budget:{kind}"
+
+
+class BudgetSourceAgent(StateMachineAgent):
+    """One spending source drawing down the shared household budget.
+
+    Announces the shared pool cap on start, then makes a single purchase at its
+    assigned tick. The wallet (shared budget) decides: a purchase that fits is
+    broadcast as ``budget:paid``; one the shared cap refuses (a raised
+    ``ValueError``) as ``budget:refused``. No value moves on a refusal.
+
+    Example::
+
+        src = BudgetSourceAgent(AgentId("human-card"), AgentId("m-0"), "pool", 1000, 340, 1)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        merchant: AgentId,
+        pool_id: str,
+        cap: int,
+        amount: int,
+        tick: int,
+    ) -> None:
+        self._id = agent_id
+        self._merchant = merchant
+        self._pool_id = pool_id
+        self._cap = cap
+        self._amount = amount
+        self._tick = tick
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Announce the shared cap, then schedule this source's single purchase.
+
+        Example::
+
+            await src.on_start(ctx)
+        """
+        await ctx.broadcast(
+            _emit({"kind": "cap", "pool": self._pool_id, "cap": self._cap}).encode()
+        )
+        await ctx.schedule(float(self._tick), b"buy")
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Make the purchase, broadcasting paid or refused.
+
+        Example::
+
+            await src.on_message(ctx, src._id, b"buy")
+        """
+        if payload != b"buy":
+            return
+        payments = ctx.plugins["payments"]
+        ref = PaymentRef(f"{self._id}-buy")
+        try:
+            await payments.pay(self._merchant, Money(amount=self._amount), ref)
+        except ValueError:
+            # The shared budget refused this purchase. No value moved.
+            await ctx.broadcast(
+                _emit(
+                    {
+                        "kind": "refused",
+                        "pool": self._pool_id,
+                        "payer": str(self._id),
+                        "amount": self._amount,
+                    }
+                ).encode()
+            )
+            return
+        await ctx.broadcast(
+            _emit(
+                {
+                    "kind": "paid",
+                    "pool": self._pool_id,
+                    "payer": str(self._id),
+                    "payee": str(self._merchant),
+                    "amount": self._amount,
+                }
+            ).encode()
+        )
+
+
+class MerchantAgent(StateMachineAgent):
+    """Receives a purchase; holds no logic. Present for roster completeness.
+
+    Example::
+
+        m = MerchantAgent(AgentId("merchant-0"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """No startup behaviour.
+
+        Example::
+
+            await m.on_start(ctx)
+        """
+        return
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Merchants receive no actionable messages.
+
+        Example::
+
+            await m.on_message(ctx, AgentId("human-card"), b"noop")
+        """
+        return
+
+
+def budget_enforcement_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Build the spending sources, all sharing one budget and one ledger.
+
+    Every source gets its own wallet instance (its own money on its own rail),
+    but all wallets share one ``spent`` holder and one ``balances`` ledger — so
+    the budget is a single pool the sources collectively draw down. A plugin
+    without a ``spent``/``budget`` kwarg (e.g. ``prepaid_credits``) falls back to
+    a budget-less wallet, which is what makes the scenario discriminate: only the
+    shared-budget plugin refuses the source that tips the combined total over.
+
+    Example::
+
+        agents = budget_enforcement_factory(config, plugins)
+    """
+    payments_cls = plugins["payments"]
+    cap = int(config.task.config.get("cap", _DEFAULT_CAP))
+
+    # One shared spend counter + one shared money ledger across every source.
+    shared_spent: dict[str, int] = {"value": 0}
+    shared_balances: dict[AgentId, int] = {}
+    shared_payments: dict[PaymentRef, Any] = {}
+
+    def _instance(agent_id: AgentId) -> Any:
+        try:
+            return payments_cls(
+                agent_id,
+                initial_balance=_SOURCE_BALANCE,
+                budget=cap,
+                balances=shared_balances,
+                payments=shared_payments,
+                spent=shared_spent,
+            )
+        except TypeError:
+            try:
+                return payments_cls(
+                    agent_id,
+                    initial_balance=_SOURCE_BALANCE,
+                    balances=shared_balances,
+                    payments=shared_payments,
+                )
+            except TypeError:
+                return payments_cls(agent_id, initial_balance=_SOURCE_BALANCE)
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    overrides: dict[AgentId, dict[str, Any]] = {}
+    for i, (name, amount) in enumerate(_DEFAULT_SOURCES):
+        source_id = AgentId(name)
+        merchant_id = AgentId(f"merchant-{i}")
+        agents[source_id] = BudgetSourceAgent(
+            source_id, merchant_id, _POOL_ID, cap, amount, tick=i + 1
+        )
+        agents[merchant_id] = MerchantAgent(merchant_id)
+        overrides[source_id] = {"payments": _instance(source_id)}
+
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/yaml/budget_enforcement.yaml
+++ b/packages/nest-core/nest_core/scenarios_builtin/yaml/budget_enforcement.yaml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Budget enforcement: one shared household restaurant budget (1000) drawn down by
+# four independent spending sources on four different rails — a human card, a
+# meal-planner agent, a travel agent, and a lunch-app subscription. Their spends
+# total 1050, so the last source is refused on the shared cap even though it spent
+# little itself. Under `payments: budget_limited` (shared budget) both validators
+# pass; under `payments: prepaid_credits` (per-rail balances, no shared budget)
+# the combined overspend goes through and both validators fail.
+
+name: budget_enforcement
+description: |
+  One household authorizes a single $1000/month restaurant budget. Four
+  independent sources spend against it — human-card (340), meal-planner (280),
+  travel-agent (250), lunch-app (180). Combined they exceed 1000, so the last to
+  spend is refused because of spend the others made on rails it cannot see. Both
+  budget validators (never_exceeds_cap, refuses_overspend) must pass under a
+  shared budget_limited wallet — the cross-source enforcement no per-rail wallet
+  can do.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 8
+  brain: state-machine
+  roles:
+    - name: source
+      count: 4
+    - name: merchant
+      count: 4
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: budget_limited
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: budget_enforcement
+  config:
+    cap: 1000
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 200"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/budget_enforcement.jsonl

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -5150,6 +5150,152 @@ def validate_attested_sybil_quarantined(
 
 
 # ---------------------------------------------------------------------------
+# Budget-enforcement validators
+# ---------------------------------------------------------------------------
+
+
+def _parse_budget_events(events: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Parse ``budget:<kind>:k=v:...`` broadcast lines into field dicts.
+
+    Only ``send`` / ``broadcast`` events whose body starts with ``budget:`` are
+    considered, in trace order. Each returned dict has a ``kind`` key plus the
+    parsed ``k=v`` fields.
+
+    Example::
+
+        parsed = _parse_budget_events(events)
+    """
+    parsed: list[dict[str, str]] = []
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        body = _message_body(ev)
+        if not body.startswith("budget:"):
+            continue
+        parts = body.split(":")
+        # parts[0] == "budget", parts[1] == kind, remainder == k=v tokens
+        if len(parts) < 2:
+            continue
+        fields: dict[str, str] = {"kind": parts[1]}
+        for token in parts[2:]:
+            key, sep, value = token.partition("=")
+            if sep:
+                fields[key] = value
+        parsed.append(fields)
+    return parsed
+
+
+def _budget_pool_caps(parsed: list[dict[str, str]]) -> dict[str, int]:
+    """Map each budget pool id to its declared cap from ``budget:cap`` lines.
+
+    Example::
+
+        caps = _budget_pool_caps(_parse_budget_events(events))
+    """
+    caps: dict[str, int] = {}
+    for ev in parsed:
+        if ev["kind"] == "cap":
+            try:
+                caps[ev.get("pool", "")] = int(ev.get("cap", ""))
+            except ValueError:
+                continue
+    return caps
+
+
+def validate_budget_never_exceeds_cap(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """A pool's combined confirmed spend across all sources may not exceed its cap.
+
+    Reads each pool's cap from its ``budget:cap`` line, then walks the
+    ``budget:paid`` lines in trace order accumulating spend **across every source**
+    in the pool. Fails if a pool's running total exceeds its cap — the overspend a
+    budget-less baseline (``prepaid_credits``), which watches no shared total, lets
+    through.
+    """
+    parsed = _parse_budget_events(events)
+    caps = _budget_pool_caps(parsed)
+
+    running: dict[str, int] = {}
+    violations: list[str] = []
+    paid_count = 0
+    for ev in parsed:
+        if ev["kind"] != "paid":
+            continue
+        paid_count += 1
+        pool = ev.get("pool", "")
+        try:
+            amount = int(ev.get("amount", ""))
+        except ValueError:
+            violations.append(f"pool={pool!r}: non-integer paid amount={ev.get('amount', '')!r}")
+            continue
+        running[pool] = running.get(pool, 0) + amount
+        cap = caps.get(pool)
+        if cap is not None and running[pool] > cap:
+            violations.append(f"pool={pool!r}: combined spend {running[pool]} exceeds cap {cap}")
+
+    if violations:
+        return [ValidationResult("budget_never_exceeds_cap", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "budget_never_exceeds_cap",
+            True,
+            f"{paid_count} payments across {len(caps)} pool(s) all within the shared cap",
+        )
+    ]
+
+
+def validate_budget_refuses_overspend(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """At least one over-cap purchase must be refused, and none silently allowed.
+
+    Walks the pool's events in trace order, accumulating confirmed spend across
+    sources. Requires a ``budget:refused`` whose amount, added to the spend
+    already confirmed for that pool, would have exceeded the cap — proof the
+    shared budget was actually exercised and enforced across sources. A budget-less
+    baseline emits no refusals, so this fails there, catching the overspend a
+    shared ledger is meant to prevent.
+    """
+    parsed = _parse_budget_events(events)
+    caps = _budget_pool_caps(parsed)
+
+    running: dict[str, int] = {}
+    genuine_refusals = 0
+    for ev in parsed:
+        pool = ev.get("pool", "")
+        if ev["kind"] == "paid":
+            try:
+                running[pool] = running.get(pool, 0) + int(ev.get("amount", ""))
+            except ValueError:
+                continue
+        elif ev["kind"] == "refused":
+            cap = caps.get(pool)
+            try:
+                amount = int(ev.get("amount", ""))
+            except ValueError:
+                continue
+            if cap is not None and running.get(pool, 0) + amount > cap:
+                genuine_refusals += 1
+
+    if genuine_refusals == 0:
+        return [
+            ValidationResult(
+                "budget_refuses_overspend",
+                False,
+                "no over-cap purchase was refused — shared budget not enforced",
+            )
+        ]
+    return [
+        ValidationResult(
+            "budget_refuses_overspend",
+            True,
+            f"{genuine_refusals} over-cap purchase(s) refused on the shared budget",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -5409,5 +5555,9 @@ VALIDATORS: dict[str, list[Any]] = {
     "rogue_trusted_agent": [
         validate_rogue_trusted_agent_blocked,
         validate_rogue_trusted_agent_reputation,
+    ],
+    "budget_enforcement": [
+        validate_budget_never_exceeds_cap,
+        validate_budget_refuses_overspend,
     ],
 }

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2146,6 +2146,7 @@ class TestValidatorRegistry:
             "parc_migration",
             "rogue_trusted_agent",
             "sybil_bond",
+            "budget_enforcement",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/budget_limited.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/budget_limited.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Budget-limited payments plugin — a prepaid ledger with a cumulative spend cap.
+
+Persona: **payments-risk engineer.** The control here exists because an
+autonomous agent that can move money is a spending-risk surface — whether it is
+merely over-eager, prompt-injected, or driven by a hostile counterparty. A
+balance check is not a budget: it only asks "are there funds?", never "is this
+authorized?". This plugin adds the missing authorization control.
+
+Unlike a plain balance check, the budget caps *total* spend over the plugin's
+lifetime: an agent with plenty of balance still cannot spend past its authorized
+budget. ``pay()`` refuses (raises) a payment that would push cumulative spend
+over the budget, *before* any value moves; ``remaining()`` reports the headroom
+an agent should check before an autonomous purchase.
+
+Threat model (each denied, and pinned by tests):
+
+* **Overspend by attrition** — many small payments that individually fit but
+  cumulatively breach the cap. Denied: the cap is checked against *cumulative*
+  spend, not the single amount.
+* **Currency confusion** — a payment declared in a different currency to slip
+  past a cap tracked in another. Denied: a mismatched currency is rejected, not
+  summed and not treated as free headroom.
+* **Refund-replay inflation** — refunding to reclaim budget headroom, then
+  replaying the refund to inflate it further. Denied: a refund releases exactly
+  the charged amount once; a second refund of the same reference raises.
+
+Example::
+
+    payments = BudgetLimitedPayments(AgentId("a1"), initial_balance=1000, budget=100)
+    await payments.pay(AgentId("a2"), Money(amount=60), PaymentRef("p1"))
+    payments.remaining()  # 40
+    await payments.pay(AgentId("a2"), Money(amount=60), PaymentRef("p2"))  # raises: over budget
+"""
+
+from __future__ import annotations
+
+from nest_core.types import (
+    AgentId,
+    Money,
+    PaymentRef,
+    PaymentStatus,
+    Quote,
+    Receipt,
+    ServiceRef,
+)
+
+
+class BudgetLimitedPayments:
+    """Prepaid debit/credit ledger that also enforces a cumulative spend budget.
+
+    The budget is single-currency: payments in a different currency are rejected
+    rather than silently summed, mirroring the rule that amounts are never added
+    across currencies.
+
+    The budget can be **shared** across several wallets by passing the same
+    mutable ``spent`` holder to each: every source then draws down one common
+    cap, so one source is refused because of spend the others made — the
+    cross-source enforcement no single per-wallet cap can do.
+
+    Example::
+
+        pay = BudgetLimitedPayments(AgentId("a1"), initial_balance=1000, budget=100)
+        receipt = await pay.pay(AgentId("a2"), Money(amount=50), PaymentRef("p1"))
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        initial_balance: int = 1000,
+        budget: int = 1000,
+        currency: str = "credits",
+        balances: dict[AgentId, int] | None = None,
+        payments: dict[PaymentRef, Receipt] | None = None,
+        spent: dict[str, int] | None = None,
+    ) -> None:
+        if budget < 0:
+            msg = f"Budget must be non-negative: {budget}"
+            raise ValueError(msg)
+        self._agent_id = agent_id
+        self._budget = budget
+        self._currency = currency
+        # Cumulative spend lives in a shared, mutable holder so multiple wallets
+        # can draw down one common budget. Own holder by default (per-wallet cap).
+        self._spent_holder = spent if spent is not None else {"value": 0}
+        self._spent_holder.setdefault("value", 0)
+        self._balances = balances if balances is not None else {}
+        self._balances.setdefault(agent_id, initial_balance)
+        self._payments = payments if payments is not None else {}
+        self._charged: dict[PaymentRef, int] = {}
+
+    @property
+    def _spent(self) -> int:
+        """Cumulative spend against the (possibly shared) budget."""
+        return self._spent_holder["value"]
+
+    @_spent.setter
+    def _spent(self, value: int) -> None:
+        self._spent_holder["value"] = value
+
+    def balance(self, agent: AgentId) -> int:
+        """Check an agent's balance.
+
+        Example::
+
+            bal = pay.balance(AgentId("a1"))
+        """
+        return self._balances.get(agent, 0)
+
+    def spent(self) -> int:
+        """Return cumulative confirmed spend counted against the budget.
+
+        Example::
+
+            total = pay.spent()
+        """
+        return self._spent
+
+    def remaining(self) -> int:
+        """Return budget headroom left (never negative).
+
+        Example::
+
+            left = pay.remaining()
+        """
+        return max(0, self._budget - self._spent)
+
+    def within_budget(self, amount: Money) -> bool:
+        """Return whether paying ``amount`` would stay within budget and currency.
+
+        Example::
+
+            ok = pay.within_budget(Money(amount=40))
+        """
+        if amount.currency != self._currency:
+            return False
+        return self._spent + amount.amount <= self._budget
+
+    async def quote(self, service: ServiceRef) -> Quote:
+        """Return a fixed quote for any service.
+
+        Example::
+
+            q = await pay.quote(ServiceRef("svc"))
+        """
+        return Quote(service=service, price=Money(amount=10, currency=self._currency))
+
+    async def pay(self, to: AgentId, amount: Money, ref: PaymentRef) -> Receipt:
+        """Execute a payment, refusing anything over the remaining budget.
+
+        Raises ``ValueError`` for a non-positive amount, a currency mismatch, a
+        duplicate reference, a budget overrun, or insufficient balance — the
+        budget is checked before any value moves.
+
+        Example::
+
+            receipt = await pay.pay(AgentId("a2"), Money(amount=50), PaymentRef("p1"))
+        """
+        if amount.amount <= 0:
+            msg = f"Payment amount must be positive: {amount.amount}"
+            raise ValueError(msg)
+        if amount.currency != self._currency:
+            msg = f"Currency mismatch: {amount.currency} != {self._currency}"
+            raise ValueError(msg)
+        if ref in self._payments:
+            msg = f"Duplicate payment reference: {ref}"
+            raise ValueError(msg)
+        if self._spent + amount.amount > self._budget:
+            msg = (
+                f"Budget exceeded: {self._spent} + {amount.amount} > {self._budget} "
+                f"({self._currency})"
+            )
+            raise ValueError(msg)
+
+        payer_balance = self._balances.get(self._agent_id, 0)
+        if payer_balance < amount.amount:
+            msg = f"Insufficient balance: {payer_balance} < {amount.amount}"
+            raise ValueError(msg)
+
+        self._balances[self._agent_id] = payer_balance - amount.amount
+        self._balances[to] = self._balances.get(to, 0) + amount.amount
+        self._spent += amount.amount
+
+        receipt = Receipt(ref=ref, payer=self._agent_id, payee=to, amount=amount)
+        self._payments[ref] = receipt
+        self._charged[ref] = amount.amount
+        return receipt
+
+    async def verify_payment(self, ref: PaymentRef) -> PaymentStatus:
+        """Verify a payment status by reference.
+
+        Example::
+
+            status = await pay.verify_payment(PaymentRef("p1"))
+        """
+        if ref in self._payments:
+            return PaymentStatus.CONFIRMED
+        return PaymentStatus.FAILED
+
+    async def refund(self, ref: PaymentRef) -> None:
+        """Refund a payment and release its amount back into the budget.
+
+        Example::
+
+            await pay.refund(PaymentRef("p1"))
+        """
+        receipt = self._payments.get(ref)
+        if receipt is None:
+            msg = f"Payment not found: {ref}"
+            raise ValueError(msg)
+
+        payee_balance = self._balances.get(receipt.payee, 0)
+        if payee_balance < receipt.amount.amount:
+            msg = (
+                f"Insufficient balance for refund: {receipt.payee} has "
+                f"{payee_balance}, needs {receipt.amount.amount}"
+            )
+            raise ValueError(msg)
+
+        self._balances[receipt.payee] = payee_balance - receipt.amount.amount
+        self._balances[receipt.payer] = self._balances.get(receipt.payer, 0) + receipt.amount.amount
+        self._spent -= self._charged.pop(ref, receipt.amount.amount)
+        del self._payments[ref]

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -62,6 +62,9 @@ aae_permit_gate = "nest_plugins_reference.trust.aae_permit_gate:AAEPermitGate"
 bonded_trust = "nest_plugins_reference.trust.bonded_trust:BondedTrust"
 attested_peering = "nest_plugins_reference.trust.attested_peering:AttestedPeeringTrust"
 
+[project.entry-points."nest.plugins.payments"]
+budget_limited = "nest_plugins_reference.payments.budget_limited:BudgetLimitedPayments"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/nest-plugins-reference/tests/test_budget_enforcement_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_budget_enforcement_scenario.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end scenario test for the budget_enforcement scenario.
+
+Boots the ``budget_enforcement`` scenario through the real ``Simulator`` twice
+-- once with ``payments: budget_limited`` and once with
+``payments: prepaid_credits`` -- and proves the two validators discriminate:
+BOTH PASS under the budget plugin (the over-cap attempt is refused), BOTH FAIL
+under the default plugin (which has no budget, so the overspend goes through).
+
+Also pins determinism: same seed -> byte-identical trace.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "budget_enforcement.yaml"
+
+
+def _swap_payments(config: ScenarioConfig, plugin_name: str) -> ScenarioConfig:
+    """Return ``config`` with the payments layer pointing at ``plugin_name``."""
+    new_layers = config.layers.model_copy(update={"payments": plugin_name})
+    return config.model_copy(update={"layers": new_layers})
+
+
+def _run(plugin_name: str, seed: int = 42) -> Path:
+    """Run the scenario with the chosen payments plugin; return the trace path."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    config = _swap_payments(config, plugin_name)
+    config = config.model_copy(update={"seed": seed})
+    tmp = Path(tempfile.mkdtemp())
+    trace_path = tmp / f"budget_{plugin_name}_{seed}.jsonl"
+    config = config.model_copy(
+        update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+    )
+    runner = ScenarioRunner(config, registry=PluginRegistry())
+    asyncio.run(runner.run())
+    return trace_path
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_budget_plugin_passes_both_validators() -> None:
+    """The budget plugin keeps spend within cap and refuses the over-cap attempt."""
+    trace_path = _run("budget_limited")
+    results = validate_trace(trace_path, "budget_enforcement")
+    summary = [f"{'PASS' if r.passed else 'FAIL'} {r.name}: {r.detail}" for r in results]
+    assert all(r.passed for r in results), (
+        "expected all validators to pass under budget_limited:\n" + "\n".join(summary)
+    )
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_prepaid_credits_fails_both_validators() -> None:
+    """The default ``prepaid_credits`` plugin has no budget, so the overspend lands.
+
+    Every attempt succeeds (balance is ample), so cumulative spend exceeds the
+    cap and no refusal is ever emitted -- both budget validators must flag it.
+    """
+    trace_path = _run("prepaid_credits")
+    results = validate_trace(trace_path, "budget_enforcement")
+    by_name = {r.name: r for r in results}
+    assert not by_name["budget_never_exceeds_cap"].passed
+    assert not by_name["budget_refuses_overspend"].passed
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_budget_scenario_deterministic_under_replay() -> None:
+    """Two runs with seed 42 produce identical trace bytes."""
+    a = _run("budget_limited", seed=42).read_bytes()
+    b = _run("budget_limited", seed=42).read_bytes()
+    assert a == b
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_budget_scenario_passes_across_seeds(seed: int) -> None:
+    """Validator discrimination holds across multiple seeds."""
+    trace_path = _run("budget_limited", seed=seed)
+    results = validate_trace(trace_path, "budget_enforcement")
+    assert all(r.passed for r in results), [
+        f"{r.name}: {r.detail}" for r in results if not r.passed
+    ]

--- a/packages/nest-plugins-reference/tests/test_budget_limited_payments.py
+++ b/packages/nest-plugins-reference/tests/test_budget_limited_payments.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the budget-limited payments plugin.
+
+Covers the cumulative spend cap (distinct from balance), currency isolation,
+refund releasing budget, and a Hypothesis invariant that confirmed spend can
+never exceed the budget across arbitrary payment sequences.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Money, PaymentRef, PaymentStatus
+from nest_plugins_reference.payments.budget_limited import BudgetLimitedPayments
+
+
+class TestBudgetLimitedPayments:
+    """Example-based tests for BudgetLimitedPayments."""
+
+    @pytest.fixture
+    def payments(self) -> BudgetLimitedPayments:
+        """A payer with ample balance but a tight budget of 1000."""
+        return BudgetLimitedPayments(AgentId("payer"), initial_balance=10000, budget=1000)
+
+    def test_init(self, payments: BudgetLimitedPayments) -> None:
+        """Balance, spend, and remaining start as configured."""
+        assert payments.balance(AgentId("payer")) == 10000
+        assert payments.spent() == 0
+        assert payments.remaining() == 1000
+
+    @pytest.mark.asyncio
+    async def test_pay_within_budget(self, payments: BudgetLimitedPayments) -> None:
+        """A payment within budget moves funds and decrements remaining."""
+        receipt = await payments.pay(AgentId("payee"), Money(amount=400), PaymentRef("p1"))
+        assert receipt.amount.amount == 400
+        assert payments.balance(AgentId("payer")) == 9600
+        assert payments.balance(AgentId("payee")) == 400
+        assert payments.spent() == 400
+        assert payments.remaining() == 600
+
+    @pytest.mark.asyncio
+    async def test_spend_accumulates(self, payments: BudgetLimitedPayments) -> None:
+        """Cumulative spend accrues across payments."""
+        await payments.pay(AgentId("payee"), Money(amount=400), PaymentRef("p1"))
+        await payments.pay(AgentId("payee"), Money(amount=400), PaymentRef("p2"))
+        assert payments.spent() == 800
+        assert payments.remaining() == 200
+
+    @pytest.mark.asyncio
+    async def test_over_budget_refused_without_moving_funds(
+        self, payments: BudgetLimitedPayments
+    ) -> None:
+        """An over-budget payment raises and leaves all state untouched."""
+        await payments.pay(AgentId("payee"), Money(amount=800), PaymentRef("p1"))
+        with pytest.raises(ValueError, match="Budget exceeded"):
+            await payments.pay(AgentId("payee"), Money(amount=400), PaymentRef("p2"))
+        # No funds moved, spend unchanged, ref not recorded.
+        assert payments.spent() == 800
+        assert payments.balance(AgentId("payer")) == 9200
+        assert await payments.verify_payment(PaymentRef("p2")) == PaymentStatus.FAILED
+
+    def test_within_budget(self, payments: BudgetLimitedPayments) -> None:
+        """within_budget reflects remaining headroom and currency."""
+        assert payments.within_budget(Money(amount=1000)) is True
+        assert payments.within_budget(Money(amount=1001)) is False
+        assert payments.within_budget(Money(amount=100, currency="usd")) is False
+
+    @pytest.mark.asyncio
+    async def test_currency_mismatch_refused(self, payments: BudgetLimitedPayments) -> None:
+        """A payment in a different currency is rejected, not summed."""
+        with pytest.raises(ValueError, match="Currency mismatch"):
+            await payments.pay(AgentId("payee"), Money(amount=10, currency="usd"), PaymentRef("p1"))
+
+    @pytest.mark.asyncio
+    async def test_non_positive_amount_refused(self, payments: BudgetLimitedPayments) -> None:
+        """Zero or negative amounts are rejected."""
+        with pytest.raises(ValueError, match="must be positive"):
+            await payments.pay(AgentId("payee"), Money(amount=0), PaymentRef("p1"))
+
+    @pytest.mark.asyncio
+    async def test_duplicate_ref_refused(self, payments: BudgetLimitedPayments) -> None:
+        """A reused payment reference is rejected."""
+        await payments.pay(AgentId("payee"), Money(amount=100), PaymentRef("p1"))
+        with pytest.raises(ValueError, match="Duplicate payment reference"):
+            await payments.pay(AgentId("payee"), Money(amount=100), PaymentRef("p1"))
+
+    @pytest.mark.asyncio
+    async def test_insufficient_balance_refused(self) -> None:
+        """Budget headroom does not bypass an insufficient balance."""
+        payments = BudgetLimitedPayments(AgentId("payer"), initial_balance=50, budget=1000)
+        with pytest.raises(ValueError, match="Insufficient balance"):
+            await payments.pay(AgentId("payee"), Money(amount=100), PaymentRef("p1"))
+
+    @pytest.mark.asyncio
+    async def test_refund_releases_budget(self, payments: BudgetLimitedPayments) -> None:
+        """Refunding a payment restores balances and frees budget."""
+        await payments.pay(AgentId("payee"), Money(amount=400), PaymentRef("p1"))
+        await payments.refund(PaymentRef("p1"))
+        assert payments.spent() == 0
+        assert payments.remaining() == 1000
+        assert payments.balance(AgentId("payer")) == 10000
+        assert payments.balance(AgentId("payee")) == 0
+        assert await payments.verify_payment(PaymentRef("p1")) == PaymentStatus.FAILED
+
+    def test_negative_budget_rejected(self) -> None:
+        """A negative budget is a construction error."""
+        with pytest.raises(ValueError, match="Budget must be non-negative"):
+            BudgetLimitedPayments(AgentId("payer"), budget=-1)
+
+    # --- adversarial cases (payments-risk threat model) ---
+
+    @pytest.mark.asyncio
+    async def test_cannot_overspend_by_attrition(self) -> None:
+        """Many small in-budget payments cannot cumulatively breach the cap."""
+        pay = BudgetLimitedPayments(AgentId("payer"), initial_balance=10000, budget=250)
+        for i in range(5):  # 5 x 50 == 250, exactly the cap
+            await pay.pay(AgentId("v"), Money(amount=50), PaymentRef(f"p{i}"))
+        assert pay.spent() == 250
+        with pytest.raises(ValueError, match="Budget exceeded"):
+            await pay.pay(AgentId("v"), Money(amount=1), PaymentRef("p-over"))
+
+    @pytest.mark.asyncio
+    async def test_currency_confusion_does_not_free_headroom(
+        self, payments: BudgetLimitedPayments
+    ) -> None:
+        """A foreign-currency payment is rejected, never counted as free spend."""
+        with pytest.raises(ValueError, match="Currency mismatch"):
+            await payments.pay(AgentId("v"), Money(amount=999, currency="usd"), PaymentRef("x"))
+        assert payments.spent() == 0
+        assert payments.remaining() == 1000
+
+    @pytest.mark.asyncio
+    async def test_cannot_inflate_budget_via_refund_replay(
+        self, payments: BudgetLimitedPayments
+    ) -> None:
+        """A refund releases the amount once; replaying it cannot inflate budget."""
+        await payments.pay(AgentId("v"), Money(amount=400), PaymentRef("p1"))
+        await payments.refund(PaymentRef("p1"))
+        assert payments.remaining() == 1000
+        with pytest.raises(ValueError, match="Payment not found"):
+            await payments.refund(PaymentRef("p1"))
+        assert payments.remaining() == 1000  # not inflated past the budget
+
+    @pytest.mark.asyncio
+    async def test_shared_budget_across_sources(self) -> None:
+        """Two wallets sharing one spend holder draw down a single budget.
+
+        This is the cross-source case: each source has its own money on its own
+        rail, but they share one budget, so the second source is refused because
+        of what the first spent — which no per-wallet cap could enforce.
+        """
+        shared_spent: dict[str, int] = {"value": 0}
+        balances: dict[AgentId, int] = {}
+        source_a = BudgetLimitedPayments(
+            AgentId("source-a"),
+            initial_balance=10000,
+            budget=1000,
+            spent=shared_spent,
+            balances=balances,
+        )
+        source_b = BudgetLimitedPayments(
+            AgentId("source-b"),
+            initial_balance=10000,
+            budget=1000,
+            spent=shared_spent,
+            balances=balances,
+        )
+        # source-a spends 700 against the shared budget.
+        await source_a.pay(AgentId("m1"), Money(amount=700), PaymentRef("a1"))
+        # source-b sees only 300 left, even though it has spent nothing itself.
+        assert source_b.remaining() == 300
+        with pytest.raises(ValueError, match="Budget exceeded"):
+            await source_b.pay(AgentId("m2"), Money(amount=400), PaymentRef("b1"))
+        # A 300 purchase from source-b fits exactly and closes the shared budget.
+        await source_b.pay(AgentId("m2"), Money(amount=300), PaymentRef("b2"))
+        assert source_a.spent() == 1000  # shared: reflects both sources' spend
+        assert source_b.remaining() == 0
+
+
+@settings(max_examples=200)
+@given(
+    budget=st.integers(min_value=0, max_value=5000),
+    amounts=st.lists(st.integers(min_value=1, max_value=1000), max_size=30),
+)
+@pytest.mark.asyncio
+async def test_spend_never_exceeds_budget(budget: int, amounts: list[int]) -> None:
+    """No sequence of payments can push confirmed spend over the budget."""
+    payments = BudgetLimitedPayments(AgentId("payer"), initial_balance=10**9, budget=budget)
+    for i, amount in enumerate(amounts):
+        with contextlib.suppress(ValueError):
+            # over-budget (or other) refusals are expected
+            await payments.pay(AgentId("payee"), Money(amount=amount), PaymentRef(f"p{i}"))
+        assert payments.spent() <= budget
+        assert payments.remaining() == budget - payments.spent()

--- a/scenarios/budget_enforcement.yaml
+++ b/scenarios/budget_enforcement.yaml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Budget enforcement: one shared household restaurant budget (1000) drawn down by
+# four independent spending sources on four different rails — a human card, a
+# meal-planner agent, a travel agent, and a lunch-app subscription. Their spends
+# total 1050, so the last source is refused on the shared cap even though it spent
+# little itself. Under `payments: budget_limited` (shared budget) both validators
+# pass; under `payments: prepaid_credits` (per-rail balances, no shared budget)
+# the combined overspend goes through and both validators fail.
+
+name: budget_enforcement
+description: |
+  One household authorizes a single $1000/month restaurant budget. Four
+  independent sources spend against it — human-card (340), meal-planner (280),
+  travel-agent (250), lunch-app (180). Combined they exceed 1000, so the last to
+  spend is refused because of spend the others made on rails it cannot see. Both
+  budget validators (never_exceeds_cap, refuses_overspend) must pass under a
+  shared budget_limited wallet — the cross-source enforcement no per-rail wallet
+  can do.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 8
+  brain: state-machine
+  roles:
+    - name: source
+      count: 4
+    - name: merchant
+      count: 4
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: budget_limited
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: budget_enforcement
+  config:
+    cap: 1000
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 200"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/budget_enforcement.jsonl


### PR DESCRIPTION
**Persona: payments-risk engineer.**

Adds a new reference plugin on the **payments** layer, `BudgetLimitedPayments`: a prepaid ledger that also enforces a **cumulative spending cap**. An autonomous agent that can move money is a spending-risk surface — a balance check only asks "are there funds?", never "is this authorized?". This plugin adds the missing authorization control: total spend cannot exceed the budget, regardless of balance, and the budget can be **shared across independent sources**.

### Threat model (each denied, pinned by tests)
- **Overspend by attrition** — many small in-budget payments that cumulatively breach the cap → denied (checked against cumulative spend).
- **Currency confusion** — a foreign-currency payment slipping past a cap tracked in another currency → rejected, never counted as free headroom.
- **Refund-replay inflation** — refunding to reclaim headroom then replaying it → a refund releases the charged amount once; a replay raises.

### Cross-source scenario (the "make the host catch something" proof)
`budget_enforcement` runs one shared household budget ($1000) drawn down by four independent sources on four rails — a human card, a meal-planner agent, a travel agent, and a lunch-app subscription — that cannot see each other. Their spends (340 + 280 + 250 + 180 = 1050) exceed the cap, so the last source is **refused because of spend the others made** — cross-source enforcement no single per-rail wallet can do.

Two validators check the trace: combined spend across sources never exceeds the shared cap, and a genuine over-cap purchase is refused. Same scenario, two plugins:
- `payments: budget_limited` (shared budget) → last source refused; both validators **PASS**.
- `payments: prepaid_credits` (per-rail balances, no shared budget) → the 1050 overspend goes through; both validators **FAIL**.

Tested end-to-end against the real `Simulator` / `ScenarioRunner` / `validate_trace`.

### API & wiring
Implements the `Payments` protocol (`quote`/`pay`/`verify_payment`/`refund`) plus `balance`/`spent`/`remaining`/`within_budget`; `pay()` refuses an over-budget payment *before* any value moves. Registered via a `nest.plugins.payments` entry-point (and a `_BUILTINS` fallback), selectable as `payments: budget_limited` with no scenario edits.

### Tests
22 total — example-based, 4 adversarial, a shared-budget case, a Hypothesis property test ("confirmed spend never exceeds budget" over arbitrary sequences), and 6 end-to-end scenario tests (discriminator + determinism + 3-seed bank).

`make ci-local` passes (ruff, ruff format, pyright strict, pytest — 758 passed). No new dependencies.