### PR TITLE
[Hackathon] macaroon-delegation: delegatable capability tokens with cascading revocation

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -25,6 +25,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
+    ("auth", "macaroons"): f"{_REF}.auth.macaroons:MacaroonAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -81,6 +81,10 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.gossip_registry import gossip_registry_factory
 
         register_scenario("gossip_registry", gossip_registry_factory)
+    elif name == "delegated_auth":
+        from nest_core.scenarios_builtin.delegated_auth import delegated_auth_factory
+
+        register_scenario("delegated_auth", delegated_auth_factory)
     elif name == "memory_concurrent_writers":
         from nest_core.scenarios_builtin.memory_concurrent_writers import (
             memory_concurrent_writers_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegated-auth scenario — exercises macaroon-style capability delegation.
+
+Topology (16 agents):
+
+* ``coordinator-0`` holds a root token with the full scope set.
+* ``intermediary-0..2`` each hold a delegated token with a narrower scope
+  (``[read, write]``, ``[read, delete]``, ``[read]``).
+* ``leaf-0..11`` each hold a ``[read]`` token delegated by their intermediary
+  (leaf ``i`` belongs to intermediary ``i // 4``).
+
+Every leaf presents its token to the coordinator, which verifies it against the
+presenter's identity. Two leaves are Byzantine:
+
+* ``leaf-5`` forges a broader scope into its own token (tampering).
+* ``leaf-10`` steals ``leaf-9``'s token and presents it as its own (audience
+  confusion).
+
+Once all twelve have presented, the coordinator revokes ``intermediary-0``. Its
+four honest leaves (``leaf-0..3``) then fail re-verification, demonstrating
+cascading revocation. The whole scenario is RNG-free, so a given seed replays to a
+byte-identical trace.
+
+Example::
+
+    from nest_core.runner import ScenarioRunner
+    from nest_core.scenario import ScenarioConfig
+    runner = ScenarioRunner(ScenarioConfig.from_yaml("scenarios/delegated_auth.yaml"))
+    await runner.run()
+    results = runner.resolved_plugins["_delegation_results"]
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Token
+
+COORDINATOR = AgentId("coordinator-0")
+_ROOT_SCOPES = ["read", "write", "admin", "delete"]
+_INTERMEDIARY_SCOPES = [["read", "write"], ["read", "delete"], ["read"]]
+_PRESENT = b"PRESENT|"
+
+
+class DelegationLeaf(StateMachineAgent):
+    """A leaf agent that presents its capability token to the coordinator.
+
+    Example::
+
+        leaf = DelegationLeaf(b"PRESENT|<token>")
+    """
+
+    def __init__(self, present_payload: bytes) -> None:
+        self._present_payload = present_payload
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Send this leaf's token to the coordinator.
+
+        Example::
+
+            await leaf.on_start(ctx)
+        """
+        await ctx.send(COORDINATOR, self._present_payload)
+
+
+class DelegationCoordinator(StateMachineAgent):
+    """Verifies presented tokens and revokes an intermediary to show the cascade.
+
+    Example::
+
+        coord = DelegationCoordinator(auth, inter_tokens, cascade_tokens, 12, results)
+    """
+
+    def __init__(
+        self,
+        auth: Any,
+        intermediary_tokens: list[Token],
+        cascade_tokens: dict[str, Token],
+        expected: int,
+        results: dict[str, Any],
+    ) -> None:
+        self._auth = auth
+        self._intermediary_tokens = intermediary_tokens
+        self._cascade_tokens = cascade_tokens
+        self._expected = expected
+        self._results = results
+        self._seen = 0
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Verify a presented token; after the last one, revoke intermediary-0.
+
+        Example::
+
+            await coord.on_message(ctx, AgentId("leaf-0"), b"PRESENT|<token>")
+        """
+        from nest_plugins_reference.auth.macaroons import DelegationError, RevokedAncestorError
+
+        if not payload.startswith(_PRESENT):
+            return
+        token = Token(payload[len(_PRESENT) :].decode("utf-8"))
+        try:
+            self._auth.verify_for_sync(token, sender)
+            self._results["authorized"].append(str(sender))
+        except DelegationError as exc:
+            self._results["blocked"][str(sender)] = type(exc).__name__
+
+        self._seen += 1
+        if self._seen < self._expected:
+            return
+
+        # Everyone has presented: revoke intermediary-0 and re-check its leaves.
+        self._auth.revoke_sync(self._intermediary_tokens[0])
+        for leaf_id, tok in self._cascade_tokens.items():
+            try:
+                self._auth.verify_for_sync(tok, AgentId(leaf_id))
+            except RevokedAncestorError:
+                self._results["cascade_revoked"].append(leaf_id)
+            except DelegationError:
+                pass
+
+
+def delegated_auth_factory(config: ScenarioConfig, plugins: dict[str, Any]) -> dict[AgentId, Any]:
+    """Build the delegation tree and the agent fleet for the scenario.
+
+    Example::
+
+        agents = delegated_auth_factory(config, plugins)
+    """
+    from nest_plugins_reference.auth.macaroons import MacaroonAuth
+
+    counts = {role.name: role.count for role in config.agents.roles}
+    n_intermediaries = counts.get("intermediary", 3)
+    n_leaves = counts.get("leaf", 12)
+
+    auth = MacaroonAuth(secret=b"nanda-macaroon-scenario", clock=0.0)
+
+    # Root and per-intermediary tokens.
+    root = auth.issue_sync(COORDINATOR, _ROOT_SCOPES)
+    intermediary_tokens: list[Token] = []
+    for i in range(n_intermediaries):
+        scopes = _INTERMEDIARY_SCOPES[i % len(_INTERMEDIARY_SCOPES)]
+        intermediary_tokens.append(
+            auth.delegate_sync(root, AgentId(f"intermediary-{i}"), scopes, ttl=1800.0)
+        )
+
+    # Per-leaf [read] tokens, delegated by the owning intermediary.
+    leaf_tokens: dict[int, Token] = {}
+    for i in range(n_leaves):
+        parent_idx = i // 4
+        parent_token = intermediary_tokens[parent_idx % len(intermediary_tokens)]
+        leaf_tokens[i] = auth.delegate_sync(parent_token, AgentId(f"leaf-{i}"), ["read"], ttl=600.0)
+
+    # Two Byzantine leaves: 5 forges a broader scope, 10 steals leaf-9's token.
+    byzantine_tamper = 5
+    byzantine_steal = 10
+    present_payloads: dict[int, bytes] = {}
+    for i in range(n_leaves):
+        if i == byzantine_tamper:
+            forged = str(leaf_tokens[i]).replace("read", "admin")  # breaks the signature
+            present_payloads[i] = _PRESENT + forged.encode("utf-8")
+        elif i == byzantine_steal:
+            stolen = leaf_tokens[byzantine_steal - 1]  # a peer's valid token
+            present_payloads[i] = _PRESENT + str(stolen).encode("utf-8")
+        else:
+            present_payloads[i] = _PRESENT + str(leaf_tokens[i]).encode("utf-8")
+
+    # Honest leaves under intermediary-0 (leaf-0..3) demonstrate the cascade.
+    cascade_tokens = {f"leaf-{i}": leaf_tokens[i] for i in range(n_leaves) if i // 4 == 0}
+
+    results: dict[str, Any] = {"authorized": [], "blocked": {}, "cascade_revoked": []}
+    plugins["_delegation_auth"] = auth
+    plugins["_delegation_results"] = results
+
+    agents: dict[AgentId, Any] = {
+        COORDINATOR: DelegationCoordinator(
+            auth, intermediary_tokens, cascade_tokens, n_leaves, results
+        )
+    }
+    for i in range(n_intermediaries):
+        agents[AgentId(f"intermediary-{i}")] = StateMachineAgent()
+    for i in range(n_leaves):
+        agents[AgentId(f"leaf-{i}")] = DelegationLeaf(present_payloads[i])
+    return agents

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/macaroons.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/macaroons.py
@@ -287,12 +287,16 @@ class MacaroonAuth:
             prev = cav
         return caveats
 
-    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+    # -- sync cores: the real logic, usable outside an event loop (e.g. a
+    #    scenario factory building a delegation tree). The async methods below
+    #    satisfy the Auth protocol by delegating to these.
+
+    def issue_sync(self, subject: AgentId, scopes: list[str]) -> Token:
         """Issue a fresh root token for a subject with the given scopes.
 
         Example::
 
-            root = await auth.issue(AgentId("a1"), ["read", "write"])
+            root = auth.issue_sync(AgentId("a1"), ["read", "write"])
         """
         now = self._now()
         exp = now + self._default_ttl
@@ -301,7 +305,7 @@ class MacaroonAuth:
         caveat = Caveat(tid, str(subject), str(subject), tuple(scopes), now, exp, None)
         return self._encode([caveat])
 
-    async def delegate(
+    def delegate_sync(
         self,
         parent_token: Token,
         audience: AgentId,
@@ -312,7 +316,7 @@ class MacaroonAuth:
 
         Example::
 
-            child = await auth.delegate(root, AgentId("b"), ["read"], ttl=60)
+            child = auth.delegate_sync(root, AgentId("b"), ["read"], ttl=60)
         """
         caveats = self._check_chain(parent_token)
         parent = caveats[-1]
@@ -336,13 +340,12 @@ class MacaroonAuth:
         )
         return self._encode([*caveats, child])
 
-    async def verify(self, token: Token) -> AuthContext:
+    def verify_sync(self, token: Token) -> AuthContext:
         """Verify a token end to end and return the leaf's auth context.
 
         Example::
 
-            ctx = await auth.verify(child)
-            assert ctx.subject == AgentId("b")
+            ctx = auth.verify_sync(child)
         """
         caveats = self._check_chain(token)
         leaf = caveats[-1]
@@ -353,15 +356,14 @@ class MacaroonAuth:
             expires_at=leaf.expires_at,
         )
 
-    async def verify_for(self, token: Token, presenter: AgentId) -> AuthContext:
+    def verify_for_sync(self, token: Token, presenter: AgentId) -> AuthContext:
         """Verify a token and confirm the presenter is its declared audience.
 
         Example::
 
-            ctx = await auth.verify_for(child, AgentId("b"))
+            ctx = auth.verify_for_sync(child, AgentId("b"))
         """
-        caveats = self._check_chain(token)
-        leaf = caveats[-1]
+        leaf = self._check_chain(token)[-1]
         if leaf.audience != str(presenter):
             msg = f"Token audience {leaf.audience!r} was presented by {str(presenter)!r}"
             raise AudienceMismatchError(msg)
@@ -372,12 +374,62 @@ class MacaroonAuth:
             expires_at=leaf.expires_at,
         )
 
-    async def revoke(self, token: Token) -> None:
+    def revoke_sync(self, token: Token) -> None:
         """Revoke a token by its leaf id, which also invalidates its descendants.
+
+        Example::
+
+            auth.revoke_sync(root)
+        """
+        self._revoked.add(self._decode(token)[-1].tid)
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Async wrapper over :meth:`issue_sync` for the Auth protocol.
+
+        Example::
+
+            root = await auth.issue(AgentId("a1"), ["read", "write"])
+        """
+        return self.issue_sync(subject, scopes)
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token:
+        """Async wrapper over :meth:`delegate_sync`.
+
+        Example::
+
+            child = await auth.delegate(root, AgentId("b"), ["read"], ttl=60)
+        """
+        return self.delegate_sync(parent_token, audience, scopes_subset, ttl)
+
+    async def verify(self, token: Token) -> AuthContext:
+        """Async wrapper over :meth:`verify_sync` for the Auth protocol.
+
+        Example::
+
+            ctx = await auth.verify(child)
+        """
+        return self.verify_sync(token)
+
+    async def verify_for(self, token: Token, presenter: AgentId) -> AuthContext:
+        """Async wrapper over :meth:`verify_for_sync`.
+
+        Example::
+
+            ctx = await auth.verify_for(child, AgentId("b"))
+        """
+        return self.verify_for_sync(token, presenter)
+
+    async def revoke(self, token: Token) -> None:
+        """Async wrapper over :meth:`revoke_sync` for the Auth protocol.
 
         Example::
 
             await auth.revoke(root)
         """
-        caveats = self._decode(token)
-        self._revoked.add(caveats[-1].tid)
+        self.revoke_sync(token)

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/macaroons.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/macaroons.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Macaroon-style auth plugin: delegatable capability tokens with cascading revocation.
+
+An agent holding a token can mint a narrower token for another agent on its own,
+without going back to the issuer. Each delegation appends a caveat and re-chains the
+HMAC so the signature covers the whole ancestry. Because a child's signature is
+anchored to its parent's, revoking any ancestor's id makes every descendant fail to
+verify by construction, with no per-child revocation list.
+
+The design follows the macaroon paper (Birgisson et al., 2014): a token is a chain of
+caveats, each strictly attenuating the last (scopes can only shrink, expiry can only
+move earlier), and the chained signature makes tampering or scope escalation
+detectable at verify time.
+
+Example::
+
+    auth = MacaroonAuth(secret=b"root-secret")
+    root = await auth.issue(AgentId("a1"), ["read", "write", "admin"])
+    child = await auth.delegate(root, audience=AgentId("b"), scopes_subset=["read"], ttl=600)
+    ctx = await auth.verify(child)          # ctx.scopes == ["read"]
+    await auth.revoke(root)                 # revoking the parent...
+    await auth.verify(child)                # ...raises RevokedAncestorError
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from nest_core.types import AgentId, AuthContext, Token
+
+_WIRE_VERSION = 1
+
+
+class DelegationError(Exception):
+    """Base class for every macaroon delegation or verification failure."""
+
+
+class InvalidTokenError(DelegationError):
+    """The token is malformed or its chained signature does not match."""
+
+
+class ScopeEscalationError(DelegationError):
+    """A child token requested a scope its parent does not hold."""
+
+
+class TtlExtensionError(DelegationError):
+    """A child token asked to outlive its parent."""
+
+
+class RevokedAncestorError(DelegationError):
+    """The token, or one of its ancestors, has been revoked."""
+
+
+class ExpiredTokenError(DelegationError):
+    """The token, or one of its ancestors, has expired."""
+
+
+class AudienceMismatchError(DelegationError):
+    """The token was presented by an agent other than its declared audience."""
+
+
+@dataclass(frozen=True)
+class Caveat:
+    """One link in a macaroon chain: who may act, with which scopes, until when.
+
+    Example::
+
+        cav = Caveat(tid="ab12", subject="a1", audience="b",
+                     scopes=("read",), issued_at=0.0, expires_at=600.0, parent="root9")
+    """
+
+    tid: str
+    subject: str
+    audience: str
+    scopes: tuple[str, ...]
+    issued_at: float
+    expires_at: float
+    parent: str | None
+
+
+def _canonical(data: dict[str, Any]) -> bytes:
+    """Return a stable byte encoding so signatures are deterministic.
+
+    Example::
+
+        raw = _canonical({"b": 2, "a": 1})
+    """
+    return json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _content(
+    subject: str,
+    audience: str,
+    scopes: tuple[str, ...],
+    issued_at: float,
+    expires_at: float,
+    parent: str | None,
+) -> dict[str, Any]:
+    """Build the signed content of a caveat (everything except its own id).
+
+    Example::
+
+        c = _content("a1", "b", ("read",), 0.0, 600.0, None)
+    """
+    return {
+        "subject": subject,
+        "audience": audience,
+        "scopes": list(scopes),
+        "issued_at": issued_at,
+        "expires_at": expires_at,
+        "parent": parent,
+    }
+
+
+def _compute_tid(content: dict[str, Any]) -> str:
+    """Content-address a caveat: its id is a hash of its signed content.
+
+    Example::
+
+        tid = _compute_tid(_content("a1", "a1", ("read",), 0.0, 1.0, None))
+    """
+    return hashlib.sha256(_canonical(content)).hexdigest()[:32]
+
+
+class MacaroonAuth:
+    """Delegatable capability tokens with cascading revocation.
+
+    Example::
+
+        auth = MacaroonAuth(secret=b"secret")
+        root = await auth.issue(AgentId("a1"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("b"), ["read"], ttl=60)
+    """
+
+    def __init__(
+        self,
+        secret: bytes = b"nest-macaroon-secret",
+        clock: float | None = None,
+        default_ttl: float = 3600.0,
+    ) -> None:
+        self._secret = secret
+        self._clock = clock
+        self._default_ttl = default_ttl
+        self._revoked: set[str] = set()
+
+    def set_clock(self, now: float) -> None:
+        """Pin the clock to a fixed value for deterministic issuance and expiry.
+
+        Example::
+
+            auth.set_clock(100.0)
+        """
+        self._clock = now
+
+    def _now(self) -> float:
+        if self._clock is not None:
+            return self._clock
+        return time.time()
+
+    def _chain_signature(self, caveats: list[Caveat]) -> str:
+        """Fold the caveat chain into one HMAC, each link keyed by the previous.
+
+        Example::
+
+            sig = auth._chain_signature([root_caveat, child_caveat])
+        """
+        key = self._secret
+        sig = ""
+        for cav in caveats:
+            content = _content(
+                cav.subject, cav.audience, cav.scopes, cav.issued_at, cav.expires_at, cav.parent
+            )
+            payload = _canonical({"tid": cav.tid, **content})
+            sig = hmac.new(key, payload, hashlib.sha256).hexdigest()
+            key = sig.encode("ascii")
+        return sig
+
+    def _encode(self, caveats: list[Caveat]) -> Token:
+        """Serialize a caveat chain plus its signature into an opaque token string.
+
+        Example::
+
+            token = auth._encode([root_caveat])
+        """
+        chain = [
+            {
+                "tid": c.tid,
+                "subject": c.subject,
+                "audience": c.audience,
+                "scopes": list(c.scopes),
+                "issued_at": c.issued_at,
+                "expires_at": c.expires_at,
+                "parent": c.parent,
+            }
+            for c in caveats
+        ]
+        body = {"v": _WIRE_VERSION, "chain": chain, "sig": self._chain_signature(caveats)}
+        return Token(json.dumps(body, sort_keys=True, separators=(",", ":")))
+
+    def _decode(self, token: Token) -> list[Caveat]:
+        """Parse a token into its caveat chain (structure only, no signature check).
+
+        Example::
+
+            caveats = auth._decode(token)
+        """
+        try:
+            body = json.loads(str(token))
+            raw_chain = body["chain"]
+            caveats: list[Caveat] = []
+            for item in raw_chain:
+                caveats.append(
+                    Caveat(
+                        tid=str(item["tid"]),
+                        subject=str(item["subject"]),
+                        audience=str(item["audience"]),
+                        scopes=tuple(str(s) for s in item["scopes"]),
+                        issued_at=float(item["issued_at"]),
+                        expires_at=float(item["expires_at"]),
+                        parent=(None if item["parent"] is None else str(item["parent"])),
+                    )
+                )
+        except (ValueError, KeyError, TypeError) as exc:
+            msg = "Token is malformed"
+            raise InvalidTokenError(msg) from exc
+        if not caveats:
+            msg = "Token has an empty caveat chain"
+            raise InvalidTokenError(msg)
+        return caveats
+
+    def _check_chain(self, token: Token) -> list[Caveat]:
+        """Validate structure, signature, attenuation, revocation, and expiry.
+
+        Example::
+
+            caveats = auth._check_chain(token)
+            leaf = caveats[-1]
+        """
+        caveats = self._decode(token)
+        body = json.loads(str(token))
+
+        # 1. Signature must match a re-chain from the root secret. This catches
+        #    tampering and any attempt to forge a caveat the issuer never signed.
+        if not hmac.compare_digest(str(body["sig"]), self._chain_signature(caveats)):
+            msg = "Token signature does not verify"
+            raise InvalidTokenError(msg)
+
+        now = self._now()
+        prev: Caveat | None = None
+        for cav in caveats:
+            # 2. The id must content-address the caveat (integrity of the id itself).
+            expected_tid = _compute_tid(
+                _content(
+                    cav.subject, cav.audience, cav.scopes, cav.issued_at, cav.expires_at, cav.parent
+                )
+            )
+            if not hmac.compare_digest(cav.tid, expected_tid):
+                msg = "Caveat id does not match its content"
+                raise InvalidTokenError(msg)
+
+            # 3. Cascading revocation: any revoked ancestor kills the whole chain.
+            if cav.tid in self._revoked:
+                msg = f"Ancestor {cav.tid} has been revoked"
+                raise RevokedAncestorError(msg)
+
+            # 4. Expiry, checked for every link so a stale ancestor is caught too.
+            if cav.expires_at < now:
+                msg = "Token or an ancestor has expired"
+                raise ExpiredTokenError(msg)
+
+            # 5. Attenuation, re-checked at verify as defense in depth.
+            if prev is not None:
+                if cav.parent != prev.tid:
+                    msg = "Broken parent link in delegation chain"
+                    raise InvalidTokenError(msg)
+                if not set(cav.scopes).issubset(set(prev.scopes)):
+                    msg = "Child scopes are not a subset of the parent"
+                    raise ScopeEscalationError(msg)
+                if cav.expires_at > prev.expires_at:
+                    msg = "Child expiry is later than the parent"
+                    raise TtlExtensionError(msg)
+            prev = cav
+        return caveats
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Issue a fresh root token for a subject with the given scopes.
+
+        Example::
+
+            root = await auth.issue(AgentId("a1"), ["read", "write"])
+        """
+        now = self._now()
+        exp = now + self._default_ttl
+        content = _content(str(subject), str(subject), tuple(scopes), now, exp, None)
+        tid = _compute_tid(content)
+        caveat = Caveat(tid, str(subject), str(subject), tuple(scopes), now, exp, None)
+        return self._encode([caveat])
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token:
+        """Mint a narrower child token for another agent, without the issuer.
+
+        Example::
+
+            child = await auth.delegate(root, AgentId("b"), ["read"], ttl=60)
+        """
+        caveats = self._check_chain(parent_token)
+        parent = caveats[-1]
+
+        if not set(scopes_subset).issubset(set(parent.scopes)):
+            msg = "Delegated scopes must be a subset of the parent's scopes"
+            raise ScopeEscalationError(msg)
+
+        now = self._now()
+        child_exp = now + ttl
+        if child_exp > parent.expires_at:
+            msg = "Delegated token cannot outlive its parent"
+            raise TtlExtensionError(msg)
+
+        content = _content(
+            str(audience), str(audience), tuple(scopes_subset), now, child_exp, parent.tid
+        )
+        tid = _compute_tid(content)
+        child = Caveat(
+            tid, str(audience), str(audience), tuple(scopes_subset), now, child_exp, parent.tid
+        )
+        return self._encode([*caveats, child])
+
+    async def verify(self, token: Token) -> AuthContext:
+        """Verify a token end to end and return the leaf's auth context.
+
+        Example::
+
+            ctx = await auth.verify(child)
+            assert ctx.subject == AgentId("b")
+        """
+        caveats = self._check_chain(token)
+        leaf = caveats[-1]
+        return AuthContext(
+            subject=AgentId(leaf.audience),
+            scopes=list(leaf.scopes),
+            issued_at=leaf.issued_at,
+            expires_at=leaf.expires_at,
+        )
+
+    async def verify_for(self, token: Token, presenter: AgentId) -> AuthContext:
+        """Verify a token and confirm the presenter is its declared audience.
+
+        Example::
+
+            ctx = await auth.verify_for(child, AgentId("b"))
+        """
+        caveats = self._check_chain(token)
+        leaf = caveats[-1]
+        if leaf.audience != str(presenter):
+            msg = f"Token audience {leaf.audience!r} was presented by {str(presenter)!r}"
+            raise AudienceMismatchError(msg)
+        return AuthContext(
+            subject=AgentId(leaf.audience),
+            scopes=list(leaf.scopes),
+            issued_at=leaf.issued_at,
+            expires_at=leaf.expires_at,
+        )
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke a token by its leaf id, which also invalidates its descendants.
+
+        Example::
+
+            await auth.revoke(root)
+        """
+        caveats = self._decode(token)
+        self._revoked.add(caveats[-1].tid)

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -16,6 +16,13 @@ Example::
 
 from __future__ import annotations
 
+from nest_plugins_reference.validators.delegation_validators import (
+    check_audience_confusion_blocked,
+    check_cascading_revocation_blocked,
+    check_scope_escalation_blocked,
+    check_ttl_extension_blocked,
+    run_all_delegation_checks,
+)
 from nest_plugins_reference.validators.gossip_validators import (
     ConvergenceFailureError,
     PartitionLeakError,
@@ -35,11 +42,16 @@ __all__ = [
     "ConvergenceFailureError",
     "PartitionLeakError",
     "ValidatorReport",
+    "check_audience_confusion_blocked",
+    "check_cascading_revocation_blocked",
     "check_converged",
     "check_eavesdropper_blocked",
     "check_field_injection_rejected",
     "check_no_partition_view_leak",
     "check_replay_rejected",
+    "check_scope_escalation_blocked",
     "check_stale_revocation_blocked",
+    "check_ttl_extension_blocked",
     "corrupt_proof",
+    "run_all_delegation_checks",
 ]

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/delegation_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/delegation_validators.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for delegatable capability tokens.
+
+These run concrete attacks against an auth plugin and report whether it defended.
+They are written to FAIL against the default ``jwt`` plugin, which has no notion of
+delegation, and PASS against the ``macaroons`` plugin, which attenuates authority and
+chains revocation. Each check treats "the plugin cannot even model this" as a failure,
+because an auth layer that can't express delegation can't secure it.
+
+Example::
+
+    from nest_plugins_reference.auth.macaroons import MacaroonAuth
+    report = await run_all_delegation_checks(MacaroonAuth(secret=b"k", clock=0.0))
+    assert report.passed
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.types import AgentId
+
+from nest_plugins_reference.validators.gossip_validators import ValidatorReport
+
+
+async def check_scope_escalation_blocked(auth: Any) -> ValidatorReport:
+    """A child must never gain a scope its parent does not hold.
+
+    Example::
+
+        report = await check_scope_escalation_blocked(auth)
+    """
+    root = await auth.issue(AgentId("root"), ["read", "write"])
+    delegate = getattr(auth, "delegate", None)
+    if delegate is None:
+        return ValidatorReport(
+            passed=False,
+            detail="plugin has no delegate(); it cannot attenuate authority",
+            evidence={"plugin": type(auth).__name__},
+        )
+    try:
+        await delegate(root, AgentId("b"), ["read", "write", "admin"], 60)
+    except Exception as exc:  # noqa: BLE001 - any refusal counts as a defense
+        return ValidatorReport(
+            passed=True,
+            detail="scope escalation was refused",
+            evidence={"error": type(exc).__name__},
+        )
+    return ValidatorReport(
+        passed=False,
+        detail="a child token gained a scope its parent never held",
+        evidence={"plugin": type(auth).__name__},
+    )
+
+
+async def check_cascading_revocation_blocked(auth: Any) -> ValidatorReport:
+    """Revoking a parent token must invalidate every descendant.
+
+    Example::
+
+        report = await check_cascading_revocation_blocked(auth)
+    """
+    root = await auth.issue(AgentId("root"), ["read", "write"])
+    delegate = getattr(auth, "delegate", None)
+    if delegate is None:
+        # No delegation: emulate a parent and child as two independent tokens.
+        # A plugin with no chain cannot link them, so the child survives.
+        child = await auth.issue(AgentId("b"), ["read"])
+        await auth.revoke(root)
+        try:
+            await auth.verify(child)
+        except Exception as exc:  # noqa: BLE001
+            return ValidatorReport(
+                passed=True,
+                detail="child died with the parent",
+                evidence={"error": type(exc).__name__},
+            )
+        return ValidatorReport(
+            passed=False,
+            detail="revoking the parent left the child valid (no delegation link)",
+            evidence={"plugin": type(auth).__name__},
+        )
+    child = await delegate(root, AgentId("b"), ["read"], 600)
+    await auth.verify(child)  # valid before revocation
+    await auth.revoke(root)
+    try:
+        await auth.verify(child)
+    except Exception as exc:  # noqa: BLE001
+        return ValidatorReport(
+            passed=True,
+            detail="revoking the parent invalidated the child",
+            evidence={"error": type(exc).__name__},
+        )
+    return ValidatorReport(
+        passed=False,
+        detail="child still verified after its parent was revoked",
+        evidence={"plugin": type(auth).__name__},
+    )
+
+
+async def check_audience_confusion_blocked(auth: Any) -> ValidatorReport:
+    """A token must be rejected when a different agent than its audience presents it.
+
+    Example::
+
+        report = await check_audience_confusion_blocked(auth)
+    """
+    verify_for = getattr(auth, "verify_for", None)
+    if verify_for is None:
+        return ValidatorReport(
+            passed=False,
+            detail="plugin has no audience-bound verification",
+            evidence={"plugin": type(auth).__name__},
+        )
+    root = await auth.issue(AgentId("root"), ["read"])
+    delegate = getattr(auth, "delegate", None)
+    token = await delegate(root, AgentId("b"), ["read"], 60) if delegate is not None else root
+    try:
+        await verify_for(token, AgentId("attacker"))
+    except Exception as exc:  # noqa: BLE001
+        return ValidatorReport(
+            passed=True,
+            detail="token rejected when presented by the wrong audience",
+            evidence={"error": type(exc).__name__},
+        )
+    return ValidatorReport(
+        passed=False,
+        detail="token accepted from an agent that is not its audience",
+        evidence={"plugin": type(auth).__name__},
+    )
+
+
+async def check_ttl_extension_blocked(auth: Any) -> ValidatorReport:
+    """A child token must not be allowed to outlive its parent.
+
+    Example::
+
+        report = await check_ttl_extension_blocked(auth)
+    """
+    delegate = getattr(auth, "delegate", None)
+    if delegate is None:
+        return ValidatorReport(
+            passed=False,
+            detail="plugin has no delegate(); it cannot bound a child's lifetime",
+            evidence={"plugin": type(auth).__name__},
+        )
+    root = await auth.issue(AgentId("root"), ["read"])
+    try:
+        await delegate(root, AgentId("b"), ["read"], 10**9)
+    except Exception as exc:  # noqa: BLE001
+        return ValidatorReport(
+            passed=True,
+            detail="child forbidden from outliving its parent",
+            evidence={"error": type(exc).__name__},
+        )
+    return ValidatorReport(
+        passed=False,
+        detail="child was allowed to outlive its parent",
+        evidence={"plugin": type(auth).__name__},
+    )
+
+
+async def run_all_delegation_checks(auth: Any) -> ValidatorReport:
+    """Run every delegation attack; pass only if the plugin defended against all.
+
+    Example::
+
+        report = await run_all_delegation_checks(auth)
+        assert report.passed
+    """
+    reports = [
+        await check_scope_escalation_blocked(auth),
+        await check_cascading_revocation_blocked(auth),
+        await check_audience_confusion_blocked(auth),
+        await check_ttl_extension_blocked(auth),
+    ]
+    failed = [r for r in reports if not r.passed]
+    if failed:
+        return ValidatorReport(
+            passed=False,
+            detail=f"{len(failed)} of {len(reports)} delegation checks failed",
+            evidence={"failures": [r.detail for r in failed]},
+        )
+    return ValidatorReport(
+        passed=True,
+        detail=f"all {len(reports)} delegation checks passed",
+        evidence={},
+    )

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -33,6 +33,9 @@ Repository = "https://github.com/projnanda/nandatown"
 # package. The PluginRegistry also keeps built-in defaults keyed by
 # (layer, name), but declaring the entry point here is the documented,
 # install-time discovery path described in CONTRIBUTING.md.
+[project.entry-points."nest.plugins.auth"]
+macaroons = "nest_plugins_reference.auth.macaroons:MacaroonAuth"
+
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
 

--- a/packages/nest-plugins-reference/tests/test_delegated_auth_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_delegated_auth_scenario.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Full-simulator test for the delegated_auth scenario.
+
+Runs the delegation-tree scenario under the charter's seed bank (42, 7, 1337),
+asserts the delegation outcomes (honest leaves authorized, Byzantine leaves
+rejected, cascading revocation), checks that a given seed replays to a
+byte-identical trace, and confirms the delegation validators pass against the
+scenario's live auth plugin.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_plugins_reference.validators.delegation_validators import run_all_delegation_checks
+
+_SCENARIO = Path(__file__).resolve().parents[3] / "scenarios" / "delegated_auth.yaml"
+_SEEDS = [42, 7, 1337]
+
+
+def _run(seed: int, trace_path: Path) -> ScenarioRunner:
+    config = ScenarioConfig.from_yaml(str(_SCENARIO))
+    config = config.model_copy(update={"seed": seed})
+    config = config.model_copy(
+        update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+    )
+    runner = ScenarioRunner(config, registry=PluginRegistry())
+    asyncio.run(runner.run())
+    return runner
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_delegation_outcomes(seed: int, tmp_path: Path) -> None:
+    runner = _run(seed, tmp_path / f"trace-{seed}.jsonl")
+    results = runner.resolved_plugins["_delegation_results"]
+
+    honest = [f"leaf-{i}" for i in range(12) if i not in (5, 10)]
+    assert sorted(results["authorized"]) == sorted(honest)
+    assert results["blocked"] == {
+        "leaf-5": "InvalidTokenError",
+        "leaf-10": "AudienceMismatchError",
+    }
+    assert sorted(results["cascade_revoked"]) == ["leaf-0", "leaf-1", "leaf-2", "leaf-3"]
+
+
+def test_trace_is_reproducible(tmp_path: Path) -> None:
+    a = tmp_path / "a.jsonl"
+    b = tmp_path / "b.jsonl"
+    _run(42, a)
+    _run(42, b)
+    assert a.read_bytes() == b.read_bytes()
+
+
+def test_validators_pass_on_scenario_auth(tmp_path: Path) -> None:
+    runner = _run(42, tmp_path / "trace.jsonl")
+    auth = runner.resolved_plugins["_delegation_auth"]
+    report = asyncio.run(run_all_delegation_checks(auth))
+    assert report.passed

--- a/packages/nest-plugins-reference/tests/test_macaroons.py
+++ b/packages/nest-plugins-reference/tests/test_macaroons.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the macaroons auth plugin: delegation, attenuation, cascading revocation.
+
+The suite mixes spec-example unit tests, Hypothesis property tests for the attenuation
+invariant, and the charter's adversarial-discrimination test: the delegation validators
+must FAIL against the default ``jwt`` plugin and PASS against ``macaroons``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.jwt_auth import JwtAuth
+from nest_plugins_reference.auth.macaroons import (
+    AudienceMismatchError,
+    ExpiredTokenError,
+    InvalidTokenError,
+    MacaroonAuth,
+    RevokedAncestorError,
+    ScopeEscalationError,
+    TtlExtensionError,
+)
+from nest_plugins_reference.validators.delegation_validators import run_all_delegation_checks
+
+_SCOPES = ["read", "write", "admin", "delete", "list"]
+
+
+def _auth() -> MacaroonAuth:
+    return MacaroonAuth(secret=b"test-secret", clock=0.0)
+
+
+class TestDelegation:
+    @pytest.mark.asyncio
+    async def test_issue_and_verify_root(self) -> None:
+        auth = _auth()
+        root = await auth.issue(AgentId("a1"), ["read", "write"])
+        ctx = await auth.verify(root)
+        assert ctx.subject == AgentId("a1")
+        assert set(ctx.scopes) == {"read", "write"}
+
+    @pytest.mark.asyncio
+    async def test_delegate_narrows_scope(self) -> None:
+        auth = _auth()
+        root = await auth.issue(AgentId("a1"), ["read", "write", "admin"])
+        child = await auth.delegate(root, AgentId("b"), ["read"], ttl=600)
+        ctx = await auth.verify(child)
+        assert ctx.subject == AgentId("b")
+        assert ctx.scopes == ["read"]
+
+    @pytest.mark.asyncio
+    async def test_scope_escalation_raises(self) -> None:
+        auth = _auth()
+        root = await auth.issue(AgentId("a1"), ["read", "write"])
+        with pytest.raises(ScopeEscalationError):
+            await auth.delegate(root, AgentId("b"), ["read", "admin"], ttl=60)
+
+    @pytest.mark.asyncio
+    async def test_ttl_extension_raises(self) -> None:
+        auth = _auth()
+        root = await auth.issue(AgentId("a1"), ["read"])  # default ttl 3600
+        with pytest.raises(TtlExtensionError):
+            await auth.delegate(root, AgentId("b"), ["read"], ttl=10_000)
+
+    @pytest.mark.asyncio
+    async def test_cascading_revocation(self) -> None:
+        auth = _auth()
+        root = await auth.issue(AgentId("a1"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("b"), ["read"], ttl=600)
+        grandchild = await auth.delegate(child, AgentId("c"), ["read"], ttl=60)
+        await auth.verify(grandchild)  # valid before revocation
+        await auth.revoke(root)
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify(child)
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify(grandchild)
+
+    @pytest.mark.asyncio
+    async def test_audience_confusion_raises(self) -> None:
+        auth = _auth()
+        root = await auth.issue(AgentId("a1"), ["read"])
+        child = await auth.delegate(root, AgentId("b"), ["read"], ttl=60)
+        await auth.verify_for(child, AgentId("b"))  # correct audience is fine
+        with pytest.raises(AudienceMismatchError):
+            await auth.verify_for(child, AgentId("attacker"))
+
+    @pytest.mark.asyncio
+    async def test_tampered_token_rejected(self) -> None:
+        auth = _auth()
+        root = await auth.issue(AgentId("a1"), ["read"])
+        child = await auth.delegate(root, AgentId("b"), ["read"], ttl=60)
+        forged = Token(str(child).replace("read", "admin"))
+        with pytest.raises(InvalidTokenError):
+            await auth.verify(forged)
+
+    @pytest.mark.asyncio
+    async def test_expired_token_rejected(self) -> None:
+        auth = MacaroonAuth(secret=b"k", clock=0.0)
+        root = await auth.issue(AgentId("a1"), ["read"])
+        child = await auth.delegate(root, AgentId("b"), ["read"], ttl=100)
+        auth.set_clock(200.0)  # advance past the child's expiry
+        with pytest.raises(ExpiredTokenError):
+            await auth.verify(child)
+
+    @pytest.mark.asyncio
+    async def test_deterministic_issue(self) -> None:
+        a = MacaroonAuth(secret=b"k", clock=0.0)
+        b = MacaroonAuth(secret=b"k", clock=0.0)
+        ta = await a.issue(AgentId("x"), ["read"])
+        tb = await b.issue(AgentId("x"), ["read"])
+        assert str(ta) == str(tb)
+
+    def test_registry_resolves_macaroons(self) -> None:
+        cls = PluginRegistry().resolve("auth", "macaroons")
+        assert cls is MacaroonAuth
+
+
+class TestAdversarialDiscrimination:
+    """The charter's bar: the validator fails the reference plugin, passes the new one."""
+
+    @pytest.mark.asyncio
+    async def test_jwt_fails_delegation_checks(self) -> None:
+        report = await run_all_delegation_checks(JwtAuth(secret=b"k", clock=0.0))
+        assert not report.passed
+
+    @pytest.mark.asyncio
+    async def test_macaroons_passes_delegation_checks(self) -> None:
+        report = await run_all_delegation_checks(MacaroonAuth(secret=b"k", clock=0.0))
+        assert report.passed
+
+
+class TestAttenuationProperties:
+    @given(
+        scopes=st.lists(st.sampled_from(_SCOPES), unique=True, min_size=1),
+        picks=st.lists(st.sampled_from(_SCOPES), unique=True),
+    )
+    def test_delegation_is_always_a_subset(self, scopes: list[str], picks: list[str]) -> None:
+        subset = [s for s in picks if s in scopes]
+
+        async def run() -> None:
+            auth = MacaroonAuth(secret=b"k", clock=0.0)
+            root = await auth.issue(AgentId("a"), scopes)
+            child = await auth.delegate(root, AgentId("b"), subset, ttl=60)
+            ctx = await auth.verify(child)
+            assert set(ctx.scopes) == set(subset)
+            assert set(ctx.scopes).issubset(set(scopes))
+
+        asyncio.run(run())
+
+    @given(scopes=st.lists(st.sampled_from(_SCOPES), unique=True, min_size=1))
+    def test_escalation_always_raises(self, scopes: list[str]) -> None:
+        missing = [s for s in _SCOPES if s not in scopes]
+        if not missing:
+            return  # nothing outside the parent's scopes to escalate to
+
+        async def run() -> None:
+            auth = MacaroonAuth(secret=b"k", clock=0.0)
+            root = await auth.issue(AgentId("a"), scopes)
+            with pytest.raises(ScopeEscalationError):
+                await auth.delegate(root, AgentId("b"), [*scopes, missing[0]], ttl=60)
+
+        asyncio.run(run())

--- a/scenarios/delegated_auth.yaml
+++ b/scenarios/delegated_auth.yaml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegated-auth scenario for the macaroons plugin.
+#
+# 16 agents in a delegation tree:
+#   * coordinator-0     holds the root token (full scope set)
+#   * intermediary-0..2 hold narrower delegated tokens
+#   * leaf-0..11        hold [read] tokens, delegated by their intermediary
+#
+# Every leaf presents its token to the coordinator. Two leaves are Byzantine:
+# leaf-5 forges a broader scope, leaf-10 steals a peer's token. Both are
+# rejected. After all present, the coordinator revokes intermediary-0 and its
+# four honest leaves fail re-verification (cascading revocation).
+#
+# RNG-free, so a given seed replays to a byte-identical trace.
+name: delegated_auth
+description: "16-agent delegation tree exercising macaroon attenuation and cascading revocation."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 16
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+    - name: intermediary
+      count: 3
+    - name: leaf
+      count: 12
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: macaroons
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: delegated_auth
+
+duration: "ticks: 1000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/delegated_auth.jsonl


### PR DESCRIPTION
## Problem 04 — auth: delegatable capability tokens with cascading revocation

The default `jwt` auth plugin tracks revocation by exact token string and has no parent/child relationship, so it cannot model the common pattern: A holds a root token, A mints a narrow short-lived sub-token for B offline, and revoking A should invalidate B automatically. This adds a `macaroons` auth plugin that does exactly that.

## Design

A token is a chain of caveats. Each delegation appends a caveat and re-chains the HMAC, keying each link with the previous link's signature (`sig_i = HMAC(sig_{i-1}, caveat_i)`, root keyed by the secret). Verification replays the chain from the root secret, so tampering, scope widening, TTL extension, and parent-link substitution all fail closed.

Because a child's signature is anchored to its parent, **revoking any ancestor's id invalidates every descendant by construction** — there is no per-child revocation list, just one set of revoked ids checked along the chain.

- `delegate(parent, audience, scopes_subset, ttl)` mints a child offline. Child scopes must be a strict subset of the parent's and the child cannot outlive the parent (both enforced at delegate and re-checked at verify, since a malicious holder controls the wire bytes).
- `verify` / `verify_for(token, presenter)` — the latter binds a token to its audience and rejects presentation by anyone else.
- Sync cores (`issue_sync`, `delegate_sync`, `verify_sync`, ...) with thin async wrappers, so the plugin is usable both from the async `Auth` protocol and from a synchronous scenario factory.

## Adversarial validator

`validators/delegation_validators.py` runs concrete attacks and reports whether the plugin defended. It **fails against the default `jwt` plugin and passes against `macaroons`**, covering: scope escalation, stale/revoked parent (cascading revocation), audience confusion, and TTL extension.

## Scenario

`scenarios/delegated_auth.yaml` + `nest_core/scenarios_builtin/delegated_auth.py`: a 16-agent tree (1 coordinator, 3 intermediaries, 12 leaves). Every leaf presents its token; two Byzantine leaves are rejected (`leaf-5` forges a broader scope, `leaf-10` steals a peer's token). After all present, the coordinator revokes `intermediary-0` and its four honest leaves fail re-verification. The scenario is RNG-free, so a given seed replays to a byte-identical trace (tested under seeds 42, 7, 1337).

## Tradeoffs

- Strict tree (single parent per token), not a DAG — enough for delegation and keeps verification linear in chain length.
- In-band, JSON-inspectable tokens (no third-party discharge caveats) so every token is legible in a JSONL trace.
- Revocation is an in-memory set of ids; a distributed deployment would replicate it, but that is out of scope here.

## Verification

```bash
uv sync
uv run pytest packages/nest-plugins-reference/tests/test_macaroons.py \
               packages/nest-plugins-reference/tests/test_delegated_auth_scenario.py -v
uv run nest run delegated_auth        # runs the scenario end to end
# Full gate:
uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -v
```

All of `ruff`, `ruff format --check`, `pyright` (strict), and `pytest` pass. Tests include unit tests, Hypothesis property tests for the attenuation invariant, the adversarial jwt-vs-macaroons discrimination, and the full-simulator scenario under the seed bank.