### PR TITLE
[Hackathon] edge: address EMPIC escrow review feedback

### DIFF
--- a/packages/nest-core/nest_core/scenarios_builtin/empic_payments.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/empic_payments.py
@@ -354,7 +354,7 @@ class WeatherConsumerAgent(StateMachineAgent):
             return
 
         if self._mode == "pull":
-            await payments.pay(
+            await payments.open_pull_escrow(
                 self._provider,
                 quote.price,
                 self._ref,

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1691,6 +1691,7 @@ def validate_empic_pubsub_billing_caps(
         result = validate_empic_pubsub_billing_caps(events)[0]
     """
     audit = _empic_audit_events(events)
+    stream_refs: set[str] = set()
     streams: dict[str, tuple[int, int]] = {}
     accepted: dict[str, set[str]] = defaultdict(set)
     released: dict[str, int] = defaultdict(int)
@@ -1702,21 +1703,25 @@ def validate_empic_pubsub_billing_caps(
         if not ref:
             continue
         if event_type == "empic_stream_opened":
+            stream_refs.add(ref)
             rate = _safe_amount(ev.get("rate_per_tick"))
             max_total = _safe_amount(ev.get("max_total") or ev.get("amount"))
             if rate <= 0 or max_total <= 0:
                 violations.append(f"{ref}: invalid stream terms rate={rate} max_total={max_total}")
             else:
                 streams[ref] = (rate, max_total)
-        elif (
+            continue
+
+        is_pubsub_ref = ref in stream_refs or ev.get("mode") == "pubsub"
+        if (
             event_type == "empic_delivery_evaluated"
             and ev.get("accepted") is True
-            and ev.get("mode") == "pubsub"
+            and is_pubsub_ref
         ):
             delivery_id = _empic_delivery_id(ev)
             if delivery_id:
                 accepted[ref].add(delivery_id)
-        elif event_type == "empic_escrow_released" and ev.get("mode") == "pubsub":
+        elif event_type == "empic_escrow_released" and is_pubsub_ref:
             amount = _safe_amount(ev.get("amount"))
             delivery_id = _empic_delivery_id(ev)
             terms = streams.get(ref)
@@ -2150,7 +2155,7 @@ def validate_empic_no_drain_after_close(
                 close_tick[ref] = _event_tick(ev)
 
     for ev in audit:
-        if ev.get("event_type") != "empic_escrow_released" or ev.get("mode") != "pubsub":
+        if ev.get("event_type") != "empic_escrow_released":
             continue
         ref = str(ev.get("payment_ref", ""))
         closed_at = close_tick.get(ref)
@@ -2204,7 +2209,7 @@ def validate_empic_no_overbill_on_partition(
                 partition_start[edge] = tick
 
     for ev in audit:
-        if ev.get("event_type") != "empic_escrow_released" or ev.get("mode") != "pubsub":
+        if ev.get("event_type") != "empic_escrow_released":
             continue
         ref = str(ev.get("payment_ref", ""))
         parties = stream_parties.get(ref)

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -1349,6 +1349,92 @@ class TestEmpicPaymentsValidators:
         assert not results[0].passed
         assert "release 20 > rate 10" in results[0].detail
 
+    def test_pubsub_billing_caps_fails_over_rate_without_release_mode(self) -> None:
+        """Pubsub cap enforcement is based on stream state, not release self-report."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_stream_opened",
+                    "payment_ref": "s1",
+                    "rate_per_tick": 10,
+                    "max_total": 40,
+                    "mode": "pubsub",
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "s1",
+                    "delivery_id": "d1",
+                    "accepted": True,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "s1",
+                    "delivery_id": "d1",
+                    "amount": 20,
+                }
+            ),
+        ]
+
+        results = validate_empic_pubsub_billing_caps(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "release 20 > rate 10" in results[0].detail
+
+    def test_pubsub_billing_caps_fails_over_total_without_release_mode(self) -> None:
+        """Omitting mode on release events cannot bypass the stream total cap."""
+        events = [
+            _empic(
+                {
+                    "event_type": "empic_stream_opened",
+                    "payment_ref": "s1",
+                    "rate_per_tick": 10,
+                    "max_total": 10,
+                    "mode": "pubsub",
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "s1",
+                    "delivery_id": "d1",
+                    "accepted": True,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_delivery_evaluated",
+                    "payment_ref": "s1",
+                    "delivery_id": "d2",
+                    "accepted": True,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "s1",
+                    "delivery_id": "d1",
+                    "amount": 10,
+                }
+            ),
+            _empic(
+                {
+                    "event_type": "empic_escrow_released",
+                    "payment_ref": "s1",
+                    "delivery_id": "d2",
+                    "amount": 10,
+                }
+            ),
+        ]
+
+        results = validate_empic_pubsub_billing_caps(events)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert "released 20 > max_total 10" in results[0].detail
+
     def test_pubsub_billing_caps_fails_without_accepted_evidence(self) -> None:
         """Accepted delivery count limits total pubsub payout."""
         events = [

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/empic_escrow.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/empic_escrow.py
@@ -13,7 +13,7 @@ Example::
         provider=AgentId("provider"),
         price=Money(amount=50),
     )
-    await payments.pay(AgentId("provider"), Money(amount=50), PaymentRef("p1"))
+    await payments.open_pull_escrow(AgentId("provider"), Money(amount=50), PaymentRef("p1"))
     await payments.fulfill(PaymentRef("p1"))
 """
 
@@ -132,7 +132,9 @@ class EMPICPaymentRecord:
 class EMPICEscrowPayments:
     """Deterministic EMPIC-shaped payment adapter for Nanda Town.
 
-    Pull payments escrow funds until a consumer accepts provider data and calls
+    Plain ``pay`` follows the generic Nanda Town ``Payments`` contract and
+    confirms immediately. EMPIC pull escrows use ``open_pull_escrow`` and
+    release funds only after a consumer accepts provider data and calls
     ``fulfill``. Pubsub streams pre-fund a maximum amount, release one tick of
     payment for each accepted delivery, and refund unused escrow on close.
 
@@ -141,7 +143,7 @@ class EMPICEscrowPayments:
         pay = EMPICEscrowPayments(AgentId("buyer"), initial_balance=1000)
         receipt = await pay.pay(AgentId("seller"), Money(amount=25), PaymentRef("p1"))
         assert receipt.amount.amount == 25
-        assert await pay.verify_payment(PaymentRef("p1")) is PaymentStatus.PENDING
+        assert await pay.verify_payment(PaymentRef("p1")) is PaymentStatus.CONFIRMED
     """
 
     def __init__(
@@ -247,14 +249,56 @@ class EMPICEscrowPayments:
         *,
         service_id: ServiceRef | None = None,
     ) -> Receipt:
-        """Create a pull escrow payment to a provider.
+        """Execute a generic immediate payment.
+
+        When ``service_id`` is provided, this delegates to ``open_pull_escrow``
+        for backwards-compatible EMPIC scenario support. Generic callers that
+        use only the ``Payments`` protocol receive immediate settlement.
+
+        Example::
+
+            await payments.pay(
+                AgentId("provider"),
+                Money(amount=50),
+                PaymentRef("pull-1"),
+            )
+        """
+        if service_id is not None:
+            return await self.open_pull_escrow(to, amount, ref, service_id=service_id)
+
+        self._validate_new_payment(to, amount.amount, ref)
+        self._move(self._agent_id, to, amount.amount)
+        record = EMPICPaymentRecord(
+            ref=ref,
+            payer=self._agent_id,
+            payee=to,
+            amount=amount,
+            mode="pull",
+            status=PaymentStatus.CONFIRMED,
+            escrow_id=f"generic:{ref}",
+            max_total=amount.amount,
+            released=amount.amount,
+            metadata={"settlement": "immediate"},
+        )
+        self._payments[ref] = record
+        return Receipt(ref=ref, payer=self._agent_id, payee=to, amount=amount)
+
+    async def open_pull_escrow(
+        self,
+        to: AgentId,
+        amount: Money,
+        ref: PaymentRef,
+        *,
+        service_id: ServiceRef | None = None,
+    ) -> Receipt:
+        """Create an EMPIC pull escrow payment to a provider.
 
         The payer's balance moves into the escrow account. Provider credit only
         happens after ``fulfill``.
 
         Example::
 
-            await payments.pay(
+            await payments.open_pull_escrow(
                 AgentId("provider"),
                 Money(amount=50),
                 PaymentRef("pull-1"),

--- a/packages/nest-plugins-reference/tests/test_empic_escrow_payments.py
+++ b/packages/nest-plugins-reference/tests/test_empic_escrow_payments.py
@@ -19,11 +19,28 @@ def payments() -> EMPICEscrowPayments:
 
 
 @pytest.mark.asyncio
+async def test_generic_pay_confirms_immediately(payments: EMPICEscrowPayments) -> None:
+    """Plain Payments.pay follows the generic immediate-settlement contract."""
+    receipt = await payments.pay(AgentId("provider"), Money(amount=50), PaymentRef("generic-1"))
+
+    assert receipt.amount.amount == 50
+    assert payments.balance(AgentId("consumer")) == 950
+    assert payments.balance(ESCROW_AGENT) == 0
+    assert payments.balance(AgentId("provider")) == 50
+    assert await payments.verify_payment(PaymentRef("generic-1")) is PaymentStatus.CONFIRMED
+
+
+@pytest.mark.asyncio
 async def test_pull_escrow_fulfills_after_accepted_delivery(
     payments: EMPICEscrowPayments,
 ) -> None:
     """Pull escrow releases funds only after accepted delivery evidence."""
-    await payments.pay(AgentId("provider"), Money(amount=50), PaymentRef("pull-1"))
+    await payments.open_pull_escrow(
+        AgentId("provider"),
+        Money(amount=50),
+        PaymentRef("pull-1"),
+        service_id=ServiceRef("weather"),
+    )
 
     assert payments.balance(AgentId("consumer")) == 950
     assert payments.balance(ESCROW_AGENT) == 50
@@ -51,7 +68,12 @@ async def test_pull_escrow_fulfills_after_accepted_delivery(
 @pytest.mark.asyncio
 async def test_pull_escrow_reject_refunds_consumer(payments: EMPICEscrowPayments) -> None:
     """Rejected pull delivery returns escrow to the consumer."""
-    await payments.pay(AgentId("provider"), Money(amount=50), PaymentRef("pull-1"))
+    await payments.open_pull_escrow(
+        AgentId("provider"),
+        Money(amount=50),
+        PaymentRef("pull-1"),
+        service_id=ServiceRef("weather"),
+    )
     payments.record_delivery(
         PaymentRef("pull-1"),
         delivery_id="d1",
@@ -76,7 +98,7 @@ async def test_pull_fulfill_rejects_mismatched_delivery(
     payments: EMPICEscrowPayments,
 ) -> None:
     """Accepted evidence must match the escrow payee and service."""
-    await payments.pay(
+    await payments.open_pull_escrow(
         AgentId("provider"),
         Money(amount=50),
         PaymentRef("pull-1"),
@@ -201,7 +223,7 @@ async def test_close_stream_refunds_unused_escrow(payments: EMPICEscrowPayments)
 @pytest.mark.asyncio
 async def test_duplicate_refs_and_insufficient_balance(payments: EMPICEscrowPayments) -> None:
     """Duplicate references and over-budget escrow are rejected."""
-    await payments.pay(AgentId("provider"), Money(amount=50), PaymentRef("pull-1"))
+    await payments.open_pull_escrow(AgentId("provider"), Money(amount=50), PaymentRef("pull-1"))
 
     with pytest.raises(ValueError, match="Duplicate"):
         await payments.open_stream(


### PR DESCRIPTION
## Summary

Follow-up to #41 addressing Skyrider3's review feedback on EMPIC Step 1 escrow behavior.

This PR keeps the change narrowly scoped to the deterministic EMPIC payments plugin, scenario, validators, and tests.

## Changes

- Harden pubsub billing validators so per-tick and max-total caps are enforced from stream lifecycle state rather than trusting a release event's self-reported mode field.
- Add regression coverage showing omitted release mode values no longer bypass pubsub rate-cap or max-total checks.
- Restore generic Payments.pay compatibility for EMPICEscrowPayments: plain pay() now settles immediately and verifies as CONFIRMED.
- Keep EMPIC pull escrow semantics behind explicit open_pull_escrow().
- Update the EMPIC scenario and tests to use open_pull_escrow() where pending escrow plus fulfill/refund behavior is intended.

## Verification

uv run pytest packages/nest-plugins-reference/tests/test_empic_escrow_payments.py packages/nest-core/tests/test_validators.py -q

Result: 124 passed.
