### PR TITLE
[Hackathon]/tani-decaying-memory

### DIFF
--- a/my_decaying_memory.py
+++ b/my_decaying_memory.py
@@ -1,0 +1,35 @@
+import time
+from typing import Optional, Any, List
+from nest_sdk import Memory 
+
+class DecayingMemory(Memory):
+    def __init__(self, ttl_seconds: int = 60):
+        self.storage: dict[str, tuple[Any, float]] = {}
+        self.ttl = ttl_seconds
+
+    async def put(self, key: str, value: Any) -> None:
+        self.storage[key] = (value, time.time())
+
+    async def get(self, key: str) -> Optional[Any]:
+        if key not in self.storage:
+            return None
+        value, timestamp = self.storage[key]
+        if time.time() - timestamp > self.ttl:
+            del self.storage[key]
+            return None
+        return value
+
+    async def delete(self, key: str) -> None:
+        if key in self.storage:
+            del self.storage[key]
+
+    # Added these to make the interface "Complete" (No more red lines)
+    async def clear(self) -> None:
+        self.storage.clear()
+
+    async def list_keys(self) -> List[str]:
+        # Cleanup expired keys before listing
+        current_keys = list(self.storage.keys())
+        for k in current_keys:
+            await self.get(k) 
+        return list(self.storage.keys())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -123,3 +122,9 @@ pythonpath = ["."]
 markers = [
     "live: end-to-end tests that hit live external services (skipped by default)",
 ]
+[project.entry-points."nest.plugins.memory"]
+decaying = "my_decaying_memory:DecayingMemory"
+
+[tool.setuptools]
+packages = ["nest_core"]
+py-modules = ["my_decaying_memory"]

--- a/test_memory.py
+++ b/test_memory.py
@@ -1,0 +1,22 @@
+import asyncio
+import time
+from my_decaying_memory import DecayingMemory
+
+async def test_forgetting():
+    # Set TTL to 2 seconds for a quick test
+    mem = DecayingMemory(ttl_seconds=2)
+    print("--- Starting Test ---")
+    
+    await mem.put("kumbh_status", "crowded")
+    val = await mem.get("kumbh_status")
+    print(f"Immediate check: {val}") # Should be 'crowded'
+    
+    print("Waiting 3 seconds for memory to decay...")
+    await asyncio.sleep(3)
+    
+    val = await mem.get("kumbh_status")
+    print(f"After 3s check: {val}") # Should be None (forgotten!)
+    print("--- Test Passed ---")
+
+if __name__ == "__main__":
+    asyncio.run(test_forgetting())


### PR DESCRIPTION
### Overview
I have implemented a new plugin for **Layer 10 (Memory)** called **DecayingMemory.** This introduces a **Time-To-Live (TTL)** mechanism to agent memory, allowing for "biological-inspired forgetting" within the Nanda Town simulator.
### Problem 
In high-density scenarios like the Kumbh Mela, agents are flooded with real-time data (crowd density, vendor prices, resource locations). If an agent remembers every update forever, its context window becomes bloated with stale, irrelevant information, leading to slow processing and incorrect decision-making based on outdated facts.
### Solution: Layer 10 Decaying Memory
My implementation ensures that:
Every memory entry is timestamped upon storage (put).
When an agent retrieves data (get), the system checks if the time elapsed exceeds the ttl_seconds.
Stale data is automatically deleted and returns None, forcing the agent to fetch fresh data from the network/discovery layer.
### Technical Implementation & Compatibility
Interface Fit:I implemented  the nest_sdk.Memory abstract base class.
Python 3.14 Support: Fixed pyproject.toml issues (removed deprecated license classifiers and added explicit package discovery) to ensure compatibility with the latest Python versions and uv build systems.
Registration: Registered via [project.entry-points."nest.plugins.memory"] as decaying.
### Testing 
I have included a test_memory.py script. The results show the protocol working exactly as intended:
code
--- Starting Test ---
Immediate check: crowded
Waiting 3 seconds for memory to decay...
After 3s check: None
--- Test Passed ---
### How to verify
Run uv sync or pip install -e .
Run uv run python test_memory.py
Optionally, use it in a scenario by setting memory: decaying in a .yaml config.