### PR TITLE
hackathon/robert-samuel-staking-primitive

### DIFF
--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/staking.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/staking.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standalone staking primitive for credibility signaling.
+
+Tracks per-agent credibility stakes in plain dicts, without touching the
+base ``Trust`` protocol. Agents post stake to signal trustworthiness; other
+agents slash it to penalize misbehavior.
+
+Example::
+
+    tracker = AgentStakeTracker()
+    tracker.post_stake("agent-a", 100)
+    tracker.slash_stake("agent-a", 30)
+    assert tracker.get_stake("agent-a") == 70
+"""
+
+from __future__ import annotations
+
+
+class AgentStakeTracker:
+    """Tracks credibility stakes per agent.
+
+    Example::
+
+        tracker = AgentStakeTracker()
+        tracker.post_stake("agent-a", 100)
+    """
+
+    def __init__(self) -> None:
+        self._stakes: dict[str, int] = {}
+
+    def post_stake(self, agent_id: str, amount: int) -> int:
+        """Add ``amount`` to an agent's stake and return the new balance.
+
+        Example::
+
+            balance = tracker.post_stake("agent-a", 100)
+        """
+        if amount < 0:
+            raise ValueError("amount must be non-negative")
+        self._stakes[agent_id] = self._stakes.get(agent_id, 0) + amount
+        return self._stakes[agent_id]
+
+    def get_stake(self, agent_id: str) -> int:
+        """Return an agent's current stake balance, 0 if never staked.
+
+        Example::
+
+            balance = tracker.get_stake("agent-a")
+        """
+        return self._stakes.get(agent_id, 0)
+
+    def slash_stake(self, agent_id: str, amount: int) -> int:
+        """Remove ``amount`` from an agent's stake and return the new balance.
+
+        Example::
+
+            balance = tracker.slash_stake("agent-a", 30)
+        """
+        if amount < 0:
+            raise ValueError("amount must be non-negative")
+        self._stakes[agent_id] = max(self._stakes.get(agent_id, 0) - amount, 0)
+        return self._stakes[agent_id]

--- a/packages/nest-plugins-reference/tests/test_staking_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_staking_scenario.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scenario test for the standalone staking primitive."""
+
+from __future__ import annotations
+
+import pytest
+from nest_plugins_reference.trust.staking import AgentStakeTracker
+
+
+def test_staking_scenario() -> None:
+    tracker = AgentStakeTracker()
+
+    # Agent A posts 100 stake to signal credibility.
+    tracker.post_stake("agent-a", 100)
+    assert tracker.get_stake("agent-a") == 100
+
+    # Agent B slashes Agent A for 30 after observing misbehavior.
+    tracker.slash_stake("agent-a", 30)
+    assert tracker.get_stake("agent-a") == 70
+
+
+def test_unstaked_agent_has_zero_balance() -> None:
+    tracker = AgentStakeTracker()
+    assert tracker.get_stake("never-staked") == 0
+
+
+def test_negative_amounts_are_rejected() -> None:
+    tracker = AgentStakeTracker()
+
+    with pytest.raises(ValueError, match="non-negative"):
+        tracker.post_stake("agent-a", -1)
+    with pytest.raises(ValueError, match="non-negative"):
+        tracker.slash_stake("agent-a", -1)


### PR DESCRIPTION
What I did
Added a basic staking interface to the trust building block. This allows agents to declare a stake amount to signal forward-looking credibility, rather than relying solely on backward-looking reputation scores.

Changes
Added postStake(agentId, amount) function
Added getStake(agentId) function
Added unit tests for both functions
All existing repo tests still pass
Why this matters (Phase 2 bridge)
This is the foundational logic for BOND, my Phase 2 service. Phase 1 proves the concept fits natively inside NANDA Town's architecture. Phase 2 exposes it as a standalone API that any external agent can consume via a SKILL.md.