### PR TITLE
[Hackathon] stellarminds-ai: AAE permit gate — pre-action authorization with signed denial receipts

### DIFF
--- a/docs/layers/trust.md
+++ b/docs/layers/trust.md
@@ -84,10 +84,14 @@ with a typed reason).
 
 Every other trust plugin scores what agents **did**. `aae_permit_gate`
 decides what an agent **may do**, before it does it — and signs the
-decision either way. A well-reputed agent attempting an unauthorized
-action sails through every post-hoc reputation layer; this one stops it,
-and the stop is not a silent absence but a signed, verifiable denial
-receipt.
+verdict either way. A well-reputed agent attempting an unauthorized
+action sails through every post-hoc reputation layer on its record
+alone; this gate answers the request before it runs, and a refusal it
+returns is a signed, first-class receipt — provable from the envelope
+chain by anyone, not a silent absence. The refusal does not consult
+reputation, so no amount of prior good standing outranks it; the
+`rogue_trusted_agent` scenario below turns that returned verdict into a
+blocked action and proves it.
 
 Source:
 [`trust/aae_permit_gate.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/aae_permit_gate.py)

--- a/docs/layers/trust.md
+++ b/docs/layers/trust.md
@@ -80,6 +80,108 @@ Scenario: `parc_migration` (two trust domains in one run; forged,
 replayed, stale-key, inflated, and wash-ring credentials each denied
 with a typed reason).
 
+## `aae_permit_gate` — pre-action authorization with signed denial receipts
+
+Every other trust plugin scores what agents **did**. `aae_permit_gate`
+decides what an agent **may do**, before it does it — and signs the
+decision either way. A well-reputed agent attempting an unauthorized
+action sails through every post-hoc reputation layer; this one stops it,
+and the stop is not a silent absence but a signed, verifiable denial
+receipt.
+
+Source:
+[`trust/aae_permit_gate.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/aae_permit_gate.py)
+· envelope format:
+[`trust/aae_envelope.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/aae_envelope.py).
+
+**The permit envelope.** Before an action runs, the gate evaluates it
+against a declarative policy table and issues a signed JSON object — a
+*pre-action envelope* — recording the verdict. Eight fields, no more:
+
+| Field | Meaning |
+|---|---|
+| `agent_id` | The acting agent's town identity (whatever string the identity layer yields). |
+| `action` | `{verb, resource, params}` — what the agent intends to do. |
+| `policy_id` | Which policy rule the action was evaluated against. |
+| `outcome` | `"authorized"` \| `"denied"` \| `"conditional"` — denials are first-class. |
+| `prev_hash` | Hash of this agent's previous envelope, or `null` — a per-agent causal chain. |
+| `issued_at` | Evaluation time (RFC 3339). |
+| `sig` | Ed25519 signature over the canonical envelope (sorted keys, compact separators) minus `sig`. |
+| `pubkey` | The verification key. |
+
+`permits(envelope)` is `True` only for `"authorized"`; `"conditional"`
+means authorized subject to the caller honoring the stated condition
+params, and is not itself permission.
+
+**How agents consult it.** The engine does not intercept actions, so
+gating is a scenario contract: an agent calls `evaluate(...)` before
+acting and proceeds only on an authorized envelope. A plugin without an
+`evaluate` method (like `score_average`) is consulted the old way — as a
+score — so scenarios stay drop-in. This is the standard capability-gate
+pattern (`hasattr(trust, "evaluate")`).
+
+**Quickstart.**
+
+```python
+from nest_plugins_reference.trust.aae_permit_gate import AAEPermitGate, permits
+
+gate = AAEPermitGate(
+    policy=[
+        {"role": "resident", "verb": "read", "resource": "town/*", "effect": "authorized"},
+        {"agent": "*", "verb": "spend", "resource": "town/treasury", "effect": "denied"},
+    ],
+    roles={"veteran": "resident"},
+    key_seed=bytes(32),  # deterministic; supply your own
+)
+env = await gate.evaluate("veteran", "spend", "town/treasury", {}, now="2026-07-04T00:00:00Z")
+assert env["outcome"] == "denied" and not permits(env)   # signed denial receipt
+```
+
+**The `rogue_trusted_agent` scenario.** One agent earns a strong
+reputation through many in-policy actions, then reaches for the treasury.
+Run it under `aae_permit_gate` and the reach is refused before it runs:
+
+```
+exec:veteran:read:town/events                       <- reputation accrued (8th in-policy action)
+rogue_attempt:veteran:spend:town/treasury
+permit:veteran:spend:town/treasury:denied:84773277  <- signed denial
+blocked:veteran:spend:town/treasury                 <- never executes
+```
+
+Swap one line — `trust: score_average` — and reputation buys the
+treasury:
+
+```
+rogue_attempt:veteran:spend:town/treasury
+exec:veteran:spend:town/treasury                    <- the rogue action executes
+```
+
+The adversarial validator `rogue_trusted_agent_blocked` FAILS on the
+first trace and PASSES on the second — with no crash on either.
+
+**Trace-line protocol.**
+`permit:<agent>:<verb>:<resource>:<outcome>:<envelope_hash_prefix8>`.
+
+**Relationship to Agent Action Capsules (#32).** Capsules and permit
+envelopes are two halves of one accountability story, on opposite sides
+of the action. A capsule seals a record of what *happened*; a permit
+envelope signs a decision about what *may* happen. They compose as an
+authorization layer over a transparency layer: when the `capsule-emit`
+package is present and anchoring is enabled, each permit — authorization
+or denial — is sealed to the capsule ledger under a `permit.granted` /
+`permit.denied` namespace so it never reads as an executed action. A
+denial that is anchored is evidence that the gate worked. Anchoring is a
+no-op when the package is absent; there is no hard dependency in either
+direction.
+
+**Boundary.** Chain integrity is bound by hash commitment
+(`envelope_hash` covers the signature and key), not by pinning an agent
+to a fixed key — binding an identity to a stable key across its chain is
+the identity layer's job (see `ed25519_rotating`), which this gate
+composes with rather than reimplements. `attest` signs a claim with the
+gate key; `report` records evidence a future policy may reference;
+`stake` is a documented parity no-op.
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -28,6 +28,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",
+    ("trust", "aae_permit_gate"): f"{_REF}.trust.aae_permit_gate:AAEPermitGate",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
     ("payments", "empic_escrow"): f"{_REF}.payments.empic_escrow:EMPICEscrowPayments",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -135,3 +135,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("parc_migration", parc_migration_factory)
+    elif name == "rogue_trusted_agent":
+        from nest_core.scenarios_builtin.rogue_trusted_agent import (
+            rogue_trusted_agent_factory,
+        )
+
+        register_scenario("rogue_trusted_agent", rogue_trusted_agent_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/rogue_trusted_agent.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/rogue_trusted_agent.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A high-reputation resident attempts one action outside its authorization.
+
+One agent — the ``veteran`` — spends the whole run building a spotless record:
+it performs many in-policy actions (reading town notices, posting to the board,
+greeting neighbours), every one of which the trust layer authorizes. Ordinary
+residents do the same, only in-policy. Then, having earned the strongest
+reputation in town, the veteran reaches for the one thing it was never entitled
+to: it tries to ``spend`` the ``town/treasury``.
+
+The scenario runs under two trust layers to make the difference legible:
+
+* ``score_average`` has no pre-action gate. Agents that cannot consult a gate
+  act unconditionally, so the veteran's out-of-policy attempt **executes** — its
+  sterling reputation buys it the treasury. The adversarial validator FAILS.
+* ``aae_permit_gate`` decides every request *before* it runs. Reputation is not
+  an input to the verdict: the policy row for ``spend town/treasury`` is a
+  refusal, so the gate returns a signed ``denied`` envelope and the action never
+  executes. The validator PASSES — proving a permit gate blocks on authority,
+  not on standing.
+
+The acting agents are capability-gated: they consult the trust plugin only when
+it exposes ``evaluate`` (``hasattr``), so the identical scenario runs unchanged
+under a plugin that has no gate at all.
+
+Trace-line protocol (carried in broadcast bodies, ``:``-delimited)::
+
+    rogue_attempt:<agent>:<verb>:<resource>
+        The agent is about to attempt an action it knows is out of policy.
+        Emitted under BOTH layers, before the gate is consulted, so the trace
+        self-declares the rogue pair independently of the outcome.
+
+    permit:<agent>:<verb>:<resource>:<outcome>:<hash8>
+        A gated evaluation result. ``outcome`` is authorized/denied/conditional
+        and ``hash8`` is the first 8 hex chars of the permit envelope's hash.
+        Only emitted when the plugin exposes a gate.
+
+    exec:<agent>:<verb>:<resource>
+        An action actually executed. Under the gate this follows an authorized
+        permit; without a gate it follows unconditionally.
+
+    blocked:<agent>:<verb>:<resource>
+        A gated action was refused and did not execute.
+
+    permit_env:<compact-json>
+        The full signed permit envelope for a veteran evaluation, emitted so an
+        end-to-end test can verify the signature and re-order the veteran's
+        chain. Validators ignore it (its prefix is not ``permit:``).
+
+Determinism: the seed drives the interleaving of turns; every action fires at a
+unique virtual-clock tick, and each evaluation's timestamp is derived purely
+from that tick (never a wall clock). Identical seed -> byte-identical trace.
+
+Example::
+
+    agents = rogue_trusted_agent_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from nest_plugins_reference.trust.aae_envelope import envelope_hash
+from nest_plugins_reference.trust.aae_permit_gate import permits
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId
+
+# Deterministic anchor for permit timestamps. The virtual clock supplies the
+# offset (in seconds) so every envelope's ``issued_at`` is reproducible.
+_EPOCH = datetime(2026, 1, 1, tzinfo=UTC)
+
+_VETERAN = AgentId("veteran")
+
+# The rogue reach: the one verb+resource the veteran's policy row refuses.
+_ROGUE_VERB = "spend"
+_ROGUE_RESOURCE = "town/treasury"
+
+# In-policy actions available to every resident (each matches an authorized
+# policy rule; see scenarios/rogue_trusted_agent.yaml).
+_IN_POLICY: tuple[tuple[str, str], ...] = (
+    ("read", "town/board"),
+    ("read", "town/events"),
+    ("read", "town/notices"),
+    ("post", "board/intro"),
+    ("post", "board/help"),
+    ("greet", "neighbor/east"),
+    ("greet", "neighbor/west"),
+)
+
+# One planned turn: the acting agent and the action it will take.
+_Turn = tuple[AgentId, str, str, bool]  # (agent, verb, resource, is_rogue)
+
+
+def _clock_rfc3339(tick: float) -> str:
+    """Render a virtual-clock tick as an RFC 3339 timestamp.
+
+    Example::
+
+        assert _clock_rfc3339(1.0) == "2026-01-01T00:00:01+00:00"
+    """
+    return (_EPOCH + timedelta(seconds=tick)).isoformat()
+
+
+def _instantiate_trust(trust_cls: Any, config: ScenarioConfig) -> Any:
+    """Build the single shared trust instance for the town.
+
+    A plugin that exposes a pre-action gate (``evaluate``) is handed the policy
+    table, role map, and signing seed from ``task.config``; a plugin without a
+    gate is built with no arguments. The capability check keeps the scenario
+    runnable under either kind of plugin.
+
+    Example::
+
+        trust = _instantiate_trust(plugins["trust"], config)
+    """
+    if not isinstance(trust_cls, type):
+        return trust_cls  # already an instance
+    if not hasattr(trust_cls, "evaluate"):
+        return trust_cls()
+    task_config = config.task.config
+    policy = task_config.get("policy", [])
+    roles = _role_map(config)
+    key_seed = bytes.fromhex(str(task_config.get("key_seed", "")))
+    return trust_cls(
+        policy=policy,
+        roles=roles,
+        default_effect=str(task_config.get("default_effect", "denied")),
+        key_seed=key_seed,
+    )
+
+
+def _role_map(config: ScenarioConfig) -> dict[str, str]:
+    """Assign every agent a role, defaulting to the town's ``resident`` role.
+
+    ``task.config.roles`` in the YAML may name specific agents (the veteran is
+    documented there); any agent it omits falls back to ``default_role`` so the
+    gate's role rules cover the whole town and no in-policy action self-denies.
+
+    Example::
+
+        roles = _role_map(config)
+    """
+    task_config = config.task.config
+    default_role = str(task_config.get("default_role", "resident"))
+    declared = task_config.get("roles", {})
+    roles = {str(a): str(r) for a, r in dict(declared).items()}
+    for agent in _town(config):
+        roles.setdefault(str(agent), default_role)
+    return roles
+
+
+def _town(config: ScenarioConfig) -> list[AgentId]:
+    """The town roster: the veteran plus ``resident-<i>`` neighbours.
+
+    Example::
+
+        roster = _town(config)
+    """
+    resident_count = max(1, config.agents.count - 1)
+    return [_VETERAN, *(AgentId(f"resident-{i}") for i in range(resident_count))]
+
+
+def _plan_turns(config: ScenarioConfig) -> dict[AgentId, list[tuple[float, str, str, bool]]]:
+    """Build each agent's timed action list from the seed.
+
+    The veteran takes ``veteran_warmup`` seeded in-policy actions and *then* its
+    single rogue attempt (so reputation genuinely accrues before the reach).
+    Each resident takes a seeded handful of in-policy actions. All per-agent
+    sequences are merged into one global order by a seeded interleave that
+    preserves each agent's own order, and every turn is stamped with a unique
+    tick so the run is free of scheduling ties.
+
+    Example::
+
+        schedule = _plan_turns(config)
+    """
+    rng = random.Random(config.seed)
+    task_config = config.task.config
+    warmup = int(task_config.get("veteran_warmup", 8))
+    resident_actions = int(task_config.get("resident_actions", 3))
+
+    per_agent: dict[AgentId, list[_Turn]] = {}
+    veteran_seq: list[_Turn] = [
+        (_VETERAN, verb, resource, False)
+        for verb, resource in (rng.choice(_IN_POLICY) for _ in range(warmup))
+    ]
+    veteran_seq.append((_VETERAN, _ROGUE_VERB, _ROGUE_RESOURCE, True))
+    per_agent[_VETERAN] = veteran_seq
+
+    for resident in _town(config)[1:]:
+        per_agent[resident] = [
+            (resident, verb, resource, False)
+            for verb, resource in (rng.choice(_IN_POLICY) for _ in range(resident_actions))
+        ]
+
+    # Seeded interleave that preserves each agent's internal order.
+    cursors = {agent: 0 for agent in per_agent}
+    order: list[_Turn] = []
+    while any(cursors[a] < len(per_agent[a]) for a in per_agent):
+        ready = sorted(a for a in per_agent if cursors[a] < len(per_agent[a]))
+        pick = rng.choice(ready)
+        order.append(per_agent[pick][cursors[pick]])
+        cursors[pick] += 1
+
+    schedule: dict[AgentId, list[tuple[float, str, str, bool]]] = {a: [] for a in per_agent}
+    for tick, (agent, verb, resource, is_rogue) in enumerate(order, start=1):
+        schedule[agent].append((float(tick), verb, resource, is_rogue))
+    return schedule
+
+
+class ResidentAgent(StateMachineAgent):
+    """A town resident that consults the permit gate before each action.
+
+    The agent self-schedules its turns on the virtual clock. On each turn it
+    consults the shared trust plugin *if* that plugin exposes a gate; a granted
+    verdict runs the action, a refusal blocks it, and a plugin with no gate at
+    all runs the action unconditionally. The veteran additionally emits the full
+    signed envelope of each of its evaluations so its chain can be verified.
+
+    Example::
+
+        agent = ResidentAgent(AgentId("resident-0"), turns, trust=gate)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        turns: list[tuple[float, str, str, bool]],
+        trust: Any,
+    ) -> None:
+        self._id = agent_id
+        self._turns = turns
+        self._trust = trust
+        self._is_veteran = agent_id == _VETERAN
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Schedule every assigned turn at its virtual-clock tick.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        for index, (tick, _verb, _resource, _rogue) in enumerate(self._turns):
+            await ctx.schedule(tick, f"act:{index}".encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Perform the scheduled turn named by an ``act:<index>`` self-message.
+
+        Example::
+
+            await agent.on_message(ctx, agent.agent_id, b"act:0")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("act:"):
+            return  # broadcast noise from other agents
+        try:
+            index = int(msg[len("act:") :])
+        except ValueError:
+            return
+        if not 0 <= index < len(self._turns):
+            return
+        _tick, verb, resource, is_rogue = self._turns[index]
+        await self._act(ctx, verb, resource, is_rogue=is_rogue)
+
+    async def _act(self, ctx: AgentContext, verb: str, resource: str, *, is_rogue: bool) -> None:
+        """Consult the gate (if any) and either run or block the action."""
+        agent = str(ctx.agent_id)
+        if is_rogue:
+            await ctx.broadcast(f"rogue_attempt:{agent}:{verb}:{resource}".encode())
+
+        if not hasattr(self._trust, "evaluate"):
+            # No pre-action gate: the action runs unconditionally.
+            await ctx.broadcast(f"exec:{agent}:{verb}:{resource}".encode())
+            return
+
+        env = await self._trust.evaluate(
+            ctx.agent_id, verb, resource, {}, now=_clock_rfc3339(ctx.time)
+        )
+        outcome = str(env["outcome"])
+        hash8 = envelope_hash(env)[:8]
+        await ctx.broadcast(f"permit:{agent}:{verb}:{resource}:{outcome}:{hash8}".encode())
+        if self._is_veteran:
+            body = json.dumps(env, sort_keys=True, separators=(",", ":"))
+            await ctx.broadcast(f"permit_env:{body}".encode())
+        if permits(env):
+            await ctx.broadcast(f"exec:{agent}:{verb}:{resource}".encode())
+        else:
+            await ctx.broadcast(f"blocked:{agent}:{verb}:{resource}".encode())
+
+
+def rogue_trusted_agent_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create the veteran and its neighbours sharing one trust instance.
+
+    The factory resolves the configured trust plugin, builds a single shared
+    instance (handing the policy table to a gate-capable plugin), and gives
+    every agent a reference to it so the veteran's reputation accrues in one
+    place. The same agents run unchanged under ``score_average`` (no gate -> the
+    rogue action executes -> validator FAILs) and ``aae_permit_gate`` (signed
+    refusal -> the rogue action is blocked -> validator PASSes).
+
+    Example::
+
+        agents = rogue_trusted_agent_factory(config, plugins)
+    """
+    trust = _instantiate_trust(plugins.get("trust"), config)
+    schedule = _plan_turns(config)
+    return {agent: ResidentAgent(agent, turns, trust=trust) for agent, turns in schedule.items()}

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -3038,6 +3038,216 @@ def validate_receipt_reputation_honest_confidence(
 
 
 # ---------------------------------------------------------------------------
+# Rogue-trusted-agent (pre-action permit gate) validators
+#
+# The rogue_trusted_agent scenario broadcasts ``:``-delimited lines (see
+# nest_core.scenarios_builtin.rogue_trusted_agent). A veteran with a strong
+# in-policy record makes one out-of-policy attempt; the trace self-declares it
+# with a ``rogue_attempt:`` line so these validators need no policy table. Under
+# a plugin with a pre-action gate the attempt is refused (``permit:...:denied``
+# + ``blocked:``) and never runs; under a plugin with no gate it ``exec:``s.
+# ---------------------------------------------------------------------------
+
+# The veteran must have executed at least this many in-policy actions before the
+# rogue attempt, so "a high-reputation agent is still refused" is grounded.
+_ROGUE_MIN_REPUTATION = 3
+
+
+def _rogue_declaration(events: list[dict[str, Any]]) -> tuple[str, str, str] | None:
+    """Return the first declared rogue ``(agent, verb, resource)``, or ``None``.
+
+    Example::
+
+        pair = _rogue_declaration(events)
+    """
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("rogue_attempt:"):
+            continue
+        parts = msg.split(":")
+        if len(parts) >= 4:
+            return parts[1], parts[2], parts[3]
+    return None
+
+
+def _rogue_triples(events: list[dict[str, Any]], prefix: str) -> list[tuple[str, str, str]]:
+    """Collect ``(agent, verb, resource)`` triples from lines with ``prefix``.
+
+    Preserves trace order. Used for ``exec:`` and ``blocked:`` lines and, with a
+    trailing field trimmed, for the ``permit:`` lines.
+
+    Example::
+
+        execs = _rogue_triples(events, "exec:")
+    """
+    out: list[tuple[str, str, str]] = []
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith(prefix):
+            continue
+        parts = msg.split(":")
+        if len(parts) >= 4:
+            out.append((parts[1], parts[2], parts[3]))
+    return out
+
+
+def _rogue_permits(events: list[dict[str, Any]]) -> list[tuple[str, str, str, str]]:
+    """Collect ``(agent, verb, resource, outcome)`` from ``permit:`` lines.
+
+    ``permit_env:`` lines are excluded — their prefix is not ``permit:``.
+
+    Example::
+
+        decisions = _rogue_permits(events)
+    """
+    out: list[tuple[str, str, str, str]] = []
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("permit:"):
+            continue
+        parts = msg.split(":")
+        if len(parts) >= 5:
+            out.append((parts[1], parts[2], parts[3], parts[4]))
+    return out
+
+
+def validate_rogue_trusted_agent_blocked(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """The declared out-of-policy attempt is refused and never executes.
+
+    Reads the trace the scenario emits — never a policy table — and holds iff:
+
+    * a ``rogue_attempt:`` line declares the veteran's out-of-policy pair,
+    * **no** ``exec:`` line runs that pair (it did not execute), and
+    * a ``permit:...:denied`` line refused that exact pair.
+
+    ``score_average`` FAILS this: with no pre-action gate the veteran acts
+    unconditionally, so an ``exec:`` line for the rogue pair is present.
+    ``aae_permit_gate`` PASSES: it returns a signed denial and the action is
+    blocked. A trace that never declared a rogue attempt also fails — without
+    crashing on either layer.
+
+    Example::
+
+        results = validate_rogue_trusted_agent_blocked(events)
+    """
+    rogue = _rogue_declaration(events)
+    if rogue is None:
+        return [
+            ValidationResult(
+                "rogue_trusted_agent_blocked",
+                False,
+                "no rogue_attempt declared in trace",
+            )
+        ]
+    agent, verb, resource = rogue
+    executed = rogue in _rogue_triples(events, "exec:")
+    denied = any(
+        (a, v, r) == rogue and outcome == "denied" for a, v, r, outcome in _rogue_permits(events)
+    )
+
+    if executed:
+        return [
+            ValidationResult(
+                "rogue_trusted_agent_blocked",
+                False,
+                f"rogue action executed: {agent} ran {verb} on {resource} "
+                "(no pre-action gate refused it)",
+            )
+        ]
+    if not denied:
+        return [
+            ValidationResult(
+                "rogue_trusted_agent_blocked",
+                False,
+                f"rogue action neither executed nor refused: {agent} {verb} {resource} "
+                "has no signed denial",
+            )
+        ]
+    return [
+        ValidationResult(
+            "rogue_trusted_agent_blocked",
+            True,
+            f"rogue action refused and blocked: {agent} denied {verb} on {resource}",
+        )
+    ]
+
+
+def validate_rogue_trusted_agent_reputation(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Reputation was earned first, and no in-policy action was refused.
+
+    Two defense-in-depth invariants that ground the demonstration:
+
+    * the veteran executed at least ``_ROGUE_MIN_REPUTATION`` in-policy actions
+      *before* its rogue attempt — so "a high-reputation agent is still refused"
+      is real, not asserted, and
+    * every refusal in the trace names the declared rogue pair — a permit gate
+      that spuriously denied an in-policy action would be caught here.
+
+    Holds under both layers (it does not depend on the rogue being blocked), so
+    it corroborates the primary check rather than duplicating it. Never crashes.
+
+    Example::
+
+        results = validate_rogue_trusted_agent_reputation(events)
+    """
+    rogue = _rogue_declaration(events)
+    if rogue is None:
+        return [
+            ValidationResult(
+                "rogue_trusted_agent_reputation",
+                False,
+                "no rogue_attempt declared in trace",
+            )
+        ]
+    veteran, _verb, _resource = rogue
+
+    # In-policy executions by the veteran, in trace order, before the rogue pair.
+    prior = 0
+    for a, v, r in _rogue_triples(events, "exec:"):
+        if (a, v, r) == rogue:
+            break
+        if a == veteran:
+            prior += 1
+
+    problems: list[str] = []
+    if prior < _ROGUE_MIN_REPUTATION:
+        problems.append(
+            f"veteran executed only {prior} in-policy action(s) before the rogue attempt "
+            f"(need >= {_ROGUE_MIN_REPUTATION} to prove reputation is irrelevant)"
+        )
+    spurious = [
+        (a, v, r)
+        for a, v, r, outcome in _rogue_permits(events)
+        if outcome == "denied" and (a, v, r) != rogue
+    ]
+    if spurious:
+        problems.append(
+            "in-policy actions spuriously denied: "
+            + ", ".join(f"{a}:{v}:{r}" for a, v, r in sorted(set(spurious)))
+        )
+
+    if problems:
+        return [ValidationResult("rogue_trusted_agent_reputation", False, "; ".join(problems))]
+    return [
+        ValidationResult(
+            "rogue_trusted_agent_reputation",
+            True,
+            f"veteran earned {prior} in-policy actions; every refusal was the declared rogue pair",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Multi-attribute negotiation (Pareto) validators
 # ---------------------------------------------------------------------------
 
@@ -4363,5 +4573,9 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_parc_ring_severed,
         validate_parc_replay_rejected,
         validate_parc_stale_key_rejected,
+    ],
+    "rogue_trusted_agent": [
+        validate_rogue_trusted_agent_blocked,
+        validate_rogue_trusted_agent_reputation,
     ],
 }

--- a/packages/nest-core/tests/test_rogue_trusted_agent.py
+++ b/packages/nest-core/tests/test_rogue_trusted_agent.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end tests for the rogue_trusted_agent scenario + adversarial validator.
+
+The headline assertions are the adversarial contrast the submission needs:
+
+* the ``rogue_trusted_agent`` block validator **FAILS** under
+  ``trust: score_average`` (no pre-action gate, so the veteran's reputation buys
+  it the treasury and the rogue action executes), and
+* **PASSES** under ``trust: aae_permit_gate`` (the request is refused before it
+  runs, a signed denial envelope is issued, and the veteran's permit chain
+  verifies),
+
+plus a byte-level determinism check (same seed -> identical trace sha256).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+from nest_plugins_reference.trust.aae_envelope import order_chain, verify_envelope
+
+_SCENARIO_YAML = (
+    Path(__file__).parent.parent.parent.parent / "scenarios" / "rogue_trusted_agent.yaml"
+)
+
+
+def _config(trust: str, trace: Path, seed: int | None = None) -> ScenarioConfig:
+    """Load the scenario YAML, override the trust plugin, seed, and trace path."""
+    config = ScenarioConfig.from_yaml(_SCENARIO_YAML)
+    config.layers.trust = trust
+    config.output.trace = str(trace)
+    if seed is not None:
+        config.seed = seed
+    return config
+
+
+def _results(trace: Path) -> dict[str, bool]:
+    return {r.name: r.passed for r in validate_trace(trace, "rogue_trusted_agent")}
+
+
+def _veteran_envelopes(trace: Path) -> list[dict[str, object]]:
+    """Reconstruct the veteran's permit envelopes from ``permit_env:`` lines."""
+    envelopes: list[dict[str, object]] = []
+    for line in trace.read_text().splitlines():
+        if not line.strip():
+            continue
+        event = json.loads(line)
+        msg = str(event.get("msg", ""))
+        if event.get("kind") == "broadcast" and msg.startswith("permit_env:"):
+            envelopes.append(json.loads(msg[len("permit_env:") :]))
+    return envelopes
+
+
+class TestAdversarialProof:
+    @pytest.mark.asyncio
+    async def test_validator_fails_under_score_average(self, tmp_path: Path) -> None:
+        trace = tmp_path / "baseline.jsonl"
+        await ScenarioRunner(_config("score_average", trace)).run()
+        # The naive baseline has no pre-action gate: the rogue action executes.
+        assert "exec:veteran:spend:town/treasury" in trace.read_text()
+        assert _results(trace)["rogue_trusted_agent_blocked"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("seed", [1, 7, 42, 123, 9999])
+    async def test_validator_passes_under_permit_gate(self, tmp_path: Path, seed: int) -> None:
+        trace = tmp_path / f"ours_{seed}.jsonl"
+        await ScenarioRunner(_config("aae_permit_gate", trace, seed=seed)).run()
+        results = _results(trace)
+        assert results["rogue_trusted_agent_blocked"] is True
+        assert results["rogue_trusted_agent_reputation"] is True
+        # The rogue action must never have executed.
+        assert "exec:veteran:spend:town/treasury" not in trace.read_text()
+
+    @pytest.mark.asyncio
+    async def test_signed_denial_and_chain_verify(self, tmp_path: Path) -> None:
+        trace = tmp_path / "gate.jsonl"
+        await ScenarioRunner(_config("aae_permit_gate", trace)).run()
+        envelopes = _veteran_envelopes(trace)
+        # Every emitted envelope is a valid signature.
+        assert envelopes
+        assert all(verify_envelope(env) for env in envelopes)
+        # Exactly the treasury spend is the signed refusal.
+        denials = [
+            env
+            for env in envelopes
+            if env["outcome"] == "denied"
+            and env["action"]
+            == {  # type: ignore[comparison-overlap]
+                "verb": "spend",
+                "resource": "town/treasury",
+                "params": {},
+            }
+        ]
+        assert len(denials) == 1
+        assert verify_envelope(denials[0])
+        # The veteran's full history is one intact, ordered chain.
+        assert order_chain(envelopes) is not None
+
+
+class TestDeterminism:
+    @pytest.mark.asyncio
+    async def test_same_seed_identical_trace(self, tmp_path: Path) -> None:
+        t1 = tmp_path / "run1.jsonl"
+        t2 = tmp_path / "run2.jsonl"
+        await ScenarioRunner(_config("aae_permit_gate", t1)).run()
+        await ScenarioRunner(_config("aae_permit_gate", t2)).run()
+        h1 = hashlib.sha256(t1.read_bytes()).hexdigest()
+        h2 = hashlib.sha256(t2.read_bytes()).hexdigest()
+        assert h1 == h2

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -39,6 +39,8 @@ from nest_core.validators import (
     validate_marketplace_responses,
     validate_reputation_scoring,
     validate_reputation_warnings,
+    validate_rogue_trusted_agent_blocked,
+    validate_rogue_trusted_agent_reputation,
     validate_supply_chain_no_lost,
     validate_supply_chain_pipeline,
     validate_trace,
@@ -1804,6 +1806,88 @@ class TestEmpicPaymentsValidators:
         assert not results[0].passed
 
 
+class TestRogueTrustedAgentValidators:
+    """Direct validator tests with synthetic broadcast trace lines."""
+
+    @staticmethod
+    def _bc(agent: str, msg: str) -> dict[str, Any]:
+        return {"kind": "broadcast", "agent": agent, "msg": msg}
+
+    def _gated(self) -> list[dict[str, Any]]:
+        """Trace under a permit gate: warm-up execs, then a blocked rogue."""
+        events: list[dict[str, Any]] = []
+        for i in range(5):
+            events.append(self._bc("veteran", f"permit:veteran:read:town/board:authorized:abc{i}"))
+            events.append(self._bc("veteran", "exec:veteran:read:town/board"))
+        events.append(self._bc("veteran", "rogue_attempt:veteran:spend:town/treasury"))
+        events.append(self._bc("veteran", "permit:veteran:spend:town/treasury:denied:dead0000"))
+        events.append(self._bc("veteran", "blocked:veteran:spend:town/treasury"))
+        return events
+
+    def _ungated(self) -> list[dict[str, Any]]:
+        """Trace with no gate: warm-up execs, then the rogue exec runs."""
+        events: list[dict[str, Any]] = []
+        for _ in range(5):
+            events.append(self._bc("veteran", "exec:veteran:read:town/board"))
+        events.append(self._bc("veteran", "rogue_attempt:veteran:spend:town/treasury"))
+        events.append(self._bc("veteran", "exec:veteran:spend:town/treasury"))
+        return events
+
+    def test_blocked_passes_under_gate(self) -> None:
+        results = validate_rogue_trusted_agent_blocked(self._gated())
+        assert results[0].passed, results[0].detail
+
+    def test_blocked_fails_when_rogue_executes(self) -> None:
+        results = validate_rogue_trusted_agent_blocked(self._ungated())
+        assert not results[0].passed
+        assert "executed" in results[0].detail
+
+    def test_blocked_fails_without_declaration(self) -> None:
+        results = validate_rogue_trusted_agent_blocked(
+            [self._bc("veteran", "exec:veteran:read:town/board")]
+        )
+        assert not results[0].passed
+        assert "no rogue_attempt" in results[0].detail
+
+    def test_blocked_fails_when_neither_run_nor_denied(self) -> None:
+        events = [self._bc("veteran", "rogue_attempt:veteran:spend:town/treasury")]
+        results = validate_rogue_trusted_agent_blocked(events)
+        assert not results[0].passed
+        assert "no signed denial" in results[0].detail
+
+    def test_reputation_passes_under_gate(self) -> None:
+        results = validate_rogue_trusted_agent_reputation(self._gated())
+        assert results[0].passed, results[0].detail
+
+    def test_reputation_passes_under_ungated(self) -> None:
+        # The corroborating invariant holds on both layers (no rogue block needed).
+        results = validate_rogue_trusted_agent_reputation(self._ungated())
+        assert results[0].passed, results[0].detail
+
+    def test_reputation_fails_without_prior_actions(self) -> None:
+        events = [
+            self._bc("veteran", "rogue_attempt:veteran:spend:town/treasury"),
+            self._bc("veteran", "permit:veteran:spend:town/treasury:denied:dead0000"),
+            self._bc("veteran", "blocked:veteran:spend:town/treasury"),
+        ]
+        results = validate_rogue_trusted_agent_reputation(events)
+        assert not results[0].passed
+        assert "in-policy action" in results[0].detail
+
+    def test_reputation_fails_on_spurious_denial(self) -> None:
+        events = self._gated()
+        # A benign in-policy action wrongly refused.
+        spurious = self._bc("resident-0", "permit:resident-0:read:town/events:denied:0badf00d")
+        events.insert(0, spurious)
+        results = validate_rogue_trusted_agent_reputation(events)
+        assert not results[0].passed
+        assert "spuriously denied" in results[0].detail
+
+    def test_no_crash_on_empty(self) -> None:
+        assert not validate_rogue_trusted_agent_blocked([])[0].passed
+        assert not validate_rogue_trusted_agent_reputation([])[0].passed
+
+
 class TestValidatorRegistry:
     def test_all_scenario_types_registered(self) -> None:
         expected = {
@@ -1825,6 +1909,7 @@ class TestValidatorRegistry:
             "escrow_marketplace",
             "failure_detection",
             "parc_migration",
+            "rogue_trusted_agent",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/aae_envelope.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/aae_envelope.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Signed pre-action permit envelopes forming a per-agent hash chain.
+
+An *envelope* is a small signed JSON object issued **before** an action
+executes: who asked to do what, which policy entry decided, and what the
+decision was. Refusals are first-class — a denied request yields a signed
+envelope exactly like a grant, so "we said no" is provable later, not just an
+absence of evidence.
+
+An envelope has exactly eight fields:
+
+- ``agent_id`` — whatever identity string the town's identity layer yields.
+- ``action`` — ``{"verb": str, "resource": str, "params": dict}``.
+- ``policy_id`` — the policy entry that produced the outcome.
+- ``outcome`` — ``"authorized"`` | ``"denied"`` | ``"conditional"``.
+- ``prev_hash`` — hex SHA-256 of the same agent's previous envelope (``None``
+  for the first): deleting or reordering history breaks the chain.
+- ``issued_at`` — RFC 3339 timestamp, **always caller-supplied** (the
+  scenario's virtual clock); validated here, never generated.
+- ``sig`` — hex Ed25519 signature over the canonical form minus ``sig``.
+- ``pubkey`` — hex of the issuer's raw 32-byte Ed25519 public key.
+
+Determinism: sorted-key compact JSON canonicalization, deterministic Ed25519
+(RFC 8032), caller-supplied time — identical inputs give byte-identical
+envelopes. Hostile input never raises out of the verifiers.
+
+Example::
+
+    env = issue_envelope(sk_hex, agent_id="a1", verb="read", resource="doc/1",
+                         params={}, policy_id="rule:0", outcome="authorized",
+                         prev_hash=None, issued_at="2026-01-01T00:00:00+00:00")
+    assert verify_envelope(env)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, cast
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+Envelope = dict[str, Any]
+"""A permit envelope document (plain dict; see the module docstring)."""
+
+OUTCOMES: frozenset[str] = frozenset({"authorized", "denied", "conditional"})
+"""The closed set of permitted ``outcome`` values."""
+
+_FIELDS = frozenset(
+    {"agent_id", "action", "policy_id", "outcome", "prev_hash", "issued_at", "sig", "pubkey"}
+)
+_ACTION_FIELDS = frozenset({"verb", "resource", "params"})
+
+
+def _is_hex(value: object, length: int) -> bool:
+    """Return whether *value* is a hex string of exactly *length* characters."""
+    if not isinstance(value, str) or len(value) != length:
+        return False
+    try:
+        bytes.fromhex(value)
+    except ValueError:
+        return False
+    return True
+
+
+def canonical_bytes(envelope: Envelope) -> bytes:
+    """Canonical signing bytes: sorted-key compact JSON of the envelope minus ``sig``.
+
+    Example::
+
+        payload = canonical_bytes(env)
+    """
+    body = {k: v for k, v in envelope.items() if k != "sig"}
+    return json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def envelope_hash(envelope: Envelope) -> str:
+    """Hex SHA-256 of the full canonical envelope **including** ``sig``.
+
+    This is the value a successor's ``prev_hash`` points at. Including the
+    signature means the chain commits to the signed artifact itself, not just
+    its content — swapping a signature breaks every later link.
+
+    Example::
+
+        h = envelope_hash(env)
+    """
+    body = json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(body).hexdigest()
+
+
+def issue_envelope(
+    signing_key: str,
+    *,
+    agent_id: str,
+    verb: str,
+    resource: str,
+    params: dict[str, Any],
+    policy_id: str,
+    outcome: str,
+    prev_hash: str | None,
+    issued_at: str,
+) -> Envelope:
+    """Build and sign a complete envelope; the only way envelopes are minted.
+
+    ``signing_key`` is the hex of a 32-byte Ed25519 private key. ``issued_at``
+    is validated (RFC 3339 via :meth:`datetime.fromisoformat`) but never
+    generated here. Raises ``ValueError`` on an unknown outcome, a bad key,
+    a malformed ``prev_hash``, or an unparseable timestamp.
+
+    Example::
+
+        env = issue_envelope(sk_hex, agent_id="a1", verb="read", resource="r",
+                             params={}, policy_id="default", outcome="denied",
+                             prev_hash=None, issued_at="2026-01-01T00:00:00+00:00")
+    """
+    if outcome not in OUTCOMES:
+        msg = f"unknown outcome {outcome!r}; expected one of {sorted(OUTCOMES)}"
+        raise ValueError(msg)
+    if prev_hash is not None and not _is_hex(prev_hash, 64):
+        msg = "prev_hash must be None or a 64-character hex SHA-256"
+        raise ValueError(msg)
+    try:
+        datetime.fromisoformat(issued_at)
+    except (ValueError, TypeError) as exc:
+        msg = f"issued_at is not a valid RFC 3339 timestamp: {issued_at!r}"
+        raise ValueError(msg) from exc
+    key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(signing_key))
+    envelope: Envelope = {
+        "agent_id": agent_id,
+        "action": {"verb": verb, "resource": resource, "params": params},
+        "policy_id": policy_id,
+        "outcome": outcome,
+        "prev_hash": prev_hash,
+        "issued_at": issued_at,
+        "pubkey": key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw).hex(),
+    }
+    envelope["sig"] = key.sign(canonical_bytes(envelope)).hex()
+    return envelope
+
+
+def _well_formed(candidate: object) -> Envelope | None:
+    """Structural validation: exactly eight fields, right types, closed enums."""
+    if not isinstance(candidate, dict):
+        return None
+    env = cast("dict[str, Any]", candidate)
+    if frozenset(env) != _FIELDS:
+        return None
+    action = env["action"]
+    if not isinstance(action, dict) or frozenset(cast("dict[str, Any]", action)) != _ACTION_FIELDS:
+        return None
+    act = cast("dict[str, Any]", action)
+    if (
+        not all(isinstance(act[k], str) for k in ("verb", "resource"))
+        or not isinstance(act["params"], dict)
+        or not isinstance(env["agent_id"], str)
+        or not env["agent_id"]
+        or not isinstance(env["policy_id"], str)
+        or env["outcome"] not in OUTCOMES
+        or (env["prev_hash"] is not None and not _is_hex(env["prev_hash"], 64))
+        or not isinstance(env["issued_at"], str)
+        or not _is_hex(env["pubkey"], 64)
+        or not _is_hex(env["sig"], 128)
+    ):
+        return None
+    try:
+        datetime.fromisoformat(env["issued_at"])
+    except ValueError:
+        return None
+    return env
+
+
+def verify_envelope(candidate: object) -> bool:
+    """Return whether *candidate* is a well-formed envelope with a valid signature.
+
+    Recomputes the canonical bytes and verifies ``sig`` under the embedded
+    ``pubkey``. Any mutation of any field — or any structural defect — yields
+    ``False``; hostile input never raises.
+
+    Example::
+
+        assert verify_envelope(env)
+    """
+    env = _well_formed(candidate)
+    if env is None:
+        return False
+    try:
+        pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(str(env["pubkey"])))
+        pub.verify(bytes.fromhex(str(env["sig"])), canonical_bytes(env))
+    except (InvalidSignature, ValueError):
+        return False
+    return True
+
+
+def order_chain(envelopes: list[Envelope]) -> list[Envelope] | None:
+    """Order one agent's envelopes into its unique causal chain, or ``None``.
+
+    Accepts envelopes in any order; returns them genesis-first, or ``None``
+    unless they form exactly one intact chain. Rejected: any invalid envelope,
+    more than one agent represented (a ``prev_hash`` reaching into another
+    agent's chain is a foreign-chain splice), zero or multiple genesis
+    envelopes, a ``prev_hash`` naming no present envelope (a gap, including a
+    deleted interior link), two envelopes sharing a predecessor (a fork), or
+    duplicates. An empty list is the empty chain.
+
+    Example::
+
+        ordered = order_chain([env_b, env_a])
+        assert ordered is not None and ordered[0]["prev_hash"] is None
+    """
+    if not envelopes:
+        return []
+    if any(not verify_envelope(e) for e in envelopes):
+        return None
+    if len({str(e["agent_id"]) for e in envelopes}) != 1:
+        return None
+    by_hash: dict[str, Envelope] = {}
+    for env in envelopes:
+        digest = envelope_hash(env)
+        if digest in by_hash:
+            return None  # duplicate envelope
+        by_hash[digest] = env
+    genesis = [e for e in envelopes if e["prev_hash"] is None]
+    if len(genesis) != 1:
+        return None
+    successor: dict[str, Envelope] = {}
+    for env in envelopes:
+        prev = env["prev_hash"]
+        if prev is None:
+            continue
+        if prev not in by_hash:
+            return None  # gap: predecessor missing (deleted or never present)
+        if prev in successor:
+            return None  # fork: two envelopes claim the same predecessor
+        successor[str(prev)] = env
+    chain = [genesis[0]]
+    while (nxt := successor.get(envelope_hash(chain[-1]))) is not None:
+        chain.append(nxt)
+    return chain if len(chain) == len(envelopes) else None

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/aae_permit_gate.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/aae_permit_gate.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pre-action permit gate: every request yields a signed, chained envelope.
+
+``AAEPermitGate`` is a trust-layer plugin that decides *before* an action runs
+whether the acting agent may proceed, and signs a permit envelope
+(:mod:`nest_plugins_reference.trust.aae_envelope`) for **every** evaluation —
+authorized, denied, and conditional alike. A denial is a first-class signed
+receipt: "we refused this request at this point in the history" is later
+provable from the envelope chain alone.
+
+Policy model: the gate is **deny-by-default** — with no matching entry the
+outcome is ``default_effect`` (``"denied"`` unless overridden). That is the
+honest posture: an unlisted action was never decided, and silence must not
+read as consent. Entries are evaluated in declaration order, first match
+wins. Each names a subject (``"agent"``: fnmatch pattern, or ``"role"``:
+exact role name looked up in ``roles``), a ``"verb"`` pattern, a
+``"resource"`` pattern, and an ``"effect"``. Matching is case-sensitive
+(``fnmatch.fnmatchcase``) so results never vary by platform.
+
+``"conditional"`` is **not** permission: it means "authorized subject to the
+caller honoring the stated condition params". :func:`permits` returns ``True``
+only for ``"authorized"``.
+
+Trace-line protocol
+-------------------
+
+Scenarios emit one line per evaluation, derived from the returned envelope::
+
+    permit:<agent>:<verb>:<resource>:<outcome>:<envelope_hash_prefix8>
+
+where ``envelope_hash_prefix8`` is the first 8 hex characters of
+``envelope_hash(envelope)``. Because envelopes are byte-deterministic, these
+lines are stable across replays of the same scenario.
+
+Determinism: no wall clock (``now`` is caller-supplied), no unseeded
+randomness (the signing key comes from ``signing_key`` or is derived from
+``key_seed``), and all reported numbers are rounded to 6 decimals.
+
+Example::
+
+    gate = AAEPermitGate(policy=[{"agent": "a*", "verb": "read", "resource": "*",
+                                  "effect": "authorized"}], key_seed=b"demo")
+    env = await gate.evaluate(AgentId("a1"), "read", "doc/1", {},
+                              now="2026-01-01T00:00:00+00:00")
+    assert permits(env)
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import importlib
+import logging
+from typing import Any, cast
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from nest_core.types import AgentId, Attestation, Claim, Evidence, ReputationScore, Signature
+
+from nest_plugins_reference.trust.aae_envelope import (
+    OUTCOMES,
+    Envelope,
+    envelope_hash,
+    issue_envelope,
+    order_chain,
+    verify_envelope,
+)
+
+logger = logging.getLogger(__name__)
+
+_RULE_KEYS = frozenset({"agent", "role", "verb", "resource", "effect"})
+
+# (kind, subject, verb, resource, effect) — kind is "agent" or "role".
+_Rule = tuple[str, str, str, str, str]
+
+
+def permits(envelope: Envelope) -> bool:
+    """Return whether *envelope* grants unconditional permission to act.
+
+    ``True`` only for a **valid** envelope whose outcome is ``"authorized"``.
+    ``"conditional"`` is not permission (the caller still owes the condition
+    params); ``"denied"`` and anything malformed or tampered are ``False``.
+
+    Example::
+
+        if permits(env):
+            ...  # dispatch the action
+    """
+    return verify_envelope(envelope) and envelope["outcome"] == "authorized"
+
+
+def _validate_rule(index: int, rule: object) -> _Rule:
+    """Validate one policy entry, returning its normalized tuple form."""
+    if not isinstance(rule, dict):
+        msg = f"policy[{index}] must be a dict, got {type(rule).__name__}"
+        raise ValueError(msg)
+    entry = cast("dict[str, Any]", rule)
+    if unknown := set(entry) - _RULE_KEYS:
+        msg = f"policy[{index}] has unknown keys {sorted(unknown)}"
+        raise ValueError(msg)
+    subjects = [k for k in ("agent", "role") if k in entry]
+    if len(subjects) != 1:
+        msg = f"policy[{index}] must name exactly one of 'agent' or 'role'"
+        raise ValueError(msg)
+    kind = subjects[0]
+    for key in (kind, "verb", "resource", "effect"):
+        if not isinstance(entry.get(key), str):
+            msg = f"policy[{index}][{key!r}] must be a string"
+            raise ValueError(msg)
+    if entry["effect"] not in OUTCOMES:
+        msg = f"policy[{index}]['effect'] must be one of {sorted(OUTCOMES)}"
+        raise ValueError(msg)
+    return (kind, entry[kind], entry["verb"], entry["resource"], entry["effect"])
+
+
+def _validate_policy(policy: object) -> list[_Rule]:
+    """Validate the whole ``policy`` constructor argument."""
+    if policy is None:
+        return []
+    if not isinstance(policy, list):
+        msg = "policy must be a list of rule dicts"
+        raise ValueError(msg)
+    return [_validate_rule(i, r) for i, r in enumerate(cast("list[object]", policy))]
+
+
+def _validate_roles(roles: object) -> dict[str, str]:
+    """Validate the ``roles`` constructor argument."""
+    if roles is None:
+        return {}
+    if not isinstance(roles, dict) or any(
+        not isinstance(k, str) or not isinstance(v, str)
+        for k, v in cast("dict[object, object]", roles).items()
+    ):
+        msg = "roles must map agent_id strings to role-name strings"
+        raise ValueError(msg)
+    return dict(cast("dict[str, str]", roles))
+
+
+class AAEPermitGate:
+    """Deny-by-default permit gate implementing the ``Trust`` Protocol.
+
+    Constructor: ``policy`` (ordered rule dicts, module docstring), ``roles``
+    (``agent_id -> role`` for ``"role"`` entries), ``default_effect``
+    (outcome when nothing matches), ``signing_key`` (hex 32-byte Ed25519
+    private key) **or** ``key_seed`` (bytes; the key is its SHA-256, so runs
+    are reproducible — for determinism the gate never invents a key, and
+    omitting both raises ``ValueError``), and ``anchor`` / ``ledger`` for
+    opt-in capsule anchoring (:meth:`_anchor_envelope`).
+
+    Example::
+
+        gate = AAEPermitGate(policy=[], key_seed=b"seed")
+        env = await gate.evaluate(AgentId("a1"), "write", "db", {},
+                                  now="2026-01-01T00:00:00+00:00")
+        assert env["outcome"] == "denied"
+    """
+
+    _SYSTEM_AGENT = AgentId("trust:aae_permit_gate")
+
+    def __init__(
+        self,
+        policy: list[dict[str, Any]] | None = None,
+        roles: dict[str, str] | None = None,
+        default_effect: str = "denied",
+        signing_key: str | None = None,
+        key_seed: bytes | None = None,
+        anchor: bool = False,
+        ledger: str = "capsule_ledger.jsonl",
+    ) -> None:
+        if default_effect not in OUTCOMES:
+            msg = f"default_effect must be one of {sorted(OUTCOMES)}, got {default_effect!r}"
+            raise ValueError(msg)
+        self._rules: list[_Rule] = _validate_policy(policy)
+        self._roles: dict[str, str] = _validate_roles(roles)
+        self._default_effect = default_effect
+        if signing_key is not None:
+            try:
+                key_ok = len(bytes.fromhex(signing_key)) == 32
+            except ValueError:
+                key_ok = False
+            if not key_ok:
+                msg = "signing_key must be the hex of a 32-byte Ed25519 private key"
+                raise ValueError(msg)
+            self._signing_key = signing_key
+        elif key_seed is not None:
+            self._signing_key = hashlib.sha256(key_seed).hexdigest()
+        else:
+            msg = "supply signing_key (hex) or key_seed (bytes); the gate never invents a key"
+            raise ValueError(msg)
+        self._anchor = anchor
+        self._ledger = ledger
+        self._anchor_unavailable_logged = False
+        self._chains: dict[str, list[Envelope]] = {}
+        self._capsule_ids: dict[str, str] = {}  # envelope_hash -> capsule_id
+        self._evidence_log: dict[str, list[Evidence]] = {}
+        self._stakes: dict[str, int] = {}
+
+    def _match(self, agent: str, verb: str, resource: str) -> tuple[str, str]:
+        """First-match-wins policy lookup; returns ``(outcome, policy_id)``."""
+        for i, (kind, subject, verb_pat, res_pat, effect) in enumerate(self._rules):
+            if kind == "agent":
+                if not fnmatch.fnmatchcase(agent, subject):
+                    continue
+            elif self._roles.get(agent) != subject:
+                continue
+            if fnmatch.fnmatchcase(verb, verb_pat) and fnmatch.fnmatchcase(resource, res_pat):
+                return effect, f"rule:{i}"
+        return self._default_effect, "default"
+
+    async def evaluate(
+        self, agent: AgentId, verb: str, resource: str, params: dict[str, Any], *, now: str
+    ) -> dict[str, Any]:
+        """Decide a proposed action and return its signed permit envelope.
+
+        Every call — grant or refusal — extends the agent's envelope chain
+        (``prev_hash`` links to the previous evaluation for the same agent).
+        ``now`` is the scenario's virtual clock (RFC 3339); the gate never
+        reads a wall clock. For ``"conditional"`` outcomes, ``params`` in the
+        envelope are the condition params the caller must honor.
+
+        Example::
+
+            env = await gate.evaluate(AgentId("a1"), "read", "doc/1", {},
+                                      now="2026-01-01T00:00:00+00:00")
+        """
+        outcome, policy_id = self._match(str(agent), verb, resource)
+        chain = self._chains.setdefault(str(agent), [])
+        env = issue_envelope(
+            self._signing_key,
+            agent_id=str(agent),
+            verb=verb,
+            resource=resource,
+            params=params,
+            policy_id=policy_id,
+            outcome=outcome,
+            prev_hash=envelope_hash(chain[-1]) if chain else None,
+            issued_at=now,
+        )
+        chain.append(env)
+        self._anchor_envelope(env)
+        return env
+
+    def chain(self, agent: AgentId | str) -> list[Envelope]:
+        """Return the agent's envelopes in issue order (a copy).
+
+        Example::
+
+            history = gate.chain(AgentId("a1"))
+        """
+        return list(self._chains.get(str(agent), []))
+
+    def verify_chain(self, agent: AgentId | str) -> bool:
+        """Return whether the agent's stored history is one intact, valid chain.
+
+        Example::
+
+            assert gate.verify_chain(AgentId("a1"))
+        """
+        return order_chain(self._chains.get(str(agent), [])) is not None
+
+    def _anchor_envelope(self, env: Envelope) -> None:
+        """Optionally seal a permit envelope into a capsule ledger.
+
+        Only active with ``anchor=True`` **and** the optional ``capsule_emit``
+        package importable; otherwise a one-time debug log and a no-op (zero
+        hard dependency). An anchored permit is evidence a **decision was
+        made, not evidence the action ran** — so the capsule's ``action`` is a
+        permit-namespaced token (``permit.granted`` / ``permit.denied`` /
+        ``permit.conditional``), never the underlying verb (which stays inside
+        the envelope, i.e. the capsule's input), and the output carries only
+        the decision. ``capsule_emit.emit`` has no external-reference field
+        for the *current* capsule (its ``confirms=`` names a parent capsule id
+        and belongs on a later execution capsule), so the ``envelope_hash`` in
+        the output object is the correlation handle; the returned capsule id
+        is kept per envelope hash so a future execution capsule can chain to
+        this permit via ``confirms=``.
+        """
+        if not self._anchor:
+            return
+        try:
+            capsule_emit = importlib.import_module("capsule_emit")
+        except ImportError:
+            if not self._anchor_unavailable_logged:
+                logger.debug("anchor=True but capsule_emit is not installed; anchoring disabled")
+                self._anchor_unavailable_logged = True
+            return
+        digest = envelope_hash(env)
+        outcome = str(env["outcome"])
+        token = {"authorized": "permit.granted", "denied": "permit.denied"}.get(
+            outcome, "permit.conditional"
+        )
+        result = capsule_emit.emit(
+            action=token,
+            operator=str(env["agent_id"]),
+            developer=str(self._SYSTEM_AGENT),
+            agent_input=env,
+            agent_output={
+                "decision": outcome,
+                "policy_id": env["policy_id"],
+                "envelope_hash": digest,
+            },
+            anchor=True,
+            ledger=self._ledger,
+        )
+        self._capsule_ids[digest] = str(result.capsule_id)
+
+    async def score(self, agent: AgentId) -> ReputationScore:
+        """Reputation as the agent's authorization rate at this gate.
+
+        ``score`` = authorized evaluations / total evaluations (0.0 with no
+        history — deny-by-default extends to reputation), ``confidence`` =
+        ``min(1.0, total / 10)``, ``sample_count`` = total. Both floats are
+        rounded to 6 decimals so traces are byte-stable across platforms.
+
+        Example::
+
+            rep = await gate.score(AgentId("a1"))
+        """
+        history = self._chains.get(str(agent), [])
+        total = len(history)
+        if total == 0:
+            return ReputationScore(agent_id=agent, score=0.0, confidence=0.0, sample_count=0)
+        granted = sum(1 for e in history if e["outcome"] == "authorized")
+        return ReputationScore(
+            agent_id=agent,
+            score=round(granted / total, 6),
+            confidence=round(min(1.0, total / 10), 6),
+            sample_count=total,
+        )
+
+    async def attest(self, agent: AgentId, claim: Claim) -> Attestation:
+        """Sign *claim* with the gate's own Ed25519 key.
+
+        The signature covers ``claim.model_dump_json()`` — the same key that
+        signs permit envelopes, so one public key verifies both.
+
+        Example::
+
+            att = await gate.attest(AgentId("a1"), claim)
+        """
+        key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(self._signing_key))
+        sig = Signature(
+            signer=self._SYSTEM_AGENT,
+            value=key.sign(claim.model_dump_json().encode()),
+            algorithm="ed25519",
+        )
+        return Attestation(issuer=self._SYSTEM_AGENT, claim=claim, signature=sig)
+
+    async def report(self, agent: AgentId, evidence: Evidence) -> None:
+        """Record evidence about an agent (storage only, by design).
+
+        The evidence log is kept so future policy revisions MAY consult it;
+        today it does **not** alter matching, scores, or envelopes — no
+        pretend enforcement.
+
+        Example::
+
+            await gate.report(AgentId("a1"), evidence)
+        """
+        self._evidence_log.setdefault(str(agent), []).append(evidence)
+
+    async def stake(self, agent: AgentId, amount: int) -> None:
+        """Stake on an agent (Protocol-parity no-op; amount recorded only).
+
+        Example::
+
+            await gate.stake(AgentId("a1"), 100)
+        """
+        self._stakes[str(agent)] = self._stakes.get(str(agent), 0) + amount

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -48,6 +48,7 @@ phi_accrual = "nest_plugins_reference.failure_detection.phi_accrual:PhiAccrualFa
 
 [project.entry-points."nest.plugins.trust"]
 parc = "nest_plugins_reference.trust.parc:ParcTrust"
+aae_permit_gate = "nest_plugins_reference.trust.aae_permit_gate:AAEPermitGate"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/nest-plugins-reference/tests/test_aae_permit_gate.py
+++ b/packages/nest-plugins-reference/tests/test_aae_permit_gate.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportPrivateUsage=false
+"""Phase-1 smoke tests for the AAE permit gate and its envelope chain.
+
+Covers: envelope round-trip sign/verify, single-field tamper detection,
+malformed-input hardening, chain ordering (intact chain of three, gap, fork,
+foreign-chain splice), deny-by-default, first-match-wins, denials as
+verifiable receipts, conditional-is-not-permission, deterministic double-run
+(byte-identical envelopes), constructor validation, scoring, attestation, and
+storage-only evidence reporting.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from nest_core.types import AgentId, Claim, Evidence
+from nest_plugins_reference.trust.aae_envelope import (
+    envelope_hash,
+    issue_envelope,
+    order_chain,
+    verify_envelope,
+)
+from nest_plugins_reference.trust.aae_permit_gate import AAEPermitGate, permits
+
+_SK = hashlib.sha256(b"aae-test-signing-key").hexdigest()
+_T0 = "2026-01-01T00:00:00+00:00"
+_ALLOW_READS = [{"agent": "a*", "verb": "read", "resource": "*", "effect": "authorized"}]
+
+
+def _make_chain(n: int, agent: str = "a1") -> list[dict[str, Any]]:
+    envs: list[dict[str, Any]] = []
+    prev: str | None = None
+    for i in range(n):
+        env = issue_envelope(
+            _SK,
+            agent_id=agent,
+            verb="read",
+            resource=f"doc/{i}",
+            params={"i": i},
+            policy_id="rule:0",
+            outcome="authorized",
+            prev_hash=prev,
+            issued_at=_T0,
+        )
+        envs.append(env)
+        prev = envelope_hash(env)
+    return envs
+
+
+# ---------------------------------------------------------------------------
+# Envelope
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_round_trip() -> None:
+    env = _make_chain(1)[0]
+    assert verify_envelope(env)
+    assert set(env) == {
+        "agent_id",
+        "action",
+        "policy_id",
+        "outcome",
+        "prev_hash",
+        "issued_at",
+        "sig",
+        "pubkey",
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("agent_id", "mallory"),
+        ("policy_id", "rule:99"),
+        ("outcome", "authorized"),
+        ("issued_at", "2026-01-01T00:00:01+00:00"),
+        ("prev_hash", "ab" * 32),
+    ],
+)
+def test_envelope_single_field_tamper_fails(field: str, value: str) -> None:
+    env = issue_envelope(
+        _SK,
+        agent_id="a1",
+        verb="write",
+        resource="db",
+        params={"n": 1},
+        policy_id="rule:0",
+        outcome="denied",
+        prev_hash=None,
+        issued_at=_T0,
+    )
+    tampered = {**env, field: value}
+    assert verify_envelope(tampered) is False
+
+
+def test_envelope_action_tamper_fails() -> None:
+    env = _make_chain(1)[0]
+    tampered = {**env, "action": {**env["action"], "verb": "delete"}}
+    assert verify_envelope(tampered) is False
+    tampered = {**env, "action": {**env["action"], "params": {"i": 999}}}
+    assert verify_envelope(tampered) is False
+
+
+def test_envelope_malformed_input_never_raises() -> None:
+    env = _make_chain(1)[0]
+    assert verify_envelope(None) is False
+    assert verify_envelope([env]) is False
+    assert verify_envelope({k: v for k, v in env.items() if k != "outcome"}) is False
+    assert verify_envelope({**env, "extra": 1}) is False
+    assert verify_envelope({**env, "outcome": "maybe"}) is False
+    assert verify_envelope({**env, "sig": "zz" * 64}) is False
+    assert verify_envelope({**env, "issued_at": "yesterday-ish"}) is False
+
+
+def test_issue_envelope_rejects_bad_inputs() -> None:
+    with pytest.raises(ValueError, match="outcome"):
+        issue_envelope(
+            _SK,
+            agent_id="a1",
+            verb="v",
+            resource="r",
+            params={},
+            policy_id="p",
+            outcome="approved",
+            prev_hash=None,
+            issued_at=_T0,
+        )
+    with pytest.raises(ValueError, match="RFC 3339"):
+        issue_envelope(
+            _SK,
+            agent_id="a1",
+            verb="v",
+            resource="r",
+            params={},
+            policy_id="p",
+            outcome="denied",
+            prev_hash=None,
+            issued_at="not-a-time",
+        )
+    with pytest.raises(ValueError, match="prev_hash"):
+        issue_envelope(
+            _SK,
+            agent_id="a1",
+            verb="v",
+            resource="r",
+            params={},
+            policy_id="p",
+            outcome="denied",
+            prev_hash="short",
+            issued_at=_T0,
+        )
+
+
+def test_chain_of_three_orders_and_verifies() -> None:
+    envs = _make_chain(3)
+    shuffled = [envs[2], envs[0], envs[1]]
+    ordered = order_chain(shuffled)
+    assert ordered == envs
+
+
+def test_chain_gap_detected() -> None:
+    envs = _make_chain(3)
+    assert order_chain([envs[0], envs[2]]) is None  # interior link deleted
+
+
+def test_chain_fork_detected() -> None:
+    envs = _make_chain(2)
+    fork = issue_envelope(
+        _SK,
+        agent_id="a1",
+        verb="read",
+        resource="doc/alt",
+        params={},
+        policy_id="rule:0",
+        outcome="authorized",
+        prev_hash=envelope_hash(envs[0]),
+        issued_at=_T0,
+    )
+    assert order_chain([*envs, fork]) is None
+
+
+def test_chain_foreign_splice_detected() -> None:
+    a_envs = _make_chain(1, agent="a1")
+    spliced = issue_envelope(
+        _SK,
+        agent_id="b1",
+        verb="read",
+        resource="doc/0",
+        params={},
+        policy_id="rule:0",
+        outcome="authorized",
+        prev_hash=envelope_hash(a_envs[0]),
+        issued_at=_T0,
+    )
+    assert order_chain([a_envs[0], spliced]) is None
+    assert order_chain([spliced]) is None  # predecessor absent entirely: gap
+
+
+# ---------------------------------------------------------------------------
+# Gate
+# ---------------------------------------------------------------------------
+
+
+async def test_deny_by_default() -> None:
+    gate = AAEPermitGate(key_seed=b"seed")
+    env = await gate.evaluate(AgentId("a1"), "write", "db", {}, now=_T0)
+    assert env["outcome"] == "denied"
+    assert env["policy_id"] == "default"
+    assert permits(env) is False
+
+
+async def test_first_match_wins() -> None:
+    gate = AAEPermitGate(
+        policy=[
+            {"agent": "a1", "verb": "read", "resource": "*", "effect": "denied"},
+            {"agent": "a*", "verb": "read", "resource": "*", "effect": "authorized"},
+        ],
+        key_seed=b"seed",
+    )
+    denied = await gate.evaluate(AgentId("a1"), "read", "doc/1", {}, now=_T0)
+    granted = await gate.evaluate(AgentId("a2"), "read", "doc/1", {}, now=_T0)
+    assert (denied["outcome"], denied["policy_id"]) == ("denied", "rule:0")
+    assert (granted["outcome"], granted["policy_id"]) == ("authorized", "rule:1")
+
+
+async def test_role_rule_matches_exactly() -> None:
+    gate = AAEPermitGate(
+        policy=[{"role": "auditor", "verb": "*", "resource": "*", "effect": "authorized"}],
+        roles={"a1": "auditor"},
+        key_seed=b"seed",
+    )
+    assert (await gate.evaluate(AgentId("a1"), "read", "x", {}, now=_T0))["outcome"] == "authorized"
+    assert (await gate.evaluate(AgentId("a2"), "read", "x", {}, now=_T0))["outcome"] == "denied"
+
+
+async def test_denial_is_a_verifiable_receipt() -> None:
+    gate = AAEPermitGate(key_seed=b"seed")
+    env = await gate.evaluate(AgentId("a1"), "shutdown", "town", {"force": True}, now=_T0)
+    assert env["outcome"] == "denied"
+    assert verify_envelope(env)
+
+
+async def test_conditional_is_not_permission() -> None:
+    gate = AAEPermitGate(
+        policy=[{"agent": "*", "verb": "pay", "resource": "*", "effect": "conditional"}],
+        key_seed=b"seed",
+    )
+    env = await gate.evaluate(AgentId("a1"), "pay", "invoice/7", {"limit": 10}, now=_T0)
+    assert env["outcome"] == "conditional"
+    assert verify_envelope(env)
+    assert permits(env) is False
+
+
+async def test_gate_chain_links_and_verifies() -> None:
+    gate = AAEPermitGate(policy=_ALLOW_READS, key_seed=b"seed")
+    for i in range(3):
+        await gate.evaluate(AgentId("a1"), "read", f"doc/{i}", {}, now=_T0)
+    chain = gate.chain(AgentId("a1"))
+    assert len(chain) == 3
+    assert chain[0]["prev_hash"] is None
+    assert chain[1]["prev_hash"] == envelope_hash(chain[0])
+    assert chain[2]["prev_hash"] == envelope_hash(chain[1])
+    assert gate.verify_chain(AgentId("a1"))
+    assert gate.verify_chain(AgentId("nobody"))  # empty history is an intact chain
+
+
+async def test_deterministic_double_run() -> None:
+    def build() -> AAEPermitGate:
+        return AAEPermitGate(policy=_ALLOW_READS, key_seed=b"twin")
+
+    runs: list[list[dict[str, Any]]] = []
+    for gate in (build(), build()):
+        for i in range(3):
+            await gate.evaluate(AgentId("a1"), "read", f"doc/{i}", {"i": i}, now=_T0)
+        await gate.evaluate(AgentId("a1"), "write", "db", {}, now=_T0)
+        runs.append(gate.chain(AgentId("a1")))
+    assert json.dumps(runs[0], sort_keys=True) == json.dumps(runs[1], sort_keys=True)
+
+
+def test_constructor_requires_a_key() -> None:
+    with pytest.raises(ValueError, match="signing_key"):
+        AAEPermitGate()
+    # Same seed -> same key; explicit hex key also accepted.
+    sk = hashlib.sha256(b"explicit").hexdigest()
+    assert AAEPermitGate(signing_key=sk)._signing_key == sk
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"default_effect": "allow", "key_seed": b"s"},
+        {"policy": [{"verb": "*", "resource": "*", "effect": "denied"}], "key_seed": b"s"},
+        {
+            "policy": [
+                {"agent": "a", "role": "r", "verb": "*", "resource": "*", "effect": "denied"}
+            ],
+            "key_seed": b"s",
+        },
+        {
+            "policy": [{"agent": "a", "verb": "*", "resource": "*", "effect": "blocked"}],
+            "key_seed": b"s",
+        },
+        {
+            "policy": [{"agent": 3, "verb": "*", "resource": "*", "effect": "denied"}],
+            "key_seed": b"s",
+        },
+        {
+            "policy": [
+                {"agent": "a", "verb": "*", "resource": "*", "effect": "denied", "priority": 1}
+            ],
+            "key_seed": b"s",
+        },
+        {"policy": ["allow-everything"], "key_seed": b"s"},
+        {"policy": "not-a-list", "key_seed": b"s"},
+        {"roles": {"a1": 7}, "key_seed": b"s"},
+        {"signing_key": "not-hex"},
+        {"signing_key": "ab" * 16 + "cd"},
+    ],
+)
+def test_constructor_validation_errors(kwargs: dict[str, Any]) -> None:
+    with pytest.raises(ValueError):
+        AAEPermitGate(**kwargs)
+
+
+async def test_score_is_authorization_rate() -> None:
+    gate = AAEPermitGate(policy=_ALLOW_READS, key_seed=b"seed")
+    empty = await gate.score(AgentId("a1"))
+    assert (empty.score, empty.confidence, empty.sample_count) == (0.0, 0.0, 0)
+    for i in range(2):
+        await gate.evaluate(AgentId("a1"), "read", f"doc/{i}", {}, now=_T0)
+        await gate.evaluate(AgentId("a1"), "write", f"doc/{i}", {}, now=_T0)
+    rep = await gate.score(AgentId("a1"))
+    assert (rep.score, rep.confidence, rep.sample_count) == (0.5, 0.4, 4)
+
+
+async def test_attest_signs_with_gate_key() -> None:
+    gate = AAEPermitGate(key_seed=b"seed")
+    claim = Claim(subject=AgentId("a1"), predicate="evaluated_by", value="aae_permit_gate")
+    att = await gate.attest(AgentId("a1"), claim)
+    key = Ed25519PrivateKey.from_private_bytes(hashlib.sha256(b"seed").digest())
+    key.public_key().verify(att.signature.value, claim.model_dump_json().encode())
+
+
+async def test_report_is_storage_only() -> None:
+    gate = AAEPermitGate(policy=_ALLOW_READS, key_seed=b"seed")
+    before = await gate.evaluate(AgentId("a1"), "read", "doc/1", {}, now=_T0)
+    ev = Evidence(reporter=AgentId("r1"), subject=AgentId("a1"), kind="negative", detail="spam")
+    await gate.report(AgentId("a1"), ev)
+    after = await gate.evaluate(AgentId("a1"), "read", "doc/1", {}, now=_T0)
+    assert gate._evidence_log["a1"] == [ev]
+    assert before["outcome"] == after["outcome"] == "authorized"  # no hidden enforcement
+    await gate.stake(AgentId("a1"), 5)  # parity no-op
+    assert gate._stakes["a1"] == 5

--- a/packages/nest-plugins-reference/tests/test_aae_permit_gate.py
+++ b/packages/nest-plugins-reference/tests/test_aae_permit_gate.py
@@ -18,8 +18,10 @@ from typing import Any
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from nest_core.types import AgentId, Claim, Evidence
 from nest_plugins_reference.trust.aae_envelope import (
+    canonical_bytes,
     envelope_hash,
     issue_envelope,
     order_chain,
@@ -184,7 +186,8 @@ def test_chain_fork_detected() -> None:
     assert order_chain([*envs, fork]) is None
 
 
-def test_chain_foreign_splice_detected() -> None:
+def test_prev_hash_points_at_foreign_agent_envelope_rejected() -> None:
+    """A prev_hash reaching into another agent's chain is a splice, not a link."""
     a_envs = _make_chain(1, agent="a1")
     spliced = issue_envelope(
         _SK,
@@ -197,8 +200,38 @@ def test_chain_foreign_splice_detected() -> None:
         prev_hash=envelope_hash(a_envs[0]),
         issued_at=_T0,
     )
-    assert order_chain([a_envs[0], spliced]) is None
+    assert order_chain([a_envs[0], spliced]) is None  # two agents: not one chain
     assert order_chain([spliced]) is None  # predecessor absent entirely: gap
+
+
+async def test_replayed_envelope_detected_out_of_sequence() -> None:
+    """Replaying a valid envelope at a second chain position is not a valid chain."""
+    envs = _make_chain(3)
+    # A verbatim replay of an earlier envelope appears twice -> duplicate rejected.
+    assert order_chain([*envs, envs[1]]) is None
+    # Through the gate: injecting a replay of the genesis into stored history
+    # (a second prev_hash=None) makes verify_chain fail (duplicate / two genesis).
+    gate = AAEPermitGate(policy=_ALLOW_READS, key_seed=b"seed")
+    for i in range(2):
+        await gate.evaluate(AgentId("a1"), "read", f"doc/{i}", {}, now=_T0)
+    gate._chains["a1"].append(gate._chains["a1"][0])  # replay genesis out of sequence
+    assert gate.verify_chain(AgentId("a1")) is False
+
+
+def test_forged_pubkey_substitution_fails() -> None:
+    """Swapping an interior envelope's pubkey — re-signed so it self-verifies in
+    isolation — still breaks the chain: envelope_hash commits to pubkey+sig, so the
+    successor's prev_hash no longer resolves (a foreign-key splice reads as a gap)."""
+    envs = _make_chain(3)
+    attacker_key = Ed25519PrivateKey.from_private_bytes(hashlib.sha256(b"attacker").digest())
+    attacker_pub = attacker_key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw).hex()
+    forged = {**envs[1], "pubkey": attacker_pub}
+    forged["sig"] = attacker_key.sign(canonical_bytes(forged)).hex()
+
+    assert verify_envelope(forged) is True  # self-consistent under the attacker key
+    assert forged["pubkey"] != envs[1]["pubkey"]
+    # env[2] still points at the ORIGINAL hash of env[1], which no longer exists.
+    assert order_chain([envs[0], forged, envs[2]]) is None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nest-plugins-reference/tests/test_aae_permit_gate_properties.py
+++ b/packages/nest-plugins-reference/tests/test_aae_permit_gate_properties.py
@@ -1,0 +1,500 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hypothesis property-based tests for the AAE permit gate and its envelopes.
+
+These complement the example-based ``test_aae_permit_gate.py`` by asserting the
+core invariants over *generated* keys, fields, chains, and policy tables rather
+than hand-picked cases:
+
+1. Round-trip: any ``issue_envelope(...)`` verifies and carries exactly the
+   eight fields with ``outcome`` in ``OUTCOMES``.
+2. Tamper: any single-field mutation (or a pubkey swap, or a truncated /
+   extended / non-hex ``sig``) makes ``verify_envelope`` return ``False`` and
+   never raise.
+3. Chain re-orderability: any valid N>=1 sequence for one agent has a unique
+   causal order; deleting an interior link (gap), a shared-predecessor fork, or
+   a foreign-agent splice each makes ``order_chain`` return ``None``.
+4. Policy determinism / no-denied-executes: ``evaluate`` is byte-deterministic
+   for fixed inputs+seed; the first matching rule (an independent fnmatch
+   oracle) decides the outcome; ``permits`` is ``True`` iff that outcome is
+   ``"authorized"`` — so a denied ``(verb, resource)`` never yields permission.
+5. Score invariants: ``score`` equals authorized/total in [0, 1], sample_count
+   equals total, and confidence stays in [0, 1] and is monotonic non-decreasing
+   as evaluations accrue.
+
+Determinism follows the repo convention for ``*_properties.py``: bounded
+``@settings(max_examples=N, deadline=None)`` with no wall clock (timestamps are
+fixed base + integer offset RFC 3339 strings) and deterministic Ed25519 keys
+(derived from generated 32-byte seeds). Ed25519 signing dominates cost, so
+generated sizes are kept small.
+
+Example::
+
+    pytest packages/nest-plugins-reference/tests/test_aae_permit_gate_properties.py
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import random
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId
+from nest_plugins_reference.trust.aae_envelope import (
+    OUTCOMES,
+    Envelope,
+    envelope_hash,
+    issue_envelope,
+    order_chain,
+    verify_envelope,
+)
+from nest_plugins_reference.trust.aae_permit_gate import AAEPermitGate, permits
+
+# ---------------------------------------------------------------------------
+# Deterministic, wall-clock-free building blocks
+# ---------------------------------------------------------------------------
+
+_BASE = datetime(2026, 1, 1, tzinfo=UTC)
+_T0 = _BASE.isoformat()
+
+
+def _ts(offset: int) -> str:
+    """RFC 3339 timestamp a fixed base plus ``offset`` seconds (no wall clock)."""
+    return (_BASE + timedelta(seconds=offset)).isoformat()
+
+
+def _pubkey_hex(sk_hex: str) -> str:
+    """Raw 32-byte Ed25519 public key (hex) for a private key given as hex."""
+    key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(sk_hex))
+    return key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw).hex()
+
+
+# A printable alphabet with no fnmatch metacharacters (``* ? [ ]``), so generated
+# field *values* are always literals; glob patterns add "*" explicitly below.
+_SAFE = "abcABC012/-_."
+_names = st.text(alphabet=_SAFE, min_size=1, max_size=8)
+_tokens = st.text(alphabet=_SAFE, min_size=0, max_size=8)
+_scalars = st.one_of(
+    st.text(alphabet=_SAFE, max_size=6),
+    st.integers(min_value=-1000, max_value=1000),
+    st.booleans(),
+    st.none(),
+    st.floats(allow_nan=False, allow_infinity=False, width=32),
+)
+_param_keys = st.text(alphabet="xyzw", min_size=1, max_size=3)
+_params = st.dictionaries(_param_keys, _scalars, max_size=4)
+_params_nonempty = st.dictionaries(_param_keys, _scalars, min_size=1, max_size=4)
+_offsets = st.integers(min_value=0, max_value=1_000_000)
+_outcomes = st.sampled_from(sorted(OUTCOMES))
+# 32-byte Ed25519 private key as hex (issue_envelope takes the raw key hex).
+_sk_hex = st.binary(min_size=32, max_size=32).map(lambda b: b.hex())
+_prev_hash = st.one_of(st.none(), st.binary(min_size=32, max_size=32).map(lambda b: b.hex()))
+
+
+# ---------------------------------------------------------------------------
+# 1. Round-trip
+# ---------------------------------------------------------------------------
+
+_EXPECTED_FIELDS = {
+    "agent_id",
+    "action",
+    "policy_id",
+    "outcome",
+    "prev_hash",
+    "issued_at",
+    "sig",
+    "pubkey",
+}
+
+
+class TestRoundTrip:
+    @settings(max_examples=100, deadline=None)
+    @given(
+        sk_hex=_sk_hex,
+        agent_id=_names,
+        verb=_tokens,
+        resource=_tokens,
+        params=_params,
+        policy_id=_tokens,
+        outcome=_outcomes,
+        prev_hash=_prev_hash,
+        offset=_offsets,
+    )
+    def test_issue_then_verify_holds_with_exactly_eight_fields(
+        self,
+        sk_hex: str,
+        agent_id: str,
+        verb: str,
+        resource: str,
+        params: dict[str, Any],
+        policy_id: str,
+        outcome: str,
+        prev_hash: str | None,
+        offset: int,
+    ) -> None:
+        """Any issued envelope verifies, has exactly the eight fields, and its
+        outcome is one of the closed ``OUTCOMES`` set."""
+        env = issue_envelope(
+            sk_hex,
+            agent_id=agent_id,
+            verb=verb,
+            resource=resource,
+            params=params,
+            policy_id=policy_id,
+            outcome=outcome,
+            prev_hash=prev_hash,
+            issued_at=_ts(offset),
+        )
+        assert verify_envelope(env) is True
+        assert set(env) == _EXPECTED_FIELDS
+        assert env["outcome"] in OUTCOMES
+
+
+# ---------------------------------------------------------------------------
+# 2. Tamper
+# ---------------------------------------------------------------------------
+
+
+class TestTamper:
+    @settings(max_examples=100, deadline=None)
+    @given(
+        sk_hex=_sk_hex,
+        agent_id=_names,
+        verb=_tokens,
+        resource=_tokens,
+        params=_params_nonempty,
+        policy_id=_tokens,
+        outcome=_outcomes,
+        prev_hash=_prev_hash,
+        offset=_offsets,
+    )
+    def test_any_single_mutation_or_bad_sig_fails_closed(
+        self,
+        sk_hex: str,
+        agent_id: str,
+        verb: str,
+        resource: str,
+        params: dict[str, Any],
+        policy_id: str,
+        outcome: str,
+        prev_hash: str | None,
+        offset: int,
+    ) -> None:
+        """For an arbitrary issued envelope, flipping any one field value, swapping
+        the pubkey, or corrupting the signature makes ``verify_envelope`` return
+        ``False`` — and it never raises on hostile input."""
+        env = issue_envelope(
+            sk_hex,
+            agent_id=agent_id,
+            verb=verb,
+            resource=resource,
+            params=params,
+            policy_id=policy_id,
+            outcome=outcome,
+            prev_hash=prev_hash,
+            issued_at=_ts(offset),
+        )
+        assert verify_envelope(env) is True  # baseline
+
+        # A distinct valid outcome, timestamp, prev_hash, and pubkey for flips.
+        other_outcome = sorted(OUTCOMES - {env["outcome"]})[0]
+        other_ts = _ts(offset + 1)
+        other_prev = "cd" * 32 if env["prev_hash"] is None else "ab" * 32
+        # Attacker key derived from (and guaranteed distinct from) the signing key.
+        sk_bytes = bytes.fromhex(sk_hex)
+        attacker_hex = bytes([sk_bytes[0] ^ 0xFF, *sk_bytes[1:]]).hex()
+        attacker_pub = _pubkey_hex(attacker_hex)
+        first_key = next(iter(params))
+        mutated_params = {**params, first_key: f"{params[first_key]!r}-tampered"}
+
+        mutations: list[Envelope] = [
+            {**env, "agent_id": env["agent_id"] + "X"},
+            {**env, "action": {**env["action"], "verb": str(env["action"]["verb"]) + "X"}},
+            {**env, "action": {**env["action"], "resource": str(env["action"]["resource"]) + "X"}},
+            {**env, "action": {**env["action"], "params": mutated_params}},
+            {**env, "policy_id": env["policy_id"] + "X"},
+            {**env, "outcome": other_outcome},
+            {**env, "prev_hash": other_prev},
+            {**env, "issued_at": other_ts},
+            {**env, "pubkey": attacker_pub},  # sig no longer matches the key
+            {**env, "sig": str(env["sig"])[:-2]},  # truncated -> wrong length
+            {**env, "sig": str(env["sig"]) + "ab"},  # extended -> wrong length
+            {**env, "sig": "zz" * 64},  # right length, non-hex
+        ]
+        assert attacker_pub != env["pubkey"]  # the swap is a genuine key change
+        for tampered in mutations:
+            assert verify_envelope(tampered) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Chain re-orderability
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def _linked_chain(draw: st.DrawFn) -> tuple[str, str, list[Envelope]]:
+    """Generate a valid N>=1 envelope chain for a single agent (one signing key).
+
+    Each envelope's ``prev_hash`` is the ``envelope_hash`` of its predecessor;
+    distinct resources keep every envelope hash distinct.
+    """
+    sk_hex = draw(_sk_hex)
+    agent = draw(_names)
+    n = draw(st.integers(min_value=1, max_value=6))
+    base = draw(_offsets)
+    envs: list[Envelope] = []
+    prev: str | None = None
+    for i in range(n):
+        env = issue_envelope(
+            sk_hex,
+            agent_id=agent,
+            verb="read",
+            resource=f"doc/{i}",
+            params={"i": i},
+            policy_id=f"rule:{i}",
+            outcome="authorized",
+            prev_hash=prev,
+            issued_at=_ts(base + i),
+        )
+        envs.append(env)
+        prev = envelope_hash(env)
+    return sk_hex, agent, envs
+
+
+class TestChainReorderability:
+    @settings(max_examples=60, deadline=None)
+    @given(built=_linked_chain(), perm_seed=st.integers(min_value=0, max_value=2**31))
+    def test_shuffle_recovers_the_unique_causal_order(
+        self, built: tuple[str, str, list[Envelope]], perm_seed: int
+    ) -> None:
+        """A shuffled valid chain re-orders to exactly one genesis-first sequence."""
+        _sk, _agent, envs = built
+        shuffled = list(envs)
+        random.Random(perm_seed).shuffle(shuffled)
+        ordered = order_chain(shuffled)
+        assert ordered == envs
+        assert order_chain(envs) == envs  # already-ordered is a fixed point
+
+    @settings(max_examples=60, deadline=None)
+    @given(built=_linked_chain())
+    def test_deleting_an_interior_link_is_a_gap(
+        self, built: tuple[str, str, list[Envelope]]
+    ) -> None:
+        """Removing any interior envelope leaves a dangling prev_hash -> ``None``.
+
+        Meaningful only for N>=3 (an interior link must exist); shorter chains
+        assert the intact chain still orders."""
+        _sk, _agent, envs = built
+        if len(envs) < 3:
+            assert order_chain(envs) == envs
+            return
+        for i in range(1, len(envs) - 1):
+            without_interior = [e for j, e in enumerate(envs) if j != i]
+            assert order_chain(without_interior) is None
+
+    @settings(max_examples=60, deadline=None)
+    @given(built=_linked_chain())
+    def test_fork_sharing_a_predecessor_is_rejected(
+        self, built: tuple[str, str, list[Envelope]]
+    ) -> None:
+        """Two envelopes claiming the same predecessor (or two genesis blocks) is
+        never one intact chain."""
+        sk_hex, agent, envs = built
+        if len(envs) >= 2:
+            # A sibling of envs[1]: same prev_hash, different resource -> distinct.
+            fork = issue_envelope(
+                sk_hex,
+                agent_id=agent,
+                verb="read",
+                resource="doc/forked",
+                params={},
+                policy_id="rule:fork",
+                outcome="authorized",
+                prev_hash=envs[1]["prev_hash"],
+                issued_at=_ts(0),
+            )
+        else:
+            # N == 1: a second genesis (prev_hash None) is the multi-genesis fork.
+            fork = issue_envelope(
+                sk_hex,
+                agent_id=agent,
+                verb="read",
+                resource="doc/forked",
+                params={},
+                policy_id="rule:fork",
+                outcome="authorized",
+                prev_hash=None,
+                issued_at=_ts(0),
+            )
+        assert order_chain([*envs, fork]) is None
+
+    @settings(max_examples=60, deadline=None)
+    @given(built=_linked_chain(), other_agent=_names)
+    def test_foreign_agent_splice_is_rejected(
+        self, built: tuple[str, str, list[Envelope]], other_agent: str
+    ) -> None:
+        """An envelope for a *different* agent, however it links, means two agents
+        are present -> not one chain."""
+        sk_hex, agent, envs = built
+        if other_agent == agent:
+            other_agent = agent + "Z"  # force a genuinely foreign identity
+        spliced = issue_envelope(
+            sk_hex,
+            agent_id=other_agent,
+            verb="read",
+            resource="doc/foreign",
+            params={},
+            policy_id="rule:foreign",
+            outcome="authorized",
+            prev_hash=envelope_hash(envs[-1]),
+            issued_at=_ts(0),
+        )
+        assert order_chain([*envs, spliced]) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Policy determinism / first-match-wins / no denied-executes
+# ---------------------------------------------------------------------------
+
+_AGENT_NAMES = ["a1", "a2", "b1"]
+_ROLE_NAMES = ["admin", "auditor"]
+_VERBS = ["read", "write", "pay"]
+_RESOURCES = ["doc/1", "db", "town/hall"]
+
+
+def _pattern(values: list[str]) -> st.SearchStrategy[str]:
+    """A glob over ``values``: ``"*"``, an exact value, or a one-char prefix + ``*``."""
+    return st.one_of(
+        st.just("*"),
+        st.sampled_from(values),
+        st.sampled_from(values).map(lambda v: v[:1] + "*"),
+    )
+
+
+@st.composite
+def _rule(draw: st.DrawFn) -> dict[str, str]:
+    """One policy entry naming exactly one of ``agent`` (glob) or ``role`` (exact)."""
+    if draw(st.booleans()):
+        subject_key, subject = "agent", draw(_pattern(_AGENT_NAMES))
+    else:
+        subject_key, subject = "role", draw(st.sampled_from(_ROLE_NAMES))
+    return {
+        subject_key: subject,
+        "verb": draw(_pattern(_VERBS)),
+        "resource": draw(_pattern(_RESOURCES)),
+        "effect": draw(_outcomes),
+    }
+
+
+_policy = st.lists(_rule(), max_size=6)
+_roles_map = st.dictionaries(
+    st.sampled_from(_AGENT_NAMES), st.sampled_from(_ROLE_NAMES), max_size=3
+)
+
+
+def _oracle(
+    rules: list[dict[str, str]],
+    roles: dict[str, str],
+    default_effect: str,
+    agent: str,
+    verb: str,
+    resource: str,
+) -> tuple[str, str]:
+    """Independent first-match-wins reimplementation, mirroring ``AAEPermitGate._match``."""
+    for i, rule in enumerate(rules):
+        if "agent" in rule:
+            if not fnmatch.fnmatchcase(agent, rule["agent"]):
+                continue
+        elif roles.get(agent) != rule["role"]:
+            continue
+        if fnmatch.fnmatchcase(verb, rule["verb"]) and fnmatch.fnmatchcase(
+            resource, rule["resource"]
+        ):
+            return rule["effect"], f"rule:{i}"
+    return default_effect, "default"
+
+
+class TestPolicyDeterminism:
+    @settings(max_examples=100, deadline=None)
+    @given(
+        policy=_policy,
+        roles=_roles_map,
+        default_effect=_outcomes,
+        agent=st.sampled_from(_AGENT_NAMES),
+        verb=st.sampled_from(_VERBS),
+        resource=st.sampled_from(_RESOURCES),
+    )
+    @pytest.mark.asyncio
+    async def test_first_match_decides_and_is_byte_deterministic(
+        self,
+        policy: list[dict[str, str]],
+        roles: dict[str, str],
+        default_effect: str,
+        agent: str,
+        verb: str,
+        resource: str,
+    ) -> None:
+        """The gate's outcome and policy_id match the independent first-match oracle;
+        ``permits`` is ``True`` iff authorized (so no denied pair ever permits); and
+        two gates with the same seed emit byte-identical envelopes."""
+        exp_effect, exp_pid = _oracle(policy, roles, default_effect, agent, verb, resource)
+
+        def build() -> AAEPermitGate:
+            return AAEPermitGate(
+                policy=policy, roles=roles, default_effect=default_effect, key_seed=b"prop"
+            )
+
+        env = await build().evaluate(AgentId(agent), verb, resource, {}, now=_T0)
+        assert env["outcome"] == exp_effect
+        assert env["policy_id"] == exp_pid
+        assert permits(env) is (exp_effect == "authorized")
+        if exp_effect == "denied":
+            assert permits(env) is False  # no denied (verb, resource) ever permits
+
+        env_twin = await build().evaluate(AgentId(agent), verb, resource, {}, now=_T0)
+        assert json.dumps(env, sort_keys=True) == json.dumps(env_twin, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# 5. Score invariants
+# ---------------------------------------------------------------------------
+
+_MIXED_POLICY = [
+    {"agent": "*", "verb": "read", "resource": "*", "effect": "authorized"},
+    {"agent": "*", "verb": "pay", "resource": "*", "effect": "conditional"},
+    {"agent": "*", "verb": "write", "resource": "*", "effect": "denied"},
+]
+_query = st.tuples(st.sampled_from(_VERBS), st.sampled_from(_RESOURCES))
+
+
+class TestScoreInvariants:
+    @settings(max_examples=60, deadline=None)
+    @given(queries=st.lists(_query, min_size=1, max_size=12))
+    @pytest.mark.asyncio
+    async def test_score_tracks_authorization_rate_and_confidence_is_monotonic(
+        self, queries: list[tuple[str, str]]
+    ) -> None:
+        """After each evaluation, ``score`` equals authorized/total (6 dp) in [0, 1],
+        ``sample_count`` equals total, and ``confidence`` stays in [0, 1] and never
+        decreases as history grows."""
+        gate = AAEPermitGate(policy=_MIXED_POLICY, key_seed=b"score")
+        authorized = 0
+        prev_confidence = -1.0
+        for total, (verb, resource) in enumerate(queries, start=1):
+            env = await gate.evaluate(AgentId("a1"), verb, resource, {}, now=_T0)
+            if env["outcome"] == "authorized":
+                authorized += 1
+            rep = await gate.score(AgentId("a1"))
+            assert rep.sample_count == total
+            assert 0.0 <= rep.score <= 1.0
+            assert rep.score == round(authorized / total, 6)
+            assert 0.0 <= rep.confidence <= 1.0
+            assert rep.confidence == round(min(1.0, total / 10), 6)
+            assert rep.confidence >= prev_confidence
+            prev_confidence = rep.confidence

--- a/scenarios/rogue_trusted_agent.yaml
+++ b/scenarios/rogue_trusted_agent.yaml
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# Rogue-trusted-agent scenario: a veteran resident earns a spotless in-policy
+# record, then reaches for the one action it was never entitled to -- spending
+# the town treasury.
+#
+# Under `trust: aae_permit_gate` (this submission's plugin) every request is
+# decided BEFORE it runs. Reputation is not an input to the verdict: the policy
+# row for `spend town/treasury` is a refusal, so the gate returns a signed
+# `denied` envelope and the action never executes -- the rogue_trusted_agent
+# validator PASSES. Swap to `trust: score_average` (see the comment on the
+# `trust:` line below) and there is no pre-action gate, so the veteran's
+# reputation buys it the treasury: the action executes and the same validator
+# FAILS. That contrast is the whole point.
+name: rogue_trusted_agent
+description: "A high-reputation veteran is refused one out-of-policy action; ordinary residents act only in-policy."
+
+tier: 1
+seed: 42
+
+agents:
+  # 1 veteran + 5 residents = 6
+  count: 6
+  brain: state-machine
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  # The whole point: aae_permit_gate refuses the out-of-policy reach before it
+  # runs. Switch this to `score_average` to watch the rogue action execute and
+  # the rogue_trusted_agent validator fail.
+  trust: aae_permit_gate
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: rogue_trusted_agent
+  config:
+    # How many in-policy actions the veteran performs before its rogue attempt,
+    # and how many each resident performs. Reputation must genuinely accrue.
+    veteran_warmup: 8
+    resident_actions: 3
+    default_role: resident
+    default_effect: denied
+    # Ed25519 signing seed for the permit gate (hex bytes). Deterministic.
+    key_seed: "6e616e64612d726f6775652d746f776e"
+    # The veteran is documented here; every other agent defaults to `resident`.
+    roles:
+      veteran: resident
+    # Deny-by-default policy, first match wins. Residents are authorized for
+    # benign town verbs; the treasury spend is the single explicit refusal.
+    policy:
+      - role: resident
+        verb: read
+        resource: "town/*"
+        effect: authorized
+      - role: resident
+        verb: post
+        resource: "board/*"
+        effect: authorized
+      - role: resident
+        verb: greet
+        resource: "neighbor/*"
+        effect: authorized
+      - role: resident
+        verb: spend
+        resource: "town/treasury"
+        effect: denied
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/rogue_trusted_agent.jsonl


### PR DESCRIPTION
**Layer:** trust · **Persona:** stellarminds-ai

## Motivation

Every trust plugin in the town — the reference `score_average`, EigenTrust variants, receipt-corroborated reputation, all of it — scores what an agent **did**. None of them decide what an agent **may do**. That gap has a name: a well-reputed agent attempting an unauthorized action sails through every post-hoc reputation layer, because reputation is measured *after* the fact and the unauthorized action is exactly the one no prior good behavior should license.

Capability-token work (Problem 04) governs who may *hold* an authority. This plugin governs each *exercise* of it: it evaluates an action before it runs, and — crucially — a denial is a first-class, signed, verifiable receipt rather than a silent absence.

## Design

`aae_permit_gate` issues a **pre-action envelope** for every evaluation. Eight fields: `agent_id`, `action{verb,resource,params}`, `policy_id`, `outcome` (`authorized`|`denied`|`conditional`), `prev_hash` (per-agent causal chain), `issued_at`, `sig` (Ed25519 over the canonical envelope minus `sig`), `pubkey`.

- **Evaluate before acting.** The engine does not intercept actions, so gating is a scenario contract: an agent calls `evaluate(...)` and proceeds only on an authorized envelope. Plugins without an `evaluate` method are consulted as scores, so scenarios stay drop-in (`hasattr` capability-gate — the house pattern).
- **Deny by default.** Unmatched actions are denied; the posture is explicit and documented.
- **Signed denials.** A denied action does not execute, and the denial envelope *is* the receipt — anyone can verify the town refused it, under which policy, when.
- **Per-agent chain.** Each envelope's `prev_hash` points at the agent's previous one; `order_chain` recovers the unique order and rejects gaps, forks, deleted interior links, and foreign-agent splices.
- Self-contained: stdlib + `cryptography` only. Deterministic: every timestamp is supplied by the caller's virtual clock; same seed → byte-identical envelopes.

Registered both ways — `_BUILTINS[("trust","aae_permit_gate")]` and the `nest.plugins.trust` entry point in `nest-plugins-reference/pyproject.toml`.

## Adversarial validator (mandatory)

`rogue_trusted_agent_blocked` catches a high-reputation agent reaching outside its authorization. In the `rogue_trusted_agent` scenario one agent earns a strong reputation through eight in-policy actions, then attempts `spend town/treasury`:

```
exec:veteran:read:town/events                       <- reputation accrued
rogue_attempt:veteran:spend:town/treasury
permit:veteran:spend:town/treasury:denied:84773277  <- signed denial
blocked:veteran:spend:town/treasury                 <- never executes
```

**FAILS against `trust: score_average`** — reputation buys the treasury, the rogue action executes:

```
rogue_attempt:veteran:spend:town/treasury
exec:veteran:spend:town/treasury                    <- rogue action executes
```

**PASSES against `trust: aae_permit_gate`** — refused before it runs. No crash on either trace. A second validator, `rogue_trusted_agent_reputation`, corroborates that the veteran genuinely accrued reputation first and that no in-policy action was ever spuriously denied — so "reputation is irrelevant to the verdict" is grounded in the trace, not asserted.

## How to verify

```
make ci-local                                              # all 5 green
uv run nest run scenarios/rogue_trusted_agent.yaml -o /tmp/b.jsonl
grep -E 'permit:veteran|blocked:veteran' /tmp/b.jsonl      # the signed denial + block
# swap trust: aae_permit_gate -> score_average and rerun:
grep -E 'exec:veteran:spend' /tmp/b.jsonl                  # the rogue action executes
uv run nest plugins list                                   # aae_permit_gate under trust
```

Local: **798 passed** (all 5 `ci-local` steps green). Coverage is example-based + a Hypothesis property battery (round-trip, single-field tamper across all eight fields + key/sig mutations, chain re-orderability with gap/fork/foreign-splice detection, policy first-match determinism with "no denied pair ever permits", score invariants) + named adversarial cases (replay out of sequence, foreign-chain splice, forged-key mid-chain). Byte-identical reruns at fixed seed; the block/execute invariant holds across a 5-seed integration bank.

## Interop with #32 (Agent Action Capsules)

@StevenMih's Agent Action Capsules give the town an anchored ledger of what agents did; this plugin adds the other bookend — signed decisions about what agents may do. The optional adapter (off by default, public `capsule_emit.emit()` API only, no-op when the package is absent) seals each permit into the capsule ledger under a `permit.granted` / `permit.denied` namespace, with the decision object as output — deliberately never the underlying verb, so a permit can never be misread as an executed action. A denial that is anchored is evidence that the gate worked. The two submissions strengthen each other and neither depends on the other to merge. (One friendly API note: an external-reference field on `emit()` would let a permit carry its envelope hash as first-class correlation metadata, so a later execution capsule and its permit read as one story.)

## Persona

StellarMinds.ai, extending its civic role. The Town Notary attests claims; receipt-corroborated reputation (#26) proves what agents *did*; Ed25519 key rotation (#25) keeps identities verifiable over time; and the permit gate governs what agents *may* do. Is, did, is-still, may — the four tenses of an accountable citizen, each a signed artifact.

## Tradeoffs

- **Hash-committed, not key-pinned.** The per-agent chain is bound by `envelope_hash` (which covers the signature and key), not by a registry mapping each agent to a fixed key. Interior tamper, gaps, forks, and foreign splices are all caught structurally; binding an agent to a *stable* key across its chain is the identity layer's job (`ed25519_rotating`), which this gate composes with rather than duplicates. Stated plainly so a reviewer knows exactly where the boundary sits.
- **`conditional` is minimal** — it records "authorized subject to the stated condition params" and is not itself permission; enforcing conditions is left to the caller.
- **`report` is storage-only** for now (evidence a future policy may reference), and **`stake` is a documented parity no-op** — this gate is authorization-based, not stake-based.
- The scenario contract (agents consult the gate) reflects a real property of the engine: there is no action interceptor, so no trust or auth plugin can *force* a denial. The validator proves the contract held over the deterministic trace — the same shape used by the merged receipt work.
