### PR TITLE
Add policy decision layer for agent actions

### DIFF
--- a/docs/layers/policy.md
+++ b/docs/layers/policy.md
@@ -1,0 +1,58 @@
+# Policy
+
+The policy layer is the decision point an agent calls before it uses a tool,
+publishes data, spends credits, or changes authority.  It turns a structured
+`PolicyRequest` into a deterministic `PolicyDecision`: `permit`, `deny`, or
+`approval_required`.
+
+This layer is intentionally small.  It does not execute the action and it does
+not replace auth, privacy, payments, or trust.  It answers one question: given
+the actor, action, resource, data classes, and optional amount, may the agent
+continue?
+
+## Interface
+
+Implementations satisfy `nest_core.layers.policy.Policy`:
+
+```python
+decision = await policy.decide(request, now=ctx.time)
+```
+
+`now` is the simulator's logical time.  Implementations should not read wall
+clock time, random sources, or process-local mutable state unless that state is
+derived from previous replayable observations.
+
+## Reference Plugins
+
+`strict_rules` is deny-by-default.  It permits declared low-risk reads, denies
+sensitive public exports, requires approval for high-value transfers, and denies
+unknown actions.
+
+`allow_all` is a deliberately unsafe baseline.  The `policy_guard` scenario uses
+it as the foil: the same trace validators that pass under `strict_rules` fail
+under `allow_all`.
+
+## Scenario
+
+Run the built-in scenario:
+
+```bash
+uv run nest run scenarios/policy_guard.yaml
+```
+
+Then validate the trace:
+
+```bash
+uv run python - <<'PY'
+from pathlib import Path
+from nest_core.validators import validate_trace
+
+for result in validate_trace(Path("traces/policy_guard.jsonl"), "policy_guard"):
+    print(result)
+PY
+```
+
+The scenario emits canonical JSON request and decision events for a safe read, a
+sensitive public export, a high-value payment, and an undeclared admin action.
+Validators assert that the policy permits the safe read, blocks public sensitive
+data, requires approval for high-impact spend, and denies undeclared actions.

--- a/packages/nest-core/nest_core/layers/__init__.py
+++ b/packages/nest-core/nest_core/layers/__init__.py
@@ -15,6 +15,7 @@ from nest_core.layers.identity import Identity
 from nest_core.layers.memory import Memory
 from nest_core.layers.negotiation import Negotiation
 from nest_core.layers.payments import Payments
+from nest_core.layers.policy import Policy, PolicyDecision, PolicyEffect, PolicyRequest
 from nest_core.layers.privacy import Privacy
 from nest_core.layers.registry import Registry
 from nest_core.layers.transport import Transport
@@ -30,6 +31,10 @@ __all__ = [
     "Memory",
     "Negotiation",
     "Payments",
+    "Policy",
+    "PolicyDecision",
+    "PolicyEffect",
+    "PolicyRequest",
     "Privacy",
     "Registry",
     "Transport",

--- a/packages/nest-core/nest_core/layers/policy.py
+++ b/packages/nest-core/nest_core/layers/policy.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Policy layer interface: deterministic action decisions for agent tools.
+
+Agents need a small, replayable gate before they call tools, spend money, or
+publish data outside the town.  A policy implementation receives a structured
+request and returns one of three effects:
+
+* ``permit`` -- the action may proceed.
+* ``deny`` -- the action must not be attempted.
+* ``approval_required`` -- the action is allowed only after an external approval.
+
+The request is plain data and every decision takes ``now`` as a keyword-only
+argument, so policy checks remain deterministic under simulator replay.
+
+Example::
+
+    request = PolicyRequest(actor=AgentId("a1"), action="read", resource="catalog/public")
+    decision = await policy.decide(request, now=ctx.time)
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+from nest_core.types import AgentId
+
+
+class PolicyEffect(enum.StrEnum):
+    """Result of a policy decision.
+
+    Example::
+
+        effect = PolicyEffect.PERMIT
+    """
+
+    PERMIT = "permit"
+    DENY = "deny"
+    APPROVAL_REQUIRED = "approval_required"
+
+
+class PolicyRequest(BaseModel):
+    """A structured action an agent wants to perform.
+
+    ``data_classes`` names the kinds of data leaving the agent, if any.  ``amount``
+    captures high-impact spend or transfer operations.  ``metadata`` is reserved
+    for policy-specific context while keeping the core interface stable.
+
+    Example::
+
+        req = PolicyRequest(
+            actor=AgentId("researcher-0"),
+            action="publish",
+            resource="web/public",
+            data_classes=["pii.email"],
+        )
+    """
+
+    actor: AgentId
+    action: str
+    resource: str
+    data_classes: list[str] = Field(default_factory=list)
+    amount: int | None = None
+    purpose: str = ""
+    metadata: dict[str, str] = Field(default_factory=dict)
+
+
+class PolicyDecision(BaseModel):
+    """The replayable verdict for one :class:`PolicyRequest`.
+
+    Example::
+
+        decision = PolicyDecision(
+            effect=PolicyEffect.DENY,
+            reason="public export contains sensitive data",
+            rule_id="deny-sensitive-public-export",
+        )
+    """
+
+    effect: PolicyEffect
+    reason: str
+    rule_id: str
+    obligations: list[str] = Field(default_factory=list)
+
+
+@runtime_checkable
+class Policy(Protocol):
+    """Decision oracle for agent actions.
+
+    Example::
+
+        policy: Policy = StrictPolicy()
+        decision = await policy.decide(request, now=ctx.time)
+    """
+
+    async def decide(self, request: PolicyRequest, *, now: float) -> PolicyDecision:
+        """Return the policy decision for *request* at logical time *now*.
+
+        Example::
+
+            decision = await policy.decide(request, now=10.0)
+        """
+        ...

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -60,6 +60,8 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("failure_detector", "phi_accrual"): (
         f"{_REF}.failure_detection.phi_accrual:PhiAccrualFailureDetector"
     ),
+    ("policy", "strict_rules"): f"{_REF}.policy.strict:StrictPolicy",
+    ("policy", "allow_all"): f"{_REF}.policy.allow_all:AllowAllPolicy",
 }
 
 
@@ -97,6 +99,7 @@ class PluginRegistry:
             "privacy",
             "datafacts",
             "failure_detector",
+            "policy",
         ]:
             group = f"nest.plugins.{layer}"
             eps = importlib.metadata.entry_points(group=group)

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -193,3 +193,7 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("capability_spoofing", capability_spoofing_factory)
+    elif name == "policy_guard":
+        from nest_core.scenarios_builtin.policy_guard import policy_guard_factory
+
+        register_scenario("policy_guard", policy_guard_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/policy_guard.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/policy_guard.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Policy-guard scenario -- agents ask before risky actions.
+
+The scenario injects five action requests into the configured ``policy`` layer:
+
+* a safe public catalog read, which should be permitted;
+* a public export containing sensitive data, which should be denied;
+* a high-value payment, which should require approval;
+* a payment with no declared amount, which should require approval;
+* an undeclared administrative action, which should be denied by default.
+
+Each request and decision is broadcast as canonical JSON so validators can check
+the exact verdicts.  Running the same scenario with ``policy_plugin:
+allow_all`` fails the adversarial validators, proving the checks distinguish a
+real guard from a permissive placeholder.
+
+Example::
+
+    agents = policy_guard_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from nest_core.layers.policy import Policy, PolicyRequest
+from nest_core.plugins import PluginRegistry
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId
+
+POLICY_TICK = b"POLICY_GUARD_EVAL"
+"""Self-message payload that starts the policy evaluation."""
+
+DEFAULT_POLICY_PLUGIN = "strict_rules"
+"""Default policy plugin name for the policy guard scenario."""
+
+
+class PolicyProbeAgent(StateMachineAgent):
+    """Evaluate a fixed adversarial policy test set.
+
+    Example::
+
+        agent = PolicyProbeAgent(AgentId("auditor-0"), requests=[...])
+    """
+
+    def __init__(self, agent_id: AgentId, requests: list[tuple[str, PolicyRequest]]) -> None:
+        self._id = agent_id
+        self._requests = requests
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Schedule the evaluation onto a non-zero deterministic tick.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        await ctx.schedule(1.0, POLICY_TICK)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """On the evaluation tick, broadcast requests and policy decisions.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("auditor-0"), POLICY_TICK)
+        """
+        if sender != ctx.agent_id or payload != POLICY_TICK:
+            return
+        policy: Policy | None = ctx.plugins.get("policy")
+        if policy is None:
+            return
+        for case_id, request in self._requests:
+            await ctx.broadcast(_request_payload(case_id, request, ctx.time))
+            decision = await policy.decide(request, now=ctx.time)
+            await ctx.broadcast(
+                _decision_payload(case_id, decision.model_dump(mode="json"), ctx.time)
+            )
+
+
+def _request_payload(case_id: str, request: PolicyRequest, now: float) -> bytes:
+    """Return a canonical trace payload for a policy request.
+
+    Example::
+
+        payload = _request_payload("safe", request, 1.0)
+    """
+    obj: dict[str, Any] = {
+        "policy": "request",
+        "case": case_id,
+        "request": request.model_dump(mode="json"),
+        "ts": round(now, 6),
+    }
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _decision_payload(case_id: str, decision: dict[str, Any], now: float) -> bytes:
+    """Return a canonical trace payload for a policy decision.
+
+    Example::
+
+        payload = _decision_payload("safe", {"effect": "permit"}, 1.0)
+    """
+    obj: dict[str, Any] = {
+        "policy": "decision",
+        "case": case_id,
+        "decision": decision,
+        "ts": round(now, 6),
+    }
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _default_requests(actor: AgentId) -> list[tuple[str, PolicyRequest]]:
+    """Return the deterministic adversarial request set.
+
+    Example::
+
+        requests = _default_requests(AgentId("auditor-0"))
+    """
+    return [
+        (
+            "safe_public_read",
+            PolicyRequest(
+                actor=actor,
+                action="read",
+                resource="catalog/public",
+                purpose="lookup public inventory",
+            ),
+        ),
+        (
+            "sensitive_public_export",
+            PolicyRequest(
+                actor=actor,
+                action="publish",
+                resource="web/public",
+                data_classes=["pii.email"],
+                purpose="post lead list to public web",
+            ),
+        ),
+        (
+            "high_value_payment",
+            PolicyRequest(
+                actor=actor,
+                action="pay",
+                resource="vendor/settlement",
+                amount=900,
+                purpose="settle large invoice",
+            ),
+        ),
+        (
+            "unknown_amount_payment",
+            PolicyRequest(
+                actor=actor,
+                action="pay",
+                resource="vendor/settlement",
+                purpose="settle invoice without declared amount",
+            ),
+        ),
+        (
+            "unknown_admin_action",
+            PolicyRequest(
+                actor=actor,
+                action="admin",
+                resource="registry/root",
+                purpose="change town root registry",
+            ),
+        ),
+    ]
+
+
+def policy_guard_factory(config: ScenarioConfig, plugins: dict[str, Any]) -> dict[AgentId, Any]:
+    """Build the single-agent policy guard scenario.
+
+    Example::
+
+        agents = policy_guard_factory(config, plugins)
+    """
+    policy_name = str(config.task.config.get("policy_plugin", DEFAULT_POLICY_PLUGIN))
+    policy_cls = PluginRegistry().resolve("policy", policy_name)
+    plugins["policy"] = policy_cls()
+    auditor = AgentId("policy-auditor-0")
+    return {auditor: PolicyProbeAgent(auditor, _default_requests(auditor))}

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -5099,7 +5099,163 @@ def validate_sybil_bond_attempts_rejected(
     ]
 
 
+# ---------------------------------------------------------------------------
+# Policy-guard validators
+# ---------------------------------------------------------------------------
+
+
+def _policy_decisions(events: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Return policy decisions keyed by scenario case id."""
+    decisions: dict[str, dict[str, Any]] = {}
+    for ev in events:
+        if ev.get("kind") != "broadcast":
+            continue
+        with contextlib.suppress(json.JSONDecodeError, TypeError):
+            raw_obj: object = json.loads(_message_body(ev))
+            if not isinstance(raw_obj, dict):
+                continue
+            obj = cast("dict[str, object]", raw_obj)
+            if obj.get("policy") != "decision":
+                continue
+            case_id = str(obj.get("case", ""))
+            raw_decision = obj.get("decision")
+            if case_id and isinstance(raw_decision, dict):
+                decisions[case_id] = cast("dict[str, Any]", raw_decision)
+    return decisions
+
+
+def _policy_effect(decisions: dict[str, dict[str, Any]], case_id: str) -> str | None:
+    """Return the recorded effect for *case_id*, if present."""
+    decision = decisions.get(case_id)
+    if decision is None:
+        return None
+    effect = decision.get("effect")
+    return str(effect) if effect is not None else None
+
+
+def validate_policy_safe_read_permitted(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Declared low-risk public reads are permitted."""
+    decisions = _policy_decisions(events)
+    effect = _policy_effect(decisions, "safe_public_read")
+    if effect != "permit":
+        return [
+            ValidationResult(
+                "policy_safe_read_permitted",
+                False,
+                f"safe_public_read expected permit, got {effect or 'missing'}",
+            )
+        ]
+    return [
+        ValidationResult(
+            "policy_safe_read_permitted",
+            True,
+            "declared public catalog read was permitted",
+        )
+    ]
+
+
+def validate_policy_blocks_sensitive_public_export(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Sensitive data must not be published to public resources."""
+    decisions = _policy_decisions(events)
+    effect = _policy_effect(decisions, "sensitive_public_export")
+    if effect != "deny":
+        return [
+            ValidationResult(
+                "policy_blocks_sensitive_public_export",
+                False,
+                f"sensitive_public_export expected deny, got {effect or 'missing'}",
+            )
+        ]
+    return [
+        ValidationResult(
+            "policy_blocks_sensitive_public_export",
+            True,
+            "sensitive public export was denied",
+        )
+    ]
+
+
+def validate_policy_requires_approval_for_high_value_payment(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """High-value payments require approval instead of autonomous execution."""
+    decisions = _policy_decisions(events)
+    effect = _policy_effect(decisions, "high_value_payment")
+    if effect != "approval_required":
+        return [
+            ValidationResult(
+                "policy_requires_approval_for_high_value_payment",
+                False,
+                f"high_value_payment expected approval_required, got {effect or 'missing'}",
+            )
+        ]
+    return [
+        ValidationResult(
+            "policy_requires_approval_for_high_value_payment",
+            True,
+            "high-value payment required approval",
+        )
+    ]
+
+
+def validate_policy_requires_approval_for_unknown_amount_payment(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Payments with omitted amounts require approval instead of using zero."""
+    decisions = _policy_decisions(events)
+    effect = _policy_effect(decisions, "unknown_amount_payment")
+    if effect != "approval_required":
+        return [
+            ValidationResult(
+                "policy_requires_approval_for_unknown_amount_payment",
+                False,
+                f"unknown_amount_payment expected approval_required, got {effect or 'missing'}",
+            )
+        ]
+    return [
+        ValidationResult(
+            "policy_requires_approval_for_unknown_amount_payment",
+            True,
+            "payment with unknown amount required approval",
+        )
+    ]
+
+
+def validate_policy_denies_unknown_admin_action(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Undeclared authority-changing actions are denied by default."""
+    decisions = _policy_decisions(events)
+    effect = _policy_effect(decisions, "unknown_admin_action")
+    if effect != "deny":
+        return [
+            ValidationResult(
+                "policy_denies_unknown_admin_action",
+                False,
+                f"unknown_admin_action expected deny, got {effect or 'missing'}",
+            )
+        ]
+    return [
+        ValidationResult(
+            "policy_denies_unknown_admin_action",
+            True,
+            "undeclared admin action was denied",
+        )
+    ]
+
+
 VALIDATORS: dict[str, list[Any]] = {
+    "policy_guard": [
+        validate_policy_safe_read_permitted,
+        validate_policy_blocks_sensitive_public_export,
+        validate_policy_requires_approval_for_high_value_payment,
+        validate_policy_requires_approval_for_unknown_amount_payment,
+        validate_policy_denies_unknown_admin_action,
+    ],
     "sybil_bond": [
         validate_sybil_bond_no_free_trust,
         validate_sybil_bond_honest_trusted,

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2071,6 +2071,7 @@ class TestValidatorRegistry:
             "parc_migration",
             "rogue_trusted_agent",
             "sybil_bond",
+            "policy_guard",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/policy/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/policy/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reference policy plugins.
+
+Example::
+
+    from nest_plugins_reference.policy.strict import StrictPolicy
+"""
+
+from nest_plugins_reference.policy.allow_all import AllowAllPolicy
+from nest_plugins_reference.policy.strict import StrictPolicy
+
+__all__ = ["AllowAllPolicy", "StrictPolicy"]

--- a/packages/nest-plugins-reference/nest_plugins_reference/policy/allow_all.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/policy/allow_all.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Permissive policy baseline used as a validator foil.
+
+Example::
+
+    policy = AllowAllPolicy()
+    decision = await policy.decide(request, now=0.0)
+"""
+
+from __future__ import annotations
+
+from nest_core.layers.policy import PolicyDecision, PolicyEffect, PolicyRequest
+
+
+class AllowAllPolicy:
+    """Permit every action.
+
+    This is useful as a deliberately unsafe baseline: the policy scenario's
+    validators should fail when this plugin is selected, proving that the checks
+    catch more than message flow.
+
+    Example::
+
+        policy = AllowAllPolicy()
+    """
+
+    async def decide(self, request: PolicyRequest, *, now: float) -> PolicyDecision:
+        """Return ``permit`` for every request.
+
+        Example::
+
+            decision = await policy.decide(request, now=1.0)
+        """
+        return PolicyDecision(
+            effect=PolicyEffect.PERMIT,
+            reason="baseline permits every request",
+            rule_id="allow-all",
+        )

--- a/packages/nest-plugins-reference/nest_plugins_reference/policy/strict.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/policy/strict.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Strict reference policy for high-impact agent actions.
+
+Example::
+
+    policy = StrictPolicy()
+    decision = await policy.decide(request, now=0.0)
+"""
+
+from __future__ import annotations
+
+from nest_core.layers.policy import PolicyDecision, PolicyEffect, PolicyRequest
+
+SENSITIVE_DATA_CLASSES = frozenset(
+    {
+        "pii.email",
+        "pii.phone",
+        "pii.address",
+        "secret",
+        "credential",
+        "medical",
+        "financial",
+    }
+)
+"""Data classes that must not be published to public resources."""
+
+PUBLIC_RESOURCES = frozenset({"web/public", "public_api", "external_web"})
+"""Resources that leave the trusted town boundary."""
+
+SAFE_READS = frozenset({("read", "catalog/public"), ("read", "docs/public")})
+"""Low-risk reads allowed without additional approval."""
+
+HIGH_IMPACT_ACTIONS = frozenset({"pay", "transfer", "delete"})
+"""Actions that can spend, destroy, or change authority."""
+
+DEFAULT_APPROVAL_THRESHOLD = 500
+"""Spend threshold at which payment-like actions require approval."""
+
+
+class StrictPolicy:
+    """Small deterministic deny-by-default policy.
+
+    The policy permits only declared low-risk reads, blocks sensitive data from
+    public resources, requires approval for high-impact spend, and denies
+    unknown actions.  The rules are intentionally simple so scenario validators
+    can assert exact, replayable decisions.
+
+    Example::
+
+        policy = StrictPolicy(approval_threshold=1000)
+    """
+
+    def __init__(self, approval_threshold: int = DEFAULT_APPROVAL_THRESHOLD) -> None:
+        self._approval_threshold = approval_threshold
+
+    async def decide(self, request: PolicyRequest, *, now: float) -> PolicyDecision:
+        """Return a deterministic decision for *request*.
+
+        Example::
+
+            decision = await policy.decide(request, now=5.0)
+        """
+        del now
+        sensitive = sorted(set(request.data_classes) & SENSITIVE_DATA_CLASSES)
+        if request.resource in PUBLIC_RESOURCES and sensitive:
+            return PolicyDecision(
+                effect=PolicyEffect.DENY,
+                reason=f"public export contains sensitive data: {','.join(sensitive)}",
+                rule_id="deny-sensitive-public-export",
+                obligations=["remove_sensitive_data_or_use_private_channel"],
+            )
+
+        if request.action in {"pay", "transfer"}:
+            amount = request.amount
+            if amount is None:
+                return PolicyDecision(
+                    effect=PolicyEffect.APPROVAL_REQUIRED,
+                    reason=f"{request.action} amount is unknown",
+                    rule_id="approval-unknown-transfer-amount",
+                    obligations=["declare_amount_before_autonomous_transfer"],
+                )
+            if amount > self._approval_threshold:
+                return PolicyDecision(
+                    effect=PolicyEffect.APPROVAL_REQUIRED,
+                    reason=f"{request.action} amount {amount} exceeds approval threshold",
+                    rule_id="approval-high-value-transfer",
+                    obligations=["collect_human_or_owner_approval"],
+                )
+            return PolicyDecision(
+                effect=PolicyEffect.PERMIT,
+                reason="low-value transfer is within autonomous limit",
+                rule_id="permit-low-value-transfer",
+            )
+
+        if request.action in HIGH_IMPACT_ACTIONS:
+            return PolicyDecision(
+                effect=PolicyEffect.APPROVAL_REQUIRED,
+                reason=f"{request.action} is high impact",
+                rule_id="approval-high-impact-action",
+                obligations=["collect_human_or_owner_approval"],
+            )
+
+        if (request.action, request.resource) in SAFE_READS:
+            return PolicyDecision(
+                effect=PolicyEffect.PERMIT,
+                reason="declared public read is allowed",
+                rule_id="permit-safe-public-read",
+            )
+
+        return PolicyDecision(
+            effect=PolicyEffect.DENY,
+            reason=f"no rule permits {request.action} on {request.resource}",
+            rule_id="deny-by-default",
+        )

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -62,6 +62,10 @@ aae_permit_gate = "nest_plugins_reference.trust.aae_permit_gate:AAEPermitGate"
 bonded_trust = "nest_plugins_reference.trust.bonded_trust:BondedTrust"
 attested_peering = "nest_plugins_reference.trust.attested_peering:AttestedPeeringTrust"
 
+[project.entry-points."nest.plugins.policy"]
+strict_rules = "nest_plugins_reference.policy.strict:StrictPolicy"
+allow_all = "nest_plugins_reference.policy.allow_all:AllowAllPolicy"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/nest-plugins-reference/tests/test_policy.py
+++ b/packages/nest-plugins-reference/tests/test_policy.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the policy layer, reference plugins, and policy_guard scenario."""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+from nest_core.layers.policy import Policy, PolicyEffect, PolicyRequest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.types import AgentId
+from nest_core.validators import ValidationResult, validate_trace
+from nest_plugins_reference.policy.allow_all import AllowAllPolicy
+from nest_plugins_reference.policy.strict import StrictPolicy
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "policy_guard.yaml"
+_ACTOR = AgentId("agent-1")
+_SEEDS = [42, 7, 1337]
+
+
+def _decide(policy: Policy, request: PolicyRequest) -> PolicyEffect:
+    decision = asyncio.run(policy.decide(request, now=10.0))
+    return decision.effect
+
+
+def _run_scenario(seed: int, policy: str = "strict_rules") -> dict[str, ValidationResult]:
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    config = config.model_copy(
+        update={
+            "seed": seed,
+            "task": config.task.model_copy(update={"config": {"policy_plugin": policy}}),
+        }
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"policy_{seed}_{policy}.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        asyncio.run(runner.run())
+        results = validate_trace(trace_path, "policy_guard")
+    return {r.name: r for r in results}
+
+
+def _run_bytes(seed: int) -> bytes:
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH)).model_copy(update={"seed": seed})
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / "policy_replay.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        asyncio.run(runner.run())
+        return trace_path.read_bytes()
+
+
+def test_strict_policy_satisfies_protocol() -> None:
+    """The strict plugin conforms to the runtime-checkable Policy Protocol."""
+    assert isinstance(StrictPolicy(), Policy)
+
+
+def test_registry_resolves_policy_plugins() -> None:
+    """Both policy plugins are discoverable through the registry."""
+    registry = PluginRegistry()
+    assert registry.resolve("policy", "strict_rules") is StrictPolicy
+    assert registry.resolve("policy", "allow_all") is AllowAllPolicy
+
+
+def test_strict_policy_permits_safe_public_read() -> None:
+    """A declared public read is safe enough for autonomous execution."""
+    request = PolicyRequest(actor=_ACTOR, action="read", resource="catalog/public")
+    assert _decide(StrictPolicy(), request) == PolicyEffect.PERMIT
+
+
+def test_strict_policy_denies_sensitive_public_export() -> None:
+    """Sensitive data cannot be sent to a public resource."""
+    request = PolicyRequest(
+        actor=_ACTOR,
+        action="publish",
+        resource="web/public",
+        data_classes=["pii.email"],
+    )
+    assert _decide(StrictPolicy(), request) == PolicyEffect.DENY
+
+
+def test_strict_policy_requires_approval_for_large_payment() -> None:
+    """Large transfers require approval instead of autonomous execution."""
+    request = PolicyRequest(
+        actor=_ACTOR,
+        action="pay",
+        resource="vendor/settlement",
+        amount=900,
+    )
+    assert _decide(StrictPolicy(), request) == PolicyEffect.APPROVAL_REQUIRED
+
+
+def test_strict_policy_requires_approval_for_missing_payment_amount() -> None:
+    """Unknown transfer amount cannot be treated as a zero-value transfer."""
+    request = PolicyRequest(
+        actor=_ACTOR,
+        action="pay",
+        resource="vendor/settlement",
+    )
+    assert _decide(StrictPolicy(), request) == PolicyEffect.APPROVAL_REQUIRED
+
+
+def test_strict_policy_spend_permission_is_monotonic() -> None:
+    """Raising payment amount never makes a strict decision more permissive."""
+    policy = StrictPolicy(approval_threshold=100)
+    ordered = {
+        PolicyEffect.DENY: 0,
+        PolicyEffect.APPROVAL_REQUIRED: 1,
+        PolicyEffect.PERMIT: 2,
+    }
+    previous = _decide(
+        policy,
+        PolicyRequest(actor=_ACTOR, action="pay", resource="vendor/settlement", amount=0),
+    )
+    for amount in [1, 50, 100, 101, 250, 1000]:
+        current = _decide(
+            policy,
+            PolicyRequest(
+                actor=_ACTOR,
+                action="pay",
+                resource="vendor/settlement",
+                amount=amount,
+            ),
+        )
+        assert ordered[current] <= ordered[previous]
+        previous = current
+
+
+def test_strict_policy_denies_unknown_action() -> None:
+    """Deny-by-default catches undeclared authority-changing actions."""
+    request = PolicyRequest(actor=_ACTOR, action="admin", resource="registry/root")
+    assert _decide(StrictPolicy(), request) == PolicyEffect.DENY
+
+
+def test_allow_all_is_the_unsafe_foil() -> None:
+    """The baseline intentionally permits an action strict policy blocks."""
+    request = PolicyRequest(
+        actor=_ACTOR,
+        action="publish",
+        resource="web/public",
+        data_classes=["pii.email"],
+    )
+    assert _decide(AllowAllPolicy(), request) == PolicyEffect.PERMIT
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_policy_guard_scenario_strict_passes_every_validator(seed: int) -> None:
+    """The strict policy passes all end-to-end policy_guard validators."""
+    results = _run_scenario(seed)
+    expected = {
+        "policy_safe_read_permitted",
+        "policy_blocks_sensitive_public_export",
+        "policy_requires_approval_for_high_value_payment",
+        "policy_requires_approval_for_unknown_amount_payment",
+        "policy_denies_unknown_admin_action",
+    }
+    assert expected <= set(results), f"missing validators: {expected - set(results)}"
+    for name, result in results.items():
+        assert result.passed, f"seed={seed} {name} failed: {result.detail}"
+
+
+def test_policy_guard_allow_all_fails_adversarial_validators() -> None:
+    """The permissive baseline fails every restrictive policy invariant."""
+    results = _run_scenario(42, policy="allow_all")
+    assert results["policy_safe_read_permitted"].passed is True
+    assert results["policy_blocks_sensitive_public_export"].passed is False
+    assert results["policy_requires_approval_for_high_value_payment"].passed is False
+    assert results["policy_requires_approval_for_unknown_amount_payment"].passed is False
+    assert results["policy_denies_unknown_admin_action"].passed is False
+
+
+def test_policy_guard_trace_is_byte_deterministic() -> None:
+    """Same seed, same policy, same trace bytes."""
+    assert _run_bytes(42) == _run_bytes(42)

--- a/scenarios/policy_guard.yaml
+++ b/scenarios/policy_guard.yaml
@@ -1,0 +1,33 @@
+name: Policy Guard
+description: Deterministic policy decisions for risky agent actions
+tier: 1
+seed: 42
+agents:
+  count: 1
+  brain: state-machine
+  roles:
+    - name: policy-auditor
+      count: 1
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+task:
+  type: policy_guard
+  config:
+    policy_plugin: strict_rules
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+duration: "ticks: 10"
+output:
+  trace: ./traces/policy_guard.jsonl


### PR DESCRIPTION
## Problem

NANDA Town has layers for identity, auth, privacy, payments, trust, memory, coordination, and failure detection, but it does not yet have a small deterministic policy decision point for agent actions.

Before an agent publishes data, spends credits, calls an external tool, or changes authority, it should be able to ask: is this action permitted, denied, or does it need approval?

This PR adds that missing policy layer.

## What is in the diff

| Path | Purpose |
| --- | --- |
| `packages/nest-core/nest_core/layers/policy.py` | New `Policy` Protocol plus `PolicyRequest`, `PolicyDecision`, and `PolicyEffect`. |
| `packages/nest-plugins-reference/nest_plugins_reference/policy/strict.py` | Reference deny-by-default policy. Permits safe public reads, denies sensitive public exports, requires approval for high-value payments, and denies unknown actions. |
| `packages/nest-plugins-reference/nest_plugins_reference/policy/allow_all.py` | Unsafe baseline plugin used as the foil. |
| `packages/nest-core/nest_core/scenarios_builtin/policy_guard.py` | Deterministic adversarial scenario that exercises safe, sensitive, high-value, and unknown actions. |
| `scenarios/policy_guard.yaml` | Runnable scenario config. |
| `packages/nest-core/nest_core/validators.py` | Four policy validators registered under `policy_guard`. |
| `packages/nest-plugins-reference/tests/test_policy.py` | Unit, integration, adversarial, and determinism tests. |
| `docs/layers/policy.md` | Documentation and usage notes. |

## Why this is useful

It fills a practical security gap. Auth answers “who are you?” Privacy answers “who can read this?” Payments answer “can value move?” A policy layer answers “should this agent be allowed to do this action right now?”

It is intentionally small and composable. The layer does not execute actions or replace other layers. It only returns a replayable decision that other layers or agents can respect.

It is testable, not just illustrative. The `strict_rules` plugin passes the scenario validators. The `allow_all` baseline fails the restrictive checks, proving the validators catch unsafe behavior instead of merely checking that messages exist.

## Verification

Ran the full local CI gate:

```bash
make ci-local