### PR TITLE
[Hackathon] protocol-security-engineer: tamper-evident comms that resist version downgrade

### DIFF
--- a/docs/layers/communication.md
+++ b/docs/layers/communication.md
@@ -22,6 +22,42 @@ Full definition: [`nest_core/layers/comms.py`](../../packages/nest-core/nest_cor
 
 Source: [`nest_plugins_reference/comms/nest_native.py`](../../packages/nest-plugins-reference/nest_plugins_reference/comms/nest_native.py).
 
+## Alternative plugins
+
+`versioned` — adds an in-band `schema_version` + `kind`, preserves unknown
+fields from newer-minor peers, and rejects breaking majors. Solves
+*compatibility* across a rolling upgrade, but trusts the wire.
+
+Source: [`nest_plugins_reference/comms/versioned.py`](../../packages/nest-plugins-reference/nest_plugins_reference/comms/versioned.py).
+
+`authenticated` — a strict superset of `versioned` that binds an
+`HMAC-SHA256` tag over the *entire* canonical envelope (version, kind, and
+every field), keyed by a per-pair channel secret an on-path attacker does not
+hold. This makes tampering **evident**: rewriting `schema_version` back to an
+older, more permissive value (a *version rollback*, cf. TLS `POODLE`/`FREAK`)
+or stripping a field a newer peer added breaks the tag and the envelope is
+refused with a `DowngradeError`. Untagged legacy traffic still flows in the
+default permissive mode; set `require_auth=True` once every peer is upgraded to
+refuse any unauthenticated envelope.
+
+Source: [`nest_plugins_reference/comms/authenticated.py`](../../packages/nest-plugins-reference/nest_plugins_reference/comms/authenticated.py).
+
+Verify the downgrade defense end-to-end (the validator fails on `versioned`,
+passes on `authenticated`):
+
+```bash
+nest run scenarios/comms_downgrade_attack.yaml
+python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
+    [print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail) \
+     for r in validate_trace(Path('traces/comms_downgrade_attack.jsonl'), 'comms_downgrade')]"
+```
+
+Threat model: the tag proves *integrity and pairwise authenticity* under an
+on-path attacker who can read, modify, drop, or reorder bytes but lacks the
+channel key. Key exchange (the pre-shared secret stands in for an ECDH session
+key) and replay of verbatim envelopes are out of scope — bind a nonce into
+`metadata` to close replay separately.
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -20,6 +20,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("transport", "in_memory"): f"{_REF}.transport.in_memory:StandaloneInMemoryTransport",
     ("comms", "nest_native"): f"{_REF}.comms.nest_native:NestNativeComms",
     ("comms", "versioned"): f"{_REF}.comms.versioned:VersionedComms",
+    ("comms", "authenticated"): f"{_REF}.comms.authenticated:AuthenticatedComms",
     ("identity", "did_key"): f"{_REF}.identity.did_key:DidKeyIdentity",
     ("identity", "ed25519_rotating"): (f"{_REF}.identity.ed25519_rotating:Ed25519RotatingIdentity"),
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -91,6 +91,10 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.comms_versioning import comms_versioning_factory
 
         register_scenario("comms_versioning", comms_versioning_factory)
+    elif name == "comms_downgrade":
+        from nest_core.scenarios_builtin.comms_downgrade import comms_downgrade_factory
+
+        register_scenario("comms_downgrade", comms_downgrade_factory)
     elif name == "receipt_reputation":
         from nest_core.scenarios_builtin.receipt_reputation import (
             receipt_reputation_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/comms_downgrade.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/comms_downgrade.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Comms downgrade-attack scenario — an on-path adversary rewrites authentic bytes.
+
+A swarm where every honest peer authenticates its envelopes with an ``auth_tag``
+(see :mod:`nest_plugins_reference.comms.authenticated`), but a man-in-the-middle
+sits on the wire and tampers with a copy before it reaches the ``auditor``. Each
+peer injects three envelopes at the auditor, all byte-identical regardless of which
+comms plugin the auditor runs (the tampering is baked into the bytes, not produced
+by a plugin), so the same scenario demonstrates both directions:
+
+* with ``comms: authenticated`` the auditor recomputes the tag, sees it no longer
+  covers the rewritten bytes, and rejects the tampered copies -> the downgrade
+  validator passes;
+* with ``comms: versioned`` (or ``nest_native``) the auditor has no tag concept and
+  accepts the rolled-back / stripped copies as if authentic -> the validator fails.
+
+Three envelope shapes per peer, keyed by id suffix for readability (the validator
+does *not* trust the suffix — it recomputes the tag as ground truth):
+
+* ``m-<i>-honest``   — a genuine ``1.1`` envelope with a valid tag (must be accepted);
+* ``m-<i>-rollback`` — the same envelope with ``schema_version`` rewritten to ``1.0``
+  and the stale tag left in place (version rollback: must be rejected);
+* ``m-<i>-strip``    — the same envelope with the newer peer's ``x-trace-id`` field
+  deleted and the stale tag left in place (field stripping: must be rejected).
+
+Example::
+
+    agents = comms_downgrade_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Message, MessageId
+
+
+def _honest_bytes(mid: str, sender: str, receiver: str) -> bytes:
+    """Serialize a genuine, correctly-tagged ``1.1`` envelope via the real plugin.
+
+    Built with :class:`~nest_plugins_reference.comms.authenticated.AuthenticatedComms`
+    so the tag is exactly what an honest sender would emit; the attacker then
+    mutates a copy of these bytes. Deterministic (no clock, no RNG).
+
+    Example::
+
+        raw = _honest_bytes("m-0-honest", "peer-0", "auditor-0")
+    """
+    from nest_plugins_reference.comms.authenticated import AuthenticatedComms
+
+    comms = AuthenticatedComms(AgentId(sender))
+    msg = Message(
+        id=MessageId(mid),
+        sender=AgentId(sender),
+        receiver=AgentId(receiver),
+        payload=b"v1.1-offer",
+        metadata={"schema_version": "1.1", "kind": "offer", "_unknown": {"x-trace-id": mid}},
+    )
+    return comms.serialize(msg)
+
+
+def _tamper(raw: bytes, *, rewrite_version: str | None, drop_field: str | None) -> bytes:
+    """Rewrite an authentic envelope's bytes while leaving its stale tag intact.
+
+    Models the on-path attacker: it can edit any cleartext field but cannot
+    recompute the HMAC tag (it lacks the channel key), so the tag no longer
+    covers the bytes. Re-canonicalizes so the result is well-formed JSON an
+    honest reader would happily parse.
+
+    Example::
+
+        rolled = _tamper(raw, rewrite_version="1.0", drop_field=None)
+    """
+    env = cast("dict[str, Any]", json.loads(raw))
+    if rewrite_version is not None:
+        env["schema_version"] = rewrite_version
+    if drop_field is not None:
+        env.pop(drop_field, None)
+    return json.dumps(env, sort_keys=True).encode("utf-8")
+
+
+def _best_effort_id(raw: bytes) -> str:
+    """Pull the ``id`` from a possibly-undecodable envelope for ack labelling.
+
+    Example::
+
+        assert _best_effort_id(b'{"id": "m-0-honest"}') == "m-0-honest"
+    """
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return "unknown"
+    if isinstance(data, dict):
+        return str(cast("dict[str, Any]", data).get("id", "unknown"))
+    return "unknown"
+
+
+class DowngradePeerAgent(StateMachineAgent):
+    """Emits an honest envelope plus the attacker's rolled-back and stripped copies.
+
+    Example::
+
+        peer = DowngradePeerAgent(AgentId("peer-0"), index=0, auditor=AgentId("auditor-0"))
+    """
+
+    def __init__(self, agent_id: AgentId, index: int, auditor: AgentId) -> None:
+        self._id = agent_id
+        self._index = index
+        self._auditor = auditor
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Stagger emissions onto distinct ticks for real virtual time.
+
+        Example::
+
+            await peer.on_start(ctx)
+        """
+        await ctx.schedule(float(self._index + 1), b"emit")
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """On the self-timer, inject the honest envelope and both tampered copies.
+
+        Example::
+
+            await peer.on_message(ctx, AgentId("peer-0"), b"emit")
+        """
+        if payload != b"emit":
+            return
+        me, to = str(self._id), str(self._auditor)
+        honest = _honest_bytes(f"m-{self._index}-honest", me, to)
+        await ctx.send(self._auditor, honest)
+
+        rollback_src = _honest_bytes(f"m-{self._index}-rollback", me, to)
+        await ctx.send(
+            self._auditor,
+            _tamper(rollback_src, rewrite_version="1.0", drop_field=None),
+        )
+
+        strip_src = _honest_bytes(f"m-{self._index}-strip", me, to)
+        await ctx.send(
+            self._auditor,
+            _tamper(strip_src, rewrite_version=None, drop_field="x-trace-id"),
+        )
+
+
+class DowngradeAuditorAgent(StateMachineAgent):
+    """Decodes each envelope with the configured comms plugin and acks the outcome.
+
+    Ack format is ``ack:<id>:<status>`` where status is ``accepted``,
+    ``rejected_tampered`` (a :class:`DowngradeError` — tag failed), or
+    ``rejected_major`` (any other decode refusal). This is the evidence the
+    downgrade validator scores.
+
+    Example::
+
+        auditor = DowngradeAuditorAgent(AgentId("auditor-0"), comms=AuthenticatedComms(...))
+    """
+
+    def __init__(self, agent_id: AgentId, comms: Any) -> None:
+        self._id = agent_id
+        self._comms = comms
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Decode one envelope and report the outcome back to the sender.
+
+        Example::
+
+            await auditor.on_message(ctx, AgentId("peer-0"), raw)
+        """
+        # Imported lazily so the scenario stays importable without the reference
+        # package present; the DowngradeError subclass drives the ack label.
+        from nest_plugins_reference.comms.authenticated import DowngradeError
+
+        try:
+            msg = self._comms.deserialize(payload)
+        except DowngradeError:
+            mid = _best_effort_id(payload)
+            await ctx.send(sender, f"ack:{mid}:rejected_tampered:".encode())
+            return
+        except (ValueError, KeyError):
+            mid = _best_effort_id(payload)
+            await ctx.send(sender, f"ack:{mid}:rejected_major:".encode())
+            return
+        await ctx.send(sender, f"ack:{msg.id}:accepted:".encode())
+
+
+def comms_downgrade_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create one auditor and a set of honest peers whose traffic is tampered in flight.
+
+    The auditor decodes with ``plugins["comms"]`` so the scenario exercises
+    whichever comms plugin the YAML selected. Peer count comes from the ``peer``
+    role (default: all agents but the auditor).
+
+    Example::
+
+        agents = comms_downgrade_factory(config, plugins)
+    """
+    peer_count = 0
+    if config.agents.roles:
+        for role in config.agents.roles:
+            if role.name == "peer":
+                peer_count = role.count
+    if peer_count == 0:
+        peer_count = max(2, config.agents.count - 1)
+
+    auditor_id = AgentId("auditor-0")
+    comms_cls = plugins["comms"]
+    auditor_comms = comms_cls(auditor_id)
+
+    agents: dict[AgentId, StateMachineAgent] = {
+        auditor_id: DowngradeAuditorAgent(auditor_id, comms=auditor_comms),
+    }
+    for i in range(peer_count):
+        aid = AgentId(f"peer-{i}")
+        agents[aid] = DowngradePeerAgent(aid, index=i, auditor=auditor_id)
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -2625,6 +2625,130 @@ def validate_comms_no_silent_drop(
 
 
 # ---------------------------------------------------------------------------
+# Comms downgrade-attack validator (adversarial)
+# ---------------------------------------------------------------------------
+# Ground truth for "was this envelope tampered?" is recomputed from the bytes a
+# receiver actually saw, independent of the decoder under test: an envelope that
+# carries an ``auth_tag`` is authentic iff that tag still covers its canonical
+# content. A comms layer passes iff it *rejects* every envelope whose tag no
+# longer verifies (rollback / field-strip) while still *accepting* the authentic
+# ones. ``versioned`` and ``nest_native`` have no tag concept, so they accept the
+# tampered copies and fail; ``authenticated`` rejects them and passes.
+
+
+def _collect_downgrade_wire(
+    events: list[dict[str, Any]],
+) -> dict[str, bool]:
+    """Map each delivered tagged envelope id to whether its ``auth_tag`` verifies.
+
+    Only envelopes that actually carry a tag are judged; untagged legacy traffic
+    is out of scope for this check. ``True`` means authentic (tag matches the
+    recomputed value), ``False`` means tampered.
+
+    Example::
+
+        authentic_by_id = _collect_downgrade_wire(events)
+    """
+    from nest_plugins_reference.comms.authenticated import (
+        AUTH_TAG_FIELD,
+        expected_auth_tag,
+    )
+
+    authentic: dict[str, bool] = {}
+    for ev in events:
+        if ev.get("kind") != "receive":
+            continue
+        env = _parse_comms_envelope(str(ev.get("msg", "")))
+        if env is None or AUTH_TAG_FIELD not in env:
+            continue
+        mid = str(env.get("id"))
+        carried = str(env.get(AUTH_TAG_FIELD))
+        authentic[mid] = carried == expected_auth_tag(env)
+    return authentic
+
+
+def validate_comms_downgrade_resistance(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Receivers must reject envelopes whose authentication tag no longer covers them.
+
+    Catches the *silent-downgrade* attack: an on-path adversary rewrites an
+    authentic envelope (rolls ``schema_version`` back, or strips a field) and
+    leaves the stale tag in place. ``authenticated`` recomputes the tag and
+    refuses the forgery; ``versioned``/``nest_native`` have no tag and accept it.
+
+    Example::
+
+        results = validate_comms_downgrade_resistance(events)
+    """
+    authentic = _collect_downgrade_wire(events)
+    acks = _collect_comms_acks(events)
+    if not authentic:
+        return [
+            ValidationResult("comms_downgrade_resistance", False, "no tagged envelopes in trace")
+        ]
+    violations: list[str] = []
+    tampered_checked = 0
+    for mid, is_authentic in authentic.items():
+        if is_authentic:
+            continue
+        tampered_checked += 1
+        status = acks.get(mid)
+        outcome = status[0] if status is not None else "no ack"
+        if not outcome.startswith("rejected"):
+            violations.append(f"{mid}: tampered envelope not rejected (got {outcome})")
+    if violations:
+        return [ValidationResult("comms_downgrade_resistance", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "comms_downgrade_resistance",
+            True,
+            f"{tampered_checked} tampered envelope(s) correctly rejected",
+        )
+    ]
+
+
+def validate_comms_authentic_delivery(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Receivers must still accept *authentic* envelopes (no false positives).
+
+    The liveness counterpart to
+    :func:`validate_comms_downgrade_resistance`: a plugin must not "pass" the
+    security check by rejecting everything. Every delivered envelope whose tag
+    verifies has to be accepted, so tamper-evidence does not break the honest
+    rolling-upgrade traffic it rides alongside.
+
+    Example::
+
+        results = validate_comms_authentic_delivery(events)
+    """
+    authentic = _collect_downgrade_wire(events)
+    acks = _collect_comms_acks(events)
+    if not authentic:
+        return [ValidationResult("comms_authentic_delivery", False, "no tagged envelopes in trace")]
+    violations: list[str] = []
+    honest_checked = 0
+    for mid, is_authentic in authentic.items():
+        if not is_authentic:
+            continue
+        honest_checked += 1
+        status = acks.get(mid)
+        outcome = status[0] if status is not None else "no ack"
+        if outcome != "accepted":
+            violations.append(f"{mid}: authentic envelope not accepted (got {outcome})")
+    if violations:
+        return [ValidationResult("comms_authentic_delivery", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "comms_authentic_delivery",
+            True,
+            f"{honest_checked} authentic envelope(s) correctly accepted",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Receipt-reputation (collusion-ring) validators
 # ---------------------------------------------------------------------------
 
@@ -4046,6 +4170,10 @@ VALIDATORS: dict[str, list[Any]] = {
     "comms_versioning": [
         validate_comms_reject_unknown_major,
         validate_comms_no_silent_drop,
+    ],
+    "comms_downgrade": [
+        validate_comms_downgrade_resistance,
+        validate_comms_authentic_delivery,
     ],
     "marketplace": [
         validate_marketplace_no_double_sell,

--- a/packages/nest-core/tests/test_comms_downgrade.py
+++ b/packages/nest-core/tests/test_comms_downgrade.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the comms downgrade-attack validator and scenario.
+
+The core claim under test: ``validate_comms_downgrade_resistance`` FAILS against
+comms layers with no integrity (``versioned``, ``nest_native`` — they accept an
+on-path attacker's rolled-back / stripped copies) and PASSES against
+``authenticated`` (which recomputes the tag and refuses the forgeries) — driven
+both from synthetic traces and from a real simulator run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.types import AgentId, Message, MessageId
+from nest_core.validators import (
+    validate_comms_authentic_delivery,
+    validate_comms_downgrade_resistance,
+    validate_trace,
+)
+from nest_plugins_reference.comms.authenticated import (
+    AUTH_TAG_FIELD,
+    AuthenticatedComms,
+    expected_auth_tag,
+)
+
+type Event = dict[str, Any]
+
+
+def _authentic_envelope(mid: str) -> dict[str, Any]:
+    """Return a genuine, correctly-tagged envelope as a dict."""
+    comms = AuthenticatedComms(AgentId("peer-1"))
+    raw = comms.serialize(
+        Message(
+            id=MessageId(mid),
+            sender=AgentId("peer-1"),
+            receiver=AgentId("auditor-0"),
+            payload=b"x",
+            metadata={"schema_version": "1.1", "kind": "offer", "_unknown": {"x-trace-id": mid}},
+        )
+    )
+    return json.loads(raw)
+
+
+def _recv(env: dict[str, Any]) -> Event:
+    return {
+        "ts": 1.0,
+        "agent": "auditor-0",
+        "kind": "receive",
+        "from": "peer-1",
+        "msg": json.dumps(env, sort_keys=True),
+    }
+
+
+def _ack(mid: str, status: str) -> Event:
+    return {
+        "ts": 2.0,
+        "agent": "auditor-0",
+        "kind": "send",
+        "to": "peer-1",
+        "msg": f"ack:{mid}:{status}:",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests (synthetic traces)
+# ---------------------------------------------------------------------------
+
+
+class TestDowngradeValidator:
+    def test_pass_when_tampered_rejected_and_honest_accepted(self) -> None:
+        honest = _authentic_envelope("m-honest")
+        rolled = _authentic_envelope("m-rollback")
+        rolled["schema_version"] = "1.0"  # stale tag no longer covers this
+        events = [
+            _recv(honest),
+            _ack("m-honest", "accepted"),
+            _recv(rolled),
+            _ack("m-rollback", "rejected_tampered"),
+        ]
+        results = validate_comms_downgrade_resistance(events)
+        assert results[0].passed is True
+
+    def test_fail_when_tampered_accepted(self) -> None:
+        """versioned/nest_native behaviour: the forgery is silently accepted."""
+        rolled = _authentic_envelope("m-rollback")
+        rolled["schema_version"] = "1.0"
+        events = [_recv(rolled), _ack("m-rollback", "accepted")]
+        results = validate_comms_downgrade_resistance(events)
+        assert results[0].passed is False
+
+    def test_fail_when_field_stripped_and_accepted(self) -> None:
+        stripped = _authentic_envelope("m-strip")
+        del stripped["x-trace-id"]
+        events = [_recv(stripped), _ack("m-strip", "accepted")]
+        results = validate_comms_downgrade_resistance(events)
+        assert results[0].passed is False
+
+    def test_fail_when_honest_rejected(self) -> None:
+        """A plugin cannot pass by rejecting everything: honest must be accepted."""
+        honest = _authentic_envelope("m-honest")
+        events = [_recv(honest), _ack("m-honest", "rejected_tampered")]
+        results = validate_comms_authentic_delivery(events)
+        assert results[0].passed is False
+
+    def test_authentic_delivery_passes_when_honest_accepted(self) -> None:
+        """The liveness check passes when authentic envelopes are accepted."""
+        honest = _authentic_envelope("m-honest")
+        events = [_recv(honest), _ack("m-honest", "accepted")]
+        results = validate_comms_authentic_delivery(events)
+        assert results[0].passed is True
+
+    def test_untagged_traffic_is_out_of_scope(self) -> None:
+        """Envelopes with no auth_tag are not judged by this validator."""
+        env = _authentic_envelope("m-legacy")
+        del env[AUTH_TAG_FIELD]
+        events = [_recv(env), _ack("m-legacy", "accepted")]
+        results = validate_comms_downgrade_resistance(events)
+        # No tagged envelopes -> the validator reports it found nothing to judge.
+        assert results[0].passed is False
+        assert "no tagged envelopes" in results[0].detail
+
+    def test_tamper_detection_matches_recompute(self) -> None:
+        """Sanity: an authentic envelope's tag verifies; a mutated one does not."""
+        env = _authentic_envelope("m1")
+        assert env[AUTH_TAG_FIELD] == expected_auth_tag(env)
+        env["kind"] = "evil"
+        assert env[AUTH_TAG_FIELD] != expected_auth_tag(env)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real simulator run
+# ---------------------------------------------------------------------------
+
+
+def _run(comms: str, out: Path, seed: int = 42) -> None:
+    cfg = ScenarioConfig.from_yaml("scenarios/comms_downgrade_attack.yaml")
+    cfg.layers.comms = comms
+    cfg.seed = seed
+    cfg.output.trace = str(out)
+    asyncio.run(ScenarioRunner(cfg).run())
+
+
+class TestScenarioEndToEnd:
+    def test_authenticated_passes(self, tmp_path: Path) -> None:
+        out = tmp_path / "authenticated.jsonl"
+        _run("authenticated", out)
+        results = validate_trace(out, "comms_downgrade")
+        assert results, "expected validator to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_versioned_fails(self, tmp_path: Path) -> None:
+        """The merged versioned plugin has no tag concept -> accepts forgeries."""
+        out = tmp_path / "versioned.jsonl"
+        _run("versioned", out)
+        results = validate_trace(out, "comms_downgrade")
+        assert results[0].passed is False
+
+    def test_nest_native_fails(self, tmp_path: Path) -> None:
+        out = tmp_path / "native.jsonl"
+        _run("nest_native", out)
+        results = validate_trace(out, "comms_downgrade")
+        assert results[0].passed is False
+
+    def test_deterministic_across_required_seeds(self, tmp_path: Path) -> None:
+        for seed in (42, 7, 1337):
+            a, b = tmp_path / f"{seed}a.jsonl", tmp_path / f"{seed}b.jsonl"
+            _run("authenticated", a, seed=seed)
+            _run("authenticated", b, seed=seed)
+            assert a.read_bytes() == b.read_bytes(), f"seed {seed} not deterministic"
+            assert all(r.passed for r in validate_trace(a, "comms_downgrade"))

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -1818,6 +1818,7 @@ class TestValidatorRegistry:
             "streaming_payments",
             "empic_payments",
             "comms_versioning",
+            "comms_downgrade",
             "receipt_reputation",
             "multi_attribute_market",
             "provenance_supply_chain",

--- a/packages/nest-plugins-reference/nest_plugins_reference/comms/authenticated.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/comms/authenticated.py
@@ -1,0 +1,388 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tamper-evident versioned comms — HMAC-bound envelopes that resist downgrade.
+
+The merged :class:`~nest_plugins_reference.comms.versioned.VersionedComms` plugin
+solved *forward/backward compatibility*: newer-minor fields survive a round-trip
+and a breaking major is rejected. But it trusts the wire. Its ``schema_version``,
+``kind`` and every field ride in cleartext with **no integrity protection**, so an
+on-path adversary — a malicious relay, a compromised transport, a buggy proxy —
+can silently rewrite them and the receiver cannot tell. Two concrete attacks slip
+straight through ``versioned`` (and, a fortiori, ``nest_native``):
+
+* **Version rollback.** Rewrite ``"schema_version": "1.1"`` to ``"1.0"`` (or delete
+  the field, which ``versioned`` reads as ``"1.0"``). The receiver now applies the
+  *older*, more permissive contract to a message that was authored under a newer,
+  stricter one — the classic downgrade that TLS fought with ``POODLE`` / ``FREAK`` /
+  ``Logjam`` and ultimately ``TLS_FALLBACK_SCSV``.
+* **Field stripping.** Delete a security-relevant field a newer peer added (an
+  ``x-trace-id``, an authorization hint) so the receiver acts on a truncated
+  message it believes is whole.
+
+This plugin closes that gap by binding an ``HMAC-SHA256`` **authentication tag**
+over the *entire* canonical envelope — version, kind, and every field — keyed by a
+per-pair channel secret the on-path attacker does not hold. Any rewrite of any
+covered byte makes the tag recomputation fail, so rollback and stripping become
+*detectable* rather than silent. It is a strict superset of ``versioned``: the
+version negotiation, unknown-field preservation and unknown-major rejection are all
+inherited unchanged, and untagged legacy traffic still flows in permissive mode.
+
+Threat model (what the tag does and does not buy)::
+
+    in scope    tamper-evidence: rewrite / strip / reorder any covered field
+                is detected at the receiver (constant-time compare).
+    in scope    version-rollback resistance: schema_version is covered, so a
+                downgrade cannot masquerade as authentic.
+    out scope   key exchange: the pairwise key is a pre-shared simulation secret
+                standing in for an ECDH/TLS session key. We test tamper-evidence,
+                not how the endpoints agreed on the key.
+    out scope   replay: a *verbatim* re-send of a genuine envelope still verifies.
+                Bind a nonce/sequence into ``metadata`` to close that separately.
+
+The MAC covers the canonical JSON of the envelope with the ``auth_tag`` field
+removed (encrypt-then-MAC's "MAC everything else" discipline, expressed in JSON),
+so the tag is deterministic and Tier-1 replayable.
+
+Example::
+
+    comms = AuthenticatedComms(AgentId("a1"))
+    raw = comms.serialize(msg)
+    assert comms.deserialize(raw) == msg          # lossless, tag-verified round-trip
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from typing import Any, cast
+
+from nest_core.types import (
+    AgentCard,
+    AgentId,
+    Message,
+    MessageId,
+    Query,
+    Response,
+)
+
+#: Major version this build understands. A higher major on the wire is a breaking
+#: change and is rejected rather than mis-decoded (inherited from ``versioned``).
+SCHEMA_MAJOR = 1
+#: Minor version this build emits. Bumping it must stay backward compatible.
+SCHEMA_MINOR = 1
+#: SemVer string stamped onto every outgoing envelope, e.g. ``"1.1"``.
+SCHEMA_VERSION = f"{SCHEMA_MAJOR}.{SCHEMA_MINOR}"
+
+#: The top-level envelope field carrying the hex authentication tag.
+AUTH_TAG_FIELD = "auth_tag"
+
+#: Pre-shared pairwise-channel secret used to key the HMAC in this simulation. In
+#: a real deployment this is replaced by a per-session key from an authenticated
+#: key exchange (e.g. X25519 ECDH); here it is a fixed constant so traces replay
+#: byte-for-byte. The security property under test is *tamper-evidence*: an
+#: attacker who lacks this secret cannot forge a tag for rewritten bytes.
+CHANNEL_SECRET_DEFAULT = b"nest-authenticated-comms/v1/pre-shared-channel-secret"
+
+#: Envelope keys this build assigns meaning to. Anything else on the wire is an
+#: unknown field from a newer peer: it is preserved (forward compat) *and* covered
+#: by the tag, so a newer peer's additions cannot be stripped undetected.
+KNOWN_FIELDS: frozenset[str] = frozenset(
+    {
+        "schema_version",
+        "kind",
+        "id",
+        "sender",
+        "receiver",
+        "payload",
+        "correlation_id",
+        "timestamp",
+        "metadata",
+        AUTH_TAG_FIELD,
+    }
+)
+
+#: ``metadata`` keys this plugin reserves for surfacing envelope control data on
+#: the decoded :class:`~nest_core.types.Message`. Treat as read-only.
+RESERVED_METADATA_KEYS: frozenset[str] = frozenset({"schema_version", "kind", "_unknown"})
+
+
+class UnsupportedSchemaError(ValueError):
+    """Raised when an envelope's schema version cannot be safely decoded.
+
+    Subclasses :class:`ValueError` so existing ``except ValueError`` guards in the
+    simulator keep catching it.
+
+    Example::
+
+        try:
+            comms.deserialize(future_major_bytes)
+        except UnsupportedSchemaError as exc:
+            assert exc.version == "2.0"
+    """
+
+    def __init__(self, version: str, detail: str = "") -> None:
+        self.version = version
+        suffix = f": {detail}" if detail else ""
+        super().__init__(f"unsupported schema version {version!r}{suffix}")
+
+
+class DowngradeError(UnsupportedSchemaError):
+    """Raised when an envelope's authentication tag does not cover its bytes.
+
+    This is the tamper alarm: the delivered envelope was rewritten (version
+    rolled back, a field stripped or altered) after it was authenticated, or it
+    arrived unauthenticated while the receiver required authentication. Kept a
+    subclass of :class:`UnsupportedSchemaError` (hence :class:`ValueError`) so a
+    receiver that only knows how to ``except ValueError`` still refuses it.
+
+    Example::
+
+        try:
+            comms.deserialize(rolled_back_bytes)
+        except DowngradeError as exc:
+            assert exc.reason in {"tag_mismatch", "tag_missing"}
+    """
+
+    def __init__(self, version: str, reason: str, detail: str = "") -> None:
+        self.reason = reason
+        super().__init__(version, detail or reason)
+
+
+def _parse_major(version: str) -> int:
+    """Return the integer major component of a SemVer string.
+
+    Example::
+
+        assert _parse_major("2.7") == 2
+    """
+    head = version.split(".", 1)[0]
+    try:
+        return int(head)
+    except ValueError as exc:
+        raise UnsupportedSchemaError(version, "malformed version") from exc
+
+
+def pair_key(a: str, b: str, channel_secret: bytes = CHANNEL_SECRET_DEFAULT) -> bytes:
+    """Derive the symmetric tag key for the unordered channel ``{a, b}``.
+
+    Both endpoints of a conversation derive the *same* key regardless of send
+    direction (the pair is sorted first), while an attacker without
+    ``channel_secret`` cannot. Models a pairwise session key; deterministic for
+    Tier-1 replay.
+
+    Example::
+
+        assert pair_key("a1", "a2") == pair_key("a2", "a1")
+    """
+    label = "::".join(sorted((a, b))).encode("utf-8")
+    return hmac.new(channel_secret, label, hashlib.sha256).digest()
+
+
+def canonical_untagged(envelope: dict[str, Any]) -> bytes:
+    """Serialize ``envelope`` (minus its ``auth_tag``) to canonical JSON bytes.
+
+    Sorting keys makes the MAC input independent of field order, so a re-encode
+    by an intermediary that reorders keys does not spuriously break the tag while
+    any change to a *value* still does.
+
+    Example::
+
+        raw = canonical_untagged({"id": "m1", "auth_tag": "deadbeef"})
+        assert b"auth_tag" not in raw
+    """
+    without_tag = {k: v for k, v in envelope.items() if k != AUTH_TAG_FIELD}
+    return json.dumps(without_tag, sort_keys=True).encode("utf-8")
+
+
+def expected_auth_tag(
+    envelope: dict[str, Any],
+    channel_secret: bytes = CHANNEL_SECRET_DEFAULT,
+) -> str:
+    """Compute the hex HMAC-SHA256 tag an authentic ``envelope`` must carry.
+
+    Keyed by the ``sender``/``receiver`` pair key and taken over the canonical
+    envelope with any existing tag excluded. Exposed at module scope so an
+    independent trace validator can recompute ground truth without instantiating
+    the plugin.
+
+    Example::
+
+        env = {"schema_version": "1.1", "id": "m1", "sender": "a1",
+               "receiver": "a2", "payload": "eA==", "kind": "offer",
+               "correlation_id": None, "timestamp": None, "metadata": {}}
+        tag = expected_auth_tag(env)
+        assert len(tag) == 64
+    """
+    key = pair_key(
+        str(envelope.get("sender", "")),
+        str(envelope.get("receiver", "")),
+        channel_secret,
+    )
+    return hmac.new(key, canonical_untagged(envelope), hashlib.sha256).hexdigest()
+
+
+class AuthenticatedComms:
+    """Versioned JSON comms with an HMAC tag bound over the whole envelope.
+
+    Drop-in for ``versioned``/``nest_native`` that additionally makes tampering
+    evident. In permissive mode (default) untagged legacy envelopes are still
+    accepted so a rolling upgrade can proceed; flip ``require_auth`` once every
+    peer is upgraded to refuse any unauthenticated envelope and fully close the
+    rollback-by-stripping-the-tag hole.
+
+    Example::
+
+        comms = AuthenticatedComms(AgentId("a1"), require_auth=True)
+        resp = await comms.send(AgentId("a2"), msg)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        transport: Any = None,
+        registry: Any = None,
+        *,
+        channel_secret: bytes = CHANNEL_SECRET_DEFAULT,
+        require_auth: bool = False,
+    ) -> None:
+        self._agent_id = agent_id
+        self._transport = transport
+        self._registry = registry
+        self._channel_secret = channel_secret
+        self._require_auth = require_auth
+
+    def serialize(self, msg: Message) -> bytes:
+        """Serialize ``msg`` into a versioned envelope carrying an ``auth_tag``.
+
+        Stamps :data:`SCHEMA_VERSION` and a ``kind`` tag, re-emits any preserved
+        forward-compat fields from ``metadata['_unknown']``, then binds the tag
+        over the finished (canonical) envelope. Byte-identical for identical
+        input (Tier-1 determinism).
+
+        Example::
+
+            raw = comms.serialize(msg)
+        """
+        meta: dict[str, Any] = dict(msg.metadata)
+        version = str(meta.pop("schema_version", SCHEMA_VERSION))
+        kind = str(meta.pop("kind", "message"))
+        unknown: dict[str, Any] = meta.pop("_unknown", {}) or {}
+
+        envelope: dict[str, Any] = {
+            "schema_version": version,
+            "kind": kind,
+            "id": str(msg.id),
+            "sender": str(msg.sender),
+            "receiver": str(msg.receiver),
+            "payload": base64.b64encode(msg.payload).decode("ascii"),
+            "correlation_id": str(msg.correlation_id) if msg.correlation_id else None,
+            "timestamp": msg.timestamp,
+            "metadata": meta,
+        }
+        # Re-emit preserved unknown fields; our own fields win on collision so a
+        # replayed unknown can never shadow a field this build authenticates.
+        for key, value in unknown.items():
+            if key not in envelope:
+                envelope[key] = value
+        envelope[AUTH_TAG_FIELD] = expected_auth_tag(envelope, self._channel_secret)
+        return json.dumps(envelope, sort_keys=True).encode("utf-8")
+
+    def deserialize(self, raw: bytes) -> Message:
+        """Deserialize an envelope, enforcing versioning *and* tamper-evidence.
+
+        Order of checks: parse → reject non-object → reject unknown major →
+        verify the authentication tag → build the message. A present-but-wrong
+        tag always raises :class:`DowngradeError`; a missing tag raises only when
+        ``require_auth`` is set (permissive mode accepts untagged legacy peers).
+
+        Example::
+
+            msg = comms.deserialize(raw)
+            assert msg.metadata["schema_version"]
+        """
+        try:
+            loaded = json.loads(raw)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise UnsupportedSchemaError("<unparseable>", str(exc)) from exc
+        if not isinstance(loaded, dict):
+            raise UnsupportedSchemaError("<non-object>", "envelope is not a JSON object")
+        data = cast("dict[str, Any]", loaded)
+
+        version = str(data.get("schema_version", "1.0"))
+        if _parse_major(version) > SCHEMA_MAJOR:
+            raise UnsupportedSchemaError(version, f"this build speaks major {SCHEMA_MAJOR}")
+
+        self._verify_tag(data, version)
+
+        unknown = {k: v for k, v in data.items() if k not in KNOWN_FIELDS}
+        meta: dict[str, Any] = dict(data.get("metadata") or {})
+        meta["schema_version"] = version
+        meta["kind"] = str(data.get("kind", "message"))
+        if unknown:
+            meta["_unknown"] = unknown
+
+        return Message(
+            id=MessageId(data["id"]),
+            sender=AgentId(data["sender"]),
+            receiver=AgentId(data["receiver"]),
+            payload=base64.b64decode(data["payload"]),
+            correlation_id=data.get("correlation_id"),
+            timestamp=data.get("timestamp"),
+            metadata=meta,
+        )
+
+    def _verify_tag(self, data: dict[str, Any], version: str) -> None:
+        """Enforce the tamper-evidence contract for one parsed envelope.
+
+        Raises :class:`DowngradeError` if a carried tag does not match the
+        recomputed tag (rewrite/rollback/strip), or if the envelope is untagged
+        while ``require_auth`` is set. A constant-time compare avoids leaking how
+        much of a forged tag was correct.
+
+        Example::
+
+            comms._verify_tag({"sender": "a1", "receiver": "a2"}, "1.1")
+        """
+        carried = data.get(AUTH_TAG_FIELD)
+        if carried is None:
+            if self._require_auth:
+                raise DowngradeError(version, "tag_missing", "unauthenticated envelope refused")
+            return
+        expected = expected_auth_tag(data, self._channel_secret)
+        if not hmac.compare_digest(str(carried), expected):
+            raise DowngradeError(version, "tag_mismatch", "envelope authentication failed")
+
+    async def send(self, to: AgentId, msg: Message) -> Response:
+        """Serialize and route a message through the transport layer.
+
+        Example::
+
+            resp = await comms.send(AgentId("a2"), msg)
+        """
+        raw = self.serialize(msg)
+        if self._transport is not None:
+            await self._transport.send(to, raw)
+        return Response(success=True)
+
+    async def advertise(self, card: AgentCard) -> None:
+        """Advertise an agent card to the registry.
+
+        Example::
+
+            await comms.advertise(my_card)
+        """
+        if self._registry is not None:
+            await self._registry.register(card)
+
+    async def discover(self, query: Query) -> list[AgentCard]:
+        """Discover agents via the registry.
+
+        Example::
+
+            cards = await comms.discover(Query(capabilities=["sell"]))
+        """
+        if self._registry is not None:
+            result: list[AgentCard] = await self._registry.lookup(query)
+            return result
+        return []

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -33,6 +33,9 @@ Repository = "https://github.com/projnanda/nandatown"
 # package. The PluginRegistry also keeps built-in defaults keyed by
 # (layer, name), but declaring the entry point here is the documented,
 # install-time discovery path described in CONTRIBUTING.md.
+[project.entry-points."nest.plugins.comms"]
+authenticated = "nest_plugins_reference.comms.authenticated:AuthenticatedComms"
+
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
 

--- a/packages/nest-plugins-reference/tests/test_authenticated_comms.py
+++ b/packages/nest-plugins-reference/tests/test_authenticated_comms.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the authenticated comms plugin: round-trip, tamper-evidence, parity.
+
+Persona note (protocol-security-engineer): the invariants under test are the ones
+a downgrade attack lives or dies on -- an authentication tag that covers every
+covered byte (so rollback and field-stripping are detected), a constant-time
+compare, and strict parity with ``versioned`` on the compatibility contract so the
+security upgrade is genuinely drop-in. Adversarial cases model an on-path attacker
+who can rewrite cleartext but cannot forge the HMAC.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import string
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.layers.comms import CommsProtocol
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, Message, MessageId
+from nest_plugins_reference.comms.authenticated import (
+    AUTH_TAG_FIELD,
+    CHANNEL_SECRET_DEFAULT,
+    KNOWN_FIELDS,
+    SCHEMA_VERSION,
+    AuthenticatedComms,
+    DowngradeError,
+    UnsupportedSchemaError,
+    expected_auth_tag,
+    pair_key,
+)
+
+_SENDER = AgentId("peer-1")
+_AUDITOR = AgentId("auditor-0")
+
+
+def _comms(**kw: Any) -> AuthenticatedComms:
+    return AuthenticatedComms(_AUDITOR, **kw)
+
+
+def _msg(mid: str = "m-1", *, unknown: dict[str, Any] | None = None) -> Message:
+    meta: dict[str, Any] = {"schema_version": "1.1", "kind": "offer"}
+    if unknown:
+        meta["_unknown"] = unknown
+    return Message(
+        id=MessageId(mid),
+        sender=_SENDER,
+        receiver=_AUDITOR,
+        payload=b"hello-world",
+        metadata=meta,
+    )
+
+
+def _decode_envelope(raw: bytes) -> dict[str, Any]:
+    return json.loads(raw)
+
+
+# ---------------------------------------------------------------------------
+# Protocol / registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_comms_protocol() -> None:
+    """The plugin structurally satisfies ``CommsProtocol``."""
+    assert isinstance(_comms(), CommsProtocol)
+
+
+def test_resolves_via_builtin_registry() -> None:
+    """``(comms, authenticated)`` resolves through the built-in plugin registry."""
+    cls = PluginRegistry().resolve("comms", "authenticated")
+    assert cls is AuthenticatedComms
+
+
+# ---------------------------------------------------------------------------
+# Round-trip (example-based)
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_is_lossless() -> None:
+    """``deserialize(serialize(m)) == m`` for a plain message."""
+    comms = _comms()
+    msg = _msg()
+    assert comms.deserialize(comms.serialize(msg)) == msg
+
+
+def test_serialized_envelope_carries_tag_and_version() -> None:
+    """Every serialized envelope stamps the version and a hex ``auth_tag``."""
+    env = _decode_envelope(_comms().serialize(_msg()))
+    assert env["schema_version"] == SCHEMA_VERSION
+    assert len(env[AUTH_TAG_FIELD]) == 64
+    assert all(c in "0123456789abcdef" for c in env[AUTH_TAG_FIELD])
+
+
+def test_serialize_is_deterministic() -> None:
+    """Identical input yields byte-identical output (Tier-1 replay)."""
+    assert _comms().serialize(_msg()) == _comms().serialize(_msg())
+
+
+def test_unknown_fields_preserved_and_covered() -> None:
+    """Forward-compat unknown fields round-trip *and* are bound by the tag."""
+    comms = _comms()
+    raw = comms.serialize(_msg(unknown={"x-trace-id": "t-9"}))
+    env = _decode_envelope(raw)
+    assert env["x-trace-id"] == "t-9"
+    # The unknown field is inside the MAC: dropping it must break verification.
+    stripped = {k: v for k, v in env.items() if k != "x-trace-id"}
+    tampered = json.dumps(stripped, sort_keys=True).encode()
+    with pytest.raises(DowngradeError):
+        comms.deserialize(tampered)
+    # And an honest round-trip restores it.
+    assert comms.deserialize(raw).metadata["_unknown"] == {"x-trace-id": "t-9"}
+
+
+def test_pair_key_is_direction_independent() -> None:
+    """Both endpoints derive the same key regardless of send direction."""
+    assert pair_key("a1", "a2") == pair_key("a2", "a1")
+    assert pair_key("a1", "a2") != pair_key("a1", "a3")
+
+
+# ---------------------------------------------------------------------------
+# Adversarial: the downgrade / tamper attacks this plugin exists to catch
+# ---------------------------------------------------------------------------
+
+
+def test_version_rollback_is_rejected() -> None:
+    """Rewriting schema_version 1.1 -> 1.0 with a stale tag is refused."""
+    comms = _comms()
+    env = _decode_envelope(comms.serialize(_msg()))
+    env["schema_version"] = "1.0"  # attacker rolls back, cannot re-tag
+    forged = json.dumps(env, sort_keys=True).encode()
+    with pytest.raises(DowngradeError) as exc:
+        comms.deserialize(forged)
+    assert exc.value.reason == "tag_mismatch"
+
+
+def test_field_strip_is_rejected() -> None:
+    """Deleting a covered field with a stale tag is refused."""
+    comms = _comms()
+    env = _decode_envelope(comms.serialize(_msg(unknown={"x-trace-id": "t-1"})))
+    del env["x-trace-id"]
+    forged = json.dumps(env, sort_keys=True).encode()
+    with pytest.raises(DowngradeError):
+        comms.deserialize(forged)
+
+
+def test_payload_tamper_is_rejected() -> None:
+    """Rewriting the payload with a stale tag is refused."""
+    comms = _comms()
+    env = _decode_envelope(comms.serialize(_msg()))
+    env["payload"] = base64.b64encode(b"evil").decode("ascii")
+    forged = json.dumps(env, sort_keys=True).encode()
+    with pytest.raises(DowngradeError):
+        comms.deserialize(forged)
+
+
+def test_attacker_without_channel_secret_cannot_forge() -> None:
+    """A tag minted under a different channel secret does not verify."""
+    honest = _comms()
+    attacker = _comms(channel_secret=b"attacker-guessed-secret")
+    forged = attacker.serialize(_msg())
+    # The receiver keyed on the real secret rejects the attacker's re-tag.
+    with pytest.raises(DowngradeError):
+        honest.deserialize(forged)
+
+
+def test_require_auth_rejects_untagged_envelope() -> None:
+    """In strict mode an envelope with no tag at all is refused."""
+    strict = _comms(require_auth=True)
+    env = _decode_envelope(_comms().serialize(_msg()))
+    del env[AUTH_TAG_FIELD]
+    untagged = json.dumps(env, sort_keys=True).encode()
+    with pytest.raises(DowngradeError) as exc:
+        strict.deserialize(untagged)
+    assert exc.value.reason == "tag_missing"
+
+
+def test_permissive_mode_accepts_untagged_legacy_envelope() -> None:
+    """Default mode still accepts untagged legacy traffic (rolling upgrade)."""
+    permissive = _comms()  # require_auth=False
+    env = _decode_envelope(_comms().serialize(_msg()))
+    del env[AUTH_TAG_FIELD]
+    untagged = json.dumps(env, sort_keys=True).encode()
+    msg = permissive.deserialize(untagged)  # must not raise
+    assert str(msg.id) == "m-1"
+
+
+def test_unknown_major_is_rejected_before_tag_check() -> None:
+    """A breaking major is refused with UnsupportedSchemaError, not accepted."""
+    comms = _comms()
+    env = _decode_envelope(comms.serialize(_msg()))
+    env["schema_version"] = "2.0"
+    forged = json.dumps(env, sort_keys=True).encode()
+    with pytest.raises(UnsupportedSchemaError):
+        comms.deserialize(forged)
+
+
+def test_non_object_envelope_is_rejected() -> None:
+    """A JSON array (or any non-object) is refused, not silently mis-decoded."""
+    with pytest.raises(UnsupportedSchemaError):
+        _comms().deserialize(b"[1, 2, 3]")
+
+
+def test_unparseable_bytes_are_rejected() -> None:
+    """Malformed bytes raise a typed error rather than a raw JSONDecodeError."""
+    with pytest.raises(UnsupportedSchemaError):
+        _comms().deserialize(b"not json{{{")
+
+
+# ---------------------------------------------------------------------------
+# Parity with the versioned contract (drop-in guarantee)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_version_treated_as_legacy_1_0() -> None:
+    """A pre-versioning envelope (no schema_version) decodes as 1.0."""
+    comms = _comms()
+    env = _decode_envelope(comms.serialize(_msg()))
+    del env["schema_version"]
+    del env[AUTH_TAG_FIELD]  # legacy peers carry no tag; permissive mode accepts
+    legacy = json.dumps(env, sort_keys=True).encode()
+    msg = comms.deserialize(legacy)
+    assert msg.metadata["schema_version"] == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Property-based: the security invariants over arbitrary envelopes
+# ---------------------------------------------------------------------------
+
+_NAME = st.text(alphabet=string.ascii_letters + string.digits + "-", min_size=1, max_size=10)
+
+
+@st.composite
+def _messages(draw: st.DrawFn) -> Message:
+    """Draw a schema-valid Message with optional forward-compat unknown fields."""
+    unknown_keys = draw(
+        st.lists(
+            st.text(alphabet=string.ascii_letters + "-", min_size=1, max_size=8).filter(
+                lambda k: k not in KNOWN_FIELDS
+            ),
+            max_size=3,
+            unique=True,
+        )
+    )
+    unknown = {k: draw(st.text(max_size=8)) for k in unknown_keys}
+    meta: dict[str, Any] = {"schema_version": "1.1", "kind": draw(_NAME)}
+    if unknown:
+        meta["_unknown"] = unknown
+    return Message(
+        id=MessageId(draw(_NAME)),
+        sender=AgentId(draw(_NAME)),
+        receiver=AgentId(draw(_NAME)),
+        payload=draw(st.binary(max_size=24)),
+        metadata=meta,
+    )
+
+
+@settings(max_examples=200)
+@given(_messages())
+def test_property_round_trip_is_lossless(msg: Message) -> None:
+    """For any schema-valid message, an honest round-trip is lossless."""
+    comms = AuthenticatedComms(msg.receiver)
+    assert comms.deserialize(comms.serialize(msg)) == msg
+
+
+@settings(max_examples=200)
+@given(_messages())
+def test_property_any_single_byte_flip_in_a_field_is_detected(msg: Message) -> None:
+    """Rewriting any covered field to a new value breaks verification."""
+    comms = AuthenticatedComms(msg.receiver)
+    env = json.loads(comms.serialize(msg))
+    # Flip the kind (a covered field) to a guaranteed-different value.
+    env["kind"] = env["kind"] + "X"
+    forged = json.dumps(env, sort_keys=True).encode()
+    with pytest.raises(DowngradeError):
+        comms.deserialize(forged)
+
+
+@settings(max_examples=200)
+@given(_messages())
+def test_property_tag_matches_independent_recompute(msg: Message) -> None:
+    """The carried tag equals the module-level ground-truth recompute."""
+    comms = AuthenticatedComms(msg.receiver)
+    env = json.loads(comms.serialize(msg))
+    carried = env[AUTH_TAG_FIELD]
+    assert carried == expected_auth_tag(env, CHANNEL_SECRET_DEFAULT)

--- a/scenarios/comms_downgrade_attack.yaml
+++ b/scenarios/comms_downgrade_attack.yaml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# Comms downgrade-attack scenario: an on-path adversary rewrites authentic bytes.
+#
+# 6 honest peers each authenticate an envelope with an HMAC `auth_tag`, but a
+# man-in-the-middle tampers with a copy in flight — one rolls `schema_version`
+# 1.1 -> 1.0, one strips the newer peer's `x-trace-id` — leaving the stale tag.
+# The auditor decodes every copy with the configured comms plugin.
+#
+#   * comms: authenticated -> recomputes the tag, rejects the forgeries -> PASS
+#   * comms: versioned      -> no tag concept, accepts the forgeries      -> FAIL
+#
+# Verify::
+#
+#     nest run scenarios/comms_downgrade_attack.yaml
+#     python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
+#         [print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail) \
+#          for r in validate_trace(Path('traces/comms_downgrade_attack.jsonl'), 'comms_downgrade')]"
+#
+# Swap `comms: authenticated` for `comms: versioned` to watch the same trace fail.
+name: comms_downgrade_attack
+description: "6 honest peers, an on-path attacker rolls back / strips their envelopes; authenticated comms rejects the forgeries."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 7
+  brain: state-machine
+  roles:
+    - name: peer
+      count: 6
+    - name: auditor
+      count: 1
+
+layers:
+  comms: authenticated
+
+task:
+  type: comms_downgrade
+  config: {}
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 1000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/comms_downgrade_attack.jsonl


### PR DESCRIPTION
## What this adds

A new `authenticated` comms plugin. It's `versioned` plus an HMAC-SHA256 tag over
the whole envelope, so tampering on the wire is detectable instead of silent.

## Why

`versioned` (PR #18) fixed compatibility, but it trusts the wire. Everything —
including `schema_version` — travels in cleartext, so an on-path attacker can:

- **roll the version back** (`1.1` → `1.0`, or just delete the field) to force the
  receiver onto the older, looser contract — the classic TLS-style downgrade, and
- **strip a field** a newer peer added and the receiver never notices.

The existing comms validators check the contract but assume an honest wire, so
nothing catches this today.

## How it works

The tag covers the entire canonical envelope, keyed by a per-pair channel secret
the attacker doesn't have. Rewrite any covered byte (version included) and the tag
no longer verifies → the envelope is rejected with a `DowngradeError`. It's a
strict superset of `versioned`, so it still passes the existing versioning
validators. Untagged legacy traffic is accepted by default (`require_auth=False`)
so a rolling upgrade can proceed; flip it on once every peer is upgraded.

Pure stdlib (`hmac`/`hashlib`), no new deps, deterministic.

## Verify

```bash
uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -v

uv run nest run scenarios/comms_downgrade_attack.yaml
python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
    [print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail) \
     for r in validate_trace(Path('traces/comms_downgrade_attack.jsonl'), 'comms_downgrade')]"
# PASS comms_downgrade_resistance - 12 tampered envelope(s) correctly rejected
# PASS comms_authentic_delivery  - 6 authentic envelope(s) correctly accepted
```

Switch the scenario to `comms: versioned` and the same trace fails — that's the point.

## Scope

The pairwise key stands in for an ECDH session key (this tests tamper-evidence, not
key exchange), and verbatim replay is deliberately out of scope — bind a nonce into
`metadata` to close that separately. `nest_native` and `versioned` are untouched.
