### PR TITLE
hackathon/superheroin888: delivery-gated streaming payments with mid-stream cancellation (problem 03)

### DIFF
--- a/docs/layers/payments.md
+++ b/docs/layers/payments.md
@@ -23,7 +23,21 @@ Source: [`nest_plugins_reference/payments/prepaid_credits.py`](../../packages/ne
 
 ## Additional reference plugins
 
-`streaming` — bilateral per-tick streams with mid-stream cancellation.
+`streaming` — bilateral per-tick streams with mid-stream cancellation
+and **delivery-gated billing**: the payer records each delivered work
+unit (`record_delivery`) and only then drains one tick (`tick_stream`),
+so dropped or partitioned payees are never billed for work they could
+not deliver — the per-request metering shape of x402-style HTTP
+payments. `open_stream`/`close_stream` bound the flow by `max_total`;
+closing settles exactly what was billed and the remainder is never
+spent. One-shot `pay()` is a stream that drains everything in one tick.
+The `streaming_payments` scenario (and its `_partition` variant)
+exercises it under 5% message drop and a full buyer/seller partition;
+three adversarial validators check conservation, drain-after-close, and
+over-bill-on-partition, and all three fail loudly under a plugin that
+quietly pre-pays instead of streaming.
+
+Source: [`nest_plugins_reference/payments/streaming.py`](../../packages/nest-plugins-reference/nest_plugins_reference/payments/streaming.py).
 
 `empic_escrow` — EMPIC-shaped escrow for service providers and
 consumers. Pull mode locks one request payment until accepted data is

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -123,3 +123,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("escrow_marketplace", escrow_marketplace_factory)
+    elif name == "streaming_payments":
+        from nest_core.scenarios_builtin.streaming_payments import (
+            streaming_payments_factory,
+        )
+
+        register_scenario("streaming_payments", streaming_payments_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/streaming_payments.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/streaming_payments.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming payments scenario -- five buyer/seller pairs with rolling streams.
+
+Each buyer opens a sequence of payment streams to its seller and bills one
+work unit at a time, **only after the seller's ack for that unit arrives**.
+Every billing-relevant transition is broadcast as a structured
+``stream:<kind>:k=v`` payload that the three ``streaming_payments``
+validators (see :mod:`nest_core.validators`) read back from the trace:
+
+* ``stream:opened`` -- ref, payer, payee, rate, max, tick;
+* ``stream:debit``  -- one per billed unit, citing the acked unit number;
+* ``stream:closed`` -- ref, settled total, tick, closing party, reason.
+
+The seller's per-unit ack travels as a *direct* message
+(``stream:ack:ref=..:unit=..``), so the trace shows exactly which acks were
+delivered (``receive``) and which the failure injector killed (``dropped``).
+A debit without a delivered ack is an over-bill — that is what the
+partition validator hunts.
+
+If the payments plugin lacks the streaming surface (e.g. ``prepaid_credits``),
+buyers fall back to one-shot ``pay()`` and the trace contains **no**
+``stream:*`` events, which the validators report as a failure. That is the
+adversarial discrimination the charter asks for.
+
+Example::
+
+    agents = streaming_payments_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Money, PaymentRef
+
+# Time layout per stream slot: open, then a cancel deadline (generous --
+# in-memory delivery is same-instant, so only dropped messages ever reach
+# it), then a gap before the next slot.
+_SLOT_PERIOD = 9.0
+_CANCEL_AFTER = 7.0
+_BUYER_STAGGER = 0.13
+
+_OP_OPEN = b"op:open:"  # + slot number
+_OP_CANCEL = b"op:cancel:"  # + slot number
+
+
+def _emit(kind: str, fields: dict[str, str | int]) -> bytes:
+    """Build a structured ``stream:<kind>:k=v:...`` payload.
+
+    The colon-separated ``k=v`` form matches the parser in
+    :func:`nest_core.validators._parse_stream_fields`.
+
+    Example::
+
+        payload = _emit("debit", {"ref": "s-buyer-0-1", "amount": 5, "unit": 2})
+    """
+    body = ":".join(f"{k}={v}" for k, v in fields.items())
+    return f"stream:{kind}:{body}".encode()
+
+
+def _parse_kv(body: str) -> dict[str, str]:
+    """Parse a ``k=v:k=v`` message body into a dict.
+
+    Example::
+
+        fields = _parse_kv("ref=s-buyer-0-1:unit=2")
+    """
+    out: dict[str, str] = {}
+    for part in body.split(":"):
+        key, sep, value = part.partition("=")
+        if sep:
+            out[key] = value
+    return out
+
+
+class StreamBuyerAgent(StateMachineAgent):
+    """Opens rolling streams to one seller and bills only acked work units.
+
+    The buyer owns the payer side: it opens each stream slot on schedule,
+    requests one work unit at a time, bills a unit when (and only when) the
+    seller's ack for that unit is delivered, and closes the stream -- at the
+    unit budget, mid-stream for every third slot, or on the cancel deadline
+    when drops or a partition stall the ack chain.
+
+    Example::
+
+        agent = StreamBuyerAgent(
+            AgentId("buyer-0"),
+            seller=AgentId("seller-0"),
+            index=0,
+            slots=20,
+            rate_per_tick=5,
+            units_per_stream=5,
+        )
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        seller: AgentId,
+        index: int,
+        slots: int,
+        rate_per_tick: int,
+        units_per_stream: int,
+    ) -> None:
+        self._id = agent_id
+        self._seller = seller
+        self._index = index
+        self._slots = slots
+        self._rate = rate_per_tick
+        self._units = units_per_stream
+        self._open_refs: set[PaymentRef] = set()
+
+    def _ref(self, slot: int) -> PaymentRef:
+        """Unique stream ref for a slot.
+
+        Example::
+
+            ref = agent._ref(3)  # PaymentRef("s-buyer-0-3")
+        """
+        return PaymentRef(f"s-{self._id}-{slot}")
+
+    def _early_close_unit(self, slot: int) -> int | None:
+        """Every third slot cancels mid-stream after two billed units.
+
+        Example::
+
+            assert StreamBuyerAgent._early_close_unit(agent, 2) == 2
+        """
+        return 2 if slot % 3 == 2 else None
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Schedule every slot's open and cancel deadline upfront.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        stagger = _BUYER_STAGGER * self._index
+        for slot in range(self._slots):
+            base = 1.0 + stagger + slot * _SLOT_PERIOD
+            await ctx.schedule(base, _OP_OPEN + str(slot).encode())
+            await ctx.schedule(base + _CANCEL_AFTER, _OP_CANCEL + str(slot).encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Dispatch open/cancel self-ops and seller acks.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("seller-0"), b"stream:ack:ref=s-buyer-0-0:unit=1")
+        """
+        payments = ctx.plugins["payments"]
+
+        if payload.startswith(_OP_OPEN):
+            slot = int(payload[len(_OP_OPEN) :])
+            await self._open(ctx, payments, slot)
+            return
+
+        if payload.startswith(_OP_CANCEL):
+            slot = int(payload[len(_OP_CANCEL) :])
+            await self._close(ctx, payments, self._ref(slot), reason="deadline")
+            return
+
+        text = payload.decode("utf-8", errors="replace")
+        if text.startswith("stream:ack:"):
+            await self._on_ack(ctx, payments, _parse_kv(text[len("stream:ack:") :]))
+
+    async def _open(self, ctx: AgentContext, payments: Any, slot: int) -> None:
+        ref = self._ref(slot)
+        if not hasattr(payments, "open_stream"):
+            # Fallback for plugins without streaming (e.g. prepaid_credits):
+            # pay the full budget upfront. The trace then carries no
+            # stream:* events, which is exactly what the validators flag.
+            await payments.pay(self._seller, Money(amount=self._rate * self._units), ref)
+            return
+        tick = int(ctx.time)
+        await payments.open_stream(
+            to=self._seller,
+            rate_per_tick=self._rate,
+            max_total=self._rate * self._units,
+            ref=ref,
+            at_tick=tick,
+        )
+        self._open_refs.add(ref)
+        await ctx.broadcast(
+            _emit(
+                "opened",
+                {
+                    "ref": ref,
+                    "payer": str(self._id),
+                    "payee": str(self._seller),
+                    "rate": self._rate,
+                    "max": self._rate * self._units,
+                    "tick": tick,
+                },
+            )
+        )
+        await ctx.send(self._seller, _emit("work", {"ref": ref, "unit": 1}))
+
+    async def _on_ack(self, ctx: AgentContext, payments: Any, fields: dict[str, str]) -> None:
+        ref = PaymentRef(fields.get("ref", ""))
+        unit = int(fields.get("unit", "0"))
+        if ref not in self._open_refs:
+            return  # late ack for a closed/unknown stream: never billed
+        if not payments.record_delivery(ref, unit):
+            return
+        tick = int(ctx.time)
+        drained = await payments.tick_stream(ref, tick)
+        if drained > 0:
+            await ctx.broadcast(
+                _emit("debit", {"ref": ref, "amount": drained, "unit": unit, "tick": tick})
+            )
+        handle = payments.stream(ref)
+        still_open = handle is not None and handle.closed_at_tick is None
+        slot = int(str(ref).rsplit("-", 1)[-1])
+        early = self._early_close_unit(slot)
+        if not still_open or (early is not None and unit >= early):
+            await self._close(ctx, payments, ref, reason="done")
+            return
+        await ctx.send(self._seller, _emit("work", {"ref": ref, "unit": unit + 1}))
+
+    async def _close(self, ctx: AgentContext, payments: Any, ref: PaymentRef, reason: str) -> None:
+        if ref not in self._open_refs:
+            return  # never opened (dropped op) or already closed
+        self._open_refs.discard(ref)
+        tick = int(ctx.time)
+        receipt = await payments.close_stream(ref, at_tick=tick)
+        await ctx.broadcast(
+            _emit(
+                "closed",
+                {
+                    "ref": ref,
+                    "total": receipt.amount.amount,
+                    "tick": tick,
+                    "by": str(self._id),
+                    "reason": reason,
+                },
+            )
+        )
+
+
+class StreamSellerAgent(StateMachineAgent):
+    """Serves work requests: one ack per requested unit, nothing else.
+
+    The ack is a direct message so the trace records its delivery
+    (``receive``) or its loss (``dropped``) between exactly this seller and
+    its buyer — the evidence the over-bill validator audits.
+
+    Example::
+
+        agent = StreamSellerAgent()
+    """
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Ack any well-formed work request from the buyer.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("buyer-0"), b"stream:work:ref=s-buyer-0-0:unit=1")
+        """
+        text = payload.decode("utf-8", errors="replace")
+        if not text.startswith("stream:work:"):
+            return
+        fields = _parse_kv(text[len("stream:work:") :])
+        ref = fields.get("ref", "")
+        unit = fields.get("unit", "")
+        if ref and unit:
+            await ctx.send(sender, _emit("ack", {"ref": ref, "unit": unit}))
+
+
+def _role_balance(config: ScenarioConfig, role: str, default: int) -> int:
+    """Read a role's ``initial_balance`` from the scenario config.
+
+    Example::
+
+        balance = _role_balance(config, "buyer", 5000)
+    """
+    for rc in config.agents.roles:
+        if rc.name == role:
+            return int(rc.config.get("initial_balance", default))
+    return default
+
+
+def streaming_payments_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Build five buyer/seller pairs with a shared ledger per pair.
+
+    ``task.config`` knobs: ``rounds`` (total work units each buyer attempts,
+    default 100), ``rate_per_tick`` (default 5), ``units_per_stream``
+    (default 5). Each pair's two agents share the same balances/payments/
+    streams dicts (the escrow-factory convention) so the buyer's drain and
+    any payee-side close hit one ledger; pairs are economically independent.
+
+    For payment plugins that do not accept the shared-dict kwargs (e.g.
+    ``prepaid_credits``), each agent gets a plain per-agent instance and
+    buyers fall back to one-shot ``pay()``.
+
+    Example::
+
+        agents = streaming_payments_factory(config, plugins)
+    """
+    payments_cls = plugins["payments"]
+    task_cfg = config.task.config
+    rounds = int(task_cfg.get("rounds", 100))
+    rate = int(task_cfg.get("rate_per_tick", 5))
+    units = int(task_cfg.get("units_per_stream", 5))
+    slots = max(1, rounds // units)
+    pairs = 5
+
+    buyer_balance = _role_balance(config, "buyer", 5000)
+    seller_balance = _role_balance(config, "seller", 100)
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    overrides: dict[AgentId, dict[str, Any]] = {}
+
+    def _pair_instances(buyer_id: AgentId, seller_id: AgentId) -> tuple[Any, Any]:
+        shared_balances: dict[AgentId, int] = {}
+        shared_payments: dict[PaymentRef, Any] = {}
+        shared_streams: dict[PaymentRef, Any] = {}
+        try:
+            buyer_inst = payments_cls(
+                buyer_id,
+                initial_balance=buyer_balance,
+                balances=shared_balances,
+                payments=shared_payments,
+                streams=shared_streams,
+            )
+            seller_inst = payments_cls(
+                seller_id,
+                initial_balance=seller_balance,
+                balances=shared_balances,
+                payments=shared_payments,
+                streams=shared_streams,
+            )
+        except TypeError:
+            buyer_inst = payments_cls(buyer_id, initial_balance=buyer_balance)
+            seller_inst = payments_cls(seller_id, initial_balance=seller_balance)
+        return buyer_inst, seller_inst
+
+    for i in range(pairs):
+        buyer_id = AgentId(f"buyer-{i}")
+        seller_id = AgentId(f"seller-{i}")
+        agents[buyer_id] = StreamBuyerAgent(
+            buyer_id,
+            seller=seller_id,
+            index=i,
+            slots=slots,
+            rate_per_tick=rate,
+            units_per_stream=units,
+        )
+        agents[seller_id] = StreamSellerAgent()
+
+        buyer_inst, seller_inst = _pair_instances(buyer_id, seller_id)
+        overrides[buyer_id] = {"payments": buyer_inst}
+        overrides[seller_id] = {"payments": seller_inst}
+
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1239,45 +1239,139 @@ def validate_memory_convergence(
 # ---------------------------------------------------------------------------
 
 
+def _parse_stream_fields(msg: str) -> tuple[str, dict[str, str]] | None:
+    """Parse a ``stream:<kind>:k=v:...`` payload into (kind, fields).
+
+    Returns None for payloads that are not stream events. Grammar matches
+    the emitter in
+    :mod:`nest_core.scenarios_builtin.streaming_payments`.
+    """
+    if not msg.startswith("stream:"):
+        return None
+    rest = msg[len("stream:") :]
+    kind, _, body = rest.partition(":")
+    fields: dict[str, str] = {}
+    for part in body.split(":"):
+        key, sep, value = part.partition("=")
+        if sep:
+            fields[key] = value
+    return kind, fields
+
+
+def _collect_stream_events(
+    events: list[dict[str, Any]],
+) -> tuple[
+    dict[str, dict[str, str]],
+    list[tuple[int, str, dict[str, str]]],
+    dict[str, int],
+    dict[tuple[str, str, str], int],
+]:
+    """Extract the streaming lifecycle from a raw trace.
+
+    Returns ``(opened, debits, first_close_index, delivered_acks)``:
+    ``opened`` maps ref -> opened fields; ``debits`` is
+    ``(event_index, payer_agent, fields)`` per debit broadcast;
+    ``first_close_index`` maps ref -> index of its first close broadcast;
+    ``delivered_acks`` maps ``(receiver_agent, ref, unit)`` to the index of
+    the first actually-delivered ack (``receive`` events only — dropped
+    acks never enter this map).
+    """
+    opened: dict[str, dict[str, str]] = {}
+    debits: list[tuple[int, str, dict[str, str]]] = []
+    first_close_index: dict[str, int] = {}
+    delivered_acks: dict[tuple[str, str, str], int] = {}
+
+    for index, ev in enumerate(events):
+        kind = ev.get("kind")
+        msg = _message_body(ev)
+        if kind == "broadcast":
+            parsed = _parse_stream_fields(msg)
+            if parsed is None:
+                continue
+            stream_kind, fields = parsed
+            ref = fields.get("ref", "")
+            if not ref:
+                continue
+            if stream_kind == "opened":
+                opened.setdefault(ref, fields)
+            elif stream_kind == "debit":
+                debits.append((index, str(ev.get("agent", "")), fields))
+            elif stream_kind == "closed":
+                first_close_index.setdefault(ref, index)
+        elif kind == "receive":
+            parsed = _parse_stream_fields(msg)
+            if parsed is None:
+                continue
+            stream_kind, fields = parsed
+            if stream_kind == "ack":
+                ref = fields.get("ref", "")
+                unit = fields.get("unit", "")
+                if ref and unit:
+                    delivered_acks.setdefault((str(ev.get("agent", "")), ref, unit), index)
+
+    return opened, debits, first_close_index, delivered_acks
+
+
 def validate_streaming_conservation(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Conservation invariant: total debited == total credited at every tick.
+    """Conservation invariant: every settled stream equals the sum of its debits.
 
-    Scans the trace for payment events and verifies that cumulative funds
-    debited from payers equals cumulative funds credited to payees.
+    For each closed stream, the settled total broadcast at close must equal
+    the sum of its per-unit debit amounts, and no stream may ever bill past
+    its declared ``max_total`` — money is neither created, destroyed, nor
+    conjured past the cap. A trace with no ``stream:opened`` events fails:
+    the plugin under test never ran a streaming lifecycle at all (e.g. a
+    one-shot plugin quietly pre-paying instead).
     """
-    cumulative_debited: dict[str, int] = defaultdict(int)
-    cumulative_credited: dict[str, int] = defaultdict(int)
+    opened, debits, first_close_index, _ = _collect_stream_events(events)
 
-    for ev in events:
-        if ev.get("kind") not in ("payment_debited", "payment_credited"):
+    if not opened:
+        return [
+            ValidationResult(
+                "streaming_conservation",
+                False,
+                "no streaming lifecycle observed (no stream:opened events in trace)",
+            )
+        ]
+
+    billed: dict[str, int] = defaultdict(int)
+    violations: list[str] = []
+    for _, _, fields in debits:
+        ref = fields.get("ref", "")
+        billed[ref] += int(fields.get("amount", "0"))
+        if ref not in opened:
+            violations.append(f"stream {ref}: debit without a stream:opened event")
+
+    for ref, fields in opened.items():
+        max_total = int(fields.get("max", "0"))
+        if billed[ref] > max_total:
+            violations.append(f"stream {ref}: billed {billed[ref]} past max_total {max_total}")
+
+    closed_totals: dict[str, int] = {}
+    for index, ev in enumerate(events):
+        if ev.get("kind") != "broadcast":
             continue
+        parsed = _parse_stream_fields(_message_body(ev))
+        if parsed is None or parsed[0] != "closed":
+            continue
+        ref = parsed[1].get("ref", "")
+        if ref and first_close_index.get(ref) == index:
+            closed_totals[ref] = int(parsed[1].get("total", "0"))
 
-        agent = ev.get("agent", "")
-        amount = ev.get("amount", 0)
+    for ref, total in closed_totals.items():
+        if billed[ref] != total:
+            violations.append(f"stream {ref}: settled total {total} != sum of debits {billed[ref]}")
 
-        if ev.get("kind") == "payment_debited":
-            cumulative_debited[agent] += amount
-        elif ev.get("kind") == "payment_credited":
-            cumulative_credited[agent] += amount
-
-    # Check conservation: sum of all debited == sum of all credited
-    total_debited = sum(cumulative_debited.values())
-    total_credited = sum(cumulative_credited.values())
-
-    if total_debited != total_credited:
-        detail = (
-            f"conservation violation: total debited={total_debited} "
-            f"!= total credited={total_credited}"
-        )
-        return [ValidationResult("streaming_conservation", False, detail)]
+    if violations:
+        return [ValidationResult("streaming_conservation", False, "; ".join(violations))]
 
     return [
         ValidationResult(
             "streaming_conservation",
             True,
-            f"conservation verified: {total_debited} total flow",
+            f"{len(opened)} streams, {sum(billed.values())} total flow, "
+            f"{len(closed_totals)} settled receipts all equal their debit sums",
         )
     ]
 
@@ -1285,40 +1379,37 @@ def validate_streaming_conservation(
 def validate_streaming_no_drain_after_close(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Attack: closed streams must not drain after closure.
+    """Attack: closed streams must not drain afterwards, and no unit twice.
 
-    Tracks open_stream -> close_stream for each ref, verifies no
-    payment_debited events occur after close for that stream ref.
+    Uses trace order (the trace is append-only): any ``stream:debit`` for a
+    ref that appears after that ref's first ``stream:closed`` broadcast is a
+    drain-after-close. Billing the same work unit twice on one stream is the
+    same theft through a different door, so it is checked here too. A trace
+    with no closed streams fails — mid-stream cancellation never happened,
+    so the property this validator guards was never exercised.
     """
-    open_times: dict[str, int] = {}  # PaymentRef -> tick
-    close_times: dict[str, int] = {}  # PaymentRef -> tick
-    stream_debits: dict[str, list[int]] = defaultdict(lambda: [])  # PaymentRef -> [ticks]
+    _, debits, first_close_index, _ = _collect_stream_events(events)
 
-    for ev in events:
-        tick = ev.get("tick", 0)
+    if not first_close_index:
+        return [
+            ValidationResult(
+                "streaming_no_drain_after_close",
+                False,
+                "no stream:closed events observed — close/cancel path never exercised",
+            )
+        ]
 
-        if ev.get("event_type") == "stream_opened":
-            ref = ev.get("stream_ref", "")
-            if ref:
-                open_times[ref] = tick
-
-        elif ev.get("event_type") == "stream_closed":
-            ref = ev.get("stream_ref", "")
-            if ref:
-                close_times[ref] = tick
-
-        elif ev.get("kind") == "payment_debited":
-            ref = ev.get("stream_ref", "")
-            if ref:
-                assert isinstance(stream_debits[ref], list)
-                stream_debits[ref].append(tick)
-
-    # Check: no debit after close
     violations: list[str] = []
-    for ref, close_tick in close_times.items():
-        debits_after = [t for t in stream_debits.get(ref, []) if t > close_tick]
-        if debits_after:
-            violations.append(f"stream {ref} debited after close at {close_tick}: {debits_after}")
+    seen_units: set[tuple[str, str]] = set()
+    for index, _, fields in debits:
+        ref = fields.get("ref", "")
+        unit = fields.get("unit", "")
+        close_index = first_close_index.get(ref)
+        if close_index is not None and index > close_index:
+            violations.append(f"stream {ref}: debit for unit {unit} after the stream closed")
+        if (ref, unit) in seen_units:
+            violations.append(f"stream {ref}: unit {unit} billed twice")
+        seen_units.add((ref, unit))
 
     if violations:
         return [ValidationResult("streaming_no_drain_after_close", False, "; ".join(violations))]
@@ -1327,7 +1418,7 @@ def validate_streaming_no_drain_after_close(
         ValidationResult(
             "streaming_no_drain_after_close",
             True,
-            f"verified {len(close_times)} streams, no drain-after-close",
+            f"verified {len(first_close_index)} closed streams, no drain-after-close",
         )
     ]
 
@@ -1335,56 +1426,37 @@ def validate_streaming_no_drain_after_close(
 def validate_streaming_no_overbill_on_partition(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Attack: payer must not keep billing when partitioned from payee.
+    """Attack: no billing for work the payee never delivered.
 
-    When the simulator drops messages between a payer and payee (network
-    partition), any ``payment_debited`` after that point is billing for
-    service the payee cannot deliver — an over-bill on partition.
-
-    Tracks (payer, payee) pairs from ``stream_opened`` events, then scans
-    for ``dropped`` events between those pairs.  Any debit that lands at or
-    after a drop-tick between the same payer and payee is a violation.
+    Every ``stream:debit`` must cite a work unit whose ack the payer
+    actually *received* earlier in the trace. When the network partitions
+    (or the failure injector drops the ack), no ack is delivered — so a
+    conforming payer bills nothing, and any debit without a delivered ack
+    is an over-bill. This subsumes the partition case: partitioned payers
+    receive no acks at all, so *any* debit they emit fails here. A trace
+    with no ``stream:opened`` events fails outright.
     """
-    # stream_ref -> (payer, payee)
-    stream_parties: dict[str, tuple[str, str]] = {}
-    # (payer, payee) -> first tick where drop was observed
-    partition_start: dict[tuple[str, str], int] = {}
+    opened, debits, _, delivered_acks = _collect_stream_events(events)
+
+    if not opened:
+        return [
+            ValidationResult(
+                "streaming_no_overbill_on_partition",
+                False,
+                "no streaming lifecycle observed (no stream:opened events in trace)",
+            )
+        ]
+
     violations: list[str] = []
-
-    for ev in events:
-        tick = ev.get("tick", 0)
-
-        if ev.get("event_type") == "stream_opened":
-            ref = ev.get("stream_ref", "")
-            payer = ev.get("agent", "")
-            payee = ev.get("to", "")
-            if ref and payer and payee:
-                stream_parties[ref] = (payer, payee)
-
-        elif ev.get("kind") == "dropped":
-            sender = ev.get("from", "")
-            receiver = ev.get("agent", "")
-            # Record the earliest tick a partition was observed either way
-            if sender and receiver:
-                key = (sender, receiver)
-                if key not in partition_start or tick < partition_start[key]:
-                    partition_start[key] = tick
-                # Reverse direction too — partition is bidirectional
-                rev_key = (receiver, sender)
-                if rev_key not in partition_start or tick < partition_start[rev_key]:
-                    partition_start[rev_key] = tick
-
-        elif ev.get("kind") == "payment_debited":
-            ref = ev.get("stream_ref", "")
-            if ref not in stream_parties:
-                continue
-            payer, payee = stream_parties[ref]
-            drop_tick = partition_start.get((payer, payee))
-            if drop_tick is not None and tick >= drop_tick:
-                violations.append(
-                    f"stream {ref}: payer={payer} debited at tick {tick} "
-                    f"but partitioned from payee={payee} since tick {drop_tick}"
-                )
+    for debit_index, payer_agent, fields in debits:
+        ref = fields.get("ref", "")
+        unit = fields.get("unit", "")
+        ack_index = delivered_acks.get((payer_agent, ref, unit))
+        if ack_index is None or ack_index > debit_index:
+            violations.append(
+                f"stream {ref}: {payer_agent} billed unit {unit} "
+                f"without a previously delivered ack (over-bill under drop/partition)"
+            )
 
     if violations:
         return [
@@ -1398,8 +1470,8 @@ def validate_streaming_no_overbill_on_partition(
         ValidationResult(
             "streaming_no_overbill_on_partition",
             True,
-            f"verified {len(stream_parties)} streams across "
-            f"{len(partition_start)} partition edges, no over-bill",
+            f"verified {len(debits)} debits across {len(opened)} streams, "
+            f"every billed unit backed by a delivered ack",
         )
     ]
 

--- a/packages/nest-core/tests/test_streaming_validators.py
+++ b/packages/nest-core/tests/test_streaming_validators.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synthetic attack traces for the streaming payments validators.
+
+Each test hand-builds the exact trace a buggy or malicious payments plugin
+would leave behind and proves the validator catches it:
+
+* drain-after-close: debits keep flowing after ``stream:closed``;
+* double-bill: the same work unit billed twice;
+* over-bill on partition: debits for units whose acks were dropped;
+* receipt mismatch: settled total disagrees with the sum of debits;
+* silent pre-pay: no streaming lifecycle at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.validators import (
+    validate_streaming_conservation,
+    validate_streaming_no_drain_after_close,
+    validate_streaming_no_overbill_on_partition,
+)
+
+
+def _broadcast(agent: str, msg: str, ts: float = 0.0) -> dict[str, Any]:
+    """A trace broadcast event as the simulator records it."""
+    return {"ts": ts, "agent": agent, "kind": "broadcast", "size": len(msg), "msg": msg}
+
+
+def _receive(agent: str, sender: str, msg: str, ts: float = 0.0) -> dict[str, Any]:
+    """A delivered-message trace event."""
+    return {"ts": ts, "agent": agent, "kind": "receive", "from": sender, "msg": msg}
+
+
+def _dropped(agent: str, sender: str, msg: str, ts: float = 0.0) -> dict[str, Any]:
+    """A dropped-message trace event (failure injection)."""
+    return {"ts": ts, "agent": agent, "kind": "dropped", "from": sender, "msg": msg}
+
+
+def _opened(ref: str, max_total: int = 25) -> dict[str, Any]:
+    """A stream:opened broadcast for ``ref``."""
+    return _broadcast(
+        "buyer-0",
+        f"stream:opened:ref={ref}:payer=buyer-0:payee=seller-0:rate=5:max={max_total}:tick=1",
+    )
+
+
+def _lifecycle(ref: str = "s-buyer-0-0") -> list[dict[str, Any]]:
+    """A minimal well-formed stream: open, two acked+billed units, close."""
+    return [
+        _opened(ref),
+        _receive("buyer-0", "seller-0", f"stream:ack:ref={ref}:unit=1"),
+        _broadcast("buyer-0", f"stream:debit:ref={ref}:amount=5:unit=1:tick=1"),
+        _receive("buyer-0", "seller-0", f"stream:ack:ref={ref}:unit=2"),
+        _broadcast("buyer-0", f"stream:debit:ref={ref}:amount=5:unit=2:tick=1"),
+        _broadcast("buyer-0", f"stream:closed:ref={ref}:total=10:tick=2:by=buyer-0:reason=done"),
+    ]
+
+
+def test_well_formed_lifecycle_passes_all_three() -> None:
+    """The clean lifecycle satisfies every streaming validator."""
+    events = _lifecycle()
+    for validator in (
+        validate_streaming_conservation,
+        validate_streaming_no_drain_after_close,
+        validate_streaming_no_overbill_on_partition,
+    ):
+        results = validator(events)
+        assert all(r.passed for r in results), results
+
+
+def test_drain_after_close_is_caught() -> None:
+    """A debit landing after the stream closed fails the close validator."""
+    events = _lifecycle()
+    events.append(_receive("buyer-0", "seller-0", "stream:ack:ref=s-buyer-0-0:unit=3"))
+    events.append(_broadcast("buyer-0", "stream:debit:ref=s-buyer-0-0:amount=5:unit=3:tick=3"))
+    results = validate_streaming_no_drain_after_close(events)
+    assert not all(r.passed for r in results)
+    assert "after the stream closed" in results[0].detail
+
+
+def test_double_billed_unit_is_caught() -> None:
+    """Billing the same unit twice fails the close validator."""
+    events = _lifecycle()
+    # Duplicate the unit-2 debit *before* the close broadcast.
+    events.insert(5, _broadcast("buyer-0", "stream:debit:ref=s-buyer-0-0:amount=5:unit=2:tick=1"))
+    results = validate_streaming_no_drain_after_close(events)
+    assert not all(r.passed for r in results)
+    assert "billed twice" in results[0].detail
+
+
+def test_overbill_without_delivered_ack_is_caught() -> None:
+    """A debit whose ack was dropped (partition) fails the over-bill validator."""
+    ref = "s-buyer-0-0"
+    events = [
+        _opened(ref),
+        # The ack never arrives — the failure injector killed it.
+        _dropped("buyer-0", "seller-0", f"stream:ack:ref={ref}:unit=1"),
+        # A buggy plugin bills the tick anyway.
+        _broadcast("buyer-0", f"stream:debit:ref={ref}:amount=5:unit=1:tick=1"),
+        _broadcast("buyer-0", f"stream:closed:ref={ref}:total=5:tick=2:by=buyer-0:reason=done"),
+    ]
+    results = validate_streaming_no_overbill_on_partition(events)
+    assert not all(r.passed for r in results)
+    assert "without a previously delivered ack" in results[0].detail
+
+
+def test_debit_before_its_ack_is_caught() -> None:
+    """Billing ahead of delivery (time-travel billing) also fails."""
+    ref = "s-buyer-0-0"
+    events = [
+        _opened(ref),
+        _broadcast("buyer-0", f"stream:debit:ref={ref}:amount=5:unit=1:tick=1"),
+        _receive("buyer-0", "seller-0", f"stream:ack:ref={ref}:unit=1"),
+        _broadcast("buyer-0", f"stream:closed:ref={ref}:total=5:tick=2:by=buyer-0:reason=done"),
+    ]
+    results = validate_streaming_no_overbill_on_partition(events)
+    assert not all(r.passed for r in results)
+
+
+def test_receipt_total_mismatch_is_caught() -> None:
+    """A settled total that disagrees with the debit sum fails conservation."""
+    events = _lifecycle()
+    events[-1] = _broadcast(
+        "buyer-0",
+        "stream:closed:ref=s-buyer-0-0:total=25:tick=2:by=buyer-0:reason=done",
+    )
+    results = validate_streaming_conservation(events)
+    assert not all(r.passed for r in results)
+    assert "!= sum of debits" in results[0].detail
+
+
+def test_billing_past_max_total_is_caught() -> None:
+    """Debits summing past the declared cap fail conservation."""
+    ref = "s-buyer-0-0"
+    events = [
+        _opened(ref, max_total=10),
+    ]
+    for unit in (1, 2, 3):
+        events.append(_receive("buyer-0", "seller-0", f"stream:ack:ref={ref}:unit={unit}"))
+        events.append(_broadcast("buyer-0", f"stream:debit:ref={ref}:amount=5:unit={unit}:tick=1"))
+    results = validate_streaming_conservation(events)
+    assert not all(r.passed for r in results)
+    assert "past max_total" in results[0].detail
+
+
+def test_missing_lifecycle_fails_not_passes() -> None:
+    """A trace with no stream events fails all three — never vacuously passes."""
+    events = [_broadcast("buyer-0", "sold:widget:100")]
+    assert not all(r.passed for r in validate_streaming_conservation(events))
+    assert not all(r.passed for r in validate_streaming_no_drain_after_close(events))
+    assert not all(r.passed for r in validate_streaming_no_overbill_on_partition(events))

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -676,123 +676,103 @@ class TestValidationResult:
 
 
 class TestStreamingValidators:
-    """Tests for the three streaming payment validators."""
+    """Smoke tests for the three streaming payment validators.
+
+    The full attack matrix (drain-after-close, double-bill, over-bill
+    under drop/partition, receipt mismatch, past-cap billing, missing
+    lifecycle) lives in ``test_streaming_validators.py``.
+    """
+
+    @staticmethod
+    def _events() -> list[dict[str, Any]]:
+        ref = "s-buyer-0-0"
+        return [
+            {
+                "kind": "broadcast",
+                "agent": "buyer-0",
+                "msg": f"stream:opened:ref={ref}:payer=buyer-0:payee=seller-0:rate=5:max=25:tick=1",
+            },
+            {
+                "kind": "receive",
+                "agent": "buyer-0",
+                "from": "seller-0",
+                "msg": f"stream:ack:ref={ref}:unit=1",
+            },
+            {
+                "kind": "broadcast",
+                "agent": "buyer-0",
+                "msg": f"stream:debit:ref={ref}:amount=5:unit=1:tick=1",
+            },
+            {
+                "kind": "broadcast",
+                "agent": "buyer-0",
+                "msg": f"stream:closed:ref={ref}:total=5:tick=2:by=buyer-0:reason=done",
+            },
+        ]
 
     def test_conservation_passes(self) -> None:
-        """Conservation passes when debited == credited."""
+        """Conservation passes when settled totals equal debit sums."""
         from nest_core.validators import validate_streaming_conservation
 
-        events = [
-            {"kind": "payment_debited", "agent": "payer", "amount": 100, "tick": 0},
-            {"kind": "payment_credited", "agent": "payee", "amount": 100, "tick": 0},
-            {"kind": "payment_debited", "agent": "payer", "amount": 50, "tick": 1},
-            {"kind": "payment_credited", "agent": "payee", "amount": 50, "tick": 1},
-        ]
-        results = validate_streaming_conservation(events)
+        results = validate_streaming_conservation(self._events())
         assert len(results) == 1
         assert results[0].passed
 
-    def test_conservation_fails_on_imbalance(self) -> None:
-        """Conservation fails when debited != credited."""
+    def test_conservation_fails_on_receipt_mismatch(self) -> None:
+        """Conservation fails when the settled total disagrees with debits."""
         from nest_core.validators import validate_streaming_conservation
 
-        events = [
-            {"kind": "payment_debited", "agent": "payer", "amount": 100, "tick": 0},
-            {"kind": "payment_credited", "agent": "payee", "amount": 50, "tick": 0},
-        ]
+        events = self._events()
+        events[-1]["msg"] = "stream:closed:ref=s-buyer-0-0:total=25:tick=2:by=buyer-0:reason=done"
         results = validate_streaming_conservation(events)
         assert len(results) == 1
         assert not results[0].passed
-        assert "conservation violation" in results[0].detail
+        assert "sum of debits" in results[0].detail
 
     def test_no_drain_after_close_passes(self) -> None:
         """No drain-after-close passes when debits stop before close."""
         from nest_core.validators import validate_streaming_no_drain_after_close
 
-        events = [
-            {"event_type": "stream_opened", "stream_ref": "s1", "tick": 0},
-            {"kind": "payment_debited", "stream_ref": "s1", "tick": 1},
-            {"kind": "payment_debited", "stream_ref": "s1", "tick": 2},
-            {"event_type": "stream_closed", "stream_ref": "s1", "tick": 3},
-        ]
-        results = validate_streaming_no_drain_after_close(events)
+        results = validate_streaming_no_drain_after_close(self._events())
         assert len(results) == 1
         assert results[0].passed
 
     def test_no_drain_after_close_fails(self) -> None:
-        """Fails when debit occurs after close."""
+        """Fails when a debit appears after the stream closed."""
         from nest_core.validators import validate_streaming_no_drain_after_close
 
-        events = [
-            {"event_type": "stream_opened", "stream_ref": "s1", "tick": 0},
-            {"kind": "payment_debited", "stream_ref": "s1", "tick": 1},
-            {"event_type": "stream_closed", "stream_ref": "s1", "tick": 2},
-            {"kind": "payment_debited", "stream_ref": "s1", "tick": 5},  # AFTER close!
-        ]
+        events = self._events()
+        events.append(
+            {
+                "kind": "broadcast",
+                "agent": "buyer-0",
+                "msg": "stream:debit:ref=s-buyer-0-0:amount=5:unit=2:tick=5",
+            }
+        )
         results = validate_streaming_no_drain_after_close(events)
         assert len(results) == 1
         assert not results[0].passed
-        assert "debited after close" in results[0].detail
+        assert "after the stream closed" in results[0].detail
 
-    def test_no_overbill_on_partition_passes(self) -> None:
-        """No over-bill passes when drops occur but no debits after."""
+    def test_no_overbill_passes_when_every_debit_has_an_ack(self) -> None:
+        """No over-bill passes when every billed unit was acked first."""
         from nest_core.validators import validate_streaming_no_overbill_on_partition
 
-        events = [
-            {
-                "event_type": "stream_opened",
-                "stream_ref": "s1",
-                "agent": "payer",
-                "to": "payee",
-                "tick": 0,
-            },
-            {"kind": "payment_debited", "stream_ref": "s1", "tick": 1},
-            {"kind": "dropped", "from": "payer", "agent": "payee", "tick": 2},
-            # No payment_debited after the partition
-        ]
-        results = validate_streaming_no_overbill_on_partition(events)
+        results = validate_streaming_no_overbill_on_partition(self._events())
         assert len(results) == 1
         assert results[0].passed
 
-    def test_no_overbill_on_partition_fails(self) -> None:
-        """Fails when debit occurs after partition between payer and payee."""
+    def test_no_overbill_fails_without_delivered_ack(self) -> None:
+        """Fails when a unit is billed although its ack was never delivered."""
         from nest_core.validators import validate_streaming_no_overbill_on_partition
 
-        events = [
-            {
-                "event_type": "stream_opened",
-                "stream_ref": "s1",
-                "agent": "payer",
-                "to": "payee",
-                "tick": 0,
-            },
-            {"kind": "payment_debited", "stream_ref": "s1", "tick": 1},
-            {"kind": "dropped", "from": "payer", "agent": "payee", "tick": 3},
-            {"kind": "payment_debited", "stream_ref": "s1", "tick": 5},  # OVER-BILL
-        ]
+        events = self._events()
+        # Remove the delivered ack: the debit is now billing undelivered work.
+        events = [ev for ev in events if ev.get("kind") != "receive"]
         results = validate_streaming_no_overbill_on_partition(events)
         assert len(results) == 1
         assert not results[0].passed
-        assert "partitioned" in results[0].detail
-
-    def test_no_overbill_ignores_other_drops(self) -> None:
-        """Drop between unrelated agents does not trigger a violation."""
-        from nest_core.validators import validate_streaming_no_overbill_on_partition
-
-        events = [
-            {
-                "event_type": "stream_opened",
-                "stream_ref": "s1",
-                "agent": "payer",
-                "to": "payee",
-                "tick": 0,
-            },
-            {"kind": "dropped", "from": "other-a", "agent": "other-b", "tick": 2},
-            {"kind": "payment_debited", "stream_ref": "s1", "tick": 5},
-        ]
-        results = validate_streaming_no_overbill_on_partition(events)
-        assert len(results) == 1
-        assert results[0].passed  # unrelated drop, not a violation
+        assert "without a previously delivered ack" in results[0].detail
 
 
 class TestEscrowValidators:

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/streaming.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/streaming.py
@@ -1,22 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 """Streaming per-tick payments plugin with mid-stream cancellation.
 
+Billing is **delivery-gated**: the payer records each delivered work unit
+(``record_delivery``) and only then drains one tick's worth of funds
+(``tick_stream``). A unit the payee never delivered — because either side
+closed the stream, a message was dropped, or the parties were partitioned —
+is never billed. This is the per-request metering shape of x402-style
+HTTP-payment proposals, expressed on the simulator's logical clock.
+
 Example::
 
-    payments = StreamingPayments(AgentId("payer"), initial_balance=10000)
-    handle = await payments.open_stream(
+    balances: dict[AgentId, int] = {}
+    payments: dict[PaymentRef, Receipt] = {}
+    streams: dict[PaymentRef, StreamHandle] = {}
+    payer = StreamingPayments(
+        AgentId("payer"),
+        initial_balance=10_000,
+        balances=balances,
+        payments=payments,
+        streams=streams,
+    )
+    handle = await payer.open_stream(
         to=AgentId("payee"),
         rate_per_tick=10,
         max_total=500,
         ref=PaymentRef("stream-1"),
     )
-    # ... ticks pass ...
-    receipt = await payments.close_stream(PaymentRef("stream-1"))
+    payer.record_delivery(PaymentRef("stream-1"), unit=1)
+    await payer.tick_stream(PaymentRef("stream-1"), current_tick=1)  # drains 10
+    receipt = await payer.close_stream(PaymentRef("stream-1"))       # remainder never spent
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from nest_core.types import (
     AgentId,
@@ -29,37 +46,64 @@ from nest_core.types import (
 )
 
 
+class StreamError(ValueError):
+    """Raised on invalid stream operations (unknown ref, bad params, refund of an open stream).
+
+    Example::
+
+        try:
+            await payments.close_stream(PaymentRef("nope"))
+        except StreamError:
+            ...
+    """
+
+
 @dataclass
 class StreamHandle:
-    """Handle to an active stream.
+    """Handle to a payment stream.
+
+    ``delivered_units`` holds work units the payee delivered that are not yet
+    billed; ``billed_units`` holds units already drained. The split is what
+    makes billing delivery-gated: ``tick_stream`` moves money only when a
+    recorded delivery is waiting.
 
     Example::
 
         handle = StreamHandle(
             ref=PaymentRef("s-1"),
+            payer=AgentId("buyer"),
             to=AgentId("worker"),
             rate_per_tick=10,
             max_total=500,
-            opened_at_tick=0,
+            opened_at_tick=3,
         )
         assert handle.total_debited == 0
     """
 
     ref: PaymentRef
+    payer: AgentId
     to: AgentId
     rate_per_tick: int
     max_total: int
     opened_at_tick: int
     closed_at_tick: int | None = None
     total_debited: int = 0
+    delivered_units: list[int] = field(default_factory=lambda: list[int]())
+    billed_units: list[int] = field(default_factory=lambda: list[int]())
 
 
 class StreamingPayments:
     """Streaming per-tick payments with mid-stream cancellation.
 
-    Extends prepaid credits with the ability to open bilateral streams that drain
-    one tick at a time. Either party can close the stream at any tick; unused
-    remainder is never spent. Satisfies the ``Payments`` protocol.
+    Satisfies the ``Payments`` protocol (``quote``/``pay``/``verify_payment``/
+    ``refund``) and adds the streaming surface the problem brief asks for:
+    ``open_stream``/``close_stream``, plus ``record_delivery``/``tick_stream``
+    for delivery-gated draining. Deterministic: ticks come from the caller
+    (the simulator's logical clock); no wall clock, no RNG.
+
+    Pass the same ``balances``/``payments``/``streams`` dicts to every
+    party's instance (the escrow-plugin convention) so payer and payee
+    operate on one ledger.
 
     Example::
 
@@ -70,7 +114,8 @@ class StreamingPayments:
             max_total=500,
             ref=PaymentRef("stream-1"),
         )
-        # Later...
+        payments.record_delivery(PaymentRef("stream-1"), unit=1)
+        await payments.tick_stream(PaymentRef("stream-1"), current_tick=1)
         receipt = await payments.close_stream(PaymentRef("stream-1"))
     """
 
@@ -97,6 +142,17 @@ class StreamingPayments:
         """
         return self._balances.get(agent, 0)
 
+    def stream(self, ref: PaymentRef) -> StreamHandle | None:
+        """Return the handle for ``ref``, or None if no such stream exists.
+
+        Example::
+
+            handle = payments.stream(PaymentRef("s-1"))
+            if handle is not None and handle.closed_at_tick is None:
+                ...  # still open
+        """
+        return self._streams.get(ref)
+
     async def quote(self, service: ServiceRef) -> Quote:
         """Return a fixed quote for any service.
 
@@ -112,12 +168,13 @@ class StreamingPayments:
         rate_per_tick: int,
         max_total: int,
         ref: PaymentRef,
+        at_tick: int = 0,
     ) -> StreamHandle:
         """Open a streaming payment from this agent to another.
 
-        Funds drain from payer to payee one tick at a time at ``rate_per_tick``
-        per tick, capped at ``max_total``. Either party can call ``close_stream``
-        at any point; unused remainder is never spent.
+        Nothing is debited at open: money follows delivered work units, so a
+        stream that never delivers costs nothing. Either party can call
+        ``close_stream`` at any point; the unused remainder is never spent.
 
         Example::
 
@@ -126,132 +183,165 @@ class StreamingPayments:
                 rate_per_tick=10,
                 max_total=500,
                 ref=PaymentRef("metered-task-1"),
+                at_tick=7,
             )
-            assert handle.total_debited == 10  # first tick drained immediately
+            assert handle.total_debited == 0
 
         Args:
             to: Recipient agent.
-            rate_per_tick: Amount to debit per tick (must be positive).
+            rate_per_tick: Amount to debit per delivered unit (must be positive).
             max_total: Maximum total to transfer (must be >= rate_per_tick).
             ref: Unique reference for this stream.
+            at_tick: Logical tick the stream opens at (from the simulator clock).
 
         Returns:
             StreamHandle with stream metadata.
 
         Raises:
-            ValueError: If params invalid or stream already exists for ref.
+            StreamError: If params are invalid, the ref exists, or the payer
+                cannot cover even one tick.
         """
         if rate_per_tick <= 0:
             msg = f"rate_per_tick must be positive: {rate_per_tick}"
-            raise ValueError(msg)
+            raise StreamError(msg)
         if max_total < rate_per_tick:
             msg = f"max_total ({max_total}) must be >= rate_per_tick ({rate_per_tick})"
-            raise ValueError(msg)
+            raise StreamError(msg)
         if ref in self._payments or ref in self._streams:
             msg = f"Payment or stream reference already exists: {ref}"
-            raise ValueError(msg)
+            raise StreamError(msg)
 
         payer_balance = self._balances.get(self._agent_id, 0)
         if payer_balance < rate_per_tick:
             msg = f"Insufficient balance for stream: {payer_balance} < {rate_per_tick}"
-            raise ValueError(msg)
-
-        # Drain first tick immediately
-        self._balances[self._agent_id] = payer_balance - rate_per_tick
-        self._balances[to] = self._balances.get(to, 0) + rate_per_tick
+            raise StreamError(msg)
 
         handle = StreamHandle(
             ref=ref,
+            payer=self._agent_id,
             to=to,
             rate_per_tick=rate_per_tick,
             max_total=max_total,
-            opened_at_tick=0,  # Will be set by context in real scenario
-            total_debited=rate_per_tick,
+            opened_at_tick=at_tick,
         )
         self._streams[ref] = handle
         return handle
 
-    async def tick_stream(self, ref: PaymentRef, current_tick: int) -> bool:
-        """Drain one tick's worth of funds from an open stream.
+    def record_delivery(self, ref: PaymentRef, unit: int) -> bool:
+        """Record that the payee delivered work unit ``unit`` on stream ``ref``.
 
-        Called automatically by the scheduler. Returns True if stream still open.
+        Idempotent per unit: recording the same unit twice queues it once, so
+        a duplicated ack can never double-bill. Deliveries against a closed
+        or unknown stream are refused — that is the drain-after-close guard.
 
         Example::
 
-            still_open = await payments.tick_stream(PaymentRef("s-1"), current_tick=3)
-            if not still_open:
-                receipt = await payments.close_stream(PaymentRef("s-1"))
+            accepted = payments.record_delivery(PaymentRef("s-1"), unit=3)
 
         Args:
             ref: Stream reference.
-            current_tick: Current simulation tick.
+            unit: Work-unit number the payee delivered.
 
         Returns:
-            True if stream is still open after this tick, False if closed.
+            True if the delivery was queued for billing, False if refused
+            (unknown ref, closed stream, or duplicate unit).
         """
-        if ref not in self._streams:
+        handle = self._streams.get(ref)
+        if handle is None or handle.closed_at_tick is not None:
             return False
-
-        handle = self._streams[ref]
-        if handle.closed_at_tick is not None:
+        if unit in handle.delivered_units or unit in handle.billed_units:
             return False
+        handle.delivered_units.append(unit)
+        return True
 
-        # Check if we've hit the max
-        if handle.total_debited >= handle.max_total:
-            handle.closed_at_tick = current_tick
-            return False
+    async def tick_stream(self, ref: PaymentRef, current_tick: int) -> int:
+        """Drain one tick's worth of funds for the oldest unbilled delivery.
 
-        # Drain one tick
-        amount_to_drain = min(
-            handle.rate_per_tick,
-            handle.max_total - handle.total_debited,
-        )
-        payer_balance = self._balances.get(self._agent_id, 0)
-        if payer_balance < amount_to_drain:
-            # Insufficient funds; stream stops
-            handle.closed_at_tick = current_tick
-            return False
-
-        self._balances[self._agent_id] = payer_balance - amount_to_drain
-        self._balances[handle.to] = self._balances.get(handle.to, 0) + amount_to_drain
-        handle.total_debited += amount_to_drain
-
-        if handle.total_debited >= handle.max_total:
-            handle.closed_at_tick = current_tick
-
-        return handle.closed_at_tick is None
-
-    async def close_stream(self, ref: PaymentRef) -> Receipt:
-        """Close a stream and return a receipt.
-
-        Either payer or payee can call this. Unused remainder is never spent.
+        No recorded delivery → no debit: a partitioned payee stops acking,
+        so the payer stops paying. Hitting ``max_total`` or running the
+        payer's balance dry closes the stream at ``current_tick``.
 
         Example::
 
-            receipt = await payments.close_stream(PaymentRef("s-1"))
-            assert receipt.amount.amount == handle.total_debited
+            payments.record_delivery(PaymentRef("s-1"), unit=1)
+            drained = await payments.tick_stream(PaymentRef("s-1"), current_tick=3)
+            assert drained in (0, handle.rate_per_tick)
 
         Args:
             ref: Stream reference.
+            current_tick: Current logical tick (from the simulator clock).
 
         Returns:
-            Receipt with total amount transferred.
+            The amount actually drained by this call (0 if the stream is
+            unknown, closed, undelivered, or the payer's balance ran dry).
+        """
+        handle = self._streams.get(ref)
+        if handle is None or handle.closed_at_tick is not None:
+            return 0
+
+        if not handle.delivered_units:
+            return 0  # nothing delivered since last drain — bill nothing
+
+        amount = min(handle.rate_per_tick, handle.max_total - handle.total_debited)
+        if amount <= 0:
+            handle.closed_at_tick = current_tick
+            return 0
+
+        payer_balance = self._balances.get(handle.payer, 0)
+        if payer_balance < amount:
+            handle.closed_at_tick = current_tick
+            return 0
+
+        unit = handle.delivered_units.pop(0)
+        handle.billed_units.append(unit)
+        self._balances[handle.payer] = payer_balance - amount
+        self._balances[handle.to] = self._balances.get(handle.to, 0) + amount
+        handle.total_debited += amount
+
+        if handle.total_debited >= handle.max_total:
+            handle.closed_at_tick = current_tick
+        return amount
+
+    async def close_stream(self, ref: PaymentRef, at_tick: int | None = None) -> Receipt:
+        """Close a stream and return the settlement receipt.
+
+        Either payer or payee can call this; the receipt always names the
+        stream's actual payer. Closing is idempotent — closing an
+        already-settled stream returns the stored receipt — and final: no
+        delivery or drain is accepted for ``ref`` afterwards.
+
+        Example::
+
+            receipt = await payments.close_stream(PaymentRef("s-1"), at_tick=12)
+            assert receipt.amount.amount <= 500  # never more than max_total
+
+        Args:
+            ref: Stream reference.
+            at_tick: Logical tick of closure; defaults to the stream's open
+                tick when omitted.
+
+        Returns:
+            Receipt for the total actually transferred (never the max).
 
         Raises:
-            ValueError: If stream not found.
+            StreamError: If no stream exists for ``ref``.
         """
-        if ref not in self._streams:
+        existing = self._payments.get(ref)
+        if existing is not None:
+            return existing
+
+        handle = self._streams.get(ref)
+        if handle is None:
             msg = f"Stream not found: {ref}"
-            raise ValueError(msg)
+            raise StreamError(msg)
 
-        handle = self._streams[ref]
         if handle.closed_at_tick is None:
-            handle.closed_at_tick = 0  # Assume current tick; real usage sets it
+            handle.closed_at_tick = at_tick if at_tick is not None else handle.opened_at_tick
+        handle.delivered_units.clear()  # unbilled deliveries die with the stream
 
-        # Create receipt
         receipt = Receipt(
             ref=ref,
-            payer=self._agent_id,
+            payer=handle.payer,
             payee=handle.to,
             amount=Money(amount=handle.total_debited),
         )
@@ -259,9 +349,11 @@ class StreamingPayments:
         return receipt
 
     async def pay(self, to: AgentId, amount: Money, ref: PaymentRef) -> Receipt:
-        """Execute a one-shot payment (one-tick stream).
+        """Execute a one-shot payment: a stream that drains the full amount in one tick.
 
-        Satisfies the Payments protocol for backward compatibility.
+        Literally implemented as ``open_stream`` at rate ``amount`` + one
+        delivered unit + one drain + ``close_stream``, so one-shot and
+        streaming settlements share every invariant and code path.
 
         Example::
 
@@ -280,29 +372,29 @@ class StreamingPayments:
             Receipt.
 
         Raises:
-            ValueError: If insufficient balance or duplicate ref.
+            StreamError: If the amount is not positive, the ref is a
+                duplicate, or the balance is insufficient.
         """
         if amount.amount <= 0:
             msg = f"Payment amount must be positive: {amount.amount}"
-            raise ValueError(msg)
-        if ref in self._payments or ref in self._streams:
-            msg = f"Duplicate payment reference: {ref}"
-            raise ValueError(msg)
-
-        payer_balance = self._balances.get(self._agent_id, 0)
-        if payer_balance < amount.amount:
-            msg = f"Insufficient balance: {payer_balance} < {amount.amount}"
-            raise ValueError(msg)
-
-        self._balances[self._agent_id] = payer_balance - amount.amount
-        self._balances[to] = self._balances.get(to, 0) + amount.amount
-
-        receipt = Receipt(ref=ref, payer=self._agent_id, payee=to, amount=amount)
-        self._payments[ref] = receipt
-        return receipt
+            raise StreamError(msg)
+        await self.open_stream(
+            to=to,
+            rate_per_tick=amount.amount,
+            max_total=amount.amount,
+            ref=ref,
+        )
+        self.record_delivery(ref, unit=1)
+        await self.tick_stream(ref, current_tick=0)
+        return await self.close_stream(ref)
 
     async def verify_payment(self, ref: PaymentRef) -> PaymentStatus:
         """Verify a payment or stream status by reference.
+
+        A half-drained open stream is ``STREAMING``, not ``PENDING``: every
+        tick already drained is final and irrevocable, so the settlement is
+        neither absent nor awaited — it is in progress. ``CONFIRMED`` is
+        reserved for settled refs (one-shot payments and closed streams).
 
         Example::
 
@@ -314,21 +406,23 @@ class StreamingPayments:
             ref: Payment or stream reference.
 
         Returns:
-            PaymentStatus.CONFIRMED for completed payments,
-            PaymentStatus.STREAMING for open streams,
-            PaymentStatus.FAILED otherwise.
+            ``CONFIRMED`` for settled refs, ``STREAMING`` for open streams,
+            ``FAILED`` for unknown refs.
         """
         if ref in self._payments:
             return PaymentStatus.CONFIRMED
-        if ref in self._streams:
-            handle = self._streams[ref]
+        handle = self._streams.get(ref)
+        if handle is not None:
             if handle.closed_at_tick is not None:
                 return PaymentStatus.CONFIRMED
             return PaymentStatus.STREAMING
         return PaymentStatus.FAILED
 
     async def refund(self, ref: PaymentRef) -> None:
-        """Refund a payment.
+        """Refund a settled payment in full.
+
+        Only settled refs can be refunded; an open stream must be closed
+        first so the refundable amount is fixed.
 
         Example::
 
@@ -338,12 +432,17 @@ class StreamingPayments:
             ref: Payment reference.
 
         Raises:
-            ValueError: If payment not found or insufficient balance for refund.
+            StreamError: If the ref is unknown, the stream is still open, or
+                the payee cannot cover the refund.
         """
         receipt = self._payments.get(ref)
         if receipt is None:
+            handle = self._streams.get(ref)
+            if handle is not None and handle.closed_at_tick is None:
+                msg = f"Cannot refund an open stream, close it first: {ref}"
+                raise StreamError(msg)
             msg = f"Payment not found: {ref}"
-            raise ValueError(msg)
+            raise StreamError(msg)
 
         payee_balance = self._balances.get(receipt.payee, 0)
         if payee_balance < receipt.amount.amount:
@@ -351,7 +450,7 @@ class StreamingPayments:
                 f"Insufficient balance for refund: {receipt.payee} has "
                 f"{payee_balance}, needs {receipt.amount.amount}"
             )
-            raise ValueError(msg)
+            raise StreamError(msg)
 
         self._balances[receipt.payee] = payee_balance - receipt.amount.amount
         self._balances[receipt.payer] = self._balances.get(receipt.payer, 0) + receipt.amount.amount

--- a/packages/nest-plugins-reference/tests/test_streaming_payments.py
+++ b/packages/nest-plugins-reference/tests/test_streaming_payments.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for streaming payments plugin.
+"""Tests for the streaming payments plugin.
 
-Tests conservation of funds, mid-stream cancellation, and streaming state.
+Covers delivery-gated draining, mid-stream cancellation, the drain-after-
+close guard, one-shot ``pay()`` equivalence, verify/refund semantics, and
+the conservation invariant.
 """
 
 from __future__ import annotations
 
 import pytest
 from nest_core.types import AgentId, Money, PaymentRef, PaymentStatus
-from nest_plugins_reference.payments.streaming import StreamingPayments
+from nest_plugins_reference.payments.streaming import StreamError, StreamingPayments
 
 
 class TestStreamingPayments:
@@ -30,7 +32,7 @@ class TestStreamingPayments:
 
     @pytest.mark.asyncio
     async def test_one_shot_pay(self, payments: StreamingPayments) -> None:
-        """Test backward-compatible one-shot pay() method."""
+        """One-shot pay() moves the full amount and issues a receipt."""
         receipt = await payments.pay(
             AgentId("payee"),
             Money(amount=100),
@@ -43,24 +45,38 @@ class TestStreamingPayments:
         assert payments.balance(AgentId("payee")) == 100
 
     @pytest.mark.asyncio
+    async def test_pay_equivalent_to_one_tick_stream(self, payments: StreamingPayments) -> None:
+        """pay() behaves exactly like a stream that drains everything in one tick."""
+        await payments.pay(AgentId("payee"), Money(amount=250), PaymentRef("pay-1"))
+        handle = payments.stream(PaymentRef("pay-1"))
+        assert handle is not None
+        assert handle.rate_per_tick == 250
+        assert handle.max_total == 250
+        assert handle.total_debited == 250
+        assert handle.closed_at_tick is not None
+        assert await payments.verify_payment(PaymentRef("pay-1")) == PaymentStatus.CONFIRMED
+
+    @pytest.mark.asyncio
     async def test_pay_insufficient_balance(self, payments: StreamingPayments) -> None:
-        """Test that pay() rejects if insufficient balance."""
-        with pytest.raises(ValueError, match="Insufficient balance"):
+        """pay() rejects if insufficient balance, and moves nothing."""
+        with pytest.raises(StreamError, match="Insufficient balance"):
             await payments.pay(
                 AgentId("payee"),
                 Money(amount=20000),
                 PaymentRef("pay-1"),
             )
+        assert payments.balance(AgentId("payer")) == 10000
+        assert payments.balance(AgentId("payee")) == 0
 
     @pytest.mark.asyncio
     async def test_pay_duplicate_ref(self, payments: StreamingPayments) -> None:
-        """Test that pay() rejects duplicate payment reference."""
+        """pay() rejects a reused payment reference."""
         await payments.pay(
             AgentId("payee"),
             Money(amount=100),
             PaymentRef("pay-1"),
         )
-        with pytest.raises(ValueError, match="Duplicate"):
+        with pytest.raises(StreamError, match="already exists"):
             await payments.pay(
                 AgentId("payee"),
                 Money(amount=100),
@@ -68,29 +84,32 @@ class TestStreamingPayments:
             )
 
     @pytest.mark.asyncio
-    async def test_open_stream_basic(self, payments: StreamingPayments) -> None:
-        """Test opening a stream."""
+    async def test_open_stream_debits_nothing(self, payments: StreamingPayments) -> None:
+        """Opening a stream moves no money — billing follows delivery."""
         handle = await payments.open_stream(
             to=AgentId("payee"),
             rate_per_tick=100,
             max_total=500,
             ref=PaymentRef("stream-1"),
+            at_tick=7,
         )
         assert handle.ref == PaymentRef("stream-1")
+        assert handle.payer == AgentId("payer")
         assert handle.to == AgentId("payee")
         assert handle.rate_per_tick == 100
         assert handle.max_total == 500
-        assert handle.total_debited == 100  # First tick drained immediately
-        assert payments.balance(AgentId("payer")) == 9900
-        assert payments.balance(AgentId("payee")) == 100
+        assert handle.opened_at_tick == 7
+        assert handle.total_debited == 0
+        assert payments.balance(AgentId("payer")) == 10000
+        assert payments.balance(AgentId("payee")) == 0
 
     @pytest.mark.asyncio
     async def test_open_stream_insufficient_balance(
         self,
         payments: StreamingPayments,
     ) -> None:
-        """Test that open_stream() rejects if insufficient balance for first tick."""
-        with pytest.raises(ValueError, match="Insufficient balance"):
+        """open_stream() rejects a payer who cannot cover even one tick."""
+        with pytest.raises(StreamError, match="Insufficient balance"):
             await payments.open_stream(
                 to=AgentId("payee"),
                 rate_per_tick=20000,
@@ -100,8 +119,8 @@ class TestStreamingPayments:
 
     @pytest.mark.asyncio
     async def test_open_stream_invalid_rate(self, payments: StreamingPayments) -> None:
-        """Test that open_stream() rejects invalid rate."""
-        with pytest.raises(ValueError, match="rate_per_tick must be positive"):
+        """open_stream() rejects a non-positive rate."""
+        with pytest.raises(StreamError, match="rate_per_tick must be positive"):
             await payments.open_stream(
                 to=AgentId("payee"),
                 rate_per_tick=0,
@@ -114,8 +133,8 @@ class TestStreamingPayments:
         self,
         payments: StreamingPayments,
     ) -> None:
-        """Test that open_stream() rejects max_total < rate_per_tick."""
-        with pytest.raises(ValueError, match="max_total"):
+        """open_stream() rejects max_total < rate_per_tick."""
+        with pytest.raises(StreamError, match="max_total"):
             await payments.open_stream(
                 to=AgentId("payee"),
                 rate_per_tick=100,
@@ -124,8 +143,25 @@ class TestStreamingPayments:
             )
 
     @pytest.mark.asyncio
-    async def test_tick_stream(self, payments: StreamingPayments) -> None:
-        """Test draining ticks from a stream."""
+    async def test_tick_without_delivery_bills_nothing(
+        self,
+        payments: StreamingPayments,
+    ) -> None:
+        """No recorded delivery → tick_stream drains nothing (partition shape)."""
+        await payments.open_stream(
+            to=AgentId("payee"),
+            rate_per_tick=100,
+            max_total=500,
+            ref=PaymentRef("stream-1"),
+        )
+        for tick in range(1, 50):
+            assert await payments.tick_stream(PaymentRef("stream-1"), tick) == 0
+        assert payments.balance(AgentId("payer")) == 10000
+        assert payments.balance(AgentId("payee")) == 0
+
+    @pytest.mark.asyncio
+    async def test_tick_stream_drains_per_delivery(self, payments: StreamingPayments) -> None:
+        """Each delivered unit is billed exactly once."""
         await payments.open_stream(
             to=AgentId("payee"),
             rate_per_tick=100,
@@ -133,86 +169,198 @@ class TestStreamingPayments:
             ref=PaymentRef("stream-1"),
         )
 
-        # Tick 1: drain 100
-        still_open = await payments.tick_stream(PaymentRef("stream-1"), 1)
-        assert still_open
+        assert payments.record_delivery(PaymentRef("stream-1"), unit=1)
+        assert await payments.tick_stream(PaymentRef("stream-1"), 1) == 100
+        assert payments.balance(AgentId("payer")) == 9900
+        assert payments.balance(AgentId("payee")) == 100
+
+        assert payments.record_delivery(PaymentRef("stream-1"), unit=2)
+        assert await payments.tick_stream(PaymentRef("stream-1"), 2) == 100
         assert payments.balance(AgentId("payer")) == 9800
         assert payments.balance(AgentId("payee")) == 200
 
-        # Tick 2: drain 100
-        still_open = await payments.tick_stream(PaymentRef("stream-1"), 2)
-        assert still_open
-        assert payments.balance(AgentId("payer")) == 9700
-        assert payments.balance(AgentId("payee")) == 300
+        # No new delivery: nothing further drains.
+        assert await payments.tick_stream(PaymentRef("stream-1"), 3) == 0
+        assert payments.balance(AgentId("payee")) == 200
+
+    @pytest.mark.asyncio
+    async def test_duplicate_delivery_never_double_bills(
+        self,
+        payments: StreamingPayments,
+    ) -> None:
+        """Recording the same unit twice queues it once."""
+        await payments.open_stream(
+            to=AgentId("payee"),
+            rate_per_tick=100,
+            max_total=500,
+            ref=PaymentRef("stream-1"),
+        )
+        assert payments.record_delivery(PaymentRef("stream-1"), unit=1)
+        assert not payments.record_delivery(PaymentRef("stream-1"), unit=1)
+        assert await payments.tick_stream(PaymentRef("stream-1"), 1) == 100
+        assert not payments.record_delivery(PaymentRef("stream-1"), unit=1)
+        assert await payments.tick_stream(PaymentRef("stream-1"), 2) == 0
+        assert payments.balance(AgentId("payee")) == 100
 
     @pytest.mark.asyncio
     async def test_tick_stream_hits_max(self, payments: StreamingPayments) -> None:
-        """Test that stream closes when max_total is reached."""
+        """The stream closes itself when max_total is reached."""
         await payments.open_stream(
             to=AgentId("payee"),
             rate_per_tick=100,
             max_total=300,
             ref=PaymentRef("stream-1"),
         )
+        for unit in (1, 2, 3):
+            payments.record_delivery(PaymentRef("stream-1"), unit)
+            await payments.tick_stream(PaymentRef("stream-1"), unit)
 
-        # First tick already drained 100
-        # Tick 1: drain 100 (total 200)
-        still_open = await payments.tick_stream(PaymentRef("stream-1"), 1)
-        assert still_open
-
-        # Tick 2: drain 100 (total 300 = max) -> stream closes
-        still_open = await payments.tick_stream(PaymentRef("stream-1"), 2)
-        assert not still_open
+        handle = payments.stream(PaymentRef("stream-1"))
+        assert handle is not None
+        assert handle.closed_at_tick == 3
         assert payments.balance(AgentId("payee")) == 300
 
-    @pytest.mark.asyncio
-    async def test_tick_stream_insufficient_balance(
-        self,
-        payments: StreamingPayments,
-    ) -> None:
-        """Test that stream closes if payer runs out of balance."""
-        await payments.open_stream(
-            to=AgentId("payee"),
-            rate_per_tick=5000,
-            max_total=50000,
-            ref=PaymentRef("stream-1"),
-        )
-
-        # First tick drained 5000 -> balance is 5000
-        # Tick 1: drain 5000 -> balance 0
-        await payments.tick_stream(PaymentRef("stream-1"), 1)
-        assert payments.balance(AgentId("payer")) == 0
-
-        # Tick 2: insufficient funds -> stream closes
-        still_open = await payments.tick_stream(PaymentRef("stream-1"), 2)
-        assert not still_open
+        # A fourth delivery is refused: the stream is closed.
+        assert not payments.record_delivery(PaymentRef("stream-1"), 4)
+        assert await payments.tick_stream(PaymentRef("stream-1"), 4) == 0
 
     @pytest.mark.asyncio
-    async def test_close_stream(self, payments: StreamingPayments) -> None:
-        """Test closing a stream."""
+    async def test_tick_stream_insufficient_balance_stops_stream(self) -> None:
+        """The stream closes when the payer runs dry mid-stream."""
+        payments = StreamingPayments(AgentId("payer"), initial_balance=150)
         await payments.open_stream(
             to=AgentId("payee"),
             rate_per_tick=100,
             max_total=500,
             ref=PaymentRef("stream-1"),
         )
+        payments.record_delivery(PaymentRef("stream-1"), 1)
+        assert await payments.tick_stream(PaymentRef("stream-1"), 1) == 100
+        payments.record_delivery(PaymentRef("stream-1"), 2)
+        assert await payments.tick_stream(PaymentRef("stream-1"), 2) == 0
 
-        # Drain 2 more ticks
-        await payments.tick_stream(PaymentRef("stream-1"), 1)
-        await payments.tick_stream(PaymentRef("stream-1"), 2)
+        handle = payments.stream(PaymentRef("stream-1"))
+        assert handle is not None
+        assert handle.closed_at_tick == 2
+        assert payments.balance(AgentId("payer")) == 50
+        assert payments.balance(AgentId("payee")) == 100
 
-        # Close the stream (300 transferred so far)
-        receipt = await payments.close_stream(PaymentRef("stream-1"))
+    @pytest.mark.asyncio
+    async def test_close_stream_mid_stream(self, payments: StreamingPayments) -> None:
+        """Closing mid-stream settles only what was billed; remainder never spent."""
+        await payments.open_stream(
+            to=AgentId("payee"),
+            rate_per_tick=100,
+            max_total=500,
+            ref=PaymentRef("stream-1"),
+        )
+        for unit in (1, 2, 3):
+            payments.record_delivery(PaymentRef("stream-1"), unit)
+            await payments.tick_stream(PaymentRef("stream-1"), unit)
+
+        receipt = await payments.close_stream(PaymentRef("stream-1"), at_tick=5)
         assert receipt.payer == AgentId("payer")
         assert receipt.payee == AgentId("payee")
         assert receipt.amount.amount == 300
+        assert payments.balance(AgentId("payer")) == 9700
+
+    @pytest.mark.asyncio
+    async def test_close_stream_stops_the_bleed(self, payments: StreamingPayments) -> None:
+        """After close, no delivery and no drain is accepted — at any tick."""
+        await payments.open_stream(
+            to=AgentId("payee"),
+            rate_per_tick=100,
+            max_total=500,
+            ref=PaymentRef("stream-1"),
+        )
+        payments.record_delivery(PaymentRef("stream-1"), 1)
+        await payments.tick_stream(PaymentRef("stream-1"), 1)
+        await payments.close_stream(PaymentRef("stream-1"), at_tick=2)
+
+        assert not payments.record_delivery(PaymentRef("stream-1"), 2)
+        for tick in range(3, 30):
+            assert await payments.tick_stream(PaymentRef("stream-1"), tick) == 0
+        assert payments.balance(AgentId("payee")) == 100
+
+    @pytest.mark.asyncio
+    async def test_close_pending_deliveries_die_with_the_stream(
+        self,
+        payments: StreamingPayments,
+    ) -> None:
+        """Deliveries recorded but not yet billed are not billed after close."""
+        await payments.open_stream(
+            to=AgentId("payee"),
+            rate_per_tick=100,
+            max_total=500,
+            ref=PaymentRef("stream-1"),
+        )
+        payments.record_delivery(PaymentRef("stream-1"), 1)
+        payments.record_delivery(PaymentRef("stream-1"), 2)
+        await payments.close_stream(PaymentRef("stream-1"), at_tick=1)
+        assert await payments.tick_stream(PaymentRef("stream-1"), 2) == 0
+        assert payments.balance(AgentId("payee")) == 0
+
+    @pytest.mark.asyncio
+    async def test_close_stream_idempotent(self, payments: StreamingPayments) -> None:
+        """A second close returns the stored receipt unchanged."""
+        await payments.open_stream(
+            to=AgentId("payee"),
+            rate_per_tick=100,
+            max_total=500,
+            ref=PaymentRef("stream-1"),
+        )
+        first = await payments.close_stream(PaymentRef("stream-1"), at_tick=1)
+        second = await payments.close_stream(PaymentRef("stream-1"), at_tick=99)
+        assert first == second
+
+    @pytest.mark.asyncio
+    async def test_close_stream_unknown_ref(self, payments: StreamingPayments) -> None:
+        """Closing a nonexistent stream raises."""
+        with pytest.raises(StreamError, match="Stream not found"):
+            await payments.close_stream(PaymentRef("nope"))
+
+    @pytest.mark.asyncio
+    async def test_payee_can_close_and_receipt_names_true_payer(self) -> None:
+        """Either party can close; the receipt names the stream's payer."""
+        balances: dict[AgentId, int] = {}
+        payments_dict: dict[PaymentRef, object] = {}
+        streams: dict[PaymentRef, object] = {}
+        payer = StreamingPayments(
+            AgentId("payer"),
+            initial_balance=1000,
+            balances=balances,
+            payments=payments_dict,  # type: ignore[arg-type]
+            streams=streams,  # type: ignore[arg-type]
+        )
+        payee = StreamingPayments(
+            AgentId("payee"),
+            initial_balance=0,
+            balances=balances,
+            payments=payments_dict,  # type: ignore[arg-type]
+            streams=streams,  # type: ignore[arg-type]
+        )
+        await payer.open_stream(
+            to=AgentId("payee"),
+            rate_per_tick=10,
+            max_total=100,
+            ref=PaymentRef("s-1"),
+        )
+        payer.record_delivery(PaymentRef("s-1"), 1)
+        await payer.tick_stream(PaymentRef("s-1"), 1)
+
+        receipt = await payee.close_stream(PaymentRef("s-1"), at_tick=2)
+        assert receipt.payer == AgentId("payer")
+        assert receipt.payee == AgentId("payee")
+        assert receipt.amount.amount == 10
+        # And the payer's instance sees the same settled state.
+        assert await payer.verify_payment(PaymentRef("s-1")) == PaymentStatus.CONFIRMED
 
     @pytest.mark.asyncio
     async def test_verify_payment_confirmed(
         self,
         payments: StreamingPayments,
     ) -> None:
-        """Test verify_payment for completed payments."""
+        """verify_payment for completed payments."""
         await payments.pay(
             AgentId("payee"),
             Money(amount=100),
@@ -226,13 +374,15 @@ class TestStreamingPayments:
         self,
         payments: StreamingPayments,
     ) -> None:
-        """Test verify_payment for open streams."""
+        """A half-drained open stream reports STREAMING."""
         await payments.open_stream(
             to=AgentId("payee"),
             rate_per_tick=100,
             max_total=500,
             ref=PaymentRef("stream-1"),
         )
+        payments.record_delivery(PaymentRef("stream-1"), 1)
+        await payments.tick_stream(PaymentRef("stream-1"), 1)
         status = await payments.verify_payment(PaymentRef("stream-1"))
         assert status == PaymentStatus.STREAMING
 
@@ -241,7 +391,7 @@ class TestStreamingPayments:
         self,
         payments: StreamingPayments,
     ) -> None:
-        """Test verify_payment for non-existent ref."""
+        """verify_payment for a nonexistent ref."""
         status = await payments.verify_payment(PaymentRef("nonexistent"))
         assert status == PaymentStatus.FAILED
 
@@ -250,11 +400,10 @@ class TestStreamingPayments:
         self,
         payments: StreamingPayments,
     ) -> None:
-        """Test conservation: total debited == total credited."""
+        """Conservation: system wealth is constant through stream activity."""
         payee1 = AgentId("payee1")
         payee2 = AgentId("payee2")
 
-        # Open two streams
         await payments.open_stream(
             to=payee1,
             rate_per_tick=100,
@@ -268,29 +417,24 @@ class TestStreamingPayments:
             ref=PaymentRef("stream-2"),
         )
 
-        # Initial: payer 10000 - 100 - 50 = 9850
-        assert payments.balance(AgentId("payer")) == 9850
-        assert payments.balance(payee1) == 100
-        assert payments.balance(payee2) == 50
+        for tick in (1, 2):
+            payments.record_delivery(PaymentRef("stream-1"), tick)
+            payments.record_delivery(PaymentRef("stream-2"), tick)
+            await payments.tick_stream(PaymentRef("stream-1"), tick)
+            await payments.tick_stream(PaymentRef("stream-2"), tick)
 
-        # Tick both streams
-        await payments.tick_stream(PaymentRef("stream-1"), 1)
-        await payments.tick_stream(PaymentRef("stream-2"), 1)
-
-        # payer: 9850 - 100 - 50 = 9700; payee1: 200; payee2: 100
-        assert payments.balance(AgentId("payer")) == 9700
+        assert payments.balance(AgentId("payer")) == 10000 - 200 - 100
         assert payments.balance(payee1) == 200
         assert payments.balance(payee2) == 100
 
-        # Verify conservation
-        total_paid_out = (
+        total = (
             payments.balance(payee1) + payments.balance(payee2) + payments.balance(AgentId("payer"))
         )
-        assert total_paid_out == 10000  # Total system wealth preserved
+        assert total == 10000
 
     @pytest.mark.asyncio
     async def test_refund(self, payments: StreamingPayments) -> None:
-        """Test refunding a payment."""
+        """A settled payment can be refunded in full."""
         await payments.pay(
             AgentId("payee"),
             Money(amount=100),
@@ -300,5 +444,34 @@ class TestStreamingPayments:
         assert payments.balance(AgentId("payee")) == 100
 
         await payments.refund(PaymentRef("pay-1"))
+        assert payments.balance(AgentId("payer")) == 10000
+        assert payments.balance(AgentId("payee")) == 0
+
+    @pytest.mark.asyncio
+    async def test_refund_open_stream_rejected(self, payments: StreamingPayments) -> None:
+        """An open stream cannot be refunded — it must be closed first."""
+        await payments.open_stream(
+            to=AgentId("payee"),
+            rate_per_tick=100,
+            max_total=500,
+            ref=PaymentRef("stream-1"),
+        )
+        with pytest.raises(StreamError, match="close it first"):
+            await payments.refund(PaymentRef("stream-1"))
+
+    @pytest.mark.asyncio
+    async def test_refund_closed_stream(self, payments: StreamingPayments) -> None:
+        """A closed stream refunds exactly the billed total."""
+        await payments.open_stream(
+            to=AgentId("payee"),
+            rate_per_tick=100,
+            max_total=500,
+            ref=PaymentRef("stream-1"),
+        )
+        payments.record_delivery(PaymentRef("stream-1"), 1)
+        await payments.tick_stream(PaymentRef("stream-1"), 1)
+        await payments.close_stream(PaymentRef("stream-1"), at_tick=2)
+
+        await payments.refund(PaymentRef("stream-1"))
         assert payments.balance(AgentId("payer")) == 10000
         assert payments.balance(AgentId("payee")) == 0

--- a/packages/nest-plugins-reference/tests/test_streaming_properties.py
+++ b/packages/nest-plugins-reference/tests/test_streaming_properties.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hypothesis property tests for the streaming payments plugin.
+
+Adapts the conservation-under-random-op-sequence invariant from the escrow
+plugin's property suite to streams:
+
+* System wealth is constant under any interleaving of deliveries, drains,
+  and closes across concurrent streams.
+* No stream ever bills past ``max_total``, in any op order.
+* After close, no op sequence can move another credit.
+* The settled receipt always equals the payee's credited total.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, PaymentRef
+from nest_plugins_reference.payments.streaming import StreamError, StreamingPayments
+
+_PAYER = AgentId("payer")
+_PAYEES = (AgentId("payee-a"), AgentId("payee-b"))
+_REFS = (PaymentRef("s-a"), PaymentRef("s-b"))
+
+# An op is (op_kind, stream_index, unit) applied in sequence.
+_OPS = st.lists(
+    st.tuples(
+        st.sampled_from(["deliver", "tick", "close"]),
+        st.integers(min_value=0, max_value=1),
+        st.integers(min_value=1, max_value=12),
+    ),
+    max_size=60,
+)
+
+
+def _total_wealth(payments: StreamingPayments) -> int:
+    """Sum every party's balance.
+
+    Example::
+
+        assert _total_wealth(payments) == 1000
+    """
+    return payments.balance(_PAYER) + payments.balance(_PAYEES[0]) + payments.balance(_PAYEES[1])
+
+
+async def _apply_ops(
+    payments: StreamingPayments,
+    ops: list[tuple[str, int, int]],
+) -> None:
+    """Apply a random op sequence against two open streams.
+
+    Example::
+
+        await _apply_ops(payments, [("deliver", 0, 1), ("tick", 0, 1)])
+    """
+    for tick, (op, stream_idx, unit) in enumerate(ops, start=1):
+        ref = _REFS[stream_idx]
+        if op == "deliver":
+            payments.record_delivery(ref, unit)
+        elif op == "tick":
+            await payments.tick_stream(ref, tick)
+        else:
+            await payments.close_stream(ref, at_tick=tick)
+
+
+@given(ops=_OPS, initial=st.integers(min_value=200, max_value=5000))
+@settings(max_examples=200, deadline=None)
+@pytest.mark.asyncio
+async def test_conservation_under_random_op_sequence(
+    ops: list[tuple[str, int, int]],
+    initial: int,
+) -> None:
+    """For any op interleaving, total system wealth never changes."""
+    payments = StreamingPayments(_PAYER, initial_balance=initial)
+    await payments.open_stream(to=_PAYEES[0], rate_per_tick=7, max_total=70, ref=_REFS[0])
+    await payments.open_stream(to=_PAYEES[1], rate_per_tick=13, max_total=39, ref=_REFS[1])
+    before = _total_wealth(payments)
+    await _apply_ops(payments, ops)
+    assert _total_wealth(payments) == before
+
+
+@given(ops=_OPS)
+@settings(max_examples=200, deadline=None)
+@pytest.mark.asyncio
+async def test_never_bills_past_max_total(ops: list[tuple[str, int, int]]) -> None:
+    """No op order can push a stream's total past its declared cap."""
+    payments = StreamingPayments(_PAYER, initial_balance=10_000)
+    await payments.open_stream(to=_PAYEES[0], rate_per_tick=7, max_total=70, ref=_REFS[0])
+    await payments.open_stream(to=_PAYEES[1], rate_per_tick=13, max_total=39, ref=_REFS[1])
+    await _apply_ops(payments, ops)
+    for ref, cap in zip(_REFS, (70, 39), strict=True):
+        handle = payments.stream(ref)
+        assert handle is not None
+        assert handle.total_debited <= cap
+
+
+@given(ops=_OPS)
+@settings(max_examples=200, deadline=None)
+@pytest.mark.asyncio
+async def test_close_is_final_under_any_following_ops(
+    ops: list[tuple[str, int, int]],
+) -> None:
+    """Once closed, no subsequent op sequence moves another credit."""
+    payments = StreamingPayments(_PAYER, initial_balance=10_000)
+    await payments.open_stream(to=_PAYEES[0], rate_per_tick=7, max_total=700, ref=_REFS[0])
+    await payments.open_stream(to=_PAYEES[1], rate_per_tick=13, max_total=390, ref=_REFS[1])
+
+    payments.record_delivery(_REFS[0], 1)
+    await payments.tick_stream(_REFS[0], 1)
+    receipt = await payments.close_stream(_REFS[0], at_tick=2)
+    credited_at_close = payments.balance(_PAYEES[0])
+    assert receipt.amount.amount == credited_at_close
+
+    await _apply_ops(payments, ops)
+    assert payments.balance(_PAYEES[0]) == credited_at_close
+
+
+@given(ops=_OPS)
+@settings(max_examples=200, deadline=None)
+@pytest.mark.asyncio
+async def test_settled_receipt_equals_payee_credit(
+    ops: list[tuple[str, int, int]],
+) -> None:
+    """After any op sequence, closing settles exactly what the payee received."""
+    payments = StreamingPayments(_PAYER, initial_balance=10_000)
+    await payments.open_stream(to=_PAYEES[0], rate_per_tick=7, max_total=70, ref=_REFS[0])
+    await payments.open_stream(to=_PAYEES[1], rate_per_tick=13, max_total=39, ref=_REFS[1])
+    await _apply_ops(payments, ops)
+    receipt_a = await payments.close_stream(_REFS[0], at_tick=999)
+    receipt_b = await payments.close_stream(_REFS[1], at_tick=999)
+    assert receipt_a.amount.amount == payments.balance(_PAYEES[0])
+    assert receipt_b.amount.amount == payments.balance(_PAYEES[1])
+
+
+@given(bad_rate=st.integers(max_value=0))
+@settings(max_examples=100, deadline=None)
+@pytest.mark.asyncio
+async def test_non_positive_rate_always_raises(bad_rate: int) -> None:
+    """Any rate <= 0 raises — no off-by-one survives."""
+    payments = StreamingPayments(_PAYER, initial_balance=1000)
+    with pytest.raises(StreamError):
+        await payments.open_stream(
+            to=_PAYEES[0],
+            rate_per_tick=bad_rate,
+            max_total=100,
+            ref=_REFS[0],
+        )

--- a/packages/nest-plugins-reference/tests/test_streaming_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_streaming_scenario.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end scenario tests for the streaming payments plugin.
+
+Boots ``streaming_payments`` (and its partition variant) through the real
+``Simulator`` and proves:
+
+* all three validators PASS under ``payments: streaming``;
+* all three validators FAIL under ``payments: prepaid_credits`` (which has
+  no streaming surface and quietly pre-pays) — the adversarial
+  discrimination the charter asks for;
+* a full buyer/seller partition results in **zero** money flow;
+* same seed → byte-identical trace (determinism).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+
+_SCENARIOS = Path(__file__).resolve().parents[3] / "scenarios"
+SCENARIO_PATH = _SCENARIOS / "streaming_payments.yaml"
+PARTITION_PATH = _SCENARIOS / "streaming_payments_partition.yaml"
+
+
+def _run(yaml_path: Path, plugin_name: str, seed: int = 42) -> Path:
+    """Run a scenario YAML with the chosen payments plugin; return the trace path."""
+    config = ScenarioConfig.from_yaml(str(yaml_path))
+    layers = config.layers.model_copy(update={"payments": plugin_name})
+    trace_path = Path(tempfile.mkdtemp()) / f"streaming_{plugin_name}_{seed}.jsonl"
+    config = config.model_copy(
+        update={
+            "layers": layers,
+            "seed": seed,
+            "output": config.output.model_copy(update={"trace": str(trace_path)}),
+        }
+    )
+    runner = ScenarioRunner(config, registry=PluginRegistry())
+    asyncio.run(runner.run())
+    return trace_path
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_streaming_plugin_passes_all_three_validators() -> None:
+    """Under 5% message drop, conservation, close-finality, and ack-gating all hold."""
+    trace_path = _run(SCENARIO_PATH, "streaming")
+    results = validate_trace(trace_path, "streaming_payments")
+    summary = [f"{'PASS' if r.passed else 'FAIL'} {r.name}: {r.detail}" for r in results]
+    assert all(r.passed for r in results), "\n".join(summary)
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_prepaid_credits_fails_all_three_validators() -> None:
+    """The one-shot default plugin cannot fake a streaming lifecycle.
+
+    Buyers fall back to a flat upfront ``pay()``, so the trace carries no
+    ``stream:*`` events and every validator reports the absence.
+    """
+    trace_path = _run(SCENARIO_PATH, "prepaid_credits")
+    results = validate_trace(trace_path, "streaming_payments")
+    by_name = {r.name: r for r in results}
+    assert not by_name["streaming_conservation"].passed
+    assert not by_name["streaming_no_drain_after_close"].passed
+    assert not by_name["streaming_no_overbill_on_partition"].passed
+
+
+@pytest.mark.skipif(not PARTITION_PATH.exists(), reason=f"scenario not at {PARTITION_PATH}")
+def test_partitioned_buyers_bill_nothing() -> None:
+    """Full buyer/seller partition: streams open, but zero money moves.
+
+    No ack can cross the partition, so delivery-gated billing drains
+    nothing — the no-overbill property in its purest form. The validators
+    still pass: not billing for undelivered work is the correct behavior.
+    """
+    trace_path = _run(PARTITION_PATH, "streaming")
+    results = validate_trace(trace_path, "streaming_payments")
+    assert all(r.passed for r in results), [
+        f"{r.name}: {r.detail}" for r in results if not r.passed
+    ]
+
+    debits = 0
+    opened = 0
+    for line in trace_path.read_text().splitlines():
+        ev = json.loads(line)
+        msg = str(ev.get("msg", ""))
+        if ev.get("kind") == "broadcast" and msg.startswith("stream:debit:"):
+            debits += 1
+        if ev.get("kind") == "broadcast" and msg.startswith("stream:opened:"):
+            opened += 1
+    assert opened > 0, "streams should still open on the buyer side"
+    assert debits == 0, f"partitioned payers must bill nothing, saw {debits} debits"
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_streaming_scenario_deterministic_under_replay() -> None:
+    """Two runs with seed 42 produce identical trace bytes."""
+    a = _run(SCENARIO_PATH, "streaming", seed=42).read_bytes()
+    b = _run(SCENARIO_PATH, "streaming", seed=42).read_bytes()
+    assert a == b
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+@pytest.mark.parametrize("seed", [7, 1337])
+def test_streaming_scenario_passes_across_seeds(seed: int) -> None:
+    """Validator verdicts hold across seeds, not just the YAML default."""
+    trace_path = _run(SCENARIO_PATH, "streaming", seed=seed)
+    results = validate_trace(trace_path, "streaming_payments")
+    assert all(r.passed for r in results), [
+        f"{r.name}: {r.detail}" for r in results if not r.passed
+    ]

--- a/scenarios/streaming_payments.yaml
+++ b/scenarios/streaming_payments.yaml
@@ -4,9 +4,11 @@
 
 name: streaming_payments
 description: |
-  Five buyers open streams to five sellers over 100 rounds with 5% message drop.
-  All three validators must pass: conservation, no-drain-after-close,
-  and no-overbill-on-partition.
+  Five buyers each attempt 100 metered work units against their seller,
+  spread over rolling streams (open -> per-unit ack -> per-unit debit ->
+  close), with 5% message drop and mid-stream cancellation on every third
+  stream. All three validators must pass: conservation,
+  no-drain-after-close, and no-overbill-on-partition.
 
 tier: 1
 seed: 42

--- a/scenarios/streaming_payments_partition.yaml
+++ b/scenarios/streaming_payments_partition.yaml
@@ -6,9 +6,11 @@
 name: streaming_payments_partition
 description: |
   Five buyers stream payments to five sellers under a network partition that
-  isolates buyers from sellers. Any payment_debited after the partition must
-  be caught by the over-bill validator. All three validators run: conservation,
-  no-drain-after-close, no-overbill-on-partition.
+  isolates buyers from sellers. No ack can cross the partition, so
+  delivery-gated billing must drain exactly nothing; any stream:debit without
+  a previously delivered ack is caught by the over-bill validator. All three
+  validators run: conservation, no-drain-after-close,
+  no-overbill-on-partition.
 
 tier: 1
 seed: 42


### PR DESCRIPTION
## What this is

**Problem 03 — streaming pay-per-second payments with mid-stream cancellation** (`payments` layer). One problem, one layer.

The tree already contained a `streaming` plugin, three validators, and two scenario YAMLs — but they were scaffolding, not a solution:

- `nest run scenarios/streaming_payments.yaml` **crashed**: no `streaming_payments` scenario factory existed.
- The plugin hardcoded `opened_at_tick=0` ("will be set by context"), stamped `closed_at_tick=0` on close, had zero partition awareness, and named the wrong payer on a payee-side close.
- All three validators checked event shapes (`payment_debited`, `event_type: stream_opened`) that the trace layer **never emits** — they passed vacuously on any trace, including an empty one.

## What ships

**Delivery-gated billing** as the core design: the payer records each delivered work unit (`record_delivery`) and only then drains one tick (`tick_stream`). A unit the payee never delivered — dropped message, network partition, or a closed stream — is never billed. This is the per-request metering shape of x402-style HTTP payments on the simulator's logical clock.

- **Plugin** (`("payments", "streaming")`, drop-in for the stock `Payments` protocol): `open_stream`/`close_stream` per the brief, close idempotent and final at any tick (unused remainder never spent), `pay()` literally implemented as a one-tick stream so one-shot and streaming share every invariant, refund only on settled refs. `verify_payment` returns `STREAMING` for a half-drained stream — drained ticks are final and irrevocable, so the settlement is in progress, not `PENDING` (documented in the docstring, as the brief asks). Deterministic: ticks come from the caller; no wall clock, no RNG.
- **Scenario factory** (was missing): 5 buyer/seller pairs, rolling streams, per-unit ack → per-unit debit, mid-stream cancellation on every third stream, cancel deadlines so the run makes progress under drop. Both existing YAMLs now run and pass.
- **Validators rewritten against the real trace format and made non-vacuous** (they FAIL on a trace with no streaming lifecycle — a plugin that quietly pre-pays cannot pass):
  1. *conservation* — settled total == sum of per-unit debits, never past `max_total`;
  2. *no-drain-after-close* — trace-order check, plus no unit billed twice;
  3. *no-overbill-on-partition* — every debit must cite a previously **delivered** ack (`receive` event), which subsumes both random drop and full partition.

## Adversarial discrimination

- Under `payments: streaming`: all three validators PASS (5% drop run: 97 streams, 297 debits, every settled receipt equals its debit sum).
- Under `payments: prepaid_credits` on the identical scenario: all three FAIL ("no streaming lifecycle observed").
- Under a full buyer/seller partition: 96 streams open, **zero** credits move, validators pass — not billing for undelivered work is the correct behavior.
- 8 synthetic attack traces (drain-after-close, double-bill, over-bill without ack, time-travel billing, receipt mismatch, past-cap billing, missing lifecycle) each caught by the right validator.

## Tests

26 plugin unit tests · 6 hypothesis properties (conservation under random op sequences — adapted from the escrow suite as the brief suggests — cap enforcement, close finality) · 6 end-to-end scenario tests (discrimination, byte-identical replay at seed 42, multi-seed, partition ⇒ zero flow) · 6 validator smoke tests.

## Reproduce

From a clone of this PR branch:

```bash
gh pr checkout 93   # or: git fetch origin pull/93/head && git checkout FETCH_HEAD
make ci-local       # the repo's Definition of Done: uv sync, ruff check,
                    # ruff format --check, pyright, pytest -v
```

Expected: `ci-local: all 5 checks passed. Safe to push.` (804 passed, 1 skipped.)

Then the behavioral evidence, straight from the scenario YAMLs:

```bash
# 1. 5% drop run — all three validators PASS
uv run nest run scenarios/streaming_payments.yaml -o ./traces/sp.jsonl
uv run python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
[print(('PASS' if r.passed else 'FAIL'), r.name, '-', r.detail) for r in validate_trace(Path('traces/sp.jsonl'),'streaming_payments')]"
# expected: 97 streams, 297 debits, every settled receipt equals its debit sum

# 2. full buyer/seller partition — streams open, ZERO credits move, validators PASS
uv run nest run scenarios/streaming_payments_partition.yaml -o ./traces/spp.jsonl
uv run python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
[print(('PASS' if r.passed else 'FAIL'), r.name, '-', r.detail) for r in validate_trace(Path('traces/spp.jsonl'),'streaming_payments')]"
# expected: '96 streams, 0 total flow' — partitioned payers bill nothing

# 3. discrimination — flip payments: streaming -> prepaid_credits in
#    scenarios/streaming_payments.yaml, re-run step 1: all three validators FAIL
#    ('no streaming lifecycle observed')

# 4. determinism — re-run step 1 twice; traces are byte-identical (seed 42)
```

CI state on this branch (on top of main @ 5527bd7): ruff ✓ · format ✓ · pyright (strict) ✓ · **804 tests passed** · `make ci-local` exits green.
