### PR TITLE
hackathon/tanisha: implemented a custom Rate Limiter layer and reference plugins

### DIFF
--- a/packages/nest-core/nest_core/layers/__init__.py
+++ b/packages/nest-core/nest_core/layers/__init__.py
@@ -16,6 +16,7 @@ from nest_core.layers.memory import Memory
 from nest_core.layers.negotiation import Negotiation
 from nest_core.layers.payments import Payments
 from nest_core.layers.privacy import Privacy
+from nest_core.layers.rate_limiter import RateLimiter
 from nest_core.layers.registry import Registry
 from nest_core.layers.transport import Transport
 from nest_core.layers.trust import Trust
@@ -31,6 +32,7 @@ __all__ = [
     "Negotiation",
     "Payments",
     "Privacy",
+    "RateLimiter",
     "Registry",
     "Transport",
     "Trust",

--- a/packages/nest-core/nest_core/layers/rate_limiter.py
+++ b/packages/nest-core/nest_core/layers/rate_limiter.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Rate-limiter layer interface: tracks and bounds traffic consumption per agent.
+
+A rate limiter provides a traffic oracle. It tracks request allowances for clients
+over logical simulation time 'now' and enforces limits to prevent message spam or
+resource starvation.
+
+Every method takes 'now' (the caller's virtual simulation time) as a keyword-only
+argument to ensure that traffic metrics and rate limiting remain fully deterministic
+and trace-reproducible.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from nest_core.types import AgentId
+
+
+@runtime_checkable
+class RateLimiter(Protocol):
+    """Traffic oracle: tracks request counts and enforces rate limits.
+
+    Example::
+
+        limiter: RateLimiter = TokenBucketRateLimiter(rate=2.0, capacity=10.0)
+        allowed = await limiter.consume(AgentId("agent-1"), now=ctx.time, tokens=1.0)
+    """
+
+    async def consume(self, client: AgentId, *, now: float, tokens: float = 1.0) -> bool:
+        """Attempt to consume 'tokens' for a client at logical time 'now'.
+
+        Returns True if the request is permitted, or False if the client is rate-limited.
+
+        Example::
+
+            if not await limiter.consume(AgentId("sender"), now=ctx.time):
+                raise Exception("Rate limit exceeded")
+        """
+        ...
+
+    async def allowance(self, client: AgentId, *, now: float) -> float:
+        """Return the current available token allowance for the client at time 'now'.
+
+        Example::
+
+            remaining = await limiter.allowance(AgentId("sender"), now=ctx.time)
+        """
+        ...

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -49,6 +49,8 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("failure_detector", "phi_accrual"): (
         f"{_REF}.failure_detection.phi_accrual:PhiAccrualFailureDetector"
     ),
+    ("rate_limit", "token_bucket"): (f"{_REF}.rate_limit.token_bucket:TokenBucketRateLimiter"),
+    ("rate_limit", "leaky_bucket"): (f"{_REF}.rate_limit.leaky_bucket:LeakyBucketRateLimiter"),
 }
 
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/rate_limit/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/rate_limit/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+from nest_plugins_reference.rate_limit.leaky_bucket import LeakyBucketRateLimiter
+from nest_plugins_reference.rate_limit.token_bucket import TokenBucketRateLimiter
+
+__all__ = [
+    "LeakyBucketRateLimiter",
+    "TokenBucketRateLimiter",
+]

--- a/packages/nest-plugins-reference/nest_plugins_reference/rate_limit/leaky_bucket.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/rate_limit/leaky_bucket.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Leaky Bucket Rate Limiter reference implementation."""
+
+from __future__ import annotations
+
+from nest_core.types import AgentId
+
+
+class LeakyBucketRateLimiter:
+    """Bucket leaks water at a constant rate. Requests fail if bucket overflows.
+
+    Example::
+
+        limiter = LeakyBucketRateLimiter(rate=1.0, capacity=5.0)
+    """
+
+    def __init__(self, rate: float = 1.0, capacity: float = 10.0) -> None:
+        self.rate = rate
+        self.capacity = capacity
+        self._water_level: dict[AgentId, float] = {}
+        self._last_updated: dict[AgentId, float] = {}
+
+    def _leak(self, client: AgentId, now: float) -> None:
+        if client not in self._water_level:
+            self._water_level[client] = 0.0
+            self._last_updated[client] = now
+            return
+
+        last = self._last_updated[client]
+        elapsed = max(0.0, now - last)
+        leaked = elapsed * self.rate
+        self._water_level[client] = max(0.0, self._water_level[client] - leaked)
+        self._last_updated[client] = now
+
+    async def consume(self, client: AgentId, *, now: float, tokens: float = 1.0) -> bool:
+        self._leak(client, now)
+        if self._water_level[client] + tokens <= self.capacity:
+            self._water_level[client] += tokens
+            return True
+        return False
+
+    async def allowance(self, client: AgentId, *, now: float) -> float:
+        if client not in self._water_level:
+            return self.capacity
+
+        last = self._last_updated[client]
+        elapsed = max(0.0, now - last)
+        leaked = elapsed * self.rate
+        current_water = max(0.0, self._water_level[client] - leaked)
+        return max(0.0, self.capacity - current_water)

--- a/packages/nest-plugins-reference/nest_plugins_reference/rate_limit/token_bucket.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/rate_limit/token_bucket.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Token Bucket Rate Limiter reference implementation."""
+
+from __future__ import annotations
+
+from nest_core.types import AgentId
+
+
+class TokenBucketRateLimiter:
+    """Refills tokens at a constant rate up to a max capacity.
+
+    Example::
+
+        limiter = TokenBucketRateLimiter(rate=2.0, capacity=10.0)
+    """
+
+    def __init__(self, rate: float = 1.0, capacity: float = 10.0) -> None:
+        self.rate = rate
+        self.capacity = capacity
+        self._tokens: dict[AgentId, float] = {}
+        self._last_updated: dict[AgentId, float] = {}
+
+    def _update_tokens(self, client: AgentId, now: float) -> None:
+        if client not in self._tokens:
+            self._tokens[client] = self.capacity
+            self._last_updated[client] = now
+            return
+
+        last = self._last_updated[client]
+        elapsed = max(0.0, now - last)
+        refill = elapsed * self.rate
+        self._tokens[client] = min(self.capacity, self._tokens[client] + refill)
+        self._last_updated[client] = now
+
+    async def consume(self, client: AgentId, *, now: float, tokens: float = 1.0) -> bool:
+        self._update_tokens(client, now)
+        if self._tokens[client] >= tokens:
+            self._tokens[client] -= tokens
+            return True
+        return False
+
+    async def allowance(self, client: AgentId, *, now: float) -> float:
+        # Dry update to get accurate allowance without updating state timestamps or consuming
+        if client not in self._tokens:
+            return self.capacity
+
+        last = self._last_updated[client]
+        elapsed = max(0.0, now - last)
+        refill = elapsed * self.rate
+        return min(self.capacity, self._tokens[client] + refill)

--- a/packages/nest-plugins-reference/tests/test_rate_limiter.py
+++ b/packages/nest-plugins-reference/tests/test_rate_limiter.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import pytest
+from nest_core.layers.rate_limiter import RateLimiter
+from nest_core.types import AgentId
+from nest_plugins_reference.rate_limit.leaky_bucket import LeakyBucketRateLimiter
+from nest_plugins_reference.rate_limit.token_bucket import TokenBucketRateLimiter
+
+
+@pytest.mark.asyncio
+async def test_protocol_conformance() -> None:
+    # Verify both implementations conform to RateLimiter Protocol
+    tb: RateLimiter = TokenBucketRateLimiter()
+    lb: RateLimiter = LeakyBucketRateLimiter()
+    assert isinstance(tb, RateLimiter)
+    assert isinstance(lb, RateLimiter)
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_limits() -> None:
+    limiter = TokenBucketRateLimiter(rate=2.0, capacity=5.0)
+    client = AgentId("agent-1")
+
+    # Initial allowance matches capacity
+    assert await limiter.allowance(client, now=0.0) == 5.0
+
+    # Consume full capacity
+    assert await limiter.consume(client, now=0.0, tokens=5.0) is True
+    assert await limiter.allowance(client, now=0.0) == 0.0
+
+    # Next consumption fails
+    assert await limiter.consume(client, now=0.0, tokens=1.0) is False
+
+    # Replenishment over virtual time
+    assert await limiter.allowance(client, now=1.0) == 2.0  # elapsed 1s * rate 2 = 2 tokens
+    assert await limiter.consume(client, now=1.0, tokens=2.0) is True
+    assert await limiter.allowance(client, now=1.0) == 0.0
+
+    # Cap at capacity
+    assert await limiter.allowance(client, now=10.0) == 5.0  # elapsed 9s * rate 2 > capacity 5
+
+
+@pytest.mark.asyncio
+async def test_leaky_bucket_limits() -> None:
+    limiter = LeakyBucketRateLimiter(rate=1.0, capacity=3.0)
+    client = AgentId("agent-1")
+
+    # Initial allowance matches capacity (bucket water level = 0)
+    assert await limiter.allowance(client, now=0.0) == 3.0
+
+    # Add water to capacity
+    assert await limiter.consume(client, now=0.0, tokens=3.0) is True
+    assert await limiter.allowance(client, now=0.0) == 0.0
+
+    # Overflows
+    assert await limiter.consume(client, now=0.0, tokens=1.0) is False
+
+    # Leaks over virtual time
+    assert await limiter.allowance(client, now=2.0) == 2.0  # leaks 2.0 water, 2.0 allowance remains
+    assert await limiter.consume(client, now=2.0, tokens=2.0) is True
+    assert await limiter.allowance(client, now=2.0) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_independent_clients() -> None:
+    limiter = TokenBucketRateLimiter(rate=1.0, capacity=2.0)
+    c1 = AgentId("agent-1")
+    c2 = AgentId("agent-2")
+
+    # Consume tokens for c1
+    assert await limiter.consume(c1, now=0.0, tokens=2.0) is True
+    assert await limiter.consume(c1, now=0.0, tokens=1.0) is False
+
+    # c2 is unaffected
+    assert await limiter.allowance(c2, now=0.0) == 2.0
+    assert await limiter.consume(c2, now=0.0, tokens=2.0) is True


### PR DESCRIPTION
# Summary
Implementation of a custom **Rate Limiting Layer** (introducing the `rate_limit` layer, `TokenBucketRateLimiter`, and `LeakyBucketRateLimiter` reference plugins) to enforce traffic and request boundaries per agent.

All changes are fully verified, formatted, typechecked, and pass the local CI checklist.

---

## 1. File Changes & Architecture

### Layer Definition
* `packages/nest-core/nest_core/layers/rate_limiter.py`:
  - Defines the `RateLimiter` Protocol interface.
  - Exposes `consume(client, *, now, tokens)` and `allowance(client, *, now)`. All calculations take logical simulation time `now` as a keyword-only argument to ensure determinism.
* `packages/nest-core/nest_core/layers/__init__.py`:
  - Imports and exports `RateLimiter`.

### Reference Plugins
* `packages/nest-plugins-reference/nest_plugins_reference/rate_limit/token_bucket.py`:
  - Class `TokenBucketRateLimiter` refilling tokens linearly at a constant rate up to a max capacity limit.
* `packages/nest-plugins-reference/nest_plugins_reference/rate_limit/leaky_bucket.py`:
  - Class `LeakyBucketRateLimiter` modeling a queue/water level that leaks constant capacity over logical time.
* `packages/nest-plugins-reference/nest_plugins_reference/rate_limit/__init__.py`:
  - Exports both plugins.
* `packages/nest-core/nest_core/plugins.py`:
  - Registers the custom plugins in the built-in registry (`("rate_limit", "token_bucket")` and `("rate_limit", "leaky_bucket")`).

### Unit Tests
* `packages/nest-plugins-reference/tests/test_rate_limiter.py`:
  - Unit tests verifying token replenishment, capacity limits, drop behavior, and independent client rate isolation.

---

## 2. Verification

Run local checks:
```bash
# Run rate limiter unit tests
uv run pytest packages/nest-plugins-reference/tests/test_rate_limiter.py -v

# Run full project checks
make ci-local