### PR TITLE
[Hackathon] memory: add mv_register, a multi-value register CRDT that never drops a concurrent write

### DIFF
--- a/docs/layers/memory.md
+++ b/docs/layers/memory.md
@@ -145,6 +145,31 @@ same key concurrently, `lww_register` keeps 1 value and `mv_register` keeps `N`.
   `mv_register_siblings` scenario; confirms every replica's final state in the
   trace holds the same set of all `N` sibling values.
 
+### Cost and scale
+
+MV-Register carries the version vector that LWW does not, so it costs more, but
+the cost is bounded by *concurrency degree* -- the number of writes to one key
+that are unresolved at the same time -- not by fleet size or total write count.
+When a write causally follows what a replica has seen (the common case), the key
+collapses to one sibling and merge is `O(vector size)`, the same order as LWW.
+Siblings only accumulate while a genuine conflict is open, and one overwrite that
+has seen them collapses them again.
+
+Two properties keep it bounded in this simulator:
+
+- **Version vectors are keyed by agent id**, which is stable and bounded by the
+  agent count, so a vector never grows past the number of writers to that key.
+- **Merge folds incrementally into the maintained sibling set** rather than
+  recomputing it, so repeated gossip rounds over state a replica already has are
+  cheap (a subset check), not quadratic.
+
+The pathological case -- every agent writing the same key at once and never
+resolving -- is what the scale test in `test_mv_register.py` exercises: 50
+replicas gossiping all-to-all still converge correctly to all 50 siblings. For
+fleets in the thousands with churned (non-reused) ids, the standard next step is
+dotted version vectors or sibling pruning; the plugin is structured so that
+change is local to the merge.
+
 ### Demo scenario
 
 `scenarios/mv_register_siblings.yaml` -- 6 agents each own a replica, write the

--- a/docs/layers/memory.md
+++ b/docs/layers/memory.md
@@ -80,10 +80,94 @@ for r in validate_trace(Path('traces/memory_concurrent_writers.jsonl'), 'memory_
 
 The trace is byte-identical under seeds 42, 7, and 1337.
 
+## CRDT plugin: `mv_register`
+
+`mv_register` -- a state-based **Multi-Value Register CvRDT**. It is the
+causality-tracking counterpart of `lww_register`, and it exists to fix a
+property that plugin cannot have.
+
+`lww_register` totally orders writes by their Lamport clock, so a concurrent
+write to the same key always has a loser: the register keeps one payload and
+**silently drops the other**. That is correct for last-writer-wins, but it means
+a value written by a live agent can vanish with no error and no trace line.
+
+`mv_register` instead tags every write with a **version vector** -- a
+`{node: counter}` map that records, per replica, how many writes this value
+causally descends from. Version vectors form a *partial* order, so the register
+can tell a causal overwrite (keep the newer, drop the older) apart from a
+genuine conflict (two writes that never saw each other) and keep **both** of the
+latter as *siblings*. Merge keeps the maximal elements of that order, which is
+commutative, associative, and idempotent -- so replicas still reach strong
+eventual consistency, but the invariant they converge on is stronger: **no
+concurrently-written value is ever lost.**
+
+Source: [`nest_plugins_reference/memory/mv_register.py`](../../packages/nest-plugins-reference/nest_plugins_reference/memory/mv_register.py).
+
+It implements the full `Memory` protocol plus the same `export` / `merge` /
+`export_all` / `merge_all` replication channel, and adds one method --
+`values(key)` -- that returns every concurrent sibling (base `read` returns a
+single deterministic representative to satisfy the single-value protocol). The
+value for a key is stored as grep-able JSON; two concurrent writes leave two
+entries, a causal overwrite leaves one::
+
+    {"crdt": "mv_register",
+     "values": [{"payload": "<base64>", "vv": {"agent-0": 1}},
+                {"payload": "<base64>", "vv": {"agent-1": 1}}]}
+
+```python
+a = MvRegisterMemory("a")
+b = MvRegisterMemory("b")
+await a.write("k", b"from-a")       # concurrent: neither has seen the other
+await b.write("k", b"from-b")
+await b.merge("k", a.export("k"))   # gossip a -> b
+await a.merge("k", b.export("k"))   # gossip b -> a
+assert await a.values("k") == await b.values("k") == [b"from-a", b"from-b"]
+```
+
+### When to pick which
+
+Use `lww_register` when one value must win and losing a concurrent write is
+acceptable (a last-known-status field, a cache entry). Use `mv_register` when
+losing a concurrent write is a bug and the application would rather see the
+conflict and resolve it (a shared tag set, an agent's claim on a resource, any
+"merge later" field). The difference is observable: after `N` agents write the
+same key concurrently, `lww_register` keeps 1 value and `mv_register` keeps `N`.
+
+### No-loss validators
+
+- `validate_mv_no_concurrent_loss(make_replica, values)`
+  ([`nest_plugins_reference/validators`](../../packages/nest-plugins-reference/nest_plugins_reference/validators/mv_register_validators.py))
+  -- the adversarial driver: it makes each replica write a distinct value
+  concurrently, gossips all-to-all, and asserts every value survives on every
+  replica. It **fails** for `lww_register` (each replica keeps one, so `N-1`
+  values are lost) and **passes** for `mv_register`.
+- `validate_mv_sibling_preservation(events)` -- registered for the
+  `mv_register_siblings` scenario; confirms every replica's final state in the
+  trace holds the same set of all `N` sibling values.
+
+### Demo scenario
+
+`scenarios/mv_register_siblings.yaml` -- 6 agents each own a replica, write the
+same key concurrently, and gossip under 10% message drop. Every replica ends
+holding all 6 writes as siblings:
+
+```bash
+nest run mv_register_siblings
+python -c "
+from pathlib import Path
+from nest_core.validators import validate_trace
+for r in validate_trace(Path('traces/mv_register_siblings.jsonl'), 'mv_register_siblings'):
+    print(('PASS' if r.passed else 'FAIL'), r.name, '-', r.detail)
+"
+```
+
+The trace is byte-identical under seeds 42, 7, and 1337.
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under
 entry point group `nest.plugins.memory`.
 
-Good fits to test here: CRDTs (LWW-Register, OR-Set), tuple spaces,
-eventually-consistent stores, snapshot isolation.
+Good fits to test here: CRDTs (`lww_register` and `mv_register` are already
+here; a sequence CRDT such as RGA or an OR-Map would be new ground), tuple
+spaces, eventually-consistent stores, snapshot isolation.

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -39,6 +39,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("negotiation", "pareto"): f"{_REF}.negotiation.pareto:ParetoNegotiation",
     ("memory", "blackboard"): f"{_REF}.memory.blackboard:Blackboard",
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
+    ("memory", "mv_register"): f"{_REF}.memory.mv_register:MvRegisterMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
     ("privacy", "hybrid_x25519"): f"{_REF}.privacy.hybrid_x25519:HybridX25519Privacy",
     ("datafacts", "datafacts_v1"): f"{_REF}.datafacts.datafacts_v1:DataFactsV1",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -87,6 +87,12 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("memory_concurrent_writers", memory_concurrent_writers_factory)
+    elif name == "mv_register_siblings":
+        from nest_core.scenarios_builtin.mv_register_siblings import (
+            mv_register_siblings_factory,
+        )
+
+        register_scenario("mv_register_siblings", mv_register_siblings_factory)
     elif name == "comms_versioning":
         from nest_core.scenarios_builtin.comms_versioning import comms_versioning_factory
 

--- a/packages/nest-core/nest_core/scenarios_builtin/mv_register_siblings.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/mv_register_siblings.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MV-Register siblings scenario -- concurrent writes must all survive.
+
+This reuses the concurrent-writers harness (each agent owns its own memory
+replica, writes one distinct value to a shared key at start-up, then runs a
+fixed number of anti-entropy gossip rounds under a lossy network), but it
+exists as a separate scenario because its **success criterion is the opposite**
+of ``memory_concurrent_writers``.
+
+``memory_concurrent_writers`` pairs with ``lww_register`` and asks the swarm to
+*converge to one winning value*. This scenario pairs with ``mv_register`` and
+asks the swarm to *converge to the same set of ``N`` sibling values* -- every
+concurrent write kept, none dropped. The ``mv_register_siblings`` trace
+validator (:func:`nest_core.validators.validate_mv_sibling_preservation`)
+checks that property on the ``final:<state>`` record each agent broadcasts on
+stop. Run against ``lww_register`` the same scenario would fail it: each replica
+would collapse to a single sibling.
+
+Example::
+
+    agents = mv_register_siblings_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.scenarios_builtin.memory_concurrent_writers import CrdtWriterAgent
+from nest_core.sim.agent import StateMachineAgent
+from nest_core.types import AgentId
+
+
+def mv_register_siblings_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create N writer agents, each with its own memory replica of a shared key.
+
+    Instantiates one replica of the configured memory plugin per agent (passing
+    the agent id as the replica's stable node id) and registers them as
+    per-agent overrides through the ``_agent_plugins`` channel the runner
+    understands. Each agent's value is derived from its id, so all writes are
+    distinct and the scenario replays byte-identically under a fixed seed.
+
+    Example::
+
+        agents = mv_register_siblings_factory(config, plugins)
+    """
+    task_config = config.task.config
+    rounds = int(task_config.get("rounds", 20))
+    key = str(task_config.get("key", "shared"))
+    count = max(config.agents.count, 4)
+
+    memory_cls = plugins["memory"]
+    agent_ids = [AgentId(f"writer-{i}") for i in range(count)]
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    overrides: dict[AgentId, dict[str, Any]] = {}
+    for aid in agent_ids:
+        agents[aid] = CrdtWriterAgent(
+            aid,
+            key=key,
+            value=f"value-from-{aid}".encode(),
+            rounds=rounds,
+        )
+        overrides[aid] = {"memory": memory_cls(str(aid))}
+
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/yaml/mv_register_siblings.yaml
+++ b/packages/nest-core/nest_core/scenarios_builtin/yaml/mv_register_siblings.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# MV-Register siblings scenario (bundled copy for `nest run mv_register_siblings`).
+# 6 agents race to write the same key, each with its own multi-value-register
+# replica, and gossip under loss. Every concurrent write must survive as a
+# sibling on every replica -- the property lww_register cannot provide.
+name: mv_register_siblings
+description: "6 agents write one shared key under 10% message drop; every concurrent write survives as a sibling."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 6
+  brain: state-machine
+  roles:
+    - name: writer
+      count: 6
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: mv_register
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: mv_register_siblings
+  config:
+    rounds: 30
+    key: shared
+
+failures:
+  message_drop: 0.1
+
+duration: "ticks: 100000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/mv_register_siblings.jsonl

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1234,6 +1234,149 @@ def validate_memory_convergence(
     return results
 
 
+def _mv_sibling_payloads(body: str) -> frozenset[str] | None:
+    """Extract the set of base64 sibling payloads from an MV-Register final record.
+
+    Returns ``None`` if the record is not a well-formed ``mv_register`` state.
+    Keyed on the payload strings alone (not the version vectors) because the
+    property under test is *which values survived*, not their causal tags.
+
+    Example::
+
+        _mv_sibling_payloads('{"crdt":"mv_register","values":[{"payload":"YQ=="}]}')
+    """
+    try:
+        parsed = json.loads(body)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    data = cast("dict[str, Any]", parsed)
+    if data.get("crdt") != "mv_register":
+        return None
+    raw = data.get("values")
+    if not isinstance(raw, list):
+        return None
+    payloads: set[str] = set()
+    for entry in cast("list[Any]", raw):
+        if not isinstance(entry, dict):
+            return None
+        payload = cast("dict[str, Any]", entry).get("payload")
+        if not isinstance(payload, str):
+            return None
+        payloads.add(payload)
+    return frozenset(payloads)
+
+
+def validate_mv_sibling_preservation(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Trace validator: every replica keeps every concurrent write as a sibling.
+
+    The ``mv_register_siblings`` scenario has each of ``N`` agents write one
+    distinct value to the same key -- concurrently, before any gossip -- and
+    then broadcast its terminal register as a ``final:<json>`` record on stop.
+    A correct MV-Register converges every replica to the *same set* of ``N``
+    sibling values; a last-writer-wins register would instead collapse each
+    replica to a single winner. This validator asserts both halves of the
+    MV-Register property that ``lww_register`` cannot satisfy:
+
+    * **convergence** -- all replicas hold an identical sibling set, and
+    * **no concurrent loss** -- that set contains all ``N`` written values, so
+      nothing was silently dropped (the set size equals the replica count).
+
+    A last-writer-wins register drives both checks to fail: every replica holds
+    a size-1 set, and (absent a tie-break agreement) those singletons need not
+    even match.
+    """
+    finals: dict[str, frozenset[str]] = {}
+    duplicates: set[str] = set()
+    malformed: list[str] = []
+
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        msg = str(ev.get("msg", ""))
+        if not msg.startswith("final:"):
+            continue
+        agent = str(ev.get("agent", ""))
+        payloads = _mv_sibling_payloads(msg[len("final:") :])
+        if payloads is None:
+            malformed.append(agent)
+            continue
+        if agent in finals:
+            duplicates.add(agent)
+        finals[agent] = payloads
+
+    results: list[ValidationResult] = []
+    if malformed:
+        results.append(
+            ValidationResult(
+                "mv_sibling_wellformed",
+                False,
+                f"{len(malformed)} malformed final record(s): {sorted(set(malformed))}",
+            )
+        )
+    if not finals:
+        results.append(
+            ValidationResult(
+                "mv_sibling_preservation",
+                False,
+                "no final replica states found in trace",
+            )
+        )
+        return results
+
+    replica_count = len(finals)
+    distinct_sets = set(finals.values())
+    if len(distinct_sets) == 1:
+        results.append(
+            ValidationResult(
+                "mv_sibling_convergence",
+                True,
+                f"all {replica_count} replicas hold an identical sibling set",
+            )
+        )
+    else:
+        results.append(
+            ValidationResult(
+                "mv_sibling_convergence",
+                False,
+                f"{replica_count} replicas hold {len(distinct_sets)} distinct sibling sets",
+            )
+        )
+
+    short = sorted(a for a, s in finals.items() if len(s) < replica_count)
+    if short:
+        results.append(
+            ValidationResult(
+                "mv_sibling_preservation",
+                False,
+                f"{len(short)} replica(s) lost concurrent writes "
+                f"(fewer than {replica_count} siblings): {short}",
+            )
+        )
+    else:
+        results.append(
+            ValidationResult(
+                "mv_sibling_preservation",
+                True,
+                f"every replica kept all {replica_count} concurrent writes as siblings",
+            )
+        )
+
+    if duplicates:
+        results.append(
+            ValidationResult(
+                "mv_sibling_one_final_per_agent",
+                False,
+                f"agents emitted multiple final records: {sorted(duplicates)}",
+            )
+        )
+
+    return results
+
+
 # ---------------------------------------------------------------------------
 # Streaming payments validators
 # ---------------------------------------------------------------------------
@@ -4081,6 +4224,10 @@ VALIDATORS: dict[str, list[Any]] = {
     ],
     "memory_concurrent_writers": [
         validate_memory_convergence,
+        validate_memory_liveness,
+    ],
+    "mv_register_siblings": [
+        validate_mv_sibling_preservation,
         validate_memory_liveness,
     ],
     "streaming_payments": [

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -1815,6 +1815,7 @@ class TestValidatorRegistry:
             "reputation",
             "identity_rotation",
             "memory_concurrent_writers",
+            "mv_register_siblings",
             "streaming_payments",
             "empic_payments",
             "comms_versioning",

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/mv_register.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/mv_register.py
@@ -180,7 +180,11 @@ class VersionVector:
             lo = VersionVector.from_dict({"a": 1})
             assert hi.dominates(lo) and not lo.dominates(hi)
         """
-        return all(self.get(n) >= other.get(n) for n in self._nodes(other))
+        # Only ``other``'s entries can make this false: a node present only in
+        # ``self`` compares against ``other``'s implicit 0 and always holds.
+        # Iterating ``other.items`` avoids allocating the node-set union on the
+        # hot dominance path.
+        return all(self.get(node) >= count for node, count in other.items)
 
     def strictly_dominates(self, other: VersionVector) -> bool:
         """Return True if this vector causally follows (and differs from) ``other``.
@@ -231,30 +235,46 @@ class Value:
         return (self.vv.items, self.payload)
 
 
-def _keep_maximal(values: list[Value]) -> list[Value]:
-    """Return the concurrent survivors: drop any value another strictly follows.
+def _merge_into_antichain(
+    current: list[Value],
+    incoming: list[Value],
+) -> tuple[list[Value], bool]:
+    """Fold ``incoming`` into a maximal ``current`` sibling set, keeping it maximal.
 
-    Deduplicates identical ``(payload, vv)`` pairs, discards every value that is
-    strictly dominated by some other value, and returns the result sorted by
-    :meth:`Value.sort_key`. What remains is an antichain under the version-vector
-    order -- the register's sibling set. This is the whole of the MV-Register
-    join, so it is commutative, associative, and idempotent by construction.
+    The result is the antichain of the version-vector order over
+    ``current + incoming`` -- every value not strictly dominated by another,
+    deduplicated by ``(payload, vv)`` and sorted by :meth:`Value.sort_key`.
+    Because the maximal set of a union is order-independent, this is exactly the
+    MV-Register join, so it is commutative, associative, and idempotent.
+
+    When ``current`` is already an antichain (the store only ever holds one),
+    folding each incoming value against the running survivors is
+    ``O(len(incoming) * len(result))`` -- it skips the quadratic
+    ``current``-vs-``current`` comparisons a from-scratch recompute would repeat
+    on every merge, which is what keeps repeated gossip rounds cheap. Passing
+    ``current=[]`` normalizes an arbitrary ``incoming`` list from scratch.
+    Returns the sorted survivors and whether anything changed.
 
     Example::
 
-        survivors = _keep_maximal([older, newer])  # -> [newer]
+        survivors, changed = _merge_into_antichain(store_values, gossiped_values)
     """
-    unique: dict[tuple[tuple[tuple[str, int], ...], bytes], Value] = {}
-    for value in values:
-        unique[value.sort_key()] = value
-    candidates = list(unique.values())
-    survivors = [
-        value
-        for value in candidates
-        if not any(other.vv.strictly_dominates(value.vv) for other in candidates)
-    ]
-    survivors.sort(key=Value.sort_key)
-    return survivors
+    result: dict[tuple[tuple[tuple[str, int], ...], bytes], Value] = {
+        value.sort_key(): value for value in current
+    }
+    changed = False
+    for value in incoming:
+        key = value.sort_key()
+        if key in result:
+            continue
+        if any(kept.vv.strictly_dominates(value.vv) for kept in result.values()):
+            continue
+        superseded = [k for k, kept in result.items() if value.vv.strictly_dominates(kept.vv)]
+        for k in superseded:
+            del result[k]
+        result[key] = value
+        changed = True
+    return sorted(result.values(), key=Value.sort_key), changed
 
 
 class MvRegisterMemory:
@@ -471,14 +491,14 @@ class MvRegisterMemory:
         before_repr = before[0].payload if before else None
         for value in incoming:
             self._clock = max(self._clock, value.vv.get(self._node_id))
-        merged = _keep_maximal(before + incoming)
+        merged, changed = _merge_into_antichain(before, incoming)
+        if not changed:
+            return False
         self._store[key] = merged
         after_repr = merged[0].payload if merged else None
-        if merged != before:
-            if after_repr is not None and after_repr != before_repr:
-                await self._notify(key, after_repr)
-            return True
-        return False
+        if after_repr is not None and after_repr != before_repr:
+            await self._notify(key, after_repr)
+        return True
 
     async def merge_all(self, state: bytes) -> list[str]:
         """Merge a full-state snapshot, returning the keys whose value changed.

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/mv_register.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/mv_register.py
@@ -1,0 +1,592 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Multi-Value Register CRDT memory plugin -- concurrent writes survive.
+
+This module implements a **state-based multi-value register** (an MV-Register
+CvRDT) for the Nanda Town memory layer. It is the causality-tracking sibling
+of the ``lww_register`` plugin, and it exists to fix a property that plugin
+*cannot* have.
+
+``lww_register`` tags every write with a Lamport clock and totally orders the
+writes, so a concurrent write to the same key always has a loser: the register
+keeps one payload and **silently drops the other**. That is correct for a
+last-writer-wins register, but it means information written by a live agent can
+vanish with no error and no trace.
+
+An MV-Register instead tags every write with a **version vector** -- a
+``{node: counter}`` map that records, per replica, how many writes this value
+causally descends from. Version vectors form a *partial* order, so the register
+can tell the difference between:
+
+* one write that *causally follows* another (keep the newer, drop the older), and
+* two writes that are *concurrent* (neither has seen the other) -- keep **both**.
+
+The value of a key is therefore a small set of **siblings**: the writes that are
+pairwise concurrent under the version-vector order. Merge keeps the maximal
+elements of that order, which makes it commutative, associative, and idempotent
+-- the three laws that give *strong eventual consistency*. Two replicas that
+have observed the same writes hold the same sibling set regardless of delivery
+order, duplication, or loss. The difference from LWW is the headline: **no
+concurrently-written value is ever lost.**
+
+The serialized state for one key is inspectable JSON so it stays grep-able
+inside a JSONL trace::
+
+    {"crdt": "mv_register",
+     "values": [{"payload": "<base64>", "vv": {"agent-0": 1}},
+                {"payload": "<base64>", "vv": {"agent-1": 1}}]}
+
+Two concurrent writes leave two entries in ``values``. A causal overwrite
+leaves one. That shape is exactly what the ``mv_register_siblings`` scenario and
+the ``validate_mv_no_concurrent_loss`` adversarial validator assert on.
+
+Example::
+
+    a = MvRegisterMemory("a")
+    b = MvRegisterMemory("b")
+    await a.write("k", b"from-a")   # concurrent: neither has seen the other
+    await b.write("k", b"from-b")
+    await b.merge("k", a.export("k"))
+    await a.merge("k", b.export("k"))
+    assert await a.values("k") == await b.values("k") == [b"from-a", b"from-b"]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any, cast
+
+CRDT_KIND = "mv_register"
+"""Schema tag stamped into every serialized register, used to detect and
+validate CRDT state when it is read back from a trace or the wire."""
+
+
+class MvStateError(ValueError):
+    """Raised when a byte string is not a valid serialized MV-Register.
+
+    Subclasses :class:`ValueError` so existing ``except ValueError`` handlers
+    keep working while callers that care can catch the specific type.
+
+    Example::
+
+        try:
+            MvRegisterMemory._decode(b"not json")
+        except MvStateError:
+            ...
+    """
+
+
+@dataclass(frozen=True)
+class VersionVector:
+    """An immutable ``{node: counter}`` clock ordered by the CRDT partial order.
+
+    Stored as a tuple of ``(node, counter)`` pairs sorted by node with all
+    zero entries dropped, so two vectors that describe the same causal history
+    are ``==`` and hash equal regardless of how they were built. That
+    canonical form is what makes serialized state byte-identical across
+    replicas.
+
+    Example::
+
+        vv = VersionVector.from_dict({"a": 2, "b": 0, "c": 1})
+        assert vv.get("a") == 2 and vv.get("b") == 0
+    """
+
+    items: tuple[tuple[str, int], ...]
+
+    @staticmethod
+    def empty() -> VersionVector:
+        """Return the bottom vector (all counters zero).
+
+        Example::
+
+            assert VersionVector.empty().get("a") == 0
+        """
+        return VersionVector(())
+
+    @staticmethod
+    def from_dict(counts: dict[str, int]) -> VersionVector:
+        """Build a canonical vector from a ``{node: counter}`` map.
+
+        Zero (and negative) counters are dropped and the remaining pairs are
+        sorted by node, so equal histories canonicalize to equal vectors.
+
+        Example::
+
+            VersionVector.from_dict({"b": 1, "a": 2})
+        """
+        items = tuple(sorted((n, c) for n, c in counts.items() if c > 0))
+        return VersionVector(items)
+
+    def as_dict(self) -> dict[str, int]:
+        """Return a plain ``{node: counter}`` copy for serialization or edits.
+
+        Example::
+
+            VersionVector.from_dict({"a": 1}).as_dict() == {"a": 1}
+        """
+        return dict(self.items)
+
+    def get(self, node: str) -> int:
+        """Return this vector's counter for ``node`` (0 if absent).
+
+        Example::
+
+            assert VersionVector.from_dict({"a": 3}).get("a") == 3
+        """
+        for name, count in self.items:
+            if name == node:
+                return count
+        return 0
+
+    def _nodes(self, other: VersionVector) -> set[str]:
+        return {n for n, _ in self.items} | {n for n, _ in other.items}
+
+    def merge(self, other: VersionVector) -> VersionVector:
+        """Return the pointwise maximum (the join) of two vectors.
+
+        Example::
+
+            a = VersionVector.from_dict({"a": 1})
+            b = VersionVector.from_dict({"b": 2})
+            assert a.merge(b).as_dict() == {"a": 1, "b": 2}
+        """
+        merged = {n: max(self.get(n), other.get(n)) for n in self._nodes(other)}
+        return VersionVector.from_dict(merged)
+
+    def with_bump(self, node: str, counter: int) -> VersionVector:
+        """Return a copy with ``node`` set to ``counter`` (used on local write).
+
+        Example::
+
+            VersionVector.empty().with_bump("a", 1).get("a") == 1
+        """
+        counts = self.as_dict()
+        counts[node] = counter
+        return VersionVector.from_dict(counts)
+
+    def dominates(self, other: VersionVector) -> bool:
+        """Return True if this vector is >= ``other`` at every node.
+
+        Equal vectors dominate each other; that is intentional and lets the
+        merge treat a duplicate as already-seen.
+
+        Example::
+
+            hi = VersionVector.from_dict({"a": 2})
+            lo = VersionVector.from_dict({"a": 1})
+            assert hi.dominates(lo) and not lo.dominates(hi)
+        """
+        return all(self.get(n) >= other.get(n) for n in self._nodes(other))
+
+    def strictly_dominates(self, other: VersionVector) -> bool:
+        """Return True if this vector causally follows (and differs from) ``other``.
+
+        Example::
+
+            hi = VersionVector.from_dict({"a": 2})
+            lo = VersionVector.from_dict({"a": 1})
+            assert hi.strictly_dominates(lo)
+        """
+        return self != other and self.dominates(other)
+
+    def concurrent(self, other: VersionVector) -> bool:
+        """Return True if neither vector dominates the other (a real conflict).
+
+        Example::
+
+            a = VersionVector.from_dict({"a": 1})
+            b = VersionVector.from_dict({"b": 1})
+            assert a.concurrent(b)
+        """
+        return not self.dominates(other) and not other.dominates(self)
+
+
+@dataclass(frozen=True)
+class Value:
+    """A single register payload tagged with the version vector that wrote it.
+
+    Two values are siblings iff their vectors are :meth:`~VersionVector.concurrent`.
+    Ordering the tuple ``(vv.items, payload)`` gives a total order used only to
+    serialize siblings deterministically -- it is not the causal order.
+
+    Example::
+
+        v = Value(b"hi", VersionVector.from_dict({"a": 1}))
+    """
+
+    payload: bytes
+    vv: VersionVector
+
+    def sort_key(self) -> tuple[tuple[tuple[str, int], ...], bytes]:
+        """Return a deterministic total-order key for stable serialization.
+
+        Example::
+
+            Value(b"x", VersionVector.empty()).sort_key()
+        """
+        return (self.vv.items, self.payload)
+
+
+def _keep_maximal(values: list[Value]) -> list[Value]:
+    """Return the concurrent survivors: drop any value another strictly follows.
+
+    Deduplicates identical ``(payload, vv)`` pairs, discards every value that is
+    strictly dominated by some other value, and returns the result sorted by
+    :meth:`Value.sort_key`. What remains is an antichain under the version-vector
+    order -- the register's sibling set. This is the whole of the MV-Register
+    join, so it is commutative, associative, and idempotent by construction.
+
+    Example::
+
+        survivors = _keep_maximal([older, newer])  # -> [newer]
+    """
+    unique: dict[tuple[tuple[tuple[str, int], ...], bytes], Value] = {}
+    for value in values:
+        unique[value.sort_key()] = value
+    candidates = list(unique.values())
+    survivors = [
+        value
+        for value in candidates
+        if not any(other.vv.strictly_dominates(value.vv) for other in candidates)
+    ]
+    survivors.sort(key=Value.sort_key)
+    return survivors
+
+
+class MvRegisterMemory:
+    """A multi-value register CRDT implementing the ``Memory`` protocol.
+
+    Each instance is an independent **replica**. A local :meth:`write` records
+    a value tagged with a version vector that dominates every sibling this
+    replica currently holds, so it supersedes them locally; replicas exchange
+    state with :meth:`export` / :meth:`merge` (typically gossiped over the
+    transport layer). Concurrent writes made on different replicas are kept as
+    **siblings** rather than one silently winning, which is the property the
+    ``lww_register`` plugin cannot provide.
+
+    The base :class:`~nest_core.layers.memory.Memory` surface
+    (``read`` / ``write`` / ``cas`` / ``subscribe``) treats values as opaque
+    payloads. Because the base ``read`` returns a single ``bytes``, it returns
+    a **deterministic representative** when siblings exist; the additional
+    :meth:`values` method returns the full sibling set, and
+    :meth:`export` / :meth:`merge` are the replication channel. All three are
+    additive -- a caller that only speaks the base protocol never has to know
+    the value is multi-valued.
+
+    Example::
+
+        mem = MvRegisterMemory("agent-0")
+        await mem.write("counter", b"42")
+        assert await mem.read("counter") == b"42"
+        assert await mem.values("counter") == [b"42"]
+    """
+
+    def __init__(self, node_id: str = "node") -> None:
+        """Create a replica with a stable, unique ``node_id``.
+
+        The ``node_id`` labels this replica's component of every version
+        vector, so it must be stable for the replica's lifetime and unique
+        across replicas. Two replicas sharing a ``node_id`` could stamp two
+        distinct writes with the same vector and lose the distinction between
+        them.
+
+        Example::
+
+            mem = MvRegisterMemory("agent-0")
+        """
+        self._node_id = str(node_id)
+        self._store: dict[str, list[Value]] = {}
+        self._clock: int = 0
+        self._subscribers: dict[str, list[asyncio.Queue[bytes]]] = {}
+
+    @property
+    def node_id(self) -> str:
+        """The stable node id labelling this replica in every version vector.
+
+        Example::
+
+            assert MvRegisterMemory("agent-0").node_id == "agent-0"
+        """
+        return self._node_id
+
+    @property
+    def clock(self) -> int:
+        """This replica's monotonic local write counter.
+
+        Example::
+
+            assert MvRegisterMemory("a").clock == 0
+        """
+        return self._clock
+
+    # -- Memory protocol -------------------------------------------------
+
+    async def read(self, key: str) -> bytes | None:
+        """Read a single representative payload for ``key`` (``None`` if unset).
+
+        When the key holds concurrent siblings, the representative is the
+        smallest payload under the deterministic sibling order, so ``read`` is
+        stable and replica-independent. Use :meth:`values` to see every
+        sibling -- ``read`` deliberately hides multiplicity to satisfy the
+        single-value base protocol, it never resolves the conflict.
+
+        Example::
+
+            val = await mem.read("counter")
+        """
+        siblings = self._store.get(key)
+        if not siblings:
+            return None
+        return siblings[0].payload
+
+    async def values(self, key: str) -> list[bytes]:
+        """Return every concurrent sibling payload for ``key``, deterministically ordered.
+
+        One element for a settled key, several while concurrent writes are
+        unresolved, empty if the key is unset. This is the method that exposes
+        the MV-Register's defining property: concurrent writes are all here,
+        none were dropped.
+
+        Example::
+
+            assert await mem.values("counter") == [b"42"]
+        """
+        siblings = self._store.get(key)
+        if not siblings:
+            return []
+        return [value.payload for value in siblings]
+
+    async def write(self, key: str, value: bytes) -> None:
+        """Locally write ``value`` for ``key``, superseding this replica's siblings.
+
+        The write is tagged with the join of every current sibling's vector,
+        with this replica's component advanced to a fresh monotonic counter.
+        That vector strictly dominates each current sibling, so the local write
+        replaces them -- a write always overrides what *this* replica has
+        already observed. Concurrency only arises across replicas, and is
+        reconciled at :meth:`merge`. Subscribers are notified, matching the
+        blackboard contract that every local write is observable.
+
+        Example::
+
+            await mem.write("counter", b"42")
+        """
+        self._clock += 1
+        joined = VersionVector.empty()
+        for sibling in self._store.get(key, []):
+            joined = joined.merge(sibling.vv)
+        new_vv = joined.with_bump(self._node_id, self._clock)
+        self._store[key] = [Value(payload=value, vv=new_vv)]
+        await self._notify(key, value)
+
+    async def subscribe(self, key: str) -> AsyncIterator[bytes]:
+        """Yield the representative payload for ``key`` each time it advances.
+
+        Example::
+
+            async for val in mem.subscribe("counter"):
+                print(val)
+        """
+        q: asyncio.Queue[bytes] = asyncio.Queue()
+        self._subscribers.setdefault(key, []).append(q)
+        try:
+            while True:
+                yield await q.get()
+        finally:
+            self._subscribers[key].remove(q)
+
+    async def cas(self, key: str, expected: bytes, new: bytes) -> bool:
+        """Compare-and-swap on this replica's representative payload.
+
+        Succeeds iff the current representative equals ``expected``, in which
+        case it performs a normal tagged :meth:`write` of ``new``. Like the
+        LWW plugin, this is linearizable *on this replica*; across replicas the
+        CRDT merge -- not CAS -- reconciles state, so a swap that raced a
+        concurrent write elsewhere surfaces as a sibling at the next
+        :meth:`merge` rather than being lost.
+
+        Example::
+
+            ok = await mem.cas("counter", b"42", b"43")
+        """
+        current = await self.read(key)
+        if current == expected:
+            await self.write(key, new)
+            return True
+        return False
+
+    # -- CRDT replication channel ---------------------------------------
+
+    def export(self, key: str) -> bytes | None:
+        """Serialize the sibling set for ``key`` for gossip (``None`` if unset).
+
+        The result is valid input to another replica's :meth:`merge`.
+
+        Example::
+
+            state = mem.export("counter")
+        """
+        siblings = self._store.get(key)
+        if not siblings:
+            return None
+        return self._encode_values(siblings)
+
+    def export_all(self) -> bytes:
+        """Serialize this replica's full state for a full-state anti-entropy push.
+
+        Example::
+
+            snapshot = mem.export_all()
+        """
+        data = {
+            "crdt": CRDT_KIND,
+            "registers": {
+                key: {"values": self._values_to_json(siblings)}
+                for key, siblings in sorted(self._store.items())
+            },
+        }
+        return json.dumps(data, sort_keys=True).encode("utf-8")
+
+    async def merge(self, key: str, state: bytes) -> bool:
+        """Merge a remote sibling set for ``key`` into the local replica.
+
+        Unions the incoming siblings with the local ones and keeps the maximal
+        elements of the version-vector order (:func:`_keep_maximal`), so causal
+        overwrites collapse and genuine conflicts stay as siblings. Advances
+        this replica's local counter past any observed component so a later
+        local write still dominates. Returns ``True`` if the representative
+        payload changed, in which case subscribers are notified. Idempotent:
+        merging the same state twice is a no-op.
+
+        Example::
+
+            changed = await mem.merge("counter", other.export("counter"))
+        """
+        incoming = self._decode_values(state)
+        before = self._store.get(key, [])
+        before_repr = before[0].payload if before else None
+        for value in incoming:
+            self._clock = max(self._clock, value.vv.get(self._node_id))
+        merged = _keep_maximal(before + incoming)
+        self._store[key] = merged
+        after_repr = merged[0].payload if merged else None
+        if merged != before:
+            if after_repr is not None and after_repr != before_repr:
+                await self._notify(key, after_repr)
+            return True
+        return False
+
+    async def merge_all(self, state: bytes) -> list[str]:
+        """Merge a full-state snapshot, returning the keys whose value changed.
+
+        Example::
+
+            changed_keys = await mem.merge_all(other.export_all())
+        """
+        registers = self._decode_all(state)
+        changed: list[str] = []
+        for key in sorted(registers):
+            if await self.merge(key, self._encode_values(registers[key])):
+                changed.append(key)
+        return changed
+
+    # -- internals -------------------------------------------------------
+
+    async def _notify(self, key: str, payload: bytes) -> None:
+        for q in self._subscribers.get(key, []):
+            await q.put(payload)
+
+    @staticmethod
+    def _values_to_json(values: list[Value]) -> list[dict[str, Any]]:
+        return [
+            {
+                "payload": base64.b64encode(value.payload).decode("ascii"),
+                "vv": value.vv.as_dict(),
+            }
+            for value in values
+        ]
+
+    @classmethod
+    def _encode_values(cls, values: list[Value]) -> bytes:
+        data = {"crdt": CRDT_KIND, "values": cls._values_to_json(values)}
+        return json.dumps(data, sort_keys=True).encode("utf-8")
+
+    @staticmethod
+    def _loads_object(state: bytes) -> object:
+        try:
+            return json.loads(state)
+        except (ValueError, TypeError) as exc:
+            msg = "state is not valid JSON"
+            raise MvStateError(msg) from exc
+
+    @staticmethod
+    def _value_from_fields(fields: dict[str, Any]) -> Value:
+        try:
+            payload = base64.b64decode(fields["payload"])
+            raw_vv = fields["vv"]
+        except (KeyError, ValueError, TypeError) as exc:
+            msg = f"malformed value fields: {fields!r}"
+            raise MvStateError(msg) from exc
+        if not isinstance(raw_vv, dict):
+            msg = f"version vector must be an object: {raw_vv!r}"
+            raise MvStateError(msg)
+        counts: dict[str, int] = {}
+        for node, count in cast("dict[str, Any]", raw_vv).items():
+            try:
+                counts[str(node)] = int(count)
+            except (ValueError, TypeError) as exc:
+                msg = f"version-vector counter for {node!r} is not an int"
+                raise MvStateError(msg) from exc
+        return Value(payload=payload, vv=VersionVector.from_dict(counts))
+
+    @classmethod
+    def _values_from_list(cls, raw: object, ctx: str) -> list[Value]:
+        if not isinstance(raw, list):
+            msg = f"{ctx} 'values' must be a list"
+            raise MvStateError(msg)
+        result: list[Value] = []
+        for entry in cast("list[Any]", raw):
+            if not isinstance(entry, dict):
+                msg = f"{ctx} value must be an object: {entry!r}"
+                raise MvStateError(msg)
+            result.append(cls._value_from_fields(cast("dict[str, Any]", entry)))
+        return result
+
+    @classmethod
+    def _decode_values(cls, state: bytes) -> list[Value]:
+        obj = cls._loads_object(state)
+        if not isinstance(obj, dict):
+            msg = f"not an {CRDT_KIND} register: {obj!r}"
+            raise MvStateError(msg)
+        data = cast("dict[str, Any]", obj)
+        if data.get("crdt") != CRDT_KIND:
+            msg = f"not an {CRDT_KIND} register: {data!r}"
+            raise MvStateError(msg)
+        return cls._values_from_list(data.get("values"), "register")
+
+    @classmethod
+    def _decode_all(cls, state: bytes) -> dict[str, list[Value]]:
+        obj = cls._loads_object(state)
+        if not isinstance(obj, dict):
+            msg = f"not an {CRDT_KIND} snapshot: {obj!r}"
+            raise MvStateError(msg)
+        data = cast("dict[str, Any]", obj)
+        if data.get("crdt") != CRDT_KIND:
+            msg = f"not an {CRDT_KIND} snapshot: {data!r}"
+            raise MvStateError(msg)
+        raw = data.get("registers", {})
+        if not isinstance(raw, dict):
+            msg = "snapshot 'registers' must be an object"
+            raise MvStateError(msg)
+        result: dict[str, list[Value]] = {}
+        for key, fields in cast("dict[str, Any]", raw).items():
+            if not isinstance(fields, dict):
+                msg = f"register for {key!r} must be an object"
+                raise MvStateError(msg)
+            values = cast("dict[str, Any]", fields).get("values")
+            result[str(key)] = cls._values_from_list(values, f"register {key!r}")
+        return result

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -23,6 +23,10 @@ from nest_plugins_reference.validators.gossip_validators import (
     check_converged,
     check_no_partition_view_leak,
 )
+from nest_plugins_reference.validators.mv_register_validators import (
+    ConcurrentWriteLossError,
+    validate_mv_no_concurrent_loss,
+)
 from nest_plugins_reference.validators.privacy_validators import (
     check_eavesdropper_blocked,
     check_field_injection_rejected,
@@ -32,6 +36,7 @@ from nest_plugins_reference.validators.privacy_validators import (
 )
 
 __all__ = [
+    "ConcurrentWriteLossError",
     "ConvergenceFailureError",
     "PartitionLeakError",
     "ValidatorReport",
@@ -42,4 +47,5 @@ __all__ = [
     "check_replay_rejected",
     "check_stale_revocation_blocked",
     "corrupt_proof",
+    "validate_mv_no_concurrent_loss",
 ]

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/mv_register_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/mv_register_validators.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validator for the multi-value register (MV-Register) plugin.
+
+The failure mode this targets is **silent loss of a concurrent write**. When
+two replicas write different payloads to the same key without having seen each
+other, both writes are live data. A register that resolves the conflict by
+picking one winner -- the ``lww_register`` plugin, by design -- discards the
+other with no error. ``validate_mv_no_concurrent_loss`` reproduces exactly that
+race and asserts every concurrently-written value survives on every replica
+after gossip.
+
+By construction:
+
+* against the **mv_register** plugin, all ``N`` concurrent writes are kept as
+  siblings on every replica, so the check passes;
+* against the **lww_register** plugin, each replica collapses the ``N`` writes
+  to a single winner, so ``N - 1`` values are lost and the check fails -- the
+  validator literally cannot be satisfied by the last-writer-wins register,
+  which is the charter's bar for "adversarial".
+
+The check is capability-based, mirroring
+:func:`nest_core.validators.validate_crdt_convergence`: gossip is delivered
+through ``export`` / ``merge`` when the plugin is a CvRDT, and the surviving
+values are read through ``values`` when the plugin exposes the multi-value
+surface, falling back to the single ``read`` otherwise. That fallback is what
+makes ``lww_register`` fail honestly rather than erroring.
+
+Example::
+
+    from nest_plugins_reference.memory.mv_register import MvRegisterMemory
+    report = await validate_mv_no_concurrent_loss(
+        MvRegisterMemory, [b"from-a", b"from-b", b"from-c"]
+    )
+    assert report.passed, report.detail
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_plugins_reference.validators.gossip_validators import ValidatorReport
+
+
+class ConcurrentWriteLossError(AssertionError):
+    """Raised when a concurrently-written value is lost after gossip.
+
+    Example::
+
+        raise ConcurrentWriteLossError("replica node-0 kept 1 of 3 writes")
+    """
+
+
+async def _surviving_values(replica: Any, key: str) -> list[bytes]:  # noqa: ANN401
+    """Return the values a replica holds for ``key``, multi-value aware.
+
+    Uses the plugin's ``values`` method when present (the MV-Register surface),
+    otherwise falls back to the single ``read`` -- so a last-writer-wins
+    register reports the one value it kept, exposing the loss instead of hiding
+    behind a missing method.
+
+    Example::
+
+        kept = await _surviving_values(mem, "k")
+    """
+    if hasattr(replica, "values"):
+        return list(await replica.values(key))
+    single = await replica.read(key)
+    return [] if single is None else [single]
+
+
+async def validate_mv_no_concurrent_loss(
+    make_replica: Any,  # noqa: ANN401
+    values: list[bytes],
+    *,
+    key: str = "k",
+) -> ValidatorReport:
+    """Assert no concurrent write is lost after all-to-all gossip.
+
+    Drives ``len(values)`` replicas through one concurrent write each (every
+    replica writes before it has merged anyone else, so the writes are pairwise
+    concurrent), gossips every replica's state to every other, then checks that
+    each replica ends up holding **all** of the written values.
+
+    Args:
+        make_replica: factory ``node_id -> plugin instance``.
+        values: one distinct payload per replica, all written to ``key``.
+        key: the shared key every replica writes.
+
+    Returns ``passed=True`` iff every replica's surviving value set equals the
+    full set of written values; otherwise ``passed=False`` with
+    ``evidence["lost"]`` naming the dropped payloads per replica.
+
+    Example::
+
+        report = await validate_mv_no_concurrent_loss(MvRegisterMemory, [b"a", b"b"])
+        assert report.passed, report.detail
+    """
+    if len(values) < 2:
+        msg = "need at least two concurrent writes to test for loss"
+        raise ValueError(msg)
+    if len(set(values)) != len(values):
+        msg = "values must be distinct so a lost write is detectable"
+        raise ValueError(msg)
+
+    replica_count = len(values)
+    replicas = [make_replica(f"node-{i}") for i in range(replica_count)]
+    has_crdt = all(hasattr(r, "export") and hasattr(r, "merge") for r in replicas)
+
+    # Phase 1: each replica writes its own value with no prior merge -- concurrent.
+    gossip: list[bytes] = []
+    for idx, payload in enumerate(values):
+        await replicas[idx].write(key, payload)
+        if has_crdt:
+            state = replicas[idx].export(key)
+            gossip.append(state if state is not None else payload)
+        else:
+            gossip.append(payload)
+
+    # Phase 2: all-to-all gossip. One round suffices for a state-based CRDT, but
+    # a second round costs nothing and proves the merge is idempotent under it.
+    for _round in range(2):
+        for r_idx in range(replica_count):
+            for w_idx in range(replica_count):
+                if w_idx == r_idx:
+                    continue
+                if has_crdt:
+                    await replicas[r_idx].merge(key, gossip[w_idx])
+                else:
+                    await replicas[r_idx].write(key, gossip[w_idx])
+
+    expected = set(values)
+    lost: dict[str, list[str]] = {}
+    for idx in range(replica_count):
+        kept = set(await _surviving_values(replicas[idx], key))
+        missing = expected - kept
+        if missing:
+            lost[f"node-{idx}"] = sorted(repr(v) for v in missing)
+
+    if lost:
+        dropped = sorted({v for vals in lost.values() for v in vals})
+        return ValidatorReport(
+            passed=False,
+            detail=(
+                f"{len(lost)} of {replica_count} replicas lost concurrent writes; "
+                f"dropped values: {', '.join(dropped)}"
+            ),
+            evidence={"lost": lost},
+        )
+    return ValidatorReport(
+        passed=True,
+        detail=(
+            f"all {replica_count} replicas kept all {replica_count} concurrent writes as siblings"
+        ),
+    )

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -35,6 +35,7 @@ Repository = "https://github.com/projnanda/nandatown"
 # install-time discovery path described in CONTRIBUTING.md.
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
+mv_register = "nest_plugins_reference.memory.mv_register:MvRegisterMemory"
 
 [project.entry-points."nest.plugins.privacy"]
 hybrid_x25519 = "nest_plugins_reference.privacy.hybrid_x25519:HybridX25519Privacy"

--- a/packages/nest-plugins-reference/tests/test_mv_register.py
+++ b/packages/nest-plugins-reference/tests/test_mv_register.py
@@ -1,0 +1,530 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the multi-value register (MV-Register) CRDT memory plugin.
+
+Covers protocol conformance, the read/write/cas/subscribe surface, the
+multi-value ``values`` surface, the export/merge replication channel, version
+vector partial-order semantics, the three CRDT algebraic laws, convergence of
+the sibling set under arbitrary delivery order, the headline property
+(concurrent writes are preserved, causal overwrites collapse), determinism,
+malformed-input handling, registry wiring, the adversarial no-loss validator
+(which must fail for ``lww_register`` and pass for the MV-Register), a
+quantified loss benchmark against LWW, and an end-to-end scenario run under
+message loss that is deterministic across seeds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.layers.memory import Memory
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+from nest_plugins_reference.memory.lww_register import LwwRegisterMemory
+from nest_plugins_reference.memory.mv_register import (
+    CRDT_KIND,
+    MvRegisterMemory,
+    MvStateError,
+    Value,
+    VersionVector,
+)
+from nest_plugins_reference.validators import validate_mv_no_concurrent_loss
+
+# ---------------------------------------------------------------------------
+# Version vector partial-order semantics
+# ---------------------------------------------------------------------------
+
+
+class TestVersionVector:
+    def test_from_dict_drops_zeros_and_sorts(self) -> None:
+        vv = VersionVector.from_dict({"b": 1, "a": 0, "c": 2})
+        assert vv.items == (("b", 1), ("c", 2))
+
+    def test_equal_histories_are_equal(self) -> None:
+        assert VersionVector.from_dict({"a": 1, "b": 0}) == VersionVector.from_dict({"a": 1})
+
+    def test_merge_is_pointwise_max(self) -> None:
+        a = VersionVector.from_dict({"a": 2, "b": 1})
+        b = VersionVector.from_dict({"a": 1, "b": 3})
+        assert a.merge(b).as_dict() == {"a": 2, "b": 3}
+
+    def test_dominates_and_strictly_dominates(self) -> None:
+        hi = VersionVector.from_dict({"a": 2, "b": 1})
+        lo = VersionVector.from_dict({"a": 1, "b": 1})
+        assert hi.dominates(lo)
+        assert hi.strictly_dominates(lo)
+        assert not lo.dominates(hi)
+
+    def test_equal_vectors_dominate_but_not_strictly(self) -> None:
+        v = VersionVector.from_dict({"a": 1})
+        assert v.dominates(v)
+        assert not v.strictly_dominates(v)
+
+    def test_concurrent_when_neither_dominates(self) -> None:
+        a = VersionVector.from_dict({"a": 1})
+        b = VersionVector.from_dict({"b": 1})
+        assert a.concurrent(b)
+        assert b.concurrent(a)
+
+    def test_not_concurrent_when_causal(self) -> None:
+        older = VersionVector.from_dict({"a": 1})
+        newer = VersionVector.from_dict({"a": 1, "b": 1})
+        assert not older.concurrent(newer)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance and base Memory surface
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_isinstance_memory(self) -> None:
+        assert isinstance(MvRegisterMemory("a"), Memory)
+
+    @pytest.mark.asyncio
+    async def test_read_missing_is_none(self) -> None:
+        mem = MvRegisterMemory("a")
+        assert await mem.read("missing") is None
+
+    @pytest.mark.asyncio
+    async def test_values_missing_is_empty(self) -> None:
+        mem = MvRegisterMemory("a")
+        assert await mem.values("missing") == []
+
+    @pytest.mark.asyncio
+    async def test_write_read_roundtrip(self) -> None:
+        mem = MvRegisterMemory("a")
+        await mem.write("k", b"value")
+        assert await mem.read("k") == b"value"
+        assert await mem.values("k") == [b"value"]
+
+    @pytest.mark.asyncio
+    async def test_local_overwrite_collapses_to_one(self) -> None:
+        mem = MvRegisterMemory("a")
+        await mem.write("k", b"old")
+        await mem.write("k", b"new")
+        # A local overwrite causally follows the prior write -- one sibling, not two.
+        assert await mem.read("k") == b"new"
+        assert await mem.values("k") == [b"new"]
+
+    @pytest.mark.asyncio
+    async def test_cas_success(self) -> None:
+        mem = MvRegisterMemory("a")
+        await mem.write("k", b"old")
+        assert await mem.cas("k", b"old", b"new") is True
+        assert await mem.read("k") == b"new"
+
+    @pytest.mark.asyncio
+    async def test_cas_failure_leaves_value(self) -> None:
+        mem = MvRegisterMemory("a")
+        await mem.write("k", b"current")
+        assert await mem.cas("k", b"wrong", b"new") is False
+        assert await mem.read("k") == b"current"
+
+    @pytest.mark.asyncio
+    async def test_cas_on_missing_key(self) -> None:
+        mem = MvRegisterMemory("a")
+        assert await mem.cas("k", b"expected", b"new") is False
+
+    @pytest.mark.asyncio
+    async def test_binary_payload(self) -> None:
+        mem = MvRegisterMemory("a")
+        blob = bytes(range(256))
+        await mem.write("k", blob)
+        assert await mem.read("k") == blob
+
+    @pytest.mark.asyncio
+    async def test_subscribe_receives_writes(self) -> None:
+        mem = MvRegisterMemory("a")
+        sub = mem.subscribe("k")
+        fut = asyncio.ensure_future(anext(sub))
+        await asyncio.sleep(0)
+        await mem.write("k", b"first")
+        assert await asyncio.wait_for(fut, 5) == b"first"
+
+    @pytest.mark.asyncio
+    async def test_subscribe_receives_merges(self) -> None:
+        a = MvRegisterMemory("a")
+        b = MvRegisterMemory("b")
+        await a.write("k", b"v")
+        sub = b.subscribe("k")
+        fut = asyncio.ensure_future(anext(sub))
+        await asyncio.sleep(0)
+        state = a.export("k")
+        assert state is not None
+        await b.merge("k", state)
+        assert await asyncio.wait_for(fut, 5) == b"v"
+
+
+# ---------------------------------------------------------------------------
+# The headline property: concurrent writes survive as siblings
+# ---------------------------------------------------------------------------
+
+
+async def _gossip_both_ways(a: MvRegisterMemory, b: MvRegisterMemory, key: str) -> None:
+    sa, sb = a.export(key), b.export(key)
+    assert sa is not None and sb is not None
+    await a.merge(key, sb)
+    await b.merge(key, sa)
+
+
+class TestConcurrentPreservation:
+    @pytest.mark.asyncio
+    async def test_two_concurrent_writes_kept_as_siblings(self) -> None:
+        a = MvRegisterMemory("a")
+        b = MvRegisterMemory("b")
+        await a.write("k", b"from-a")  # concurrent: neither has seen the other
+        await b.write("k", b"from-b")
+        await _gossip_both_ways(a, b, "k")
+        assert await a.values("k") == [b"from-a", b"from-b"]
+        assert await b.values("k") == [b"from-a", b"from-b"]
+
+    @pytest.mark.asyncio
+    async def test_causal_overwrite_collapses_sibling(self) -> None:
+        a = MvRegisterMemory("a")
+        b = MvRegisterMemory("b")
+        await a.write("k", b"from-a")
+        await b.write("k", b"from-b")
+        await _gossip_both_ways(a, b, "k")
+        # b has now SEEN a's write; overwriting supersedes both siblings causally.
+        await b.write("k", b"resolved")
+        assert await b.values("k") == [b"resolved"]
+        # a merges b's resolution: the conflict collapses to the single new value.
+        state = b.export("k")
+        assert state is not None
+        await a.merge("k", state)
+        assert await a.values("k") == [b"resolved"]
+
+    @pytest.mark.asyncio
+    async def test_lww_would_lose_a_concurrent_write(self) -> None:
+        # Same race on the LWW register keeps exactly one value -- the contrast
+        # this whole plugin exists to remove.
+        a = LwwRegisterMemory("a")
+        b = LwwRegisterMemory("b")
+        await a.write("k", b"from-a")
+        await b.write("k", b"from-b")
+        sa, sb = a.export("k"), b.export("k")
+        assert sa is not None and sb is not None
+        await a.merge("k", sb)
+        await b.merge("k", sa)
+        assert await a.read("k") == await b.read("k")  # converged...
+        # ...but only one of the two written values remains anywhere.
+        survivors = {await a.read("k")}
+        assert survivors < {b"from-a", b"from-b"}
+
+
+# ---------------------------------------------------------------------------
+# Export / merge replication channel
+# ---------------------------------------------------------------------------
+
+
+class TestExportMerge:
+    @pytest.mark.asyncio
+    async def test_export_missing_is_none(self) -> None:
+        assert MvRegisterMemory("a").export("k") is None
+
+    @pytest.mark.asyncio
+    async def test_export_is_grep_able_json(self) -> None:
+        mem = MvRegisterMemory("a")
+        await mem.write("k", b"hi")
+        raw = mem.export("k")
+        assert raw is not None
+        assert CRDT_KIND.encode() in raw
+
+    @pytest.mark.asyncio
+    async def test_merge_into_empty_adopts_value(self) -> None:
+        a = MvRegisterMemory("a")
+        b = MvRegisterMemory("b")
+        await a.write("k", b"from-a")
+        state = a.export("k")
+        assert state is not None
+        assert await b.merge("k", state) is True
+        assert await b.read("k") == b"from-a"
+
+    @pytest.mark.asyncio
+    async def test_merge_is_idempotent(self) -> None:
+        a = MvRegisterMemory("a")
+        b = MvRegisterMemory("b")
+        await a.write("k", b"x")
+        state = a.export("k")
+        assert state is not None
+        assert await b.merge("k", state) is True
+        assert await b.merge("k", state) is False
+        assert await b.values("k") == [b"x"]
+
+    @pytest.mark.asyncio
+    async def test_merge_advances_local_clock(self) -> None:
+        a = MvRegisterMemory("a")
+        await a.write("k", b"a1")  # a:1
+        b = MvRegisterMemory("a")  # same node id, higher observed counter
+        await b.write("k", b"b1")
+        await b.write("k", b"b2")  # a:2
+        state = b.export("k")
+        assert state is not None
+        await a.merge("k", state)
+        await a.write("k", b"a-next")
+        # The post-merge local write must dominate the merged value, not tie it.
+        assert await a.values("k") == [b"a-next"]
+
+    @pytest.mark.asyncio
+    async def test_export_all_merge_all_roundtrip(self) -> None:
+        a = MvRegisterMemory("a")
+        await a.write("k1", b"v1")
+        await a.write("k2", b"v2")
+        b = MvRegisterMemory("b")
+        changed = await b.merge_all(a.export_all())
+        assert changed == ["k1", "k2"]
+        assert await b.read("k1") == b"v1"
+        assert await b.read("k2") == b"v2"
+
+
+# ---------------------------------------------------------------------------
+# Malformed input handling
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedState:
+    @pytest.mark.asyncio
+    async def test_merge_rejects_non_json(self) -> None:
+        with pytest.raises(MvStateError):
+            await MvRegisterMemory("a").merge("k", b"\xff\xfenot json")
+
+    @pytest.mark.asyncio
+    async def test_merge_rejects_wrong_kind(self) -> None:
+        with pytest.raises(MvStateError):
+            await MvRegisterMemory("a").merge("k", b'{"crdt": "other", "values": []}')
+
+    @pytest.mark.asyncio
+    async def test_merge_rejects_bad_values_shape(self) -> None:
+        with pytest.raises(MvStateError):
+            await MvRegisterMemory("a").merge("k", b'{"crdt": "mv_register", "values": {}}')
+
+    @pytest.mark.asyncio
+    async def test_merge_rejects_bad_version_vector(self) -> None:
+        bad = b'{"crdt": "mv_register", "values": [{"payload": "aGk=", "vv": {"a": "x"}}]}'
+        with pytest.raises(MvStateError):
+            await MvRegisterMemory("a").merge("k", bad)
+
+    def test_state_error_is_value_error(self) -> None:
+        assert issubclass(MvStateError, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# CRDT algebraic laws (property-based) over the version-vector merge
+# ---------------------------------------------------------------------------
+
+_node = st.text(alphabet="abc", min_size=1, max_size=2)
+_payload = st.binary(min_size=0, max_size=4)
+_vv = st.dictionaries(_node, st.integers(min_value=0, max_value=4), max_size=3).map(
+    VersionVector.from_dict
+)
+_value = st.builds(Value, payload=_payload, vv=_vv)
+
+
+def _state(value: Value) -> bytes:
+    """Serialize one value to a single-value MV-Register state via the public wire shape."""
+    data = {
+        "crdt": CRDT_KIND,
+        "values": [
+            {
+                "payload": base64.b64encode(value.payload).decode("ascii"),
+                "vv": value.vv.as_dict(),
+            }
+        ],
+    }
+    return json.dumps(data, sort_keys=True).encode("utf-8")
+
+
+async def _merged(states: list[bytes]) -> bytes | None:
+    replica = MvRegisterMemory("merger")
+    for s in states:
+        await replica.merge("k", s)
+    return replica.export("k")
+
+
+class TestCrdtLaws:
+    @settings(max_examples=60, deadline=None)
+    @given(v1=_value, v2=_value)
+    @pytest.mark.asyncio
+    async def test_merge_is_commutative(self, v1: Value, v2: Value) -> None:
+        forward = await _merged([_state(v1), _state(v2)])
+        backward = await _merged([_state(v2), _state(v1)])
+        assert forward == backward
+
+    @settings(max_examples=60, deadline=None)
+    @given(v1=_value, v2=_value, v3=_value)
+    @pytest.mark.asyncio
+    async def test_merge_is_associative(self, v1: Value, v2: Value, v3: Value) -> None:
+        left = await _merged([_state(v1), _state(v2), _state(v3)])
+        right = await _merged([_state(v3), _state(v2), _state(v1)])
+        assert left == right
+
+    @settings(max_examples=60, deadline=None)
+    @given(v1=_value)
+    @pytest.mark.asyncio
+    async def test_merge_is_idempotent(self, v1: Value) -> None:
+        once = await _merged([_state(v1)])
+        twice = await _merged([_state(v1), _state(v1)])
+        assert once == twice
+
+
+# ---------------------------------------------------------------------------
+# Sibling-set convergence under arbitrary delivery order
+# ---------------------------------------------------------------------------
+
+
+class TestConvergence:
+    @settings(max_examples=40, deadline=None)
+    @given(data=st.data())
+    @pytest.mark.asyncio
+    async def test_replicas_converge_to_same_sibling_set(self, data: st.DataObject) -> None:
+        replica_count = data.draw(st.integers(min_value=2, max_value=5))
+        replicas = [MvRegisterMemory(f"node-{i}") for i in range(replica_count)]
+        # Each replica makes one concurrent write, then all-to-all gossip in a
+        # per-replica-random order. Every replica must end with the same set.
+        gossip: list[bytes] = []
+        for i in range(replica_count):
+            await replicas[i].write("k", f"v{i}".encode())
+            state = replicas[i].export("k")
+            assert state is not None
+            gossip.append(state)
+        for i in range(replica_count):
+            order = data.draw(st.permutations(list(range(replica_count))))
+            for j in order:
+                if j != i:
+                    await replicas[i].merge("k", gossip[j])
+        finals = [await r.values("k") for r in replicas]
+        assert all(f == finals[0] for f in finals)
+        assert len(finals[0]) == replica_count  # no write lost
+
+    @pytest.mark.asyncio
+    async def test_determinism_same_ops_same_state(self) -> None:
+        async def build() -> bytes:
+            a = MvRegisterMemory("a")
+            b = MvRegisterMemory("b")
+            await a.write("k", b"one")
+            await b.write("k", b"two")
+            sa, sb = a.export("k"), b.export("k")
+            assert sa is not None and sb is not None
+            await a.merge("k", sb)
+            await b.merge("k", sa)
+            return a.export_all()
+
+        assert await build() == await build()
+
+
+# ---------------------------------------------------------------------------
+# Adversarial validator: LWW must fail, MV-Register must pass
+# ---------------------------------------------------------------------------
+
+
+class TestNoLossValidator:
+    _values = [b"A", b"B", b"C"]
+
+    @pytest.mark.asyncio
+    async def test_mv_register_passes(self) -> None:
+        report = await validate_mv_no_concurrent_loss(MvRegisterMemory, self._values)
+        assert report.passed, report.detail
+
+    @pytest.mark.asyncio
+    async def test_lww_register_fails(self) -> None:
+        report = await validate_mv_no_concurrent_loss(LwwRegisterMemory, self._values)
+        assert not report.passed
+        assert "lost" in report.evidence
+
+    @pytest.mark.asyncio
+    async def test_validator_rejects_too_few_values(self) -> None:
+        with pytest.raises(ValueError, match="two concurrent writes"):
+            await validate_mv_no_concurrent_loss(MvRegisterMemory, [b"only-one"])
+
+    @pytest.mark.asyncio
+    async def test_validator_rejects_duplicate_values(self) -> None:
+        with pytest.raises(ValueError, match="distinct"):
+            await validate_mv_no_concurrent_loss(MvRegisterMemory, [b"x", b"x"])
+
+
+# ---------------------------------------------------------------------------
+# Quantified loss benchmark: how much does LWW silently drop?
+# ---------------------------------------------------------------------------
+
+
+async def _surviving_after_concurrent_writes(
+    factory: Callable[[str], Any],
+    n: int,
+) -> int:
+    """Return how many of ``n`` concurrent writes survive on the first replica."""
+    replicas: list[Any] = [factory(f"node-{i}") for i in range(n)]
+    gossip: list[bytes] = []
+    for i in range(n):
+        await replicas[i].write("k", f"v{i}".encode())
+        gossip.append(replicas[i].export("k"))
+    for i in range(n):
+        for j in range(n):
+            if j != i:
+                await replicas[i].merge("k", gossip[j])
+    if hasattr(replicas[0], "values"):
+        return len(await replicas[0].values("k"))
+    return 1 if await replicas[0].read("k") is not None else 0
+
+
+class TestLossBenchmark:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("n", [2, 5, 10])
+    async def test_mv_keeps_all_lww_keeps_one(self, n: int) -> None:
+        mv_survivors = await _surviving_after_concurrent_writes(MvRegisterMemory, n)
+        lww_survivors = await _surviving_after_concurrent_writes(LwwRegisterMemory, n)
+        assert mv_survivors == n, "MV-Register must keep every concurrent write"
+        assert lww_survivors == 1, "LWW keeps one; the rest are silently dropped"
+        # The hidden property, quantified: LWW drops n-1 of every n concurrent writes.
+        assert (n - lww_survivors) == (n - 1)
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_builtin_resolves(self) -> None:
+        cls = PluginRegistry().resolve("memory", "mv_register")
+        assert cls is MvRegisterMemory
+
+    def test_listed_for_memory_layer(self) -> None:
+        assert ("memory", "mv_register") in PluginRegistry().list_plugins("memory")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end scenario: siblings preserved under loss, deterministic across seeds
+# ---------------------------------------------------------------------------
+
+
+class TestScenario:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("seed", [42, 7, 1337])
+    async def test_scenario_preserves_siblings_and_is_deterministic(self, seed: int) -> None:
+        traces: list[bytes] = []
+        with tempfile.TemporaryDirectory() as tmp:
+            for run in range(2):
+                config = ScenarioConfig.from_yaml("scenarios/mv_register_siblings.yaml")
+                config.seed = seed
+                out = Path(tmp) / f"run-{run}.jsonl"
+                config.output.trace = str(out)
+                trace_path = await ScenarioRunner(config).run()
+                traces.append(trace_path.read_bytes())
+                if run == 0:
+                    results = validate_trace(trace_path, "mv_register_siblings")
+                    assert results, "validator produced no results"
+                    assert all(r.passed for r in results), [
+                        (r.name, r.detail) for r in results if not r.passed
+                    ]
+        assert traces[0] == traces[1], "trace not byte-identical under same seed"

--- a/packages/nest-plugins-reference/tests/test_mv_register.py
+++ b/packages/nest-plugins-reference/tests/test_mv_register.py
@@ -488,6 +488,16 @@ class TestLossBenchmark:
         # The hidden property, quantified: LWW drops n-1 of every n concurrent writes.
         assert (n - lww_survivors) == (n - 1)
 
+    @pytest.mark.asyncio
+    async def test_correct_at_scale_with_full_all_to_all_gossip(self) -> None:
+        # The worst case for a multi-value register: 50 replicas all write the
+        # same key concurrently and never resolve, then gossip all-to-all. The
+        # merge stays correct (every replica converges to all 50 siblings) --
+        # this is what the incremental antichain fold has to get right at size.
+        n = 50
+        survivors = await _surviving_after_concurrent_writes(MvRegisterMemory, n)
+        assert survivors == n
+
 
 # ---------------------------------------------------------------------------
 # Registry wiring

--- a/scenarios/mv_register_siblings.yaml
+++ b/scenarios/mv_register_siblings.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# MV-Register siblings scenario: 6 agents race to write the same key, each with
+# its own multi-value-register replica, and gossip under loss. Unlike
+# memory_concurrent_writers (which converges to ONE winner), every concurrent
+# write must survive as a sibling on every replica.
+name: mv_register_siblings
+description: "6 agents write one shared key under 10% message drop; every concurrent write survives as a sibling."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 6
+  brain: state-machine
+  roles:
+    - name: writer
+      count: 6
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: mv_register
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: mv_register_siblings
+  config:
+    rounds: 30
+    key: shared
+
+failures:
+  message_drop: 0.1
+
+duration: "ticks: 100000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/mv_register_siblings.jsonl


### PR DESCRIPTION
## Summary

Adds `mv_register`, a **Multi-Value Register CvRDT** for the memory layer. The existing `lww_register` is last-writer-wins: on two concurrent writes to a key it keeps one and **silently drops the other**. `mv_register` tags every write with a **version vector**, detects causal concurrency, and keeps concurrent writes as **siblings** — no concurrently-written value is ever lost. After N agents write one key concurrently, `lww_register` keeps 1 value and `mv_register` keeps N.

Ships as a plugin + adversarial validator + deterministic scenario + docs + 49 tests.

## What and where — exact file manifest

**New plugin** — `packages/nest-plugins-reference/nest_plugins_reference/memory/mv_register.py` (612 lines)
- `VersionVector` (**line 83**): immutable `{node: counter}` clock; `dominates` / `strictly_dominates` / `concurrent` / `merge`.
- `Value` (**line 213**): a payload tagged with the version vector that wrote it.
- `_merge_into_antichain` (**line 238**): incremental merge that keeps only the maximal (pairwise-concurrent) set; `O(incoming × current)`, not a from-scratch recompute.
- `MvRegisterMemory` (**line 280**): implements the `Memory` protocol (`read` / `write` / `cas` / `subscribe`) plus `values(key)` (**line 366**) for the sibling set and `export` / `merge` / `export_all` / `merge_all` (**lines 444 / 474 / 503**) for gossip.

**Registration (2 lines)**
- `packages/nest-core/nest_core/plugins.py:42` — `("memory", "mv_register")` builtin.
- `packages/nest-plugins-reference/pyproject.toml:38` — `nest.plugins.memory` entry point.

**Adversarial validator** — `packages/nest-plugins-reference/nest_plugins_reference/validators/mv_register_validators.py:71`
- `validate_mv_no_concurrent_loss(make_replica, values)`: N replicas each write a distinct value concurrently, gossip all-to-all, then assert every value survives on every replica. **Fails** against `lww_register` (N-1 values lost), **passes** against `mv_register`. Exported from `validators/__init__.py`.

**Trace validator + scenario**
- `packages/nest-core/nest_core/validators.py:1271` — `validate_mv_sibling_preservation`; registered in the `VALIDATORS` table at **line 4229** under `"mv_register_siblings"`.
- `packages/nest-core/nest_core/scenarios_builtin/mv_register_siblings.py` (70 lines) + a registration branch in `scenarios.py`.
- `scenarios/mv_register_siblings.yaml` and the bundled `scenarios_builtin/yaml/mv_register_siblings.yaml`.

**Tests** — `packages/nest-plugins-reference/tests/test_mv_register.py` (540 lines, **49 tests**): version-vector partial-order semantics, `Memory` protocol conformance, the three CRDT laws (property-based via Hypothesis), sibling-set convergence under random delivery order, a quantified loss benchmark vs LWW (n = 2, 5, 10) plus a 50-replica scale test, and the end-to-end scenario asserted byte-identical under seeds 42, 7, 1337. `test_validators.py` +1 line (adds `mv_register_siblings` to the scenario-registration expected set).

**Docs** — `docs/layers/memory.md` (+113): contrasts the two registers, a "when to pick which" guide, and a cost/scale note.

## Try it

```
uv run nest run mv_register_siblings
uv run python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
[print(('PASS' if r.passed else 'FAIL'), r.name, '-', r.detail) for r in \
validate_trace(Path('traces/mv_register_siblings.jsonl'), 'mv_register_siblings')]"
# all 6 replicas keep all 6 concurrent writes as siblings under 10% message drop
```

## Files changed

13 files, **+1747 / -2** (plugin 612, tests 540, docs +113, validators +147, scenario 70, plus the 4 registration/entry-point lines and YAML).

## Verification — full CI, branch merged with current `main`

`uv run ruff check .` clean · `uv run ruff format --check .` clean · `uv run pyright` strict **0 errors** · `uv run pytest` **841 passed**, 1 skipped. Cost note: the incremental antichain merge keeps a 50-replica all-to-all gossip correct and fast; cost scales with concurrency degree (open conflicts per key), not fleet size.
