### PR TITLE
[Hackathon] theodornengoy (security-engineer): strict holder-derived capability delegation

### DIFF
--- a/docs/layers/auth.md
+++ b/docs/layers/auth.md
@@ -42,6 +42,29 @@ Source: [`nest_plugins_reference/auth/delegatable.py`](../../packages/nest-plugi
 Validators: [`nest_plugins_reference/validators/delegation_validators.py`](../../packages/nest-plugins-reference/nest_plugins_reference/validators/delegation_validators.py).
 Scenario: [`scenarios/delegated_auth.yaml`](../../scenarios/delegated_auth.yaml).
 
+## Strict holder-derived variant: `delegatable_strict`
+
+`delegatable_strict` coexists with the baseline `delegatable` plugin while
+making three additional choices load-bearing: every child must remove at
+least one parent scope, child-signing keys are derived from the parent token's
+signature and hash rather than the issuer secret, and the public-API validator
+crafts a direct parent-signature key-confusion forgery.
+
+The base protocol's `verify(token)` call authenticates a valid child as a
+bearer token. Call `verify_for(token, presenter)` when the caller must also
+enforce that the presenter matches the child's audience. `AuthContext.subject`
+therefore identifies the holder/audience; the token's `sub` claim retains the
+original delegator.
+
+The validator records the exception type for every rejected attack so a typed
+security rejection remains distinguishable from an unrelated plugin crash.
+The deterministic `strict_delegated_auth` scenario preserves the requested
+1 coordinator, 3 intermediary, and 12 leaf topology.
+
+Source: [`nest_plugins_reference/auth/strict_delegatable.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/strict_delegatable.py).
+Validator: [`nest_plugins_reference/validators/strict_delegation_validators.py`](../../packages/nest-plugins-reference/nest_plugins_reference/validators/strict_delegation_validators.py).
+Scenario: [`scenarios/strict_delegated_auth.yaml`](../../scenarios/strict_delegated_auth.yaml).
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -27,6 +27,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
+    ("auth", "delegatable_strict"): (f"{_REF}.auth.strict_delegatable:StrictDelegatableAuth"),
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -131,6 +131,12 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.delegated_auth import delegated_auth_factory
 
         register_scenario("delegated_auth", delegated_auth_factory)
+    elif name == "strict_delegated_auth":
+        from nest_core.scenarios_builtin.strict_delegated_auth import (
+            strict_delegated_auth_factory,
+        )
+
+        register_scenario("strict_delegated_auth", strict_delegated_auth_factory)
     elif name == "multi_attribute_market":
         from nest_core.scenarios_builtin.multi_attribute_market import (
             multi_attribute_market_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/strict_delegated_auth.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/strict_delegated_auth.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Strict delegated-auth scenario -- coordinator, intermediaries, and leaves.
+
+The factory builds the exact problem-04 topology: one coordinator mints
+strict child capabilities for three intermediaries, each intermediary mints
+four narrower leaf capabilities, and leaves verify their audience-bound
+tokens before acknowledging the coordinator.  The coordinator also runs the
+three adversarial checks from the problem statement so the trace proves the
+scenario exercised the auth plugin instead of merely booting.
+
+Example::
+
+    agents = strict_delegated_auth_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Token
+
+_ROOT_SCOPES = [
+    "orders:read",
+    "orders:write",
+    "orders:approve",
+    "orders:audit",
+    "orders:export",
+]
+_INTERMEDIARY_SCOPES = [
+    ["orders:read", "orders:write", "orders:audit"],
+    ["orders:read", "orders:approve", "orders:audit"],
+    ["orders:read", "orders:export", "orders:audit"],
+]
+_LEAF_SCOPES = ["orders:read"]
+
+
+class _DelegationState:
+    """Shared in-memory grant table used by the deterministic scenario.
+
+    Example::
+
+        state = _DelegationState()
+        state.tokens[AgentId("worker")] = token
+    """
+
+    def __init__(self) -> None:
+        self.tokens: dict[AgentId, Token] = {}
+
+
+class CoordinatorAgent(StateMachineAgent):
+    """Root capability holder that delegates to intermediaries.
+
+    Example::
+
+        agent = CoordinatorAgent(AgentId("coordinator"), intermediaries, leaves, state)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        intermediaries: list[AgentId],
+        leaves_by_intermediary: dict[AgentId, list[AgentId]],
+        state: _DelegationState,
+    ) -> None:
+        self._id = agent_id
+        self._intermediaries = intermediaries
+        self._leaves_by_intermediary = leaves_by_intermediary
+        self._state = state
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Issue a root token, delegate intermediary grants, and run attacks.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        auth = ctx.plugins["auth"]
+        root = await auth.issue(self._id, list(_ROOT_SCOPES))
+        self._state.tokens[self._id] = root
+
+        await self._run_attack_suite(ctx, auth)
+
+        for idx, intermediary in enumerate(self._intermediaries):
+            grant = await auth.delegate(
+                root,
+                intermediary,
+                list(_INTERMEDIARY_SCOPES[idx]),
+                ttl=300.0,
+            )
+            self._state.tokens[intermediary] = grant
+            leaves = ",".join(str(leaf) for leaf in self._leaves_by_intermediary[intermediary])
+            await ctx.send(
+                intermediary,
+                f"grant:intermediary:{intermediary}:leaves={leaves}".encode(),
+            )
+
+    async def _run_attack_suite(self, ctx: AgentContext, auth: Any) -> None:
+        """Emit trace-visible attack-check outcomes.
+
+        Example::
+
+            await agent._run_attack_suite(ctx, auth)
+        """
+        parent = await auth.issue(AgentId("attack-coordinator"), ["read", "write"])
+        try:
+            await auth.delegate(parent, AgentId("attacker"), ["read", "admin"], ttl=60.0)
+        except Exception:
+            await ctx.send(self._intermediaries[0], b"attack:scope_escalation:blocked")
+        else:
+            await ctx.send(self._intermediaries[0], b"attack:scope_escalation:allowed")
+
+        stale_parent = await auth.issue(AgentId("stale-coordinator"), ["docs:read", "docs:write"])
+        stale_child = await auth.delegate(
+            stale_parent, AgentId("stale-worker"), ["docs:read"], 60.0
+        )
+        await auth.revoke(stale_parent)
+        try:
+            await auth.verify(stale_child)
+        except Exception:
+            await ctx.send(self._intermediaries[1], b"attack:stale_parent:blocked")
+        else:
+            await ctx.send(self._intermediaries[1], b"attack:stale_parent:allowed")
+
+        audience_parent = await auth.issue(
+            AgentId("aud-coordinator"), ["files:read", "files:write"]
+        )
+        audience_child = await auth.delegate(
+            audience_parent,
+            AgentId("aud-worker"),
+            ["files:read"],
+            60.0,
+        )
+        try:
+            await auth.verify_for(audience_child, AgentId("wrong-worker"))
+        except Exception:
+            await ctx.send(self._intermediaries[2], b"attack:audience_confusion:blocked")
+        else:
+            await ctx.send(self._intermediaries[2], b"attack:audience_confusion:allowed")
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Receive leaf acknowledgements for trace completeness.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("leaf-0"), b"ack")
+        """
+        if payload.startswith(b"leaf:verified:"):
+            await ctx.send(sender, b"coordinator:ack")
+
+
+class IntermediaryAgent(StateMachineAgent):
+    """Intermediate capability holder that delegates to four leaves.
+
+    Example::
+
+        agent = IntermediaryAgent(AgentId("intermediary-0"), leaves, state)
+    """
+
+    def __init__(self, agent_id: AgentId, leaves: list[AgentId], state: _DelegationState) -> None:
+        self._id = agent_id
+        self._leaves = leaves
+        self._state = state
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Delegate leaf grants after the coordinator grant arrives.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("coordinator"), b"grant")
+        """
+        if not payload.startswith(b"grant:intermediary:"):
+            return
+        auth = ctx.plugins["auth"]
+        parent = self._state.tokens[self._id]
+        for leaf in self._leaves:
+            grant = await auth.delegate(parent, leaf, list(_LEAF_SCOPES), ttl=120.0)
+            self._state.tokens[leaf] = grant
+            await ctx.send(leaf, f"grant:leaf:{leaf}:from={self._id}".encode())
+        await ctx.send(
+            sender, f"intermediary:delegated:{self._id}:count={len(self._leaves)}".encode()
+        )
+
+
+class LeafAgent(StateMachineAgent):
+    """Leaf agent that verifies its audience-bound child capability.
+
+    Example::
+
+        agent = LeafAgent(AgentId("leaf-0"), AgentId("coordinator"), state)
+    """
+
+    def __init__(self, agent_id: AgentId, coordinator: AgentId, state: _DelegationState) -> None:
+        self._id = agent_id
+        self._coordinator = coordinator
+        self._state = state
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Verify the received grant and acknowledge the coordinator.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("intermediary-0"), b"grant")
+        """
+        if not payload.startswith(b"grant:leaf:"):
+            return
+        auth = ctx.plugins["auth"]
+        token = self._state.tokens[self._id]
+        ctx_auth = await auth.verify_for(token, self._id)
+        scopes = ",".join(ctx_auth.scopes)
+        await ctx.send(
+            self._coordinator,
+            f"leaf:verified:{self._id}:via={sender}:scopes={scopes}".encode(),
+        )
+
+
+def strict_delegated_auth_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create the problem-04 delegated-auth scenario agents.
+
+    Example::
+
+        agents = strict_delegated_auth_factory(config, plugins)
+    """
+    auth_cls = plugins.get("auth")
+    if isinstance(auth_cls, type):
+        try:
+            plugins["auth"] = auth_cls(clock=0.0)
+        except TypeError:
+            plugins["auth"] = auth_cls()
+
+    coordinator = AgentId("coordinator")
+    intermediary_count, leaf_count = _role_counts(config)
+    intermediaries = [AgentId(f"intermediary-{idx}") for idx in range(intermediary_count)]
+    leaves = [AgentId(f"leaf-{idx}") for idx in range(leaf_count)]
+    leaves_by_intermediary = {
+        intermediary: leaves[idx * 4 : (idx + 1) * 4]
+        for idx, intermediary in enumerate(intermediaries)
+    }
+    state = _DelegationState()
+
+    agents: dict[AgentId, StateMachineAgent] = {
+        coordinator: CoordinatorAgent(coordinator, intermediaries, leaves_by_intermediary, state),
+    }
+    for intermediary in intermediaries:
+        agents[intermediary] = IntermediaryAgent(
+            intermediary,
+            leaves_by_intermediary[intermediary],
+            state,
+        )
+    for leaf in leaves:
+        agents[leaf] = LeafAgent(leaf, coordinator, state)
+    return agents
+
+
+def _role_counts(config: ScenarioConfig) -> tuple[int, int]:
+    counts = {role.name: role.count for role in config.agents.roles}
+    intermediary_count = counts.get("intermediary", 3)
+    leaf_count = counts.get("leaf", 12)
+    if counts.get("coordinator", 1) != 1:
+        msg = "strict_delegated_auth scenario requires exactly one coordinator"
+        raise ValueError(msg)
+    if intermediary_count != 3 or leaf_count != 12:
+        msg = "strict_delegated_auth scenario requires 3 intermediaries and 12 leaves"
+        raise ValueError(msg)
+    return intermediary_count, leaf_count

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/strict_delegatable.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/strict_delegatable.py
@@ -1,0 +1,412 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Strict delegatable capability-token auth with cascading revocation.
+
+The reference ``jwt`` auth plugin issues independent bearer tokens.  This
+plugin models a common multi-agent pattern instead: an orchestrator holds a
+root capability, attenuates it into a narrower child capability for a worker,
+and can revoke the parent to invalidate the whole subtree.
+
+Example::
+
+    auth = StrictDelegatableAuth(secret=b"demo", clock=1000.0)
+    root = await auth.issue(AgentId("coordinator"), ["read", "write"])
+    child = await auth.delegate(root, AgentId("worker-1"), ["read"], ttl=60)
+    ctx = await auth.verify_for(child, AgentId("worker-1"))
+    assert ctx.scopes == ["read"]
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any, cast
+
+from nest_core.types import AgentId, AuthContext, Token
+
+_TOKEN_SIGN_DOMAIN = b"nest.delegatable-strict.token.v1|"
+_CHILD_KEY_DOMAIN = b"nest.delegatable-strict.child-key.v1|"
+
+
+class DelegationError(ValueError):
+    """Base class for failures raised by ``StrictDelegatableAuth``.
+
+    Example::
+
+        raise DelegationError("invalid delegated token")
+    """
+
+
+class ScopeEscalationError(DelegationError):
+    """Raised when a child token asks for scopes outside its parent.
+
+    Example::
+
+        raise ScopeEscalationError("child scopes must be a strict subset")
+    """
+
+
+class RevokedAncestorError(DelegationError):
+    """Raised when a token verifies only because an ancestor was ignored.
+
+    Example::
+
+        raise RevokedAncestorError("ancestor token has been revoked")
+    """
+
+
+class ExpiredAncestorError(DelegationError):
+    """Raised when a child token outlives an ancestor token.
+
+    Example::
+
+        raise ExpiredAncestorError("ancestor token has expired")
+    """
+
+
+class AudienceMismatchError(DelegationError):
+    """Raised when a token is presented by an agent outside its audience.
+
+    Example::
+
+        raise AudienceMismatchError("token audience is worker-1, not worker-2")
+    """
+
+
+@dataclass(frozen=True)
+class _Claims:
+    token_id: str
+    subject: AgentId
+    audience: AgentId
+    scopes: tuple[str, ...]
+    issued_at: float
+    expires_at: float
+    parent_hash: str | None
+
+
+@dataclass(frozen=True)
+class _ParsedToken:
+    raw: str
+    payload_b64: str
+    signature: str
+    claims: _Claims
+
+
+class StrictDelegatableAuth:
+    """Auth plugin with strict child attenuation and revocation trees.
+
+    Tokens remain opaque ``Token`` strings to satisfy the base ``Auth``
+    protocol.  Delegation is the one extra API: ``delegate(parent, audience,
+    scopes_subset, ttl)``.  Child signatures are derived from the parent
+    token's signature and hash, so the child is attenuated from the parent
+    capability rather than re-signed with the issuer root secret.  Verification
+    walks the in-process ancestor chain, checks every signature, and rejects
+    the child if any ancestor is revoked or expired.
+
+    Example::
+
+        auth = StrictDelegatableAuth(secret=b"secret", clock=10.0)
+        parent = await auth.issue(AgentId("root"), ["orders:read", "orders:write"])
+        child = await auth.delegate(parent, AgentId("worker"), ["orders:read"], ttl=5)
+        assert (await auth.verify(child)).subject == AgentId("worker")
+    """
+
+    def __init__(
+        self,
+        secret: bytes = b"nest-delegatable-strict-secret",
+        clock: float | Callable[[], float] | None = None,
+    ) -> None:
+        self._secret = secret
+        self._clock = clock
+        self._counter = 0
+        self._issued_tokens: dict[str, Token] = {}
+        self._revoked_hashes: set[str] = set()
+
+    def _now(self) -> float:
+        if callable(self._clock):
+            return float(self._clock())
+        if self._clock is not None:
+            return float(self._clock)
+        return time.time()
+
+    def _next_token_id(
+        self,
+        subject: AgentId,
+        audience: AgentId,
+        scopes: Iterable[str],
+        parent_hash: str | None,
+        issued_at: float,
+    ) -> str:
+        self._counter += 1
+        material = json.dumps(
+            {
+                "aud": str(audience),
+                "counter": self._counter,
+                "iat": issued_at,
+                "parent": parent_hash,
+                "scopes": list(scopes),
+                "sub": str(subject),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(material.encode()).hexdigest()[:32]
+
+    @staticmethod
+    def _b64_json(data: dict[str, Any]) -> str:
+        raw = json.dumps(data, sort_keys=True, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    @staticmethod
+    def _json_from_b64(data: str) -> dict[str, Any]:
+        try:
+            padded = data + "=" * (-len(data) % 4)
+            raw = base64.urlsafe_b64decode(padded.encode())
+            decoded = json.loads(raw)
+        except (binascii.Error, json.JSONDecodeError, UnicodeDecodeError) as exc:
+            msg = "Invalid token payload"
+            raise DelegationError(msg) from exc
+        if not isinstance(decoded, dict):
+            msg = "Invalid token payload"
+            raise DelegationError(msg)
+        return cast("dict[str, Any]", decoded)
+
+    def _signing_key(self, parent_hash: str | None) -> bytes:
+        if parent_hash is None:
+            return self._secret
+        parent_token = self._issued_tokens.get(parent_hash)
+        if parent_token is None:
+            msg = "Ancestor token is unknown"
+            raise RevokedAncestorError(msg)
+        _, parent_signature = str(parent_token).rsplit(".", 1)
+        return hmac.new(
+            parent_signature.encode(),
+            _CHILD_KEY_DOMAIN + parent_hash.encode(),
+            hashlib.sha256,
+        ).digest()
+
+    def _sign(self, payload_b64: str, parent_hash: str | None) -> str:
+        key = self._signing_key(parent_hash)
+        return hmac.new(
+            key,
+            _TOKEN_SIGN_DOMAIN + payload_b64.encode(),
+            hashlib.sha256,
+        ).hexdigest()
+
+    @staticmethod
+    def _token_hash(token: Token | str) -> str:
+        return hashlib.sha256(str(token).encode()).hexdigest()
+
+    def _make_token(
+        self,
+        *,
+        subject: AgentId,
+        audience: AgentId,
+        scopes: list[str],
+        ttl: float,
+        parent_hash: str | None,
+    ) -> Token:
+        issued_at = self._now()
+        expires_at = issued_at + ttl
+        token_id = self._next_token_id(subject, audience, scopes, parent_hash, issued_at)
+        payload = {
+            "aud": str(audience),
+            "exp": expires_at,
+            "iat": issued_at,
+            "jti": token_id,
+            "parent": parent_hash,
+            "scopes": scopes,
+            "sub": str(subject),
+        }
+        payload_b64 = self._b64_json(payload)
+        signature = self._sign(payload_b64, parent_hash)
+        token = Token(f"{payload_b64}.{signature}")
+        self._issued_tokens[self._token_hash(token)] = token
+        return token
+
+    def _parse(self, token: Token) -> _ParsedToken:
+        raw = str(token)
+        parts = raw.rsplit(".", 1)
+        if len(parts) != 2:
+            msg = "Invalid token format"
+            raise DelegationError(msg)
+        payload_b64, signature = parts
+        data = self._json_from_b64(payload_b64)
+        parent_hash = data.get("parent")
+        if parent_hash is not None and not isinstance(parent_hash, str):
+            msg = "Invalid parent hash"
+            raise DelegationError(msg)
+        expected = self._sign(payload_b64, parent_hash)
+        try:
+            signature_matches = hmac.compare_digest(signature, expected)
+        except TypeError as exc:
+            msg = "Invalid token signature"
+            raise DelegationError(msg) from exc
+        if not signature_matches:
+            msg = "Invalid token signature"
+            raise DelegationError(msg)
+
+        scopes_obj = data.get("scopes")
+        if not isinstance(scopes_obj, list):
+            msg = "Invalid scope list"
+            raise DelegationError(msg)
+        scopes_raw = cast("list[object]", scopes_obj)
+        if not all(isinstance(scope, str) for scope in scopes_raw):
+            msg = "Invalid scope list"
+            raise DelegationError(msg)
+        scopes = cast("list[str]", scopes_raw)
+        try:
+            claims = _Claims(
+                token_id=str(data["jti"]),
+                subject=AgentId(str(data["sub"])),
+                audience=AgentId(str(data["aud"])),
+                scopes=tuple(scopes),
+                issued_at=float(data["iat"]),
+                expires_at=float(data["exp"]),
+                parent_hash=parent_hash,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            msg = "Invalid token claims"
+            raise DelegationError(msg) from exc
+        return _ParsedToken(raw=raw, payload_b64=payload_b64, signature=signature, claims=claims)
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Issue a root token for ``subject``.
+
+        Example::
+
+            token = await auth.issue(AgentId("coordinator"), ["read", "write"])
+        """
+        return self._make_token(
+            subject=subject,
+            audience=subject,
+            scopes=list(scopes),
+            ttl=3600.0,
+            parent_hash=None,
+        )
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token:
+        """Mint a child token from ``parent_token`` without central re-issuance.
+
+        ``scopes_subset`` must be a strict subset of the parent's scopes and
+        ``ttl`` must not outlive the parent.
+
+        Example::
+
+            child = await auth.delegate(parent, AgentId("worker"), ["read"], ttl=30)
+        """
+        parent_ctx = await self.verify(parent_token)
+        parent_hash = self._token_hash(parent_token)
+        self._issued_tokens.setdefault(parent_hash, parent_token)
+        requested = list(scopes_subset)
+        parent_scopes = set(parent_ctx.scopes)
+        requested_scopes = set(requested)
+        if not requested_scopes or not requested_scopes < parent_scopes:
+            msg = "Child scopes must be a non-empty strict subset of parent scopes"
+            raise ScopeEscalationError(msg)
+        if parent_ctx.expires_at is None:
+            msg = "Parent token has no expiry"
+            raise DelegationError(msg)
+        remaining = parent_ctx.expires_at - self._now()
+        if ttl <= 0 or ttl > remaining:
+            msg = "Child TTL must be positive and no longer than parent TTL"
+            raise DelegationError(msg)
+        return self._make_token(
+            subject=parent_ctx.subject,
+            audience=audience,
+            scopes=requested,
+            ttl=ttl,
+            parent_hash=parent_hash,
+        )
+
+    async def verify(self, token: Token) -> AuthContext:
+        """Verify ``token`` and reject stale delegated descendants.
+
+        This base-protocol method treats a valid child as a bearer token.
+        Call :meth:`verify_for` when the presenter must match its audience.
+
+        Example::
+
+            ctx = await auth.verify(child)
+            assert ctx.subject == AgentId("worker")
+        """
+        parsed = self._parse(token)
+        self._verify_ancestor_chain(parsed)
+        claims = parsed.claims
+        return AuthContext(
+            # AuthContext.subject is the holder/audience. The ``sub`` claim
+            # remains the original delegator for ancestry inspection.
+            subject=claims.audience,
+            scopes=list(claims.scopes),
+            issued_at=claims.issued_at,
+            expires_at=claims.expires_at,
+        )
+
+    async def verify_for(self, token: Token, presenter: AgentId) -> AuthContext:
+        """Verify ``token`` as presented by ``presenter``.
+
+        Example::
+
+            await auth.verify_for(child, AgentId("worker-1"))
+        """
+        ctx = await self.verify(token)
+        if ctx.subject != presenter:
+            msg = f"Token audience is {ctx.subject}, not {presenter}"
+            raise AudienceMismatchError(msg)
+        return ctx
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke ``token`` and therefore every delegated descendant.
+
+        Example::
+
+            await auth.revoke(parent)
+        """
+        self._revoked_hashes.add(self._token_hash(token))
+
+    def _verify_ancestor_chain(self, parsed: _ParsedToken) -> None:
+        now = self._now()
+        current = parsed
+        current_hash = self._token_hash(current.raw)
+        first = True
+        while True:
+            if current_hash in self._revoked_hashes:
+                if first:
+                    msg = "Token has been revoked"
+                    raise DelegationError(msg)
+                msg = "Ancestor token has been revoked"
+                raise RevokedAncestorError(msg)
+            if current.claims.expires_at < now:
+                if first:
+                    msg = "Token has expired"
+                    raise DelegationError(msg)
+                msg = "Ancestor token has expired"
+                raise ExpiredAncestorError(msg)
+            parent_hash = current.claims.parent_hash
+            if parent_hash is None:
+                return
+            parent_token = self._issued_tokens.get(parent_hash)
+            if parent_token is None:
+                msg = "Ancestor token is unknown"
+                raise RevokedAncestorError(msg)
+            parent = self._parse(parent_token)
+            if not set(current.claims.scopes) < set(parent.claims.scopes):
+                msg = "Child scopes are not a strict subset of parent scopes"
+                raise ScopeEscalationError(msg)
+            if current.claims.expires_at > parent.claims.expires_at:
+                msg = "Child token outlives parent token"
+                raise ExpiredAncestorError(msg)
+            current = parent
+            current_hash = parent_hash
+            first = False

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -36,6 +36,10 @@ from nest_plugins_reference.validators.privacy_validators import (
     check_stale_revocation_blocked,
     corrupt_proof,
 )
+from nest_plugins_reference.validators.strict_delegation_validators import (
+    check_strict_delegated_auth_attack_suite,
+    materialize_strict_delegation_report,
+)
 from nest_plugins_reference.validators.trust_gate_validators import (
     check_denial_receipt_auditable,
     check_gate_tamper_rejected,
@@ -61,7 +65,9 @@ __all__ = [
     "check_partial_redaction_enforced",
     "check_replay_rejected",
     "check_stale_revocation_blocked",
+    "check_strict_delegated_auth_attack_suite",
     "corrupt_proof",
     "extract_delegation_audits",
     "forge_tier_upgrade",
+    "materialize_strict_delegation_report",
 ]

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/strict_delegation_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/strict_delegation_validators.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for strict delegated auth capability tokens.
+
+The default ``jwt`` auth plugin can issue and revoke bearer tokens, but it
+cannot model parent-issued child capabilities.  These validators check the
+three attacks from the hackathon auth brief: scope escalation, stale parent,
+and audience confusion. They also probe a delegated-token forgery shape that
+would pass if an implementation reused the public parent signature directly
+as a child-token HMAC key.
+
+Example::
+
+    report = await check_strict_delegated_auth_attack_suite(auth)
+    assert report.passed, report.detail
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from typing import Any, Protocol, cast
+
+from nest_core.types import AgentId, AuthContext, Token
+
+from nest_plugins_reference.validators.gossip_validators import ValidatorReport
+
+_TOKEN_SIGN_DOMAIN = b"nest.delegatable-strict.token.v1|"
+
+
+class _StrictDelegatedAuthLike(Protocol):
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token: ...
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token: ...
+
+    async def verify(self, token: Token) -> AuthContext: ...
+
+    async def verify_for(self, token: Token, presenter: AgentId) -> AuthContext: ...
+
+    async def revoke(self, token: Token) -> None: ...
+
+
+async def check_strict_delegated_auth_attack_suite(auth: object) -> ValidatorReport:
+    """Run the strict delegated-auth adversarial suite against ``auth``.
+
+    Returns ``passed=True`` only if all attacks are blocked:
+
+    * child scope escalation beyond the parent;
+    * child verification after the parent is revoked;
+    * presentation by an agent outside the child token's audience.
+    * signature/key-confusion forgery against the delegated-token format.
+
+    Example::
+
+        report = await check_strict_delegated_auth_attack_suite(
+            StrictDelegatableAuth()
+        )
+        assert report.passed
+    """
+    if not all(hasattr(auth, attr) for attr in ("issue", "delegate", "verify", "verify_for")):
+        return ValidatorReport(
+            passed=False,
+            detail="auth plugin does not expose delegate/verify_for capability checks",
+            evidence={"missing_api": True},
+        )
+
+    typed_auth = cast("_StrictDelegatedAuthLike", auth)
+    issue = typed_auth.issue
+    delegate = typed_auth.delegate
+    verify = typed_auth.verify
+    verify_for = typed_auth.verify_for
+    failures: list[str] = []
+    rejections: dict[str, str] = {}
+
+    parent = await issue(AgentId("coordinator"), ["orders:read", "orders:write"])
+    try:
+        await delegate(parent, AgentId("worker-escalate"), ["orders:read", "admin"], 60.0)
+    except Exception as exc:
+        rejections["scope_escalation"] = type(exc).__name__
+    else:
+        failures.append("scope_escalation_allowed")
+
+    stale_parent = await issue(AgentId("coordinator-stale"), ["docs:read", "docs:write"])
+    child = await delegate(stale_parent, AgentId("worker-stale"), ["docs:read"], 60.0)
+    revoke = typed_auth.revoke
+    await revoke(stale_parent)
+    try:
+        await verify(child)
+    except Exception as exc:
+        rejections["stale_parent"] = type(exc).__name__
+    else:
+        failures.append("revoked_parent_child_verified")
+
+    audience_parent = await issue(AgentId("coordinator-audience"), ["files:read", "files:write"])
+    audience_child = await delegate(audience_parent, AgentId("worker-a"), ["files:read"], 60.0)
+    try:
+        await verify_for(Token(str(audience_child)), AgentId("worker-b"))
+    except Exception as exc:
+        rejections["audience_confusion"] = type(exc).__name__
+    else:
+        failures.append("audience_confusion_allowed")
+
+    forge_parent = await issue(AgentId("coordinator-forge"), ["safe:read", "safe:write"])
+    forged = _forged_key_confusion_child(forge_parent)
+    try:
+        await verify(forged)
+    except Exception as exc:
+        rejections["token_forgery"] = type(exc).__name__
+    else:
+        failures.append("forged_child_verified")
+
+    if failures:
+        return ValidatorReport(
+            passed=False,
+            detail=f"{len(failures)} delegated-auth attack(s) passed",
+            evidence={"failures": failures, "rejections": rejections},
+        )
+    return ValidatorReport(
+        passed=True,
+        detail="scope escalation, stale parent, audience confusion, and token forgery were blocked",
+        evidence={
+            "attacks": [
+                "scope_escalation",
+                "stale_parent",
+                "audience_confusion",
+                "token_forgery",
+            ],
+            "rejections": rejections,
+        },
+    )
+
+
+async def materialize_strict_delegation_report(auth: object) -> dict[str, Any]:
+    """Return a JSON-serializable delegated-auth validator result.
+
+    Example::
+
+        report = await materialize_strict_delegation_report(
+            StrictDelegatableAuth()
+        )
+        assert report["passed"] is True
+    """
+    result = await check_strict_delegated_auth_attack_suite(auth)
+    return {
+        "detail": result.detail,
+        "evidence": result.evidence,
+        "passed": result.passed,
+    }
+
+
+def _forged_key_confusion_child(parent_token: Token) -> Token:
+    """Craft a child token that reuses the public parent signature as a key.
+
+    This targets HMAC constructions where a root signature ``HMAC(secret,
+    parent_payload)`` can also be interpreted as a delegated child signing
+    key.  A correct implementation rejects the forged token at signature
+    parsing, before any in-process ancestry lookup.
+
+    Example::
+
+        forged = _forged_key_confusion_child(parent)
+        assert isinstance(forged, Token)
+    """
+    _, parent_signature = str(parent_token).rsplit(".", 1)
+    parent_hash = hashlib.sha256(str(parent_token).encode()).hexdigest()
+    payload = {
+        "aud": "forge-worker",
+        "exp": 1100.0,
+        "iat": 1000.0,
+        "jti": "forged-child",
+        "parent": parent_hash,
+        "scopes": ["safe:read", "admin"],
+        "sub": "coordinator-forge",
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    forged_payload = base64.urlsafe_b64encode(raw).decode().rstrip("=")
+    forged_signature = hmac.new(
+        parent_signature.encode(),
+        _TOKEN_SIGN_DOMAIN + forged_payload.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    return Token(f"{forged_payload}.{forged_signature}")

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -49,6 +49,9 @@ trust_gated = "nest_plugins_reference.privacy.trust_gated:TrustGatedPrivacy"
 [project.entry-points."nest.plugins.datafacts"]
 cid_facts = "nest_plugins_reference.datafacts.cid_facts:CidFacts"
 
+[project.entry-points."nest.plugins.auth"]
+delegatable_strict = "nest_plugins_reference.auth.strict_delegatable:StrictDelegatableAuth"
+
 [project.entry-points."nest.plugins.failure_detector"]
 heartbeat = "nest_plugins_reference.failure_detection.heartbeat:HeartbeatFailureDetector"
 phi_accrual = "nest_plugins_reference.failure_detection.phi_accrual:PhiAccrualFailureDetector"

--- a/packages/nest-plugins-reference/tests/test_strict_delegatable_auth.py
+++ b/packages/nest-plugins-reference/tests/test_strict_delegatable_auth.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for strict delegated auth capability tokens.
+
+The suite is deliberately security-shaped: it proves the new plugin blocks
+scope escalation, stale-parent delegation, and audience confusion while the
+default JWT plugin fails the delegated-auth validator because it has no
+delegation surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.layers.auth import Auth
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.jwt_auth import JwtAuth
+from nest_plugins_reference.auth.strict_delegatable import (
+    AudienceMismatchError,
+    DelegationError,
+    RevokedAncestorError,
+    ScopeEscalationError,
+    StrictDelegatableAuth,
+)
+from nest_plugins_reference.validators import check_strict_delegated_auth_attack_suite
+
+_CHILD_KEY_DOMAIN = b"nest.delegatable-strict.child-key.v1|"
+_SCOPES = ["read", "write", "approve", "audit", "export"]
+_SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "strict_delegated_auth.yaml"
+_TOKEN_SIGN_DOMAIN = b"nest.delegatable-strict.token.v1|"
+
+
+def _legacy_issuer_sign(
+    secret: bytes,
+    payload_b64: str,
+    parent_hash: str | None,
+) -> str:
+    key = secret
+    if parent_hash is not None:
+        key = hmac.new(
+            secret,
+            _CHILD_KEY_DOMAIN + parent_hash.encode(),
+            hashlib.sha256,
+        ).digest()
+    return hmac.new(
+        key,
+        _TOKEN_SIGN_DOMAIN + payload_b64.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+class MutableClock:
+    """Small deterministic clock for token-expiry tests."""
+
+    def __init__(self, value: float = 1000.0) -> None:
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+
+def test_strict_delegatable_auth_is_auth_protocol() -> None:
+    auth = StrictDelegatableAuth(clock=1000.0)
+    assert isinstance(auth, Auth)
+
+
+def test_registry_resolves_strict_delegatable_auth() -> None:
+    cls = PluginRegistry().resolve("auth", "delegatable_strict")
+    assert cls is StrictDelegatableAuth
+
+
+@pytest.mark.asyncio
+async def test_issue_verify_root_token() -> None:
+    auth = StrictDelegatableAuth(secret=b"test-secret", clock=1000.0)
+    token = await auth.issue(AgentId("coordinator"), ["read", "write"])
+
+    ctx = await auth.verify(token)
+
+    assert ctx.subject == AgentId("coordinator")
+    assert ctx.scopes == ["read", "write"]
+    assert ctx.issued_at == 1000.0
+    assert ctx.expires_at == 4600.0
+
+
+@pytest.mark.asyncio
+async def test_delegate_strict_scope_subset_to_audience() -> None:
+    auth = StrictDelegatableAuth(secret=b"test-secret", clock=1000.0)
+    parent = await auth.issue(AgentId("coordinator"), ["orders:read", "orders:write"])
+
+    child = await auth.delegate(parent, AgentId("worker-1"), ["orders:read"], ttl=120.0)
+    ctx = await auth.verify_for(child, AgentId("worker-1"))
+
+    assert ctx.subject == AgentId("worker-1")
+    assert ctx.scopes == ["orders:read"]
+    assert ctx.expires_at == 1120.0
+
+
+@pytest.mark.asyncio
+async def test_scope_escalation_is_rejected() -> None:
+    auth = StrictDelegatableAuth(clock=1000.0)
+    parent = await auth.issue(AgentId("coordinator"), ["orders:read", "orders:write"])
+
+    with pytest.raises(ScopeEscalationError, match="strict subset"):
+        await auth.delegate(parent, AgentId("worker-1"), ["orders:read", "admin"], ttl=60.0)
+
+    with pytest.raises(ScopeEscalationError, match="strict subset"):
+        await auth.delegate(
+            parent,
+            AgentId("worker-2"),
+            ["orders:read", "orders:write"],
+            ttl=60.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_parent_revocation_cascades_to_child_and_grandchild() -> None:
+    auth = StrictDelegatableAuth(clock=1000.0)
+    parent = await auth.issue(AgentId("coordinator"), ["read", "write", "comment"])
+    child = await auth.delegate(parent, AgentId("worker-1"), ["read", "write"], ttl=120.0)
+    grandchild = await auth.delegate(child, AgentId("leaf-1"), ["read"], ttl=30.0)
+
+    await auth.revoke(parent)
+
+    with pytest.raises(RevokedAncestorError, match="Ancestor"):
+        await auth.verify(child)
+    with pytest.raises(RevokedAncestorError, match="Ancestor"):
+        await auth.verify(grandchild)
+
+
+@pytest.mark.asyncio
+async def test_child_expires_no_later_than_parent_horizon() -> None:
+    clock = MutableClock(1000.0)
+    auth = StrictDelegatableAuth(clock=clock)
+    parent = await auth.issue(AgentId("coordinator"), ["read", "write"])
+    child = await auth.delegate(parent, AgentId("worker-1"), ["read"], ttl=3600.0)
+
+    clock.value = 4700.0
+
+    with pytest.raises(DelegationError, match="expired"):
+        await auth.verify(child)
+
+
+@pytest.mark.asyncio
+async def test_child_cannot_outlive_parent() -> None:
+    clock = MutableClock(1000.0)
+    auth = StrictDelegatableAuth(clock=clock)
+    parent = await auth.issue(AgentId("coordinator"), ["read", "write"])
+    clock.value = 4500.0
+
+    with pytest.raises(DelegationError, match="no longer than parent"):
+        await auth.delegate(parent, AgentId("worker-1"), ["read"], ttl=200.0)
+
+
+@pytest.mark.asyncio
+async def test_audience_confusion_is_rejected() -> None:
+    auth = StrictDelegatableAuth(clock=1000.0)
+    parent = await auth.issue(AgentId("coordinator"), ["files:read", "files:write"])
+    child = await auth.delegate(parent, AgentId("worker-a"), ["files:read"], ttl=60.0)
+
+    with pytest.raises(AudienceMismatchError, match="worker-a"):
+        await auth.verify_for(child, AgentId("worker-b"))
+
+
+@pytest.mark.asyncio
+async def test_strict_delegated_auth_validator_passes_new_plugin() -> None:
+    report = await check_strict_delegated_auth_attack_suite(StrictDelegatableAuth(clock=1000.0))
+    assert report.passed, report.detail
+    assert report.evidence["rejections"] == {
+        "audience_confusion": "AudienceMismatchError",
+        "scope_escalation": "ScopeEscalationError",
+        "stale_parent": "RevokedAncestorError",
+        "token_forgery": "DelegationError",
+    }
+
+
+@pytest.mark.asyncio
+async def test_strict_delegated_auth_validator_fails_default_jwt() -> None:
+    report = await check_strict_delegated_auth_attack_suite(JwtAuth(clock=1000.0))
+    assert not report.passed
+    assert report.evidence["missing_api"] is True
+
+
+@pytest.mark.asyncio
+async def test_key_confusion_forged_child_rejected_at_signature_gate() -> None:
+    auth = StrictDelegatableAuth(secret=b"test-secret", clock=1000.0)
+    parent = await auth.issue(AgentId("coordinator"), ["orders:read", "orders:write"])
+    _, parent_signature = str(parent).rsplit(".", 1)
+    parent_hash = hashlib.sha256(str(parent).encode()).hexdigest()
+    forged_claims = {
+        "aud": "worker",
+        "exp": 1060.0,
+        "iat": 1000.0,
+        "jti": "forged-child",
+        "parent": parent_hash,
+        "scopes": ["orders:read", "admin"],
+        "sub": "coordinator",
+    }
+    forged_raw = json.dumps(forged_claims, sort_keys=True, separators=(",", ":")).encode()
+    forged_payload = base64.urlsafe_b64encode(forged_raw).decode().rstrip("=")
+    forged_signature = hmac.new(
+        parent_signature.encode(),
+        _TOKEN_SIGN_DOMAIN + forged_payload.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    forged = Token(f"{forged_payload}.{forged_signature}")
+
+    with pytest.raises(DelegationError, match="signature"):
+        await auth.verify(forged)
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_signature_raises_delegation_error() -> None:
+    auth = StrictDelegatableAuth(secret=b"test-secret", clock=1000.0)
+    token = await auth.issue(AgentId("coordinator"), ["orders:read"])
+    payload, _ = str(token).rsplit(".", 1)
+
+    with pytest.raises(DelegationError, match="signature"):
+        await auth.verify(Token(f"{payload}.not-ascii-\N{SNOWMAN}"))
+
+
+@pytest.mark.asyncio
+async def test_child_signature_is_derived_from_parent_token_not_issuer_secret() -> None:
+    auth = StrictDelegatableAuth(secret=b"test-secret", clock=1000.0)
+    parent = await auth.issue(AgentId("coordinator"), ["orders:read", "orders:write"])
+    child = await auth.delegate(parent, AgentId("worker"), ["orders:read"], ttl=60.0)
+    child_payload, child_signature = str(child).rsplit(".", 1)
+    _, parent_signature = str(parent).rsplit(".", 1)
+    parent_hash = hashlib.sha256(str(parent).encode()).hexdigest()
+    holder_key = hmac.new(
+        parent_signature.encode(),
+        _CHILD_KEY_DOMAIN + parent_hash.encode(),
+        hashlib.sha256,
+    ).digest()
+    holder_signature = hmac.new(
+        holder_key,
+        _TOKEN_SIGN_DOMAIN + child_payload.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    issuer_secret_signature = _legacy_issuer_sign(b"test-secret", child_payload, parent_hash)
+
+    assert child_signature == holder_signature
+    assert child_signature != issuer_secret_signature
+
+
+@pytest.mark.asyncio
+async def test_legacy_issuer_secret_child_signature_is_rejected() -> None:
+    auth = StrictDelegatableAuth(secret=b"test-secret", clock=1000.0)
+    parent = await auth.issue(AgentId("coordinator"), ["orders:read", "orders:write"])
+    child = await auth.delegate(parent, AgentId("worker"), ["orders:read"], ttl=60.0)
+    child_payload, _ = str(child).rsplit(".", 1)
+    parent_hash = hashlib.sha256(str(parent).encode()).hexdigest()
+    bad_signature = _legacy_issuer_sign(b"test-secret", child_payload, parent_hash)
+    bad_child = Token(f"{child_payload}.{bad_signature}")
+
+    with pytest.raises(DelegationError, match="signature"):
+        await auth.verify(bad_child)
+
+
+@pytest.mark.asyncio
+async def test_malformed_tokens_raise_delegation_error() -> None:
+    auth = StrictDelegatableAuth(clock=1000.0)
+
+    for raw in ("not-a-token", "a.b", "W10.bad-signature"):
+        with pytest.raises(DelegationError):
+            await auth.verify(Token(raw))
+
+
+@given(scopes=st.lists(st.sampled_from(_SCOPES), min_size=2, max_size=5, unique=True))
+@settings(max_examples=25, deadline=None)
+def test_delegated_scope_subset_property(scopes: list[str]) -> None:
+    async def check() -> None:
+        auth = StrictDelegatableAuth(clock=1000.0)
+        parent = await auth.issue(AgentId("coordinator"), scopes)
+        child_scopes = scopes[:-1]
+        child = await auth.delegate(parent, AgentId("worker"), child_scopes, ttl=60.0)
+        child_ctx = await auth.verify_for(child, AgentId("worker"))
+
+        assert set(child_ctx.scopes) < set(scopes)
+        with pytest.raises(ScopeEscalationError):
+            await auth.delegate(parent, AgentId("attacker"), scopes, ttl=60.0)
+
+    asyncio.run(check())
+
+
+@pytest.mark.asyncio
+async def test_strict_delegated_auth_scenario_emits_tree_trace(tmp_path: Path) -> None:
+    config = ScenarioConfig.from_yaml(_SCENARIO_PATH)
+    config.output.trace = str(tmp_path / "strict_delegated_auth.jsonl")
+    runner = ScenarioRunner(config)
+
+    trace_path = await runner.run()
+
+    events = [json.loads(line) for line in trace_path.read_text().splitlines()]
+    messages = [str(event.get("msg", "")) for event in events]
+    sent_messages = [str(event.get("msg", "")) for event in events if event.get("kind") == "send"]
+    assert len(events) > 0
+    assert runner.metrics["agent_count"] == 16.0
+    assert runner.metrics["message_count"] > 0.0
+    assert any("attack:scope_escalation:blocked" in msg for msg in messages)
+    assert any("attack:stale_parent:blocked" in msg for msg in messages)
+    assert any("attack:audience_confusion:blocked" in msg for msg in messages)
+    leaf_acks = [msg for msg in sent_messages if msg.startswith("leaf:verified:")]
+    assert len(leaf_acks) == 12

--- a/scenarios/strict_delegated_auth.yaml
+++ b/scenarios/strict_delegated_auth.yaml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegated auth scenario: one coordinator delegates read-only capabilities
+# through intermediaries to leaf agents, while validators assert that stale
+# parents and audience confusion fail closed.
+name: strict_delegated_auth
+description: "Coordinator delegates strict child capabilities to 3 intermediaries and 12 leaves."
+
+tier: 1
+seed: 4242
+
+agents:
+  count: 16
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+    - name: intermediary
+      count: 3
+    - name: leaf
+      count: 12
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: delegatable_strict
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: strict_delegated_auth
+  config:
+    delegation_tree: coordinator-3x4-leaves
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 3000"
+
+metrics:
+  - agent_count
+  - message_count
+  - delivery_rate
+
+output:
+  trace: ./traces/strict_delegated_auth.jsonl


### PR DESCRIPTION

## Problem

Solves problem 04, auth capability delegation, as a distinct implementation
that coexists with the baseline `delegatable` plugin merged in #138.

The reference `jwt` plugin cannot model a coordinator attenuating its
capability through intermediaries to leaf workers while retaining cascading
revocation. The new plugin preserves the base `Auth` protocol and adds an
explicit audience-aware verification API for that workflow.

## Differentiation from #138

This revision uses separate module, plugin, scenario, validator, and test names
so both implementations remain runnable and scoreable:

- `StrictDelegatableAuth`, registered as `auth: delegatable_strict`;
- `scenarios/strict_delegated_auth.yaml` and task type
  `strict_delegated_auth`;
- `check_strict_delegated_auth_attack_suite`, which exercises only public auth
  APIs and records the exception type for every rejected attack.

The implementation also makes three different choices load-bearing:

- child scopes must be a non-empty **strict** subset; equal scopes are rejected;
- a child-signing key is derived from the parent token's signature and hash,
  and a test rejects issuer-secret child re-signing;
- the validator crafts the direct parent-signature key-confusion forgery shape
  that the merged suite does not construct.

## What changed

- Added `delegate(parent_token, audience, scopes_subset, ttl)` without changing
  the base `Auth.verify(token)` protocol signature.
- Added `verify_for(token, presenter)` for explicit audience enforcement.
- Added transitive ancestor verification, cascading revocation, and strict
  scope and expiry attenuation.
- Added domain-separated HMAC signing for roots, holder-derived child keys, and
  child payloads.
- Added the requested deterministic topology: 1 coordinator, 3 intermediaries,
  and 12 leaves.
- Added adversarial coverage for scope escalation, stale-parent use, audience
  confusion, and key-confusion token forgery.

## Security model and tradeoffs

This is intentionally an in-process Nanda Town rig, not a production token
introspection service. The instance retains an in-memory ancestor-token table
so the simulator can deterministically verify the full chain and prove
cascading revocation.

`verify(token)` follows the base protocol and therefore treats a valid child as
a bearer token. Callers that must bind the presenter to the child audience use
`verify_for(token, presenter)`. `AuthContext.subject` identifies that
holder/audience, while the token's `sub` claim retains the original delegator.

Invalid child TTL requests now raise `DelegationError`; `ExpiredAncestorError`
is reserved for a chain whose ancestor actually expired or is outlived.

## Verification

Rebased onto current `main` after #138 and ran:

```bash
uv run ruff check .
uv run ruff format --check .
uv run pyright
uv run pytest -q
uv run nest run scenarios/strict_delegated_auth.yaml
```

Results:

```text
ruff check: all checks passed
ruff format --check: 215 files already formatted
pyright: 0 errors, 0 warnings, 0 informations
pytest: 1168 passed, 1 skipped, 1 deselected, 1 warning
scenario: Running scenario: strict_delegated_auth
scenario: agents: 16 seed: 4242 ticks: 3000
scenario determinism: two fresh runs produced byte-identical 122-line traces
scenario SHA-256: fd9877021de5396c31a2de13f1f52231acc77f0254410571c29f633828443fce
merge simulation against current main: clean
```

The scenario trace contains all three required attack outcomes:

- `attack:scope_escalation:blocked`
- `attack:stale_parent:blocked`
- `attack:audience_confusion:blocked`

The focused strict-delegation suite has 18 tests, including key-confusion
forgery rejection, issuer-secret child-signature rejection, non-ASCII malformed
signature handling, typed rejection evidence, and a Hypothesis strict-subset
property.