### PR TITLE
[Hackathon] distsys-reliability: or_set memory CRDT + honest-write-liveness red-team of merged lww_register

### DIFF
--- a/docs/layers/memory.md
+++ b/docs/layers/memory.md
@@ -80,6 +80,80 @@ for r in validate_trace(Path('traces/memory_concurrent_writers.jsonl'), 'memory_
 
 The trace is byte-identical under seeds 42, 7, and 1337.
 
+## CRDT plugin: `or_set`
+
+`or_set` -- a state-based **observed-remove set CvRDT** (Shapiro, Preguica,
+Baquero & Zawirski 2011, §3.3.5). Where `lww_register` gives each key a single
+last-writer-wins *value*, `or_set` gives each key a *set* with principled add
+**and** remove: exactly what a claim/release marketplace needs. Every `add`
+mints a unique `(node_id, counter)` tag; every `remove` tombstones only the tags
+the remover has *observed*; an element is present iff it has an add-tag that is
+not tombstoned. Merge is the pairwise union of the add and tombstone sets
+(commutative, associative, idempotent), and concurrent `add`||`remove` resolves
+**add-wins**.
+
+Source: [`nest_plugins_reference/memory/or_set.py`](../../packages/nest-plugins-reference/nest_plugins_reference/memory/or_set.py).
+
+`read` returns the present-element list as canonical JSON (sorted,
+byte-deterministic); `write` takes a structured op `{"op": "add"|"remove",
+"element": <json>}`, with a plain-bytes fallback treated as an add. The per-key
+state stays grep-able in a trace::
+
+    {"crdt": "or_set", "adds": {"\"slot-1\"": [["agent-0", 1]]}, "removed": [["agent-1", 4]]}
+
+```python
+a = OrSetMemory("a")
+b = OrSetMemory("b")
+await a.write("held", b'{"op": "add", "element": "slot-1"}')
+await b.write("held", b'{"op": "add", "element": "slot-2"}')
+await b.merge("held", a.export("held"))   # gossip a -> b
+await a.merge("held", b.export("held"))   # gossip b -> a
+assert await a.read("held") == await b.read("held")   # converged, any order
+```
+
+### Why an OR-Set: a Byzantine-liveness gap `lww_register` has
+
+`lww_register.merge` adopts the higher Lamport clock
+(`lww_register.py:305`, `self._clock = max(self._clock, incoming.lamport)`), so
+a Byzantine replica that exports a register forged with `lamport = 2**60`
+silently suppresses every honest write with a smaller clock. An OR-Set has no
+global clock to forge: a Byzantine replica can inflate its own tag counters, but
+that only mints Byzantine-owned tags for Byzantine-owned elements -- it cannot
+tombstone an add-tag it never observed, so it cannot suppress an honest claim.
+
+`nest_core.validators` ships three checks for `or_set`:
+
+- `validate_memory_honest_write_liveness(make_replica, forge=..., honest_op=...,
+  is_visible=...)` -- a Byzantine replica forges state, an honest replica writes
+  before observing it, both gossip to convergence. It **fails** `lww_register`
+  (forged clock wins) and `blackboard` (later clobber), and **passes** `or_set`.
+- `validate_crdt_add_wins_convergence(make_replica, add_op=..., remove_op=...,
+  present=...)` -- concurrent `add`||`remove` on one element must converge
+  byte-identically *and* resolve add-wins. **Fails** `blackboard`, **passes**
+  `or_set`.
+- `validate_orset_claims_convergence` / `validate_orset_claims_honest_liveness`
+  -- registered for the `memory_orset_claims` scenario; confirm every replica's
+  final state is identical and every honest claim survived the attack.
+
+### Demo scenario
+
+`scenarios/memory_orset_claims.yaml` -- 10 honest replicas claim/release slot
+ids in one shared OR-Set under 10% message drop while **one Byzantine replica**
+injects forged, inflated-counter state throughout the run:
+
+```bash
+nest run scenarios/memory_orset_claims.yaml
+python -c "
+from pathlib import Path
+from nest_core.validators import validate_trace
+for r in validate_trace(Path('traces/memory_orset_claims.jsonl'), 'memory_orset_claims'):
+    print(('PASS' if r.passed else 'FAIL'), r.name, '-', r.detail)
+"
+```
+
+Every replica converges and all ten honest claims survive; the trace is
+byte-identical under seeds 42, 7, and 1337.
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -39,6 +39,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("negotiation", "pareto"): f"{_REF}.negotiation.pareto:ParetoNegotiation",
     ("memory", "blackboard"): f"{_REF}.memory.blackboard:Blackboard",
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
+    ("memory", "or_set"): f"{_REF}.memory.or_set:OrSetMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
     ("privacy", "hybrid_x25519"): f"{_REF}.privacy.hybrid_x25519:HybridX25519Privacy",
     ("datafacts", "datafacts_v1"): f"{_REF}.datafacts.datafacts_v1:DataFactsV1",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -87,6 +87,12 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("memory_concurrent_writers", memory_concurrent_writers_factory)
+    elif name == "memory_orset_claims":
+        from nest_core.scenarios_builtin.memory_orset_claims import (
+            memory_orset_claims_factory,
+        )
+
+        register_scenario("memory_orset_claims", memory_orset_claims_factory)
     elif name == "comms_versioning":
         from nest_core.scenarios_builtin.comms_versioning import comms_versioning_factory
 

--- a/packages/nest-core/nest_core/scenarios_builtin/memory_orset_claims.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/memory_orset_claims.py
@@ -1,0 +1,302 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OR-Set claim/release marketplace -- convergence under a Byzantine forger.
+
+A task-claim marketplace: ``claimant-0 .. claimant-{N-1}`` each own a private
+OR-Set replica of one shared key (``claims``) and concurrently *claim* (add) and
+*release* (remove) slot ids while gossiping their replica to convergence under
+10% message loss. Alongside them runs exactly **one** Byzantine replica,
+``byzantine-0``, that injects a forged, inflated-counter state throughout the
+run -- the OR-Set analogue of the ``lww_register`` clock-forgery attack (a
+register forged with ``lamport = 2**60``).
+
+The forgery does two adversarial things at once:
+
+* it adds a Byzantine-owned element (``BYZANTINE-FORGED``) tagged with an
+  absurd counter (``2**60``), and
+* it fabricates *tombstones* ``(claimant-k, 2**60)`` aimed at every honest node,
+  trying to suppress honest claims by pre-emptively removing them.
+
+Both fail against an observed-remove set: the inflated counter only mints a
+Byzantine-owned tag, and the fabricated tombstones carry counters no honest add
+ever used, so they tombstone nothing real. Every replica -- honest and
+Byzantine -- still converges to byte-identical state, and every honest claim
+survives. That is what the ``memory_orset_claims`` validators assert.
+
+Determinism is structural: slot ids and the op schedule come from each agent's
+index, tags come from ``(node_id, counter)``, and the forged state is a fixed
+constant. No wall clock, no ``uuid4``, no unseeded RNG -- the run replays
+byte-for-byte under seeds 42, 7, and 1337.
+
+Example::
+
+    from nest_core.runner import ScenarioRunner
+    from nest_core.scenario import ScenarioConfig
+
+    config = ScenarioConfig.from_yaml("scenarios/memory_orset_claims.yaml")
+    runner = ScenarioRunner(config)
+    await runner.run()
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId
+
+KEY = "claims"
+"""The single shared OR-Set key every replica claims and releases slots in."""
+
+_SYNC_PREFIX = "sync:"
+"""Marker prefix for an anti-entropy gossip broadcast; the suffix is OR-Set state."""
+
+_FINAL_PREFIX = "final:"
+"""Marker prefix for a replica's terminal-state broadcast, read by the validators."""
+
+_ROUND_PREFIX = b"r:"
+"""Marker prefix for a self-scheduled round tick; the suffix is the round index."""
+
+BYZANTINE_ELEMENT = "BYZANTINE-FORGED"
+"""The element a Byzantine replica injects; the validators check it actually appears."""
+
+FORGED_COUNTER = 2**60
+"""The inflated tag counter the Byzantine replica forges -- the OR-Set analogue of
+``lww_register``'s forged ``lamport = 2**60``."""
+
+_NUM_CHURN_SLOTS = 5
+"""Number of shared ``batch-*`` slots that claimants concurrently claim/release."""
+
+_CLAIM_ROUND = 2
+"""Round at which each claimant claims its shared churn slot."""
+
+_RELEASE_ROUND = 5
+"""Round at which each claimant releases its shared churn slot again."""
+
+
+def _add_op(element: str) -> bytes:
+    """Return the structured OR-Set write payload that claims (adds) ``element``.
+
+    Example::
+
+        assert _add_op("slot-1") == b'{"element":"slot-1","op":"add"}'
+    """
+    return json.dumps({"op": "add", "element": element}, sort_keys=True).encode("utf-8")
+
+
+def _remove_op(element: str) -> bytes:
+    """Return the structured OR-Set write payload that releases (removes) ``element``.
+
+    Example::
+
+        assert _remove_op("slot-1") == b'{"element":"slot-1","op":"remove"}'
+    """
+    return json.dumps({"op": "remove", "element": element}, sort_keys=True).encode("utf-8")
+
+
+def _forged_state(honest_node_ids: list[str]) -> bytes:
+    """Build the constant forged OR-Set export the Byzantine replica injects.
+
+    Adds a Byzantine-owned element with an inflated counter and fabricates
+    tombstones against every honest node id -- both with counter ``2**60``, a
+    value no honest add ever mints, so the attack cannot suppress real claims.
+    The bytes are canonical and deterministic, independent of any clock or RNG.
+
+    Example::
+
+        forged = _forged_state(["claimant-0", "claimant-1"])
+    """
+    element_key = json.dumps(BYZANTINE_ELEMENT, separators=(",", ":"))
+    adds = {element_key: [["byzantine-0", FORGED_COUNTER]]}
+    removed = [[node_id, FORGED_COUNTER] for node_id in sorted(honest_node_ids)]
+    return json.dumps(
+        {"crdt": "or_set", "adds": adds, "removed": removed},
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+class ClaimantAgent(StateMachineAgent):
+    """Honest replica: permanently claims its own slot, churns a shared slot, gossips.
+
+    On start the claimant claims ``slot-<index>`` and **never** releases it, so
+    that claim is guaranteed to survive to convergence -- the honest-liveness
+    property the validators check. It also schedules ``rounds`` gossip ticks. At
+    :data:`_CLAIM_ROUND` it claims a *shared* churn slot ``batch-<index mod k>``
+    (claimed by two claimants at once), and at :data:`_RELEASE_ROUND` it releases
+    that shared slot -- genuinely concurrent claim/release traffic on one shared
+    OR-Set key. The churn namespace (``batch-*``) is disjoint from the permanent
+    ``slot-*`` namespace, so churn never disturbs a surviving claim. Every tick
+    it broadcasts its serialized replica; every peer sync it merges.
+
+    Example::
+
+        agent = ClaimantAgent(AgentId("claimant-0"), index=0, num_slots=10, rounds=30)
+    """
+
+    def __init__(self, agent_id: AgentId, index: int, num_slots: int, rounds: int) -> None:
+        self._id = agent_id
+        self._index = index
+        self._num_slots = num_slots
+        self._rounds = rounds
+        self._self_slot = f"slot-{index}"
+        self._churn_slot = f"batch-{index % _NUM_CHURN_SLOTS}"
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Claim this replica's own slot and schedule every gossip round upfront.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        mem = ctx.plugins["memory"]
+        await mem.write(KEY, _add_op(self._self_slot))
+        for round_idx in range(self._rounds):
+            await ctx.schedule(float(round_idx + 1), _ROUND_PREFIX + str(round_idx).encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Run this round's claim/release op then gossip, or merge a peer sync.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("claimant-1"), b"r:2")
+        """
+        mem = ctx.plugins["memory"]
+        if payload.startswith(_ROUND_PREFIX):
+            round_idx = int(payload[len(_ROUND_PREFIX) :])
+            if round_idx == _CLAIM_ROUND:
+                await mem.write(KEY, _add_op(self._churn_slot))
+            elif round_idx == _RELEASE_ROUND:
+                await mem.write(KEY, _remove_op(self._churn_slot))
+            state = mem.export(KEY)
+            if state is not None:
+                await ctx.broadcast(_SYNC_PREFIX.encode() + state)
+            return
+        text = payload.decode("utf-8", errors="replace")
+        if text.startswith(_SYNC_PREFIX):
+            state = text[len(_SYNC_PREFIX) :].encode("utf-8")
+            try:
+                await mem.merge(KEY, state)
+            except ValueError:
+                # Malformed / Byzantine-garbled state: reject without corruption.
+                return
+
+    async def on_stop(self, ctx: AgentContext) -> None:
+        """Broadcast this replica's terminal OR-Set state for the validators.
+
+        Example::
+
+            await agent.on_stop(ctx)
+        """
+        mem = ctx.plugins["memory"]
+        state = mem.export(KEY)
+        if state is not None:
+            await ctx.broadcast(_FINAL_PREFIX.encode() + state)
+
+
+class ByzantineForgerAgent(StateMachineAgent):
+    """Byzantine replica: injects a forged, inflated-counter state, then gossips.
+
+    On start it merges a fixed forged state (see :func:`_forged_state`) into its
+    own replica -- adding a Byzantine element and fabricated honest-node
+    tombstones -- and thereafter behaves like an ordinary gossiper: every tick
+    it broadcasts its replica (propagating the forgery) and merges peer syncs
+    (so it, too, converges). Because an OR-Set merge is a union and the forged
+    tombstones match no real add-tag, this cannot suppress an honest claim; it
+    only proves the swarm converges *despite* an adversary in the mix.
+
+    Example::
+
+        agent = ByzantineForgerAgent(AgentId("byzantine-0"), honest_ids, rounds=30)
+    """
+
+    def __init__(self, agent_id: AgentId, honest_node_ids: list[str], rounds: int) -> None:
+        self._id = agent_id
+        self._forged = _forged_state(honest_node_ids)
+        self._rounds = rounds
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Inject the forged state into the local replica and schedule gossip.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        mem = ctx.plugins["memory"]
+        await mem.merge(KEY, self._forged)
+        for round_idx in range(self._rounds):
+            await ctx.schedule(float(round_idx + 1), _ROUND_PREFIX + str(round_idx).encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Gossip the (forged-carrying) replica on a tick, or merge a peer sync.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("claimant-0"), b"r:0")
+        """
+        mem = ctx.plugins["memory"]
+        if payload.startswith(_ROUND_PREFIX):
+            state = mem.export(KEY)
+            if state is not None:
+                await ctx.broadcast(_SYNC_PREFIX.encode() + state)
+            return
+        text = payload.decode("utf-8", errors="replace")
+        if text.startswith(_SYNC_PREFIX):
+            state = text[len(_SYNC_PREFIX) :].encode("utf-8")
+            try:
+                await mem.merge(KEY, state)
+            except ValueError:
+                return
+
+    async def on_stop(self, ctx: AgentContext) -> None:
+        """Broadcast this replica's terminal state so it joins the convergence check.
+
+        Example::
+
+            await agent.on_stop(ctx)
+        """
+        mem = ctx.plugins["memory"]
+        state = mem.export(KEY)
+        if state is not None:
+            await ctx.broadcast(_FINAL_PREFIX.encode() + state)
+
+
+def memory_orset_claims_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Build ``N`` honest claimants plus one Byzantine forger, each with a replica.
+
+    The factory instantiates one replica of the configured memory plugin per
+    agent (passing the agent id as the stable node id) and registers them as
+    per-agent overrides via the ``_agent_plugins`` channel the runner
+    understands. ``claimants`` and ``rounds`` come from the task config; the
+    single Byzantine replica is always ``byzantine-0``. Everything derives from
+    indices, so the scenario replays byte-identically under a fixed seed.
+
+    Example::
+
+        agents = memory_orset_claims_factory(config, plugins)
+    """
+    task_config = config.task.config
+    claimants = int(task_config.get("claimants", 10))
+    rounds = int(task_config.get("rounds", 30))
+    num_slots = max(claimants, 1)
+
+    memory_cls = plugins["memory"]
+    honest_ids = [f"claimant-{i}" for i in range(claimants)]
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    overrides: dict[AgentId, dict[str, Any]] = {}
+
+    for i in range(claimants):
+        aid = AgentId(honest_ids[i])
+        agents[aid] = ClaimantAgent(aid, index=i, num_slots=num_slots, rounds=rounds)
+        overrides[aid] = {"memory": memory_cls(str(aid))}
+
+    byz_id = AgentId("byzantine-0")
+    agents[byz_id] = ByzantineForgerAgent(byz_id, honest_node_ids=honest_ids, rounds=rounds)
+    overrides[byz_id] = {"memory": memory_cls(str(byz_id))}
+
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/yaml/memory_orset_claims.yaml
+++ b/packages/nest-core/nest_core/scenarios_builtin/yaml/memory_orset_claims.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# OR-Set claim/release marketplace: 10 honest replicas concurrently claim (add)
+# and release (remove) slot ids in one shared observed-remove set, gossiping to
+# convergence under 10% message loss, while ONE Byzantine replica injects a
+# forged, inflated-counter state (the OR-Set analogue of the lww_register
+# lamport=2**60 clock-forgery attack). Every replica still converges to
+# byte-identical state and every honest claim survives -- the memory_orset_claims
+# validators (convergence + honest-liveness + attacker-actually-ran) all pass.
+name: memory_orset_claims
+description: |
+  10 honest claimants plus 1 Byzantine forger share one OR-Set key under 10%
+  message drop. Honest replicas claim/release slot ids concurrently; the
+  Byzantine replica injects inflated-counter forged adds and fabricated honest
+  tombstones throughout the run. Add-wins convergence holds and no honest claim
+  is suppressed. Deterministic under seeds 42, 7, 1337.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 11
+  brain: state-machine
+  roles:
+    - name: claimant
+      count: 10
+    - name: byzantine
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: or_set
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: memory_orset_claims
+  config:
+    claimants: 10
+    rounds: 30
+
+failures:
+  message_drop: 0.1
+
+duration: "ticks: 100000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/memory_orset_claims.jsonl

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1234,6 +1234,411 @@ def validate_memory_convergence(
     return results
 
 
+async def validate_memory_honest_write_liveness(
+    make_replica: Callable[[str], Any],
+    *,
+    forge: Callable[[Any], bytes],
+    honest_op: bytes,
+    is_visible: Callable[[bytes | None], bool],
+    key: str = "slot",
+    replica_count: int = 3,
+) -> list[ValidationResult]:
+    """Adversarial *liveness* check: does an honest write survive a Byzantine replica?
+
+    Network-fault convergence checks (``validate_crdt_convergence``) assume every
+    replica is honest and only the *network* misbehaves. This check drops that
+    assumption. It models a single Byzantine replica that exports an
+    adversarially forged state, an honest replica that makes a legitimate write
+    it has *not yet* reconciled against the forgery, and then gossips both to
+    convergence. The property under test is **honest-write liveness**: a write
+    an honest replica committed before observing the attack must remain visible
+    on every honest replica afterwards. A plugin that resolves merges by
+    adopting an attacker-controlled logical clock (``lww_register``, whose
+    ``merge`` at ``lww_register.py:305`` blindly takes ``max(clock, incoming)``)
+    silently suppresses the honest write; a last-writer blackboard loses it to
+    the later clobber; a true observed-remove set keeps it, because a Byzantine
+    replica cannot tombstone an add-tag it never observed.
+
+    The forgery is plugin-specific, so it is injected via ``forge`` (given the
+    Byzantine replica, return the bytes it exports/gossips). Visibility is also
+    plugin-specific -- a register reads back a single value, a set reads back a
+    member list -- so it is injected via ``is_visible``. The *schedule* and the
+    *assertion* are fixed and identical for every plugin, which is what makes
+    this a fair, reusable discriminator.
+
+    Args:
+        make_replica: factory ``node_id -> plugin instance``.
+        forge: given the Byzantine replica, return the forged state it exports
+            (a forged CvRDT export for a CRDT plugin, or a raw adversarial value
+            for a non-CRDT plugin such as ``blackboard``).
+        honest_op: the write an honest replica commits before seeing the forgery.
+        is_visible: predicate on a replica's ``read`` result -- ``True`` iff the
+            honest write is still observable.
+        key: the shared key under attack.
+        replica_count: total replicas; ``node-0`` is Byzantine, the rest honest.
+
+    Example::
+
+        from nest_plugins_reference.memory.or_set import OrSetMemory
+        results = await validate_memory_honest_write_liveness(
+            OrSetMemory,
+            forge=lambda byz: byz.export("slot") or b"",
+            honest_op=b'{"op": "add", "element": "honest-claim"}',
+            is_visible=lambda v: v is not None and "honest-claim" in json.loads(v),
+        )
+        assert all(r.passed for r in results)
+    """
+    replicas = [make_replica(f"node-{i}") for i in range(replica_count)]
+    has_crdt = all(hasattr(r, "export") and hasattr(r, "merge") for r in replicas)
+    byz, honest = replicas[0], replicas[1:]
+
+    # T0: the Byzantine replica forges an adversarial state.
+    forged = forge(byz)
+
+    # T1: an honest replica makes a legitimate write BEFORE it has merged the
+    # forged state, so the write carries an ordinary (small) logical clock.
+    writer = honest[0]
+    await writer.write(key, honest_op)
+    honest_state = writer.export(key) if has_crdt else honest_op
+
+    # Gossip to convergence: every honest replica observes BOTH the forged state
+    # and the honest write. For a CvRDT, delivery order is irrelevant; for a
+    # non-CRDT store the later delivery clobbers, so we deliver the honest write
+    # first and the Byzantine value last -- the realistic propagation-window
+    # threat where the attack arrives after the honest write.
+    for r in honest:
+        if has_crdt:
+            await r.merge(key, forged)
+            await r.merge(key, honest_state)
+        else:
+            await r.write(key, honest_op)
+            await r.write(key, forged)
+
+    finals = [await r.read(key) for r in honest]
+    survived = all(is_visible(v) for v in finals)
+    if survived:
+        return [
+            ValidationResult(
+                "memory_honest_write_liveness",
+                True,
+                f"honest write stayed visible on all {len(honest)} honest replicas "
+                "after merging the Byzantine forgery",
+            )
+        ]
+    lost = sum(1 for v in finals if not is_visible(v))
+    return [
+        ValidationResult(
+            "memory_honest_write_liveness",
+            False,
+            f"Byzantine forgery suppressed the honest write on {lost}/{len(honest)} "
+            "honest replica(s)",
+        )
+    ]
+
+
+async def validate_crdt_add_wins_convergence(
+    make_replica: Callable[[str], Any],
+    *,
+    add_op: Callable[[str], bytes],
+    remove_op: Callable[[str], bytes],
+    present: Callable[[bytes | None], set[str]],
+    element: str = "slot-7",
+    key: str = "claims",
+    replica_count: int = 6,
+) -> list[ValidationResult]:
+    """Discriminating check: concurrent add||remove converges *and* resolves add-wins.
+
+    This is the memory-CRDT problem's mandatory set-semantics validator. It
+    drives ``replica_count`` replicas through a genuinely concurrent add/remove
+    interleaving on the *same* element: ``node-0`` adds and the add is observed
+    everywhere; then, concurrently, the odd replicas remove the element
+    (tombstoning the tag they observed) while the even replicas mint a *fresh*
+    add of the same element (a tag the removers never saw). After full
+    anti-entropy every replica must (1) read byte-identical state and (2) show
+    the element **present** -- the add-wins resolution an observed-remove set
+    guarantees. A blackboard has no set to converge and no notion of "present
+    after concurrent add/remove", so it fails; the same ops applied to an OR-Set
+    pass.
+
+    Args:
+        make_replica: factory ``node_id -> plugin instance``.
+        add_op: ``element -> write payload`` that adds the element.
+        remove_op: ``element -> write payload`` that removes the element.
+        present: ``read result -> set of present element keys`` adapter.
+        element: the element raced between add and remove.
+        key: the shared key.
+        replica_count: replica count (>= 3 for a meaningful interleaving).
+
+    Example::
+
+        from nest_plugins_reference.memory.or_set import OrSetMemory
+        results = await validate_crdt_add_wins_convergence(
+            OrSetMemory,
+            add_op=lambda e: json.dumps({"op": "add", "element": e}).encode(),
+            remove_op=lambda e: json.dumps({"op": "remove", "element": e}).encode(),
+            present=lambda v: set(json.loads(v)) if v else set(),
+        )
+        assert all(r.passed for r in results)
+    """
+    replicas = [make_replica(f"node-{i}") for i in range(replica_count)]
+    has_crdt = all(hasattr(r, "export") and hasattr(r, "merge") for r in replicas)
+
+    # Phase 1: node-0 adds the element; everyone observes that add.
+    await replicas[0].write(key, add_op(element))
+    base = replicas[0].export(key) if has_crdt else None
+    for r in replicas[1:]:
+        if has_crdt and base is not None:
+            await r.merge(key, base)
+        elif not has_crdt:
+            await r.write(key, add_op(element))
+
+    # Phase 2: concurrent divergence. Odd replicas remove (tombstoning the tag
+    # they observed); even replicas re-add (minting a fresh, unobserved tag).
+    for i, r in enumerate(replicas):
+        if i == 0:
+            continue
+        if i % 2 == 1:
+            await r.write(key, remove_op(element))
+        else:
+            await r.write(key, add_op(element))
+
+    # Phase 3: full anti-entropy in a fixed order (irrelevant for a CvRDT,
+    # decisive for a last-writer store).
+    states = [r.export(key) if has_crdt else None for r in replicas]
+    for i, r in enumerate(replicas):
+        for j in range(replica_count):
+            if i == j:
+                continue
+            if has_crdt:
+                st = states[j]
+                if st is not None:
+                    await r.merge(key, st)
+            else:
+                op = remove_op(element) if (j != 0 and j % 2 == 1) else add_op(element)
+                await r.write(key, op)
+
+    reads = [await r.read(key) for r in replicas]
+    canonical = {(v if v is not None else b"") for v in reads}
+    converged = len(canonical) == 1
+    add_wins = all(element in present(v) for v in reads)
+
+    results: list[ValidationResult] = []
+    if converged:
+        results.append(
+            ValidationResult(
+                "crdt_add_wins_converged",
+                True,
+                f"{replica_count} replicas converged to byte-identical state",
+            )
+        )
+    else:
+        results.append(
+            ValidationResult(
+                "crdt_add_wins_converged",
+                False,
+                f"replicas diverged into {len(canonical)} distinct state(s)",
+            )
+        )
+    if add_wins:
+        results.append(
+            ValidationResult(
+                "crdt_add_wins_resolution",
+                True,
+                f"concurrent add||remove of {element!r} resolved add-wins on all replicas",
+            )
+        )
+    else:
+        losers = sum(1 for v in reads if element not in present(v))
+        results.append(
+            ValidationResult(
+                "crdt_add_wins_resolution",
+                False,
+                f"{element!r} not present on {losers}/{replica_count} replicas "
+                "after concurrent add||remove (add-wins violated)",
+            )
+        )
+    return results
+
+
+def _orset_present_elements(state_json: str) -> set[str]:
+    """Return the present element keys of a serialized ``or_set`` state.
+
+    Parses the public ``{"adds": {ek: [[node, ctr], ...]}, "removed": [...]}``
+    JSON (no plugin import needed) and returns the element keys that carry at
+    least one add-tag absent from the tombstone set.
+    """
+    obj = json.loads(state_json)
+    if not isinstance(obj, dict):
+        return set()
+    data = cast("dict[str, Any]", obj)
+    adds_raw = data.get("adds", {})
+    removed_raw = data.get("removed", [])
+    if not isinstance(adds_raw, dict) or not isinstance(removed_raw, list):
+        return set()
+    removed = _tag_pairs(cast("list[Any]", removed_raw))
+    present: set[str] = set()
+    for element_key, tags in cast("dict[str, Any]", adds_raw).items():
+        if not isinstance(tags, list):
+            continue
+        if _tag_pairs(cast("list[Any]", tags)) - removed:
+            present.add(str(element_key))
+    return present
+
+
+def _tag_pairs(raw: list[Any]) -> set[tuple[Any, ...]]:
+    """Coerce a serialized ``[[node, counter], ...]`` list into a set of tuples."""
+    return {tuple(cast("list[Any]", t)) for t in raw if isinstance(t, list)}
+
+
+def validate_orset_claims_convergence(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Trace validator: every OR-Set replica converged to byte-identical state.
+
+    The ``memory_orset_claims`` scenario has each replica broadcast its terminal
+    OR-Set export as a ``final:<json>`` record on stop. This validator confirms
+    every replica emitted exactly one such record and that all of them decode to
+    byte-identical state -- strong eventual consistency, held even though one
+    replica was injecting forged, inflated-counter adds throughout the run.
+    """
+    finals: dict[str, str] = {}
+    duplicates: set[str] = set()
+    malformed: list[str] = []
+
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        msg = str(ev.get("msg", ""))
+        if not msg.startswith("final:"):
+            continue
+        agent = str(ev.get("agent", ""))
+        body = msg[len("final:") :]
+        try:
+            parsed = json.loads(body)
+            canonical = json.dumps(parsed, sort_keys=True)
+        except (ValueError, TypeError):
+            malformed.append(agent)
+            continue
+        if agent in finals:
+            duplicates.add(agent)
+        finals[agent] = canonical
+
+    results: list[ValidationResult] = []
+    if malformed:
+        results.append(
+            ValidationResult(
+                "orset_claims_wellformed",
+                False,
+                f"{len(malformed)} malformed final record(s): {sorted(set(malformed))}",
+            )
+        )
+    if not finals:
+        results.append(
+            ValidationResult(
+                "orset_claims_convergence",
+                False,
+                "no final replica states found in trace",
+            )
+        )
+        return results
+
+    distinct = set(finals.values())
+    results.append(
+        ValidationResult(
+            "orset_claims_convergence",
+            len(distinct) == 1,
+            f"all {len(finals)} replicas converged to identical state"
+            if len(distinct) == 1
+            else f"{len(finals)} replicas hold {len(distinct)} distinct final states",
+        )
+    )
+    if duplicates:
+        results.append(
+            ValidationResult(
+                "orset_claims_one_final_per_agent",
+                False,
+                f"agents emitted multiple final records: {sorted(duplicates)}",
+            )
+        )
+    return results
+
+
+def validate_orset_claims_honest_liveness(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Trace validator: honest claims survived the Byzantine inflation attack.
+
+    Decodes the converged OR-Set state and asserts at least one honest claim
+    (an element keyed ``slot-*``) is still present. This is the trace-level
+    analogue of :func:`validate_memory_honest_write_liveness`: it proves the
+    Byzantine replica's inflated-counter forgery did not suppress the honest
+    claim/release traffic. It also confirms the attacker actually ran (its
+    forged marker element is present), so a silently no-op'd Byzantine agent
+    cannot make the check pass by doing nothing.
+    """
+    finals: list[str] = []
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        msg = str(ev.get("msg", ""))
+        if msg.startswith("final:"):
+            finals.append(msg[len("final:") :])
+    if not finals:
+        return [
+            ValidationResult(
+                "orset_claims_honest_liveness",
+                False,
+                "no final replica states found in trace",
+            )
+        ]
+
+    try:
+        present = _orset_present_elements(finals[0])
+    except (ValueError, TypeError):
+        return [
+            ValidationResult(
+                "orset_claims_honest_liveness",
+                False,
+                "converged final state was not decodable OR-Set JSON",
+            )
+        ]
+
+    honest_claims: set[str] = set()
+    attacker_present = False
+    for element_key in present:
+        try:
+            value = json.loads(element_key)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(value, str) and value.startswith("slot-"):
+            honest_claims.add(value)
+        if isinstance(value, str) and value.startswith("BYZANTINE"):
+            attacker_present = True
+
+    results: list[ValidationResult] = []
+    results.append(
+        ValidationResult(
+            "orset_claims_honest_liveness",
+            bool(honest_claims),
+            f"{len(honest_claims)} honest claim(s) survived the Byzantine attack: "
+            f"{sorted(honest_claims)}"
+            if honest_claims
+            else "no honest claim survived -- the attack suppressed honest writes",
+        )
+    )
+    results.append(
+        ValidationResult(
+            "orset_claims_attacker_ran",
+            attacker_present,
+            "Byzantine forged element observed in converged state (attack actually ran)"
+            if attacker_present
+            else "no Byzantine element found -- attacker silently no-op'd, "
+            "so liveness was never tested",
+        )
+    )
+    return results
+
+
 # ---------------------------------------------------------------------------
 # Streaming payments validators
 # ---------------------------------------------------------------------------
@@ -4081,6 +4486,11 @@ VALIDATORS: dict[str, list[Any]] = {
     ],
     "memory_concurrent_writers": [
         validate_memory_convergence,
+        validate_memory_liveness,
+    ],
+    "memory_orset_claims": [
+        validate_orset_claims_convergence,
+        validate_orset_claims_honest_liveness,
         validate_memory_liveness,
     ],
     "streaming_payments": [

--- a/packages/nest-core/tests/test_orset_scenario.py
+++ b/packages/nest-core/tests/test_orset_scenario.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end tests for the memory_orset_claims scenario and its validators.
+
+The core claims under test: the claim/release marketplace replays byte-identically
+across the required seeds; under 10% message loss and one Byzantine forger every
+replica converges, every honest claim survives, and the attacker provably ran;
+and the memory_orset_claims validators FAIL against a trace with no OR-Set final
+records at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_events, validate_trace
+
+_SCENARIO = "scenarios/memory_orset_claims.yaml"
+_SEEDS = (42, 7, 1337)
+
+
+def _run(out: Path, seed: int) -> None:
+    cfg = ScenarioConfig.from_yaml(_SCENARIO)
+    cfg.seed = seed
+    cfg.output.trace = str(out)
+    asyncio.run(ScenarioRunner(cfg).run())
+
+
+class TestOrSetClaimsScenario:
+    def test_runs_and_passes_all_validators(self, tmp_path: Path) -> None:
+        out = tmp_path / "orset.jsonl"
+        _run(out, seed=42)
+        results = validate_trace(out, "memory_orset_claims")
+        assert results, "expected validators to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_deterministic_across_required_seeds(self, tmp_path: Path) -> None:
+        for seed in _SEEDS:
+            a, b = tmp_path / f"{seed}a.jsonl", tmp_path / f"{seed}b.jsonl"
+            _run(a, seed=seed)
+            _run(b, seed=seed)
+            assert a.read_bytes() == b.read_bytes(), f"seed {seed} not byte-deterministic"
+            assert all(r.passed for r in validate_trace(a, "memory_orset_claims")), seed
+
+    def test_all_ten_honest_claims_survive(self, tmp_path: Path) -> None:
+        out = tmp_path / "orset.jsonl"
+        _run(out, seed=1337)
+        results = {r.name: r for r in validate_trace(out, "memory_orset_claims")}
+        liveness = results["orset_claims_honest_liveness"]
+        assert liveness.passed
+        # All ten permanent self-claims must be present at convergence.
+        for i in range(10):
+            assert f"slot-{i}" in liveness.detail, liveness.detail
+
+    def test_attacker_actually_ran(self, tmp_path: Path) -> None:
+        out = tmp_path / "orset.jsonl"
+        _run(out, seed=7)
+        results = {r.name: r for r in validate_trace(out, "memory_orset_claims")}
+        # Sanity: if this ever fails, the Byzantine forger silently no-op'd and
+        # liveness was never actually tested.
+        assert results["orset_claims_attacker_ran"].passed
+
+
+class TestValidatorsFailAgainstNonOrSetTrace:
+    def test_fails_against_empty_style_trace(self) -> None:
+        events = [
+            {"kind": "start", "agent": "claimant-0"},
+            {"kind": "send", "agent": "claimant-0", "msg": "bids:[]"},
+            {"kind": "stop", "agent": "claimant-0"},
+        ]
+        results = validate_events(events, "memory_orset_claims")
+        assert any(not r.passed for r in results), "expected at least one validator to fail"
+
+    def test_fails_when_a_replica_never_reports(self) -> None:
+        # A started replica that emits no final: record is a liveness failure.
+        events = [
+            {"kind": "start", "agent": "claimant-0"},
+            {"kind": "start", "agent": "claimant-1"},
+            {
+                "kind": "broadcast",
+                "agent": "claimant-0",
+                "msg": 'final:{"crdt": "or_set", "adds": {"\\"slot-0\\"": [["claimant-0", 1]]}, '
+                '"removed": []}',
+            },
+        ]
+        results = {r.name: r for r in validate_events(events, "memory_orset_claims")}
+        assert results["memory_liveness"].passed is False

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -1815,6 +1815,7 @@ class TestValidatorRegistry:
             "reputation",
             "identity_rotation",
             "memory_concurrent_writers",
+            "memory_orset_claims",
             "streaming_payments",
             "empic_payments",
             "comms_versioning",

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/or_set.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/or_set.py
@@ -1,0 +1,575 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OR-Set (observed-remove set) CRDT memory plugin -- a set that survives Byzantine merges.
+
+This module implements a **state-based, observed-remove set** (an OR-Set CvRDT)
+for the Nanda Town memory layer. Where the ``lww_register`` plugin gives every
+key a single last-writer-wins *value*, an OR-Set gives every key a *set* with
+principled add **and** remove semantics: exactly what a claim/release
+marketplace needs, where ten agents concurrently claim and release slot ids and
+the swarm has to converge on *which slots are held* without a coordinator.
+
+The construction is the classic tag-set OR-Set of Shapiro, Preguica, Baquero &
+Zawirski, "A comprehensive study of Convergent and Commutative Replicated Data
+Types" (INRIA RR-7506, 2011), Section 3.3.5 ("Observed-Remove Set"). Every
+``add(e)`` mints a globally unique **tag** and records ``(e, tag)`` in an add
+set; every ``remove(e)`` moves the tags the remover has *observed* for ``e``
+into a tombstone set. An element is *present* iff it carries at least one
+add-tag that is not tombstoned. Merge is the pairwise union of the add sets and
+the tombstone sets -- **commutative, associative, and idempotent** -- so any
+replicas that have observed the same operations read back byte-identical state
+regardless of delivery order, duplication, or loss. Concurrent ``add(e)`` and
+``remove(e)`` resolve **add-wins**: the remove only tombstones the tags it saw,
+so a concurrent add mints a *fresh* tag the remove could not have observed and
+the element stays present.
+
+**Why the tags are structural, not random.** The charter's headline
+anti-pattern is nondeterminism smuggled in through ``uuid4``, ``time.time()``,
+or an unseeded RNG. This OR-Set mints tags as ``(node_id, counter)`` where
+``node_id`` is the replica's stable id and ``counter`` is a per-node,
+strictly-monotone integer bumped once per local add. Two tags collide only if
+two replicas share a ``node_id`` (the same misconfiguration that breaks
+``lww_register``'s tie-break), so uniqueness is *structural* and the whole
+plugin replays byte-for-byte under a fixed seed.
+
+**Why an OR-Set and not just an LWW-Register.** A register has no principled
+delete -- "erase" is modelled as writing a tombstone sentinel and hoping every
+replica agrees it means "gone". More importantly, ``lww_register`` merges by
+adopting the higher Lamport clock (``lww_register.py:305``), so a Byzantine
+replica that exports a register forged with ``lamport = 2**60`` silently
+suppresses every honest write with a smaller clock. An OR-Set has no global
+clock to forge: a Byzantine replica can inflate its *own* tag counters as high
+as it likes, but that only mints Byzantine-owned tags for Byzantine-owned
+elements. It cannot tombstone an add-tag it never observed, so it cannot
+suppress an honest claim. That difference is the point of this submission and
+is pinned by ``validate_memory_honest_write_liveness``.
+
+The per-key state is encoded as inspectable, canonical JSON so it stays
+grep-able inside a JSONL trace::
+
+    {"crdt": "or_set",
+     "adds": {"\\"slot-1\\"": [["agent-0", 1]]},
+     "removed": [["agent-1", 4]]}
+
+Example::
+
+    a = OrSetMemory("a")
+    b = OrSetMemory("b")
+    await a.write("held", b'{"op": "add", "element": "slot-1"}')
+    await b.write("held", b'{"op": "add", "element": "slot-2"}')
+    # Gossip both ways; order does not matter.
+    await b.merge("held", a.export("held"))
+    await a.merge("held", b.export("held"))
+    assert await a.read("held") == await b.read("held")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+CRDT_KIND = "or_set"
+"""Schema tag stamped into every serialized OR-Set, used to detect and validate
+CRDT state when it is read back from a trace or the wire."""
+
+# A causal add-tag: a replica's stable node id paired with a per-node,
+# strictly-monotone counter. Structural (not random), so replays are
+# byte-identical under a fixed seed.
+Tag = tuple[str, int]
+
+# Structured-write op verbs understood by :meth:`OrSetMemory.write`.
+_OP_ADD = "add"
+_OP_REMOVE = "remove"
+
+
+class OrSetStateError(ValueError):
+    """Raised when a byte string is not a valid serialized OR-Set state.
+
+    Subclasses :class:`ValueError` so existing ``except ValueError`` handlers
+    (such as the gossip loop in the concurrent-writers scenario) keep working
+    while callers that care can catch the specific type. Decoding validates the
+    whole payload *before* any local state is touched, so a malformed or
+    Byzantine-garbled merge can never leave a replica half-updated.
+
+    Example::
+
+        try:
+            OrSetMemory._decode(b"not json")
+        except OrSetStateError:
+            ...
+    """
+
+
+@dataclass
+class _KeyState:
+    """The OR-Set state for a single key: an add set and a tombstone set.
+
+    ``adds`` maps each element's canonical-JSON key to the set of add-tags
+    minted for it; ``removed`` is the set of tombstoned tags. An element is
+    present iff ``adds[element_key] - removed`` is non-empty.
+
+    Example::
+
+        st = _KeyState()
+        st.adds["\\"slot-1\\""] = {("agent-0", 1)}
+        assert st.present() == {"\\"slot-1\\""}
+    """
+
+    adds: dict[str, set[Tag]] = field(default_factory=lambda: dict[str, set[Tag]]())
+    removed: set[Tag] = field(default_factory=lambda: set[Tag]())
+
+    def present(self) -> set[str]:
+        """Return the element keys with at least one non-tombstoned add-tag.
+
+        Example::
+
+            keys = state.present()
+        """
+        return {ek for ek, tags in self.adds.items() if tags - self.removed}
+
+    def all_tags(self) -> set[Tag]:
+        """Return every tag this key has observed (added or tombstoned).
+
+        Used by :meth:`OrSetMemory.cas` to decide whether a caller's observed
+        context still covers the live state.
+
+        Example::
+
+            observed = state.all_tags()
+        """
+        tags: set[Tag] = set(self.removed)
+        for element_tags in self.adds.values():
+            tags |= element_tags
+        return tags
+
+
+def _element_key(element: Any) -> str:
+    """Canonicalize an element to a stable, hashable string key.
+
+    Two elements are the same set member iff their canonical JSON is equal, so
+    ``{"a": 1, "b": 2}`` and ``{"b": 2, "a": 1}`` collapse to one member. The
+    compact separators keep the key short inside a trace.
+
+    Example::
+
+        assert _element_key({"b": 2, "a": 1}) == '{"a":1,"b":2}'
+    """
+    return json.dumps(element, sort_keys=True, separators=(",", ":"))
+
+
+class OrSetMemory:
+    """An observed-remove set CRDT implementing the ``Memory`` protocol.
+
+    Each instance is an independent **replica**. Local writes are structured
+    ops that add or remove elements from the set stored at a key; each add
+    mints a fresh ``(node_id, counter)`` tag. Replicas exchange state with
+    :meth:`export` / :meth:`merge` (typically gossiped over the transport
+    layer). Merge is the pairwise union of the add and tombstone sets, so it is
+    conflict-free: any set of replicas that have observed the same ops read
+    back identical elements no matter the order, duplication, or loss.
+
+    The standard :class:`~nest_core.layers.memory.Memory` surface
+    (``read`` / ``write`` / ``cas`` / ``subscribe``) is honoured exactly; the
+    CRDT machinery is internal. :meth:`read` returns the present-element list as
+    canonical JSON (sorted, byte-deterministic). The extra
+    :meth:`export` / :meth:`merge` / :meth:`export_all` / :meth:`merge_all`
+    methods are the replication channel and are additive -- a caller that only
+    speaks the base protocol never has to know the values are OR-Sets.
+
+    Example::
+
+        mem = OrSetMemory("agent-0")
+        await mem.write("held", b'{"op": "add", "element": "slot-1"}')
+        assert await mem.read("held") == b'["slot-1"]'
+    """
+
+    def __init__(self, node_id: str = "node") -> None:
+        """Create a replica with a stable, unique ``node_id``.
+
+        The ``node_id`` must be stable for the lifetime of the replica and
+        unique across replicas, since it is the first component of every add
+        tag. Two replicas sharing a ``node_id`` could mint colliding tags and
+        break the convergence guarantee -- the same constraint ``lww_register``
+        places on its tie-break id.
+
+        Example::
+
+            mem = OrSetMemory("agent-0")
+        """
+        self._node_id = str(node_id)
+        self._store: dict[str, _KeyState] = {}
+        self._counter: int = 0
+        self._subscribers: dict[str, list[asyncio.Queue[bytes]]] = {}
+
+    @property
+    def node_id(self) -> str:
+        """The stable node identifier stamped into every add-tag.
+
+        Example::
+
+            assert OrSetMemory("agent-0").node_id == "agent-0"
+        """
+        return self._node_id
+
+    @property
+    def counter(self) -> int:
+        """The current per-node monotone add counter of this replica.
+
+        Example::
+
+            mem = OrSetMemory("a")
+            assert mem.counter == 0
+        """
+        return self._counter
+
+    # -- Memory protocol -------------------------------------------------
+
+    async def read(self, key: str) -> bytes | None:
+        """Read the present-element list for ``key`` as canonical JSON bytes.
+
+        Returns ``None`` if the key was never written. Otherwise returns the
+        JSON array of currently-present elements, sorted by their canonical
+        key so the bytes are identical on every converged replica -- e.g.
+        ``b'["slot-1","slot-3"]'``. An empty set reads back as ``b'[]'``.
+
+        Example::
+
+            val = await mem.read("held")
+        """
+        state = self._store.get(key)
+        if state is None:
+            return None
+        present = sorted(state.present())
+        elements = [json.loads(ek) for ek in present]
+        return json.dumps(elements, separators=(",", ":")).encode("utf-8")
+
+    async def write(self, key: str, value: bytes) -> None:
+        """Apply a structured add/remove op to the set at ``key``.
+
+        ``value`` is parsed as a JSON object ``{"op": "add"|"remove",
+        "element": <json>}``. An ``add`` mints a fresh ``(node_id, counter)``
+        tag for the element; a ``remove`` tombstones exactly the add-tags this
+        replica has *observed* for the element (observed-remove semantics), so
+        a concurrent add elsewhere is unaffected and add-wins holds.
+
+        **Plain-bytes fallback.** If ``value`` is not a well-formed op object,
+        it is treated as ``add`` of the raw payload decoded as a UTF-8 string.
+        This keeps the plugin drop-in for base-protocol callers (and scenarios)
+        that write opaque byte values without knowing the memory layer is a
+        set: ``await mem.write("held", b"slot-1")`` adds the element
+        ``"slot-1"``. A remove therefore always requires the explicit op form,
+        which is the safe default -- an ambiguous byte string never silently
+        deletes.
+
+        Example::
+
+            await mem.write("held", b'{"op": "add", "element": "slot-1"}')
+            await mem.write("held", b'{"op": "remove", "element": "slot-1"}')
+        """
+        op, element = self._parse_op(value)
+        state = self._store.setdefault(key, _KeyState())
+        if op == _OP_REMOVE:
+            element_key = _element_key(element)
+            observed = state.adds.get(element_key, set())
+            if observed:
+                state.removed |= observed
+        else:
+            self._counter += 1
+            tag: Tag = (self._node_id, self._counter)
+            element_key = _element_key(element)
+            state.adds.setdefault(element_key, set()).add(tag)
+        await self._notify(key)
+
+    async def subscribe(self, key: str) -> AsyncIterator[bytes]:
+        """Yield the present-element JSON each time the set at ``key`` advances.
+
+        Example::
+
+            async for val in mem.subscribe("held"):
+                print(val)
+        """
+        q: asyncio.Queue[bytes] = asyncio.Queue()
+        self._subscribers.setdefault(key, []).append(q)
+        try:
+            while True:
+                yield await q.get()
+        finally:
+            self._subscribers[key].remove(q)
+
+    async def cas(self, key: str, expected: bytes, new: bytes) -> bool:
+        """Observed-context compare-and-swap: apply ``new`` only if not raced.
+
+        Unlike a register CAS -- which compares a single winning value --
+        an OR-Set CAS compares *causal context*. ``expected`` is an OR-Set
+        state export (typically ``mem.export(key)`` captured earlier) describing
+        the tag-set the caller has observed. The swap succeeds iff that observed
+        context **covers** the key's current tag-set -- i.e. no add or remove
+        tag has appeared that the caller did not see. On success ``new`` (a
+        structured op) is applied; on a stale context the call returns ``False``
+        without mutating state, so it can never blindly clobber a concurrent
+        update it never observed.
+
+        This is the CRDT's *natural* conflict rule rather than blackboard's
+        racing last-writer CAS: because merge unions add-tags, an update
+        admitted here is never lost, and an update it did *not* see is never
+        overwritten. :mod:`test_or_set_properties` pins the lost-update-freedom
+        invariant against a blackboard that races.
+
+        Example::
+
+            ctx = mem.export("held")
+            ok = await mem.cas("held", ctx or b"", b'{"op": "add", "element": "slot-9"}')
+        """
+        try:
+            observed = self._observed_tags(expected)
+        except OrSetStateError:
+            return False
+        state = self._store.get(key)
+        current = state.all_tags() if state is not None else set[Tag]()
+        if not current <= observed:
+            return False
+        await self.write(key, new)
+        return True
+
+    # -- CRDT replication channel ---------------------------------------
+
+    def export(self, key: str) -> bytes | None:
+        """Serialize the OR-Set state for ``key`` for gossip.
+
+        Returns ``None`` if the key was never written. The result is valid
+        input to another replica's :meth:`merge`.
+
+        Example::
+
+            state = mem.export("held")
+        """
+        state = self._store.get(key)
+        if state is None:
+            return None
+        return self._encode_state(state)
+
+    def export_all(self) -> bytes:
+        """Serialize this replica's full state for a full-state anti-entropy push.
+
+        Example::
+
+            snapshot = mem.export_all()
+        """
+        data = {
+            "crdt": CRDT_KIND,
+            "keys": {key: self._state_fields(state) for key, state in sorted(self._store.items())},
+        }
+        return json.dumps(data, sort_keys=True).encode("utf-8")
+
+    async def merge(self, key: str, state: bytes) -> bool:
+        """Merge a remote OR-Set for ``key`` into the local replica.
+
+        Unions the incoming add and tombstone sets into the local state
+        (commutative, associative, idempotent) and advances this replica's
+        counter past any observed tag it minted under the same ``node_id`` so a
+        future local add cannot re-mint a colliding tag. Returns ``True`` iff
+        the present-element set changed, in which case subscribers are
+        notified. Idempotent: merging the same state twice is a no-op. Raises
+        :class:`OrSetStateError` on malformed input *before* touching state.
+
+        Example::
+
+            changed = await mem.merge("held", other.export("held"))
+        """
+        incoming = self._decode(state)
+        local = self._store.get(key)
+        before = local.present() if local is not None else set[str]()
+        target = self._store.setdefault(key, _KeyState())
+        for element_key, tags in incoming.adds.items():
+            target.adds.setdefault(element_key, set()).update(tags)
+        target.removed |= incoming.removed
+        self._advance_counter(incoming)
+        after = target.present()
+        if after != before:
+            await self._notify(key)
+            return True
+        return False
+
+    async def merge_all(self, state: bytes) -> list[str]:
+        """Merge a full-state snapshot, returning the keys whose value changed.
+
+        Example::
+
+            changed_keys = await mem.merge_all(other.export_all())
+        """
+        keys = self._decode_all(state)
+        changed: list[str] = []
+        for key in sorted(keys):
+            if await self.merge(key, self._encode_state(keys[key])):
+                changed.append(key)
+        return changed
+
+    # -- internals -------------------------------------------------------
+
+    async def _notify(self, key: str) -> None:
+        subscribers = self._subscribers.get(key)
+        if not subscribers:
+            return
+        snapshot = await self.read(key)
+        if snapshot is None:
+            return
+        for q in subscribers:
+            await q.put(snapshot)
+
+    def _advance_counter(self, incoming: _KeyState) -> None:
+        """Bump the local counter past any self-minted tag in ``incoming``.
+
+        Keeps ``(node_id, counter)`` strictly monotone for this replica even
+        after merging back a state that echoes its own earlier adds, so a fresh
+        local add never re-mints a tag that is already tombstoned.
+        """
+        highest = self._counter
+        for tags in incoming.adds.values():
+            for node, counter in tags:
+                if node == self._node_id and counter > highest:
+                    highest = counter
+        for node, counter in incoming.removed:
+            if node == self._node_id and counter > highest:
+                highest = counter
+        self._counter = highest
+
+    def _parse_op(self, value: bytes) -> tuple[str, Any]:
+        """Parse a structured op, falling back to ``add`` of the raw payload."""
+        try:
+            obj = json.loads(value)
+        except (ValueError, TypeError):
+            return _OP_ADD, value.decode("utf-8", errors="replace")
+        if isinstance(obj, dict):
+            data = cast("dict[str, Any]", obj)
+            op = data.get("op")
+            if op in (_OP_ADD, _OP_REMOVE) and "element" in data:
+                return str(op), data["element"]
+        return _OP_ADD, value.decode("utf-8", errors="replace")
+
+    def _observed_tags(self, state: bytes) -> set[Tag]:
+        """Decode an export and return every tag it records (adds and removes)."""
+        return self._decode(state).all_tags()
+
+    @staticmethod
+    def _encode_state(state: _KeyState) -> bytes:
+        return json.dumps(
+            OrSetMemory._state_fields(state) | {"crdt": CRDT_KIND},
+            sort_keys=True,
+        ).encode("utf-8")
+
+    @staticmethod
+    def _state_fields(state: _KeyState) -> dict[str, Any]:
+        return {
+            "adds": {
+                element_key: _encode_tags(tags)
+                for element_key, tags in sorted(state.adds.items())
+                if tags
+            },
+            "removed": _encode_tags(state.removed),
+        }
+
+    @staticmethod
+    def _loads_object(state: bytes) -> object:
+        try:
+            return json.loads(state)
+        except (ValueError, TypeError) as exc:
+            msg = "state is not valid JSON"
+            raise OrSetStateError(msg) from exc
+
+    @staticmethod
+    def _decode(state: bytes) -> _KeyState:
+        obj = OrSetMemory._loads_object(state)
+        if not isinstance(obj, dict):
+            msg = f"not an {CRDT_KIND} state: {obj!r}"
+            raise OrSetStateError(msg)
+        data = cast("dict[str, Any]", obj)
+        if data.get("crdt") != CRDT_KIND:
+            msg = f"not an {CRDT_KIND} state: {data!r}"
+            raise OrSetStateError(msg)
+        return OrSetMemory._state_from_fields(data)
+
+    @staticmethod
+    def _decode_all(state: bytes) -> dict[str, _KeyState]:
+        obj = OrSetMemory._loads_object(state)
+        if not isinstance(obj, dict):
+            msg = f"not an {CRDT_KIND} snapshot: {obj!r}"
+            raise OrSetStateError(msg)
+        data = cast("dict[str, Any]", obj)
+        if data.get("crdt") != CRDT_KIND:
+            msg = f"not an {CRDT_KIND} snapshot: {data!r}"
+            raise OrSetStateError(msg)
+        raw = data.get("keys", {})
+        if not isinstance(raw, dict):
+            msg = "snapshot 'keys' must be an object"
+            raise OrSetStateError(msg)
+        raw_keys = cast("dict[str, Any]", raw)
+        result: dict[str, _KeyState] = {}
+        for key, fields in raw_keys.items():
+            if not isinstance(fields, dict):
+                msg = f"state for {key!r} must be an object"
+                raise OrSetStateError(msg)
+            result[str(key)] = OrSetMemory._state_from_fields(cast("dict[str, Any]", fields))
+        return result
+
+    @staticmethod
+    def _state_from_fields(fields: dict[str, Any]) -> _KeyState:
+        raw_adds = fields.get("adds", {})
+        raw_removed = fields.get("removed", [])
+        if not isinstance(raw_adds, dict):
+            msg = f"'adds' must be an object: {raw_adds!r}"
+            raise OrSetStateError(msg)
+        adds: dict[str, set[Tag]] = {}
+        for element_key, tag_list in cast("dict[str, Any]", raw_adds).items():
+            adds[str(element_key)] = _decode_tags(tag_list)
+        removed = _decode_tags(raw_removed)
+        return _KeyState(adds=adds, removed=removed)
+
+
+def _encode_tags(tags: set[Tag]) -> list[list[Any]]:
+    """Serialize a tag set to a sorted list of ``[node, counter]`` pairs.
+
+    Sorting makes the encoding canonical, so two converged replicas emit
+    byte-identical JSON.
+
+    Example::
+
+        assert _encode_tags({("b", 2), ("a", 1)}) == [["a", 1], ["b", 2]]
+    """
+    return [[node, counter] for node, counter in sorted(tags)]
+
+
+def _decode_tags(raw: Any) -> set[Tag]:
+    """Parse a ``[[node, counter], ...]`` list back into a tag set.
+
+    Raises :class:`OrSetStateError` on any malformed pair so a garbled or
+    Byzantine payload is rejected wholesale rather than partially applied.
+
+    Example::
+
+        assert _decode_tags([["a", 1]]) == {("a", 1)}
+    """
+    if not isinstance(raw, list):
+        msg = f"tag list must be an array: {raw!r}"
+        raise OrSetStateError(msg)
+    tags: set[Tag] = set()
+    for item in cast("list[Any]", raw):
+        if not isinstance(item, list):
+            msg = f"tag must be a [node, counter] pair: {item!r}"
+            raise OrSetStateError(msg)
+        pair = cast("list[Any]", item)
+        if len(pair) != 2:
+            msg = f"tag must have exactly two fields: {pair!r}"
+            raise OrSetStateError(msg)
+        try:
+            node = str(pair[0])
+            counter = int(pair[1])
+        except (ValueError, TypeError) as exc:
+            msg = f"malformed tag: {pair!r}"
+            raise OrSetStateError(msg) from exc
+        if isinstance(pair[1], bool):
+            msg = f"tag counter must be an integer, not a bool: {pair!r}"
+            raise OrSetStateError(msg)
+        tags.add((node, counter))
+    return tags

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -35,6 +35,7 @@ Repository = "https://github.com/projnanda/nandatown"
 # install-time discovery path described in CONTRIBUTING.md.
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
+or_set = "nest_plugins_reference.memory.or_set:OrSetMemory"
 
 [project.entry-points."nest.plugins.privacy"]
 hybrid_x25519 = "nest_plugins_reference.privacy.hybrid_x25519:HybridX25519Privacy"

--- a/packages/nest-plugins-reference/tests/test_or_set.py
+++ b/packages/nest-plugins-reference/tests/test_or_set.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Example-based tests for the OR-Set (observed-remove set) memory plugin.
+
+Covers the observed-remove semantics of Shapiro, Preguica, Baquero & Zawirski
+(2011), Section 3.3.5: empty and single-element sets, the add/remove/re-add
+lifecycle, add-wins under concurrent add||remove, idempotent self-merge,
+cross-key isolation, structured-op parsing with the documented plain-bytes
+fallback, observed-context CAS, and rejection of malformed merge payloads
+without state corruption.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from nest_plugins_reference.memory.or_set import (
+    CRDT_KIND,
+    OrSetMemory,
+    OrSetStateError,
+)
+
+
+def _add(element: object) -> bytes:
+    return json.dumps({"op": "add", "element": element}, sort_keys=True).encode()
+
+
+def _remove(element: object) -> bytes:
+    return json.dumps({"op": "remove", "element": element}, sort_keys=True).encode()
+
+
+def _present(raw: bytes | None) -> list[object]:
+    assert raw is not None
+    return list(json.loads(raw))
+
+
+class TestReadWrite:
+    async def test_unset_key_reads_none(self) -> None:
+        mem = OrSetMemory("a")
+        assert await mem.read("missing") is None
+
+    async def test_single_element_present(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("held", _add("slot-1"))
+        assert await mem.read("held") == b'["slot-1"]'
+
+    async def test_empty_after_add_then_remove(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("held", _add("slot-1"))
+        await mem.write("held", _remove("slot-1"))
+        assert await mem.read("held") == b"[]"
+
+    async def test_add_remove_re_add(self) -> None:
+        # Re-adding after a remove mints a FRESH tag not covered by the old
+        # tombstone, so the element comes back -- the OR-Set's defining behavior.
+        mem = OrSetMemory("a")
+        await mem.write("held", _add("slot-1"))
+        await mem.write("held", _remove("slot-1"))
+        assert await mem.read("held") == b"[]"
+        await mem.write("held", _add("slot-1"))
+        assert await mem.read("held") == b'["slot-1"]'
+
+    async def test_read_is_sorted_and_canonical(self) -> None:
+        mem = OrSetMemory("a")
+        for element in ("slot-3", "slot-1", "slot-2"):
+            await mem.write("held", _add(element))
+        # Present list is sorted by canonical element key -> byte-deterministic.
+        assert await mem.read("held") == b'["slot-1","slot-2","slot-3"]'
+
+    async def test_duplicate_add_is_idempotent_read(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("held", _add("slot-1"))
+        await mem.write("held", _add("slot-1"))
+        assert await mem.read("held") == b'["slot-1"]'
+
+
+class TestOpParsing:
+    async def test_plain_bytes_fallback_is_add(self) -> None:
+        # Documented decision: a non-op byte payload is treated as add of the
+        # UTF-8 string, keeping the plugin drop-in for opaque-byte callers.
+        mem = OrSetMemory("a")
+        await mem.write("held", b"slot-9")
+        assert await mem.read("held") == b'["slot-9"]'
+
+    async def test_non_string_element_supported(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("held", _add({"host": "h1", "port": 22}))
+        present = _present(await mem.read("held"))
+        assert present == [{"host": "h1", "port": 22}]
+
+    async def test_remove_requires_explicit_op(self) -> None:
+        # A raw byte string that happens to read like "remove" is still an add;
+        # only the structured op form can delete, so nothing deletes by accident.
+        mem = OrSetMemory("a")
+        await mem.write("held", _add("slot-1"))
+        await mem.write("held", b"remove")
+        present = _present(await mem.read("held"))
+        assert set(present) == {"slot-1", "remove"}
+
+    async def test_malformed_op_object_falls_back_to_add(self) -> None:
+        mem = OrSetMemory("a")
+        # Valid JSON, but not an op object -> treated as add of the raw text.
+        await mem.write("held", b'{"not":"an-op"}')
+        present = _present(await mem.read("held"))
+        assert present == ['{"not":"an-op"}']
+
+
+class TestCrossKeyIsolation:
+    async def test_keys_are_independent(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k1", _add("x"))
+        await mem.write("k2", _add("y"))
+        assert await mem.read("k1") == b'["x"]'
+        assert await mem.read("k2") == b'["y"]'
+        await mem.write("k1", _remove("x"))
+        assert await mem.read("k1") == b"[]"
+        assert await mem.read("k2") == b'["y"]'
+
+
+class TestMergeGossip:
+    async def test_merge_unions_disjoint_adds(self) -> None:
+        a = OrSetMemory("a")
+        b = OrSetMemory("b")
+        await a.write("held", _add("slot-1"))
+        await b.write("held", _add("slot-2"))
+        await a.merge("held", _require(b.export("held")))
+        await b.merge("held", _require(a.export("held")))
+        assert await a.read("held") == await b.read("held")
+        assert _present(await a.read("held")) == ["slot-1", "slot-2"]
+
+    async def test_self_merge_is_noop(self) -> None:
+        a = OrSetMemory("a")
+        await a.write("held", _add("slot-1"))
+        changed = await a.merge("held", _require(a.export("held")))
+        assert changed is False
+        assert await a.read("held") == b'["slot-1"]'
+
+    async def test_merge_is_idempotent(self) -> None:
+        a = OrSetMemory("a")
+        b = OrSetMemory("b")
+        await b.write("held", _add("slot-2"))
+        state = _require(b.export("held"))
+        assert await a.merge("held", state) is True
+        assert await a.merge("held", state) is False
+
+    async def test_merge_returns_false_when_present_unchanged(self) -> None:
+        # Merging an add whose element is already present (via another tag) does
+        # not change the present set, so merge reports no change.
+        a = OrSetMemory("a")
+        b = OrSetMemory("b")
+        await a.write("held", _add("slot-1"))
+        await b.write("held", _add("slot-1"))
+        assert await a.merge("held", _require(b.export("held"))) is False
+
+    async def test_export_all_merge_all_roundtrip(self) -> None:
+        a = OrSetMemory("a")
+        b = OrSetMemory("b")
+        await a.write("k1", _add("x"))
+        await a.write("k2", _add("y"))
+        changed = await b.merge_all(a.export_all())
+        assert sorted(changed) == ["k1", "k2"]
+        assert await b.read("k1") == b'["x"]'
+        assert await b.read("k2") == b'["y"]'
+
+    async def test_export_unset_key_is_none(self) -> None:
+        assert OrSetMemory("a").export("missing") is None
+
+
+class TestAddWins:
+    async def test_concurrent_add_beats_remove(self) -> None:
+        # r1 adds x; r2 observes x then removes it; concurrently r1 re-adds x
+        # with a fresh tag r2 never saw. After merge, x is present (add-wins).
+        r1 = OrSetMemory("r1")
+        r2 = OrSetMemory("r2")
+        await r1.write("k", _add("x"))
+        await r2.merge("k", _require(r1.export("k")))
+        await r2.write("k", _remove("x"))
+        await r1.write("k", _add("x"))  # concurrent, unobserved by r2
+        await r1.merge("k", _require(r2.export("k")))
+        await r2.merge("k", _require(r1.export("k")))
+        assert await r1.read("k") == await r2.read("k")
+        assert await r1.read("k") == b'["x"]'
+
+
+class TestObservedContextCas:
+    async def test_cas_applies_on_current_context(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("held", _add("slot-1"))
+        ctx = _require(mem.export("held"))
+        ok = await mem.cas("held", ctx, _add("slot-2"))
+        assert ok is True
+        assert _present(await mem.read("held")) == ["slot-1", "slot-2"]
+
+    async def test_cas_rejects_stale_context(self) -> None:
+        # Capture context, then let a concurrent add land via merge; the stale
+        # context no longer covers the live tag-set, so the CAS is rejected.
+        a = OrSetMemory("a")
+        b = OrSetMemory("b")
+        await a.write("held", _add("slot-1"))
+        stale = _require(a.export("held"))
+        await b.write("held", _add("slot-2"))
+        await a.merge("held", _require(b.export("held")))
+        ok = await a.cas("held", stale, _add("slot-3"))
+        assert ok is False
+        assert "slot-3" not in _present(await a.read("held"))
+
+    async def test_cas_on_fresh_key_with_empty_context(self) -> None:
+        mem = OrSetMemory("a")
+        ok = await mem.cas("held", b'{"crdt": "or_set", "adds": {}, "removed": []}', _add("slot-1"))
+        assert ok is True
+        assert await mem.read("held") == b'["slot-1"]'
+
+    async def test_cas_on_malformed_context_returns_false(self) -> None:
+        mem = OrSetMemory("a")
+        assert await mem.cas("held", b"not json", _add("slot-1")) is False
+
+
+class TestMalformedRejected:
+    async def test_merge_rejects_non_json(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("held", _add("slot-1"))
+        before = await mem.read("held")
+        with pytest.raises(OrSetStateError):
+            await mem.merge("held", b"not json")
+        assert await mem.read("held") == before
+
+    async def test_merge_rejects_wrong_crdt_tag(self) -> None:
+        mem = OrSetMemory("a")
+        payload = json.dumps({"crdt": "lww_register", "adds": {}, "removed": []}).encode()
+        with pytest.raises(OrSetStateError):
+            await mem.merge("held", payload)
+
+    async def test_merge_rejects_malformed_tag(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("held", _add("slot-1"))
+        before = await mem.read("held")
+        bad = json.dumps(
+            {"crdt": CRDT_KIND, "adds": {'"x"': [["node", "not-an-int"]]}, "removed": []}
+        ).encode()
+        with pytest.raises(OrSetStateError):
+            await mem.merge("held", bad)
+        # State untouched by the rejected merge.
+        assert await mem.read("held") == before
+
+    async def test_merge_rejects_non_pair_tag(self) -> None:
+        mem = OrSetMemory("a")
+        bad = json.dumps(
+            {"crdt": CRDT_KIND, "adds": {'"x"': [["only-one"]]}, "removed": []}
+        ).encode()
+        with pytest.raises(OrSetStateError):
+            await mem.merge("held", bad)
+
+    async def test_merge_rejects_bool_counter(self) -> None:
+        # A JSON bool would int()-coerce to 0/1; reject it so a forged bool tag
+        # cannot alias a real integer-counter tag.
+        mem = OrSetMemory("a")
+        bad = json.dumps(
+            {"crdt": CRDT_KIND, "adds": {'"x"': [["node", True]]}, "removed": []}
+        ).encode()
+        with pytest.raises(OrSetStateError):
+            await mem.merge("held", bad)
+
+
+class TestProperties:
+    async def test_node_id_and_counter_exposed(self) -> None:
+        mem = OrSetMemory("agent-0")
+        assert mem.node_id == "agent-0"
+        assert mem.counter == 0
+        await mem.write("held", _add("slot-1"))
+        assert mem.counter == 1
+
+    async def test_counter_advances_past_merged_self_tags(self) -> None:
+        # After merging back a state echoing this replica's own high-counter tag,
+        # a fresh local add must not re-mint a colliding (already-tombstoned) tag.
+        a = OrSetMemory("a")
+        forged_self = json.dumps(
+            {"crdt": CRDT_KIND, "adds": {'"x"': [["a", 100]]}, "removed": []}
+        ).encode()
+        await a.merge("held", forged_self)
+        await a.write("held", _add("y"))
+        assert a.counter > 100
+
+
+def _require(state: bytes | None) -> bytes:
+    assert state is not None
+    return state

--- a/packages/nest-plugins-reference/tests/test_or_set_adversarial.py
+++ b/packages/nest-plugins-reference/tests/test_or_set_adversarial.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial tests: the honest-write-liveness red-team of the memory plugins.
+
+These tests run the two factory-based CRDT validators against three memory
+plugins and assert the discrimination matrix the charter asks for:
+
+* ``validate_memory_honest_write_liveness`` -- a Byzantine replica forges state,
+  an honest replica writes before observing it, both gossip to convergence:
+
+    - ``lww_register``  FAILS  (a register forged with ``lamport = 2**60`` wins
+      the ``max(clock, incoming)`` merge at ``lww_register.py:305`` and silently
+      suppresses the honest write),
+    - ``blackboard``    FAILS  (the later Byzantine value clobbers the honest one),
+    - ``or_set``        PASSES (a Byzantine replica cannot tombstone an add-tag
+      it never observed, so the honest claim survives).
+
+* ``validate_crdt_add_wins_convergence`` -- concurrent add||remove on one element:
+
+    - ``blackboard``    FAILS  (no set to converge, no add-wins),
+    - ``or_set``        PASSES (byte-identical convergence + add-wins).
+
+The point of this file: it ships a validator that FAILS a plugin already merged
+into ``main`` (``lww_register``), which is exactly the "make the host catch
+something it currently wouldn't" the charter demands.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, cast
+
+from nest_core.validators import (
+    validate_crdt_add_wins_convergence,
+    validate_memory_honest_write_liveness,
+)
+from nest_plugins_reference.memory.blackboard import Blackboard
+from nest_plugins_reference.memory.lww_register import LwwRegisterMemory
+from nest_plugins_reference.memory.or_set import CRDT_KIND, OrSetMemory
+
+_HONEST = "honest-claim"
+
+
+def _element_key(element: str) -> str:
+    """Canonical OR-Set element key, mirroring the plugin's internal encoding."""
+    return json.dumps(element, sort_keys=True, separators=(",", ":"))
+
+
+# -- forge functions: how each plugin's Byzantine replica fabricates state ----
+
+
+def _forge_lww(_byz: Any) -> bytes:
+    """A register forged with an astronomically large Lamport clock."""
+    return json.dumps(
+        {
+            "crdt": "lww_register",
+            "payload": base64.b64encode(b"BYZANTINE").decode("ascii"),
+            "lamport": 2**60,
+            "node": "node-0",
+        },
+        sort_keys=True,
+    ).encode()
+
+
+def _forge_orset(_byz: Any) -> bytes:
+    """An OR-Set forged with an inflated counter and a fabricated honest tombstone.
+
+    The inflated counter only mints a Byzantine-owned tag; the fabricated
+    tombstone ``(node-1, 2**60)`` targets an honest node but with a counter no
+    honest add ever used, so it removes nothing real.
+    """
+    return json.dumps(
+        {
+            "crdt": CRDT_KIND,
+            "adds": {_element_key("BYZANTINE"): [["node-0", 2**60]]},
+            "removed": [["node-1", 2**60]],
+        },
+        sort_keys=True,
+    ).encode()
+
+
+def _forge_blackboard(_byz: Any) -> bytes:
+    """No CvRDT channel: the Byzantine value is delivered as a raw later write."""
+    return b"BYZANTINE-JUNK"
+
+
+def _bb_factory(_node_id: str) -> Blackboard:
+    """Blackboard ignores the node id (it is not a replica-aware CRDT)."""
+    return Blackboard()
+
+
+# -- add/remove op adapters (identical ops for or_set and blackboard) ---------
+
+
+def _add_op(element: str) -> bytes:
+    return json.dumps({"op": "add", "element": element}, sort_keys=True).encode()
+
+
+def _remove_op(element: str) -> bytes:
+    return json.dumps({"op": "remove", "element": element}, sort_keys=True).encode()
+
+
+def _present(raw: bytes | None) -> set[str]:
+    if not raw:
+        return set()
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return set()
+    if not isinstance(parsed, list):
+        return set()
+    return {str(element) for element in cast("list[Any]", parsed)}
+
+
+def _passed(results: list[Any]) -> bool:
+    return bool(results) and all(r.passed for r in results)
+
+
+class TestHonestWriteLiveness:
+    async def test_lww_register_fails(self) -> None:
+        results = await validate_memory_honest_write_liveness(
+            LwwRegisterMemory,
+            forge=_forge_lww,
+            honest_op=_HONEST.encode(),
+            is_visible=lambda v: v == _HONEST.encode(),
+        )
+        assert not _passed(results)
+        assert "suppressed" in results[0].detail
+
+    async def test_blackboard_fails(self) -> None:
+        results = await validate_memory_honest_write_liveness(
+            _bb_factory,
+            forge=_forge_blackboard,
+            honest_op=_HONEST.encode(),
+            is_visible=lambda v: v == _HONEST.encode(),
+        )
+        assert not _passed(results)
+
+    async def test_or_set_passes(self) -> None:
+        results = await validate_memory_honest_write_liveness(
+            OrSetMemory,
+            forge=_forge_orset,
+            honest_op=_add_op(_HONEST),
+            is_visible=lambda v: v is not None and _HONEST in json.loads(v),
+        )
+        assert _passed(results)
+
+
+class TestAddWinsConvergence:
+    async def test_or_set_passes(self) -> None:
+        results = await validate_crdt_add_wins_convergence(
+            OrSetMemory,
+            add_op=_add_op,
+            remove_op=_remove_op,
+            present=_present,
+        )
+        assert _passed(results)
+        names = {r.name for r in results}
+        assert {"crdt_add_wins_converged", "crdt_add_wins_resolution"} <= names
+
+    async def test_blackboard_fails(self) -> None:
+        results = await validate_crdt_add_wins_convergence(
+            _bb_factory,
+            add_op=_add_op,
+            remove_op=_remove_op,
+            present=_present,
+        )
+        assert not _passed(results)
+
+
+class TestVerifiedVulnerabilityRepro:
+    async def test_lww_register_silently_suppresses_honest_write(self) -> None:
+        """Direct repro of the lww_register.py:305 finding, independent of the validator.
+
+        An honest replica commits a legitimate write, then merges a register a
+        Byzantine peer forged with ``lamport = 2**60``. The honest write is
+        silently discarded -- the write-suppression this submission red-teams.
+        """
+        honest = LwwRegisterMemory("honest")
+        await honest.write("slot", b"honest-claim")
+        assert await honest.read("slot") == b"honest-claim"
+        forged = _forge_lww(None)
+        await honest.merge("slot", forged)
+        assert await honest.read("slot") == b"BYZANTINE"  # honest write lost
+
+    async def test_or_set_preserves_honest_write_under_same_attack(self) -> None:
+        """The same attack against the OR-Set leaves the honest claim intact."""
+        honest = OrSetMemory("honest")
+        await honest.write("slot", _add_op("honest-claim"))
+        await honest.merge("slot", _forge_orset(None))
+        present = json.loads(await honest.read("slot") or b"[]")
+        assert "honest-claim" in present

--- a/packages/nest-plugins-reference/tests/test_or_set_properties.py
+++ b/packages/nest-plugins-reference/tests/test_or_set_properties.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hypothesis property tests for the OR-Set memory plugin.
+
+Pins the algebraic laws that make a state-based OR-Set a CvRDT (Shapiro,
+Preguica, Baquero & Zawirski, 2011): merge is commutative, associative, and
+idempotent, so any merge order yields byte-identical state (strong eventual
+consistency). Also pins the two semantic guarantees the plugin sells: add-wins
+resolution survives arbitrary preceding interleavings, and observed-context CAS
+never loses a concurrent update -- unlike a racing blackboard.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_plugins_reference.memory.blackboard import Blackboard
+from nest_plugins_reference.memory.or_set import OrSetMemory
+
+_KEY = "k"
+_EMPTY = b'{"crdt": "or_set", "adds": {}, "removed": []}'
+_ELEMENTS = st.sampled_from(["a", "b", "c", "d", "e"])
+_OP = st.tuples(st.sampled_from(["add", "remove"]), _ELEMENTS)
+_OPS = st.lists(_OP, max_size=12)
+
+
+def _add(element: str) -> bytes:
+    return json.dumps({"op": "add", "element": element}, sort_keys=True).encode()
+
+
+def _remove(element: str) -> bytes:
+    return json.dumps({"op": "remove", "element": element}, sort_keys=True).encode()
+
+
+def _require(state: bytes | None) -> bytes:
+    assert state is not None
+    return state
+
+
+async def _source(node_id: str, ops: list[tuple[str, str]]) -> OrSetMemory:
+    """Build a replica by applying an op sequence locally."""
+    mem = OrSetMemory(node_id)
+    for op, element in ops:
+        await mem.write(_KEY, _add(element) if op == "add" else _remove(element))
+    return mem
+
+
+async def _merge_all(target: OrSetMemory, states: list[bytes]) -> bytes:
+    for state in states:
+        await target.merge(_KEY, state)
+    export = target.export(_KEY)
+    return export if export is not None else b""
+
+
+@given(ops_a=_OPS, ops_b=_OPS)
+@settings(max_examples=100, deadline=None)
+@pytest.mark.asyncio
+async def test_merge_is_commutative(
+    ops_a: list[tuple[str, str]], ops_b: list[tuple[str, str]]
+) -> None:
+    """A then B merges to the same state as B then A."""
+    a = await _source("sa", ops_a)
+    b = await _source("sb", ops_b)
+    state_a = a.export(_KEY) or _EMPTY
+    state_b = b.export(_KEY) or _EMPTY
+    left = await _merge_all(OrSetMemory("t1"), [state_a, state_b])
+    right = await _merge_all(OrSetMemory("t2"), [state_b, state_a])
+    assert left == right
+
+
+@given(ops_a=_OPS, ops_b=_OPS, ops_c=_OPS)
+@settings(max_examples=80, deadline=None)
+@pytest.mark.asyncio
+async def test_merge_is_associative(
+    ops_a: list[tuple[str, str]],
+    ops_b: list[tuple[str, str]],
+    ops_c: list[tuple[str, str]],
+) -> None:
+    """((A merge B) merge C) equals (A merge (B merge C))."""
+    a = await _source("sa", ops_a)
+    b = await _source("sb", ops_b)
+    c = await _source("sc", ops_c)
+    state_a = a.export(_KEY) or _EMPTY
+    state_b = b.export(_KEY) or _EMPTY
+    state_c = c.export(_KEY) or _EMPTY
+
+    # left = (A merge B) merge C
+    ab = OrSetMemory("ab")
+    await ab.merge(_KEY, state_a)
+    await ab.merge(_KEY, state_b)
+    left_target = OrSetMemory("left")
+    await left_target.merge(_KEY, _require(ab.export(_KEY)))
+    await left_target.merge(_KEY, state_c)
+
+    # right = A merge (B merge C)
+    bc = OrSetMemory("bc")
+    await bc.merge(_KEY, state_b)
+    await bc.merge(_KEY, state_c)
+    right_target = OrSetMemory("right")
+    await right_target.merge(_KEY, state_a)
+    await right_target.merge(_KEY, _require(bc.export(_KEY)))
+
+    assert left_target.export(_KEY) == right_target.export(_KEY)
+
+
+@given(ops=_OPS)
+@settings(max_examples=100, deadline=None)
+@pytest.mark.asyncio
+async def test_merge_is_idempotent(ops: list[tuple[str, str]]) -> None:
+    """Merging the same state twice equals merging it once, and reports no change."""
+    src = await _source("s", ops)
+    state = src.export(_KEY)
+    if state is None:
+        return
+    target = OrSetMemory("t")
+    await target.merge(_KEY, state)
+    once = target.export(_KEY)
+    changed_again = await target.merge(_KEY, state)
+    twice = target.export(_KEY)
+    assert once == twice
+    assert changed_again is False
+
+
+@given(ops_a=_OPS, ops_b=_OPS, ops_c=_OPS, perm=st.permutations([0, 1, 2]))
+@settings(max_examples=100, deadline=None)
+@pytest.mark.asyncio
+async def test_permutation_invariance(
+    ops_a: list[tuple[str, str]],
+    ops_b: list[tuple[str, str]],
+    ops_c: list[tuple[str, str]],
+    perm: list[int],
+) -> None:
+    """Any order of merging the same three replica states yields identical bytes."""
+    sources = [
+        await _source("sa", ops_a),
+        await _source("sb", ops_b),
+        await _source("sc", ops_c),
+    ]
+    states = [_require(s.export(_KEY)) for s in sources if s.export(_KEY) is not None]
+    baseline = await _merge_all(OrSetMemory("base"), states)
+    reordered_states = [
+        _require(sources[i].export(_KEY)) for i in perm if sources[i].export(_KEY) is not None
+    ]
+    permuted = await _merge_all(OrSetMemory("perm"), reordered_states)
+    assert baseline == permuted
+
+
+@given(churn=_OPS, element=_ELEMENTS)
+@settings(max_examples=100, deadline=None)
+@pytest.mark.asyncio
+async def test_add_wins_under_arbitrary_interleaving(
+    churn: list[tuple[str, str]], element: str
+) -> None:
+    """A fresh add of an element, concurrent with all prior removes, always wins.
+
+    Arbitrary add/remove churn happens first across several replicas. Then a new
+    replica observes the whole mess and adds ``element`` once more -- minting a
+    tag no remover could have tombstoned. At convergence ``element`` is present.
+    """
+    churners = [await _source(f"c{i}", churn) for i in range(3)]
+    states = [_require(c.export(_KEY)) for c in churners if c.export(_KEY) is not None]
+
+    adder = OrSetMemory("adder")
+    for state in states:
+        await adder.merge(_KEY, state)
+    await adder.write(_KEY, _add(element))  # fresh, unobservable-by-removers tag
+
+    converged = OrSetMemory("conv")
+    for state in [*states, _require(adder.export(_KEY))]:
+        await converged.merge(_KEY, state)
+    present = json.loads(_require(await converged.read(_KEY)))
+    assert element in present
+
+
+@given(x=_ELEMENTS, y=_ELEMENTS)
+@settings(max_examples=100, deadline=None)
+@pytest.mark.asyncio
+async def test_observed_context_cas_never_loses_update(x: str, y: str) -> None:
+    """Two racing observed-context CAS adds both survive the merge (no lost update).
+
+    Both replicas start from a shared base, each captures that context, and each
+    CAS-adds a distinct element concurrently. Because merge unions add-tags,
+    neither update is lost -- the lost-update-freedom an OR-Set guarantees.
+    """
+    if x == y:
+        return
+    base = OrSetMemory("base")
+    await base.write(_KEY, _add("seed"))
+    base_state = _require(base.export(_KEY))
+
+    a = OrSetMemory("a")
+    b = OrSetMemory("b")
+    await a.merge(_KEY, base_state)
+    await b.merge(_KEY, base_state)
+    ctx_a = _require(a.export(_KEY))
+    ctx_b = _require(b.export(_KEY))
+
+    assert await a.cas(_KEY, ctx_a, _add(x)) is True
+    assert await b.cas(_KEY, ctx_b, _add(y)) is True
+
+    await a.merge(_KEY, _require(b.export(_KEY)))
+    await b.merge(_KEY, _require(a.export(_KEY)))
+    present_a = set(json.loads(_require(await a.read(_KEY))))
+    assert {x, y} <= present_a
+    assert (await a.read(_KEY)) == (await b.read(_KEY))
+
+
+@given(x=_ELEMENTS, y=_ELEMENTS)
+@settings(max_examples=50, deadline=None)
+@pytest.mark.asyncio
+async def test_blackboard_races_and_loses_an_update(x: str, y: str) -> None:
+    """Contrast: a blackboard under the same concurrent CAS pattern loses an update.
+
+    The same two distinct writes, applied to one shared blackboard as racing
+    compare-and-swaps and then serialized, cannot both survive -- exactly the
+    lost update an OR-Set's union merge prevents.
+    """
+    if x == y:
+        return
+    bb = Blackboard()
+    await bb.write(_KEY, b"seed")
+    # Two racers each swap from the same observed value; the second clobbers.
+    assert await bb.cas(_KEY, b"seed", x.encode()) is True
+    assert await bb.cas(_KEY, b"seed", y.encode()) is False
+    final = await bb.read(_KEY)
+    # Only one of the two updates survives; there is no set to hold both.
+    assert final == x.encode()
+    assert final != y.encode()

--- a/scenarios/memory_orset_claims.yaml
+++ b/scenarios/memory_orset_claims.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# OR-Set claim/release marketplace: 10 honest replicas concurrently claim (add)
+# and release (remove) slot ids in one shared observed-remove set, gossiping to
+# convergence under 10% message loss, while ONE Byzantine replica injects a
+# forged, inflated-counter state (the OR-Set analogue of the lww_register
+# lamport=2**60 clock-forgery attack). Every replica still converges to
+# byte-identical state and every honest claim survives -- the memory_orset_claims
+# validators (convergence + honest-liveness + attacker-actually-ran) all pass.
+name: memory_orset_claims
+description: |
+  10 honest claimants plus 1 Byzantine forger share one OR-Set key under 10%
+  message drop. Honest replicas claim/release slot ids concurrently; the
+  Byzantine replica injects inflated-counter forged adds and fabricated honest
+  tombstones throughout the run. Add-wins convergence holds and no honest claim
+  is suppressed. Deterministic under seeds 42, 7, 1337.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 11
+  brain: state-machine
+  roles:
+    - name: claimant
+      count: 10
+    - name: byzantine
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: or_set
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: memory_orset_claims
+  config:
+    claimants: 10
+    rounds: 30
+
+failures:
+  message_drop: 0.1
+
+duration: "ticks: 100000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/memory_orset_claims.jsonl


### PR DESCRIPTION
# [Hackathon] distsys-reliability: OR-Set memory CRDT + honest-write-liveness red-team of `lww_register`

**Persona:** `distsys-reliability` — a distributed-systems reliability engineer.
My risk model is not "does it converge on a flaky network"; the merged
`lww_register` already survives that. It is **"do the convergence claims survive
an adversarial replica"** — a peer that speaks the protocol but lies. That gap
is where write-suppression, split-brain, and silent data loss actually come
from in production replicated state.

## Motivation

The reference memory layer has a register (`lww_register`) and a racing dict
(`blackboard`). A register has **no principled delete**: "remove" has to be
modelled as writing a tombstone sentinel and hoping every replica agrees that
value means "gone". A claim/release marketplace — ten agents concurrently
*claiming* and *releasing* slot ids and needing to agree on *which slots are
held* — is a **set**, not a register. It needs add and remove as first-class,
conflict-free operations with a defined answer for concurrent `add`||`remove`.

This PR adds `or_set`: a state-based **observed-remove set CvRDT** (Shapiro,
Preguiça, Baquero & Zawirski, "A comprehensive study of Convergent and
Commutative Replicated Data Types", INRIA RR-7506, 2011, §3.3.5). Every `add`
mints a unique `(node_id, counter)` tag; every `remove` tombstones only the tags
the remover has *observed*; an element is present iff it carries an add-tag that
is not tombstoned. Merge is the pairwise union of the add and tombstone sets —
commutative, associative, idempotent — and concurrent `add`||`remove` resolves
**add-wins**.

## Threat model

Two distinct fault classes, and the reference plugins only defend the first:

- **Network faults** (drop, reorder, duplicate). `lww_register` handles these:
  its merge is a semilattice join, so honest replicas converge regardless of
  delivery order. `validate_crdt_convergence` already proves it.
- **A Byzantine replica** — honest-looking, protocol-speaking, but exporting
  *forged* state. This is the reliability engineer's real adversary, and no
  shipped validator tests for it. My headline contribution is a validator that
  does, and that **fails a plugin already merged into `main`**.

## The finding: `lww_register.py:305`

```python
# packages/nest-plugins-reference/nest_plugins_reference/memory/lww_register.py:305
self._clock = max(self._clock, incoming.lamport)
```

`merge()` blindly adopts any incoming Lamport clock, and `Register.dominates`
picks the higher `(lamport, node, payload)` as the winner. So a Byzantine
replica exports a register forged with `lamport = 2**60`. Any honest write made
**before** an honest replica merges that forgery carries an ordinary small
clock; once states gossip to convergence the forged register wins and the honest
write is **silently discarded** — write-suppression across the entire
propagation window. Verified repro (also pinned as a test in
`test_or_set_adversarial.py::TestVerifiedVulnerabilityRepro`):

```python
honest = LwwRegisterMemory("honest")
await honest.write("slot", b"honest-claim")   # legitimate write, lamport = 1
await honest.merge("slot", forged)            # forged register, lamport = 2**60
assert await honest.read("slot") == b"BYZANTINE"   # the honest write is gone
```

`or_set` closes the gap structurally: **there is no global clock to forge.** A
Byzantine replica can inflate its own tag counters as high as it likes, but that
only mints Byzantine-owned tags for Byzantine-owned elements. To suppress an
honest claim it would have to tombstone an add-tag it never observed — which it
cannot, because tags are `(node_id, counter)` and the honest counter is small
and unpredictable to the attacker. Its fabricated tombstones (`(claimant-k,
2**60)`) target real honest nodes but with counters no honest add ever used, so
they tombstone nothing.

## Design & tradeoffs

- **Classic tag-set OR-Set, not the optimized (Bieniusa et al.) variant.** The
  optimized OR-Set compresses per-element tags into a per-node version vector
  and drops the explicit tombstone set. I deliberately chose the **classic
  tag-set** construction: every tag and every tombstone is individually visible
  in the exported JSON, so a converged replica's state is **auditable** — you
  can point at exactly which `(node, counter)` add is holding a slot and which
  tombstone tried to remove it. For a reliability tool whose whole job is
  *explaining* what a replicated store did under attack, auditability beats the
  constant-factor space win.
- **Tombstone growth** is the honest cost of that choice: the `removed` set
  grows monotonically with releases. That is fine for a bounded hackathon
  scenario, and I document it as **future work** (a causal-stability GC that
  drops tombstones once every replica has observed the corresponding add — the
  standard OR-Set garbage-collection story).
- **Structural, not random, tags.** The charter's headline anti-pattern is
  nondeterminism smuggled in via `uuid4` / `time.time()` / an unseeded RNG. Tags
  are `(node_id, per-node monotone counter)`, so uniqueness is structural and
  the plugin replays byte-for-byte under a fixed seed.
- **`write` op format + documented fallback.** `write` parses
  `{"op": "add"|"remove", "element": <json>}`; a non-op byte payload is treated
  as `add` of the UTF-8 string (drop-in for opaque-byte callers). A `remove`
  therefore always requires the explicit op form — an ambiguous byte string
  never silently deletes.
- **`read` is byte-deterministic.** It returns the present-element list as
  canonical JSON, sorted by canonical element key, so two converged replicas
  emit identical bytes (what the trace-level validator compares).
- **Observed-context CAS.** `cas(expected, new)` compares *causal context*, not
  a single value: it succeeds iff the caller's observed tag-set still covers the
  key's current tag-set, then applies `new`. Because merge unions add-tags, an
  admitted update is never lost and an unobserved concurrent add is never
  clobbered — lost-update-freedom, pinned by a Hypothesis property against a
  blackboard that races.

## Runnable verification

```bash
# 1. Run the scenario (10 honest claimants + 1 Byzantine forger, 10% drop):
nest run scenarios/memory_orset_claims.yaml

# 2. Validate the trace — convergence, honest-liveness, attacker-actually-ran:
python -c "
from pathlib import Path
from nest_core.validators import validate_trace
for r in validate_trace(Path('traces/memory_orset_claims.jsonl'), 'memory_orset_claims'):
    print(('PASS' if r.passed else 'FAIL'), r.name, '-', r.detail)
"
```

Output (identical under seeds 42, 7, 1337; trace is byte-deterministic):

```
PASS orset_claims_convergence     - all 11 replicas converged to identical state
PASS orset_claims_honest_liveness - 10 honest claim(s) survived the Byzantine attack: [slot-0 … slot-9]
PASS orset_claims_attacker_ran    - Byzantine forged element observed in converged state (attack actually ran)
PASS memory_liveness              - all 11 replicas reported a final state
```

The three adversarial validators discriminate exactly as the charter asks
(`test_or_set_adversarial.py`):

| validator                             | `lww_register` | `blackboard` | `or_set` |
|---------------------------------------|:--------------:|:------------:|:--------:|
| `validate_memory_honest_write_liveness` | **FAIL**     | **FAIL**     | **PASS** |
| `validate_crdt_add_wins_convergence`    | —            | **FAIL**     | **PASS** |

`validate_memory_honest_write_liveness` **fails a merged plugin** — that is the
point.

## Relationship to merged #22 and open #94 / #76

- **#22 (`memory_concurrent_writers` / `lww_register`, merged):** same layer,
  *different data type and different conflict semantics*. #22 is a
  last-writer-wins **register**; this is an observed-remove **set** with add-wins
  resolution and a real delete. I reuse #22's scenario shape (per-agent replica
  overrides, gossip rounds, `final:` records) and its `validate_memory_liveness`,
  and I do **not** touch its files or reuse its scenario filename. Crucially, I
  ship a validator (`validate_memory_honest_write_liveness`) that #22's
  `lww_register` **fails** — I catch a fault its design does not defend against.
- **#94 / #76 (open memory-layer PRs):** these are also memory-layer work with
  different data types and conflict rules (e.g. a semantic/embedding store).
  This PR is orthogonal: a different CRDT (state-based OR-Set), a different
  conflict rule (observed-remove add-wins), and — the reason it stands alone — a
  Byzantine honest-write-liveness validator that their register/similarity
  designs fail for the same reason `lww_register` does (they resolve conflicts by
  an attacker-influenceable scalar rather than by a union that cannot forge a
  removal).

## Test summary

49 new tests, all green:

- **29 example-based** (`test_or_set.py`): empty/single-element sets,
  add/remove/re-add, self-merge no-op, idempotent + order-independent merge,
  cross-key isolation, structured-op parsing + plain-bytes fallback,
  observed-context CAS (fresh/stale/malformed), and malformed-merge rejection
  without state corruption (non-JSON, wrong CRDT tag, bad tag, bool-counter).
- **7 property-based** (`test_or_set_properties.py`, Hypothesis): merge
  commutativity / associativity / idempotence; permutation invariance
  (any merge order → identical canonical bytes); add-wins under arbitrary
  interleavings; observed-context CAS never loses an update — with a blackboard
  contrast that provably does.
- **7 adversarial** (`test_or_set_adversarial.py`): the clock-forgery matrix
  (FAIL `lww_register` / FAIL `blackboard` / PASS `or_set`), the add-wins matrix,
  and the direct `lww_register.py:305` repro.
- **6 end-to-end** (`test_orset_scenario.py`): the scenario passes all validators
  and is byte-identical across seeds 42 / 7 / 1337; all ten honest claims
  survive; the attacker provably ran; and the validators fail against a
  non-OR-Set trace.

## CI status

`make ci-local` (uv sync, ruff check, ruff format --check, pyright strict,
pytest -v): **840 passed, 1 skipped — all 5 checks green.** No edits to other
participants' plugins, validators' logic, scenarios, simulator internals, the
rubric, seed bank, or scoreboard. Shared-file edits are purely additive: one
`_BUILTINS` row, one `pyproject.toml` entry point, one `scenarios.py` lazy-load
branch, new validator functions + one `VALIDATORS` dict entry (and the one-line
registry-test update every prior scenario PR made).
