### PR TITLE
hackathon/sam04-trust-gated-privacy

### DIFF
--- a/docs/layers/privacy.md
+++ b/docs/layers/privacy.md
@@ -37,6 +37,24 @@ attacks — failing against `noop` and passing against this plugin. Supports a
 Source: [`nest_plugins_reference/privacy/hybrid_x25519.py`](../../packages/nest-plugins-reference/nest_plugins_reference/privacy/hybrid_x25519.py).
 See `scenarios/sealed_bid_with_privacy.yaml` for a wired example.
 
+## Trust-gated plugin
+
+`trust_gated` — **disclosure by reputation.** Composes `hybrid_x25519`
+(re-implementing no cryptography) with the live **trust layer**: at encrypt
+time each audience member's trust score selects a disclosure tier — full
+plaintext (score ≥ 0.8), a redacted selectively-disclosed view with a salted
+Merkle proof (0.5–0.8), or a refusal carrying a **signed denial receipt**
+(< 0.5). The gate table is digest-bound inside the AEAD plaintexts, so it
+cannot be doctored around the ciphertexts; poisoned trust scores (NaN/inf/
+out-of-range) fail closed. Ships four adversarial validators
+([`validators/trust_gate_validators.py`](../../packages/nest-plugins-reference/nest_plugins_reference/validators/trust_gate_validators.py))
+that fail against **both** `noop` and `hybrid_x25519` and pass against this
+plugin. Supports `deterministic=True` for byte-reproducible Tier-1 traces.
+
+Source: [`nest_plugins_reference/privacy/trust_gated.py`](../../packages/nest-plugins-reference/nest_plugins_reference/privacy/trust_gated.py).
+Full write-up: [`trust_gated_privacy.md`](trust_gated_privacy.md).
+See `scenarios/trust_gated_exchange.yaml` for a wired example.
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/docs/layers/trust_gated_privacy.md
+++ b/docs/layers/trust_gated_privacy.md
@@ -1,0 +1,102 @@
+# Trust-Gated Privacy: disclosure tiers driven by live reputation
+
+Plugin: `("privacy", "trust_gated")` —
+[`nest_plugins_reference/privacy/trust_gated.py`](../../packages/nest-plugins-reference/nest_plugins_reference/privacy/trust_gated.py)
+
+## Problem
+
+[Problem 09 (privacy)](../hackathon/problems/09-privacy-hybrid-encryption-with-selective-disclosure.md)
+was solved by the merged `hybrid_x25519` plugin: real hybrid encryption,
+selective disclosure, revocation. But that plugin — by design — answers only
+*"who can read this?"* with a **static, all-or-nothing audience**: every agent
+the sender lists receives the full plaintext, whether its reputation is 0.99
+or 0.01. Meanwhile the trust layer (layer 6) computes reputation scores that
+**no privacy plugin consumes**. The two layers that most obviously belong
+together — *how much do I trust you* and *how much may you see* — are not
+connected anywhere in the stack. Concretely, with `hybrid_x25519` a sender
+who must include a low-reputation broker in a workflow has exactly two
+options: leak everything to it, or exclude it and break the workflow.
+
+## Solution
+
+`TrustGatedPrivacy` connects them by **composition, not re-implementation**:
+all cryptography is delegated to the merged `hybrid_x25519` plugin; this
+plugin adds the disclosure policy it deliberately lacks. At encrypt time the
+sender queries the live `Trust` layer per audience member and assigns a tier:
+
+| Trust score | Tier | What the recipient can decrypt |
+|---|---|---|
+| ≥ 0.8 | full | The complete plaintext (inner hybrid envelope #1). |
+| 0.5 – 0.8 | partial | A redacted view (inner envelope #2): the policy's `reveal_fields` subset **plus a salted-Merkle selective-disclosure proof** that the hidden fields are committed under the same root. Opaque payloads get an honest SHA-256 commitment — never a pretend proof. |
+| < 0.5 | denied | Nothing. No wrap entry exists in any envelope — the cryptography enforces the gate, not the JSON. The refusal carries a **signed denial receipt** (Identity-signed, or HMAC as sender-verifiable fallback) naming the score and failed threshold, so denials are auditable. |
+
+Tamper resistance: the gate table (agent → tier → score) is hashed and the
+digest sealed **inside** every AEAD-authenticated inner plaintext, so a
+doctored gate cannot be re-attached to real ciphertexts (`TamperError`).
+Poisoned trust feeds (NaN, ±inf, out-of-range) **fail closed** to denied.
+With `deterministic=True`, envelopes are byte-reproducible for Tier-1 traces.
+
+Ships with four adversarial validators
+([`validators/trust_gate_validators.py`](../../packages/nest-plugins-reference/nest_plugins_reference/validators/trust_gate_validators.py))
+— low-trust exfiltration, partial-tier overexposure, gate laundering, silent
+denial — that **fail against both `noop` and `hybrid_x25519`** and pass
+against this plugin, plus a wired scenario
+([`scenarios/trust_gated_exchange.yaml`](../../scenarios/trust_gated_exchange.yaml)).
+
+## How to run
+
+```bash
+uv sync
+
+# Full test suite for this plugin (36 tests: tiers, discrimination,
+# Byzantine, validators, scenario integration):
+uv run pytest packages/nest-plugins-reference/tests/test_trust_gated.py \
+              packages/nest-plugins-reference/tests/test_trust_gated_scenario.py -v
+
+# Run the wired scenario (resolves ./scenarios/trust_gated_exchange.yaml):
+uv run nest run trust_gated_exchange
+
+# The whole CI gate:
+make ci-local
+```
+
+## Results
+
+Measured over 200 structured payloads (4 fields, 2 sensitive) sent to a
+3-member audience with trust scores 0.9 / 0.6 / 0.1, same machine, same seed
+(script: encrypt + 3 decrypts per message):
+
+| Plugin | Low-trust plaintext reads | Mid-trust hidden-field exposures | Wire leaks | Auditable denials | Mean envelope | Mean enc+3×dec |
+|---|---|---|---|---|---|---|
+| `noop` | 200/200 | 200/200 | 200/200 | 0 | 82 B | ~0 ms |
+| `hybrid_x25519` | 200/200 | 200/200 | 0/200 | 0 | 676 B | 0.76 ms |
+| `trust_gated` | **0/200** | **0/200** | **0/200** | **200/200** | 3 558 B | 1.32 ms |
+
+Low-trust and mid-trust data exposure drop from 100% (under both reference
+plugins — `hybrid_x25519` encrypts *to* whoever is listed, trust-blind) to
+**0%**, and every denial is refused with a receipt the issuer can verify.
+The price is ~5× envelope size versus `hybrid_x25519` (two inner envelopes +
+gate table + receipts) and +0.6 ms per message — stated honestly below.
+
+## Limits
+
+- **Gate-time trust, not read-time.** Tiers bind the score *at encrypt time*.
+  A recipient whose reputation later collapses keeps envelopes it already
+  received (same future-only stance as `hybrid_x25519` revocation, for the
+  same reason). Pair with `revoke()` for key-level exclusion going forward.
+- **No exfiltration control.** A full-tier recipient can always re-share
+  plaintext out-of-band; the gate governs disclosure, not use.
+- **HMAC receipts are sender-verifiable only.** Without an `Identity` plugin
+  the denial receipt proves nothing to third parties. Supply one (e.g.
+  `did_key`) for third-party-verifiable receipts.
+- **Merkle commitments, not zero-knowledge circuits.** The partial tier
+  proves *set membership under a committed root* (salted-Merkle, per the
+  problem-09 pattern); it does not prove arbitrary predicates over hidden
+  values. Full zk-SNARKs are explicitly out of scope per the problem brief.
+- **Overhead.** ~5× envelope size and ~2× latency versus plain
+  `hybrid_x25519` for a 3-member tiered audience. If every recipient is the
+  same tier, prefer the composed plugin directly.
+- **Trust quality is upstream.** The gate is only as good as the trust
+  layer's scores. It fails closed on malformed scores, but it cannot detect
+  a *plausible-but-wrong* score (e.g. Sybil-inflated averages) — that is the
+  trust layer's problem statement, not this plugin's.

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -44,6 +44,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
     ("privacy", "hybrid_x25519"): f"{_REF}.privacy.hybrid_x25519:HybridX25519Privacy",
+    ("privacy", "trust_gated"): f"{_REF}.privacy.trust_gated:TrustGatedPrivacy",
     ("datafacts", "datafacts_v1"): f"{_REF}.datafacts.datafacts_v1:DataFactsV1",
     ("datafacts", "cid_facts"): f"{_REF}.datafacts.cid_facts:CidFacts",
     ("failure_detector", "heartbeat"): (

--- a/packages/nest-plugins-reference/nest_plugins_reference/privacy/trust_gated.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/privacy/trust_gated.py
@@ -1,0 +1,671 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Trust-gated disclosure tiers on top of hybrid X25519 encryption.
+
+:class:`~nest_plugins_reference.privacy.hybrid_x25519.HybridX25519Privacy`
+answers *"who can read this?"* with a **static audience**: every recipient the
+sender lists gets the full plaintext. This plugin answers the question the
+trust layer has been asking all along — *"how much should each recipient be
+allowed to read?"* — by composing the existing hybrid-encryption primitives
+with a live :class:`~nest_core.layers.trust.Trust` feed. It re-implements **no
+cryptography**: all confidentiality comes from the merged ``hybrid_x25519``
+plugin; this module adds the *disclosure policy* that plugin deliberately does
+not have.
+
+Tier policy (evaluated per recipient at encrypt time)
+-----------------------------------------------------
+
+* **score >= policy.full** (default ``0.8``) — *full tier*. The recipient is
+  wrapped into an inner hybrid envelope carrying the complete plaintext.
+* **policy.partial <= score < policy.full** (default ``0.5``) — *partial
+  tier*. The recipient is wrapped into a **separate** inner envelope that
+  carries a redacted view: for a structured payload (a JSON object of string
+  fields) that is the configured ``reveal_fields`` subset **plus a salted
+  Merkle selective-disclosure proof** (via the composed plugin's
+  :meth:`~HybridX25519Privacy.prove`) that the hidden fields are committed
+  under the same issuer root; for an opaque payload it is an honest
+  SHA-256 commitment and size — never a fake proof.
+* **score < policy.partial** — *denied*. The recipient appears in **no** wrap
+  set and receives a **signed denial receipt** (Ed25519 via the ``Identity``
+  layer when provided, else an HMAC-SHA256 tag only the sender can verify —
+  the receipt says which threshold failed and at what score, so a denial is
+  auditable rather than silent).
+
+Why the gate cannot be forged or stripped
+------------------------------------------
+
+The gate table (agent → tier → score) and policy are hashed into a
+``gate_digest`` that is embedded **inside every inner plaintext** before
+encryption. AEAD already authenticates the inner envelopes; the digest binds
+them to *this* gate decision. Re-attaching an inner envelope to a doctored
+gate table (a confused-deputy attempt to launder a partial-tier ciphertext as
+full-tier, or to hide a denial) is detected at decrypt time and raises
+:class:`~nest_plugins_reference.privacy.hybrid_x25519.TamperError`.
+
+Threat model — what each guard defeats
+--------------------------------------
+
+1. **Gate bypass.** A denied or unknown agent holds no wrap entry in either
+   inner envelope, so decryption fails exactly as an eavesdropper's would
+   (:class:`NotInAudienceError`); the cryptography, not the JSON, enforces
+   the gate.
+2. **Tier forgery.** A partial-tier recipient tampering the revealed fields,
+   salts, or Merkle path of its redacted view breaks the proof against the
+   committed root (``verify_proof`` returns ``False``).
+3. **Gate-table tampering.** Editing tiers, scores, or policy in the outer
+   envelope changes the ``gate_digest`` and no longer matches the digest
+   sealed inside the inner plaintexts — :class:`TamperError`.
+4. **Denial-receipt forgery.** Receipts are signed (or MAC'd) over a
+   canonical payload; :meth:`TrustGatedPrivacy.verify_denial` rejects edits
+   to the score, threshold, or subject.
+5. **Trust-score poisoning.** A Byzantine trust feed returning NaN,
+   infinities, or out-of-range values grants nothing: the gate fails closed,
+   denying the recipient with a ``-1.0`` sentinel score in its receipt.
+
+Honest limitations (read before trusting)
+-----------------------------------------
+
+* **Gate-time trust.** Tiers are decided from the trust score *at encrypt
+  time*. A recipient whose score later collapses keeps any envelope it
+  already received (same future-only stance, and the same reason, as
+  ``hybrid_x25519`` revocation). Pair with :meth:`revoke` for key-level
+  exclusion going forward.
+* **No exfiltration control.** A full-tier recipient can always re-share
+  plaintext out-of-band. The gate controls *disclosure*, not *use*.
+* **HMAC receipts are sender-verifiable only.** Without an ``Identity``
+  instance the denial receipt proves nothing to third parties; supply an
+  identity plugin for third-party-verifiable receipts.
+
+Determinism
+-----------
+
+With ``deterministic=True`` (and a deterministic trust plugin) the entire
+envelope — inner ephemeral keys, nonces, commitment salts, receipts — is a
+pure function of ``(seed, agent, epoch, seq, payload, audience, scores)``,
+so Tier-1 traces stay byte-identical. The secure default is
+``deterministic=False``.
+
+Example::
+
+    trust = ScoreAverageTrust()
+    alice = TrustGatedPrivacy(AgentId("alice"), trust, seed=b"a", deterministic=True)
+    bob = TrustGatedPrivacy(AgentId("bob"), trust, seed=b"b", deterministic=True)
+    alice.register_peer(AgentId("bob"), bob.public_key)
+    env = await alice.encrypt(b"quarterly-figures", [AgentId("bob")])
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import math
+from dataclasses import dataclass
+from typing import Any, cast
+
+from nest_core.layers import Identity, Trust
+from nest_core.types import AgentId, Proof, Signature, Statement, Witness
+
+from nest_plugins_reference.privacy.hybrid_x25519 import (
+    HybridX25519Privacy,
+    MalformedEnvelopeError,
+    NotInAudienceError,
+    PrivacyError,
+    TamperError,
+    commit_credential,
+)
+
+GATE_SCHEME = "trust-gated-hybrid-x25519/1"
+"""Wire-format tag on every trust-gated outer envelope.
+
+Example::
+
+    assert GATE_SCHEME.startswith("trust-gated")
+"""
+
+PARTIAL_SCHEME = "trust-gated-partial/1"
+"""Scheme tag on the redacted view delivered to partial-tier recipients.
+
+Example::
+
+    assert PARTIAL_SCHEME.startswith("trust-gated-partial")
+"""
+
+DENIAL_SCHEME = "trust-gated-denial/1"
+"""Scheme tag on signed denial receipts.
+
+Example::
+
+    assert DENIAL_SCHEME.startswith("trust-gated-denial")
+"""
+
+DISCLOSURE_PREDICATE = "trust_gated_disclosure"
+"""Statement predicate used for partial-tier selective-disclosure proofs.
+
+Example::
+
+    assert DISCLOSURE_PREDICATE == "trust_gated_disclosure"
+"""
+
+_TIER_FULL = "full"
+_TIER_PARTIAL = "partial"
+_TIER_DENIED = "denied"
+
+_INVALID_SCORE = -1.0
+"""Sentinel recorded in gate/receipt when the trust layer emitted a non-finite
+or out-of-range score; the recipient is denied (fail-closed), and the envelope
+stays canonical JSON instead of carrying NaN/inf."""
+
+
+class TrustDeniedError(PrivacyError):
+    """Raised when this agent was gated out of an envelope for low trust.
+
+    Carries the (signed) denial ``receipt`` naming the score and the failed
+    threshold, so callers can distinguish a policy denial from an ordinary
+    :class:`NotInAudienceError` and can audit or appeal it.
+
+    Example::
+
+        try:
+            await priv.decrypt(env)
+        except TrustDeniedError as exc:
+            assert exc.receipt is not None and exc.receipt["s"] == DENIAL_SCHEME
+    """
+
+    def __init__(self, message: str, receipt: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.receipt: dict[str, Any] | None = receipt
+
+
+@dataclass(frozen=True)
+class TierPolicy:
+    """Trust thresholds selecting the disclosure tier per recipient.
+
+    ``full`` is the minimum score for full plaintext; ``partial`` is the
+    minimum score for the redacted view. Anything below ``partial`` is denied.
+    Both boundaries are inclusive. Construction validates
+    ``0.0 <= partial <= full <= 1.0``.
+
+    Example::
+
+        policy = TierPolicy(full=0.8, partial=0.5)
+    """
+
+    full: float = 0.8
+    partial: float = 0.5
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.partial <= self.full <= 1.0:
+            msg = f"invalid tier policy: require 0 <= partial <= full <= 1, got {self}"
+            raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Local canonical-encoding helpers (kept private to this module on purpose:
+# reaching into a sibling module's underscore-prefixed helpers would couple us
+# to its internals).
+# ---------------------------------------------------------------------------
+
+
+def _canon(obj: dict[str, Any]) -> bytes:
+    """Canonical sorted-key JSON bytes; the only encoding we hash or MAC."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _b64(raw: bytes) -> str:
+    """Standard base64 for embedding raw bytes as ASCII in the JSON envelope."""
+    return base64.b64encode(raw).decode("ascii")
+
+
+def _unb64(text: str) -> bytes:
+    """Inverse of :func:`_b64`; raises on malformed input."""
+    return base64.b64decode(text.encode("ascii"))
+
+
+def _round_score(score: float) -> float:
+    """Quantize a trust score for canonical, replay-stable envelope bytes."""
+    return round(score, 6)
+
+
+def _as_str_fields(data: bytes) -> dict[str, str] | None:
+    """Return the payload as a flat ``{str: str}`` credential, else ``None``."""
+    try:
+        loaded: Any = json.loads(data)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    mapping = cast("dict[Any, Any]", loaded)
+    fields: dict[str, str] = {}
+    for key, value in mapping.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            return None
+        fields[key] = value
+    return fields
+
+
+def _require(mapping: dict[str, Any], key: str) -> Any:
+    if key not in mapping:
+        raise MalformedEnvelopeError(f"missing field {key!r}")
+    return mapping[key]
+
+
+def _parse_object(data: bytes, context: str) -> dict[str, Any]:
+    """Parse *data* as a JSON object or raise :class:`MalformedEnvelopeError`."""
+    try:
+        loaded: Any = json.loads(data)
+    except (ValueError, TypeError) as exc:
+        raise MalformedEnvelopeError(f"{context}: not JSON") from exc
+    if not isinstance(loaded, dict):
+        raise MalformedEnvelopeError(f"{context}: not a JSON object")
+    return cast("dict[str, Any]", loaded)
+
+
+# ---------------------------------------------------------------------------
+# The plugin
+# ---------------------------------------------------------------------------
+
+
+class TrustGatedPrivacy:
+    """Per-agent privacy plugin gating disclosure by live trust score.
+
+    Implements the ``Privacy`` protocol by composition: an internal
+    :class:`HybridX25519Privacy` provides all encryption and proof machinery,
+    while this class decides — per recipient, per message, from the ``trust``
+    layer — whether that recipient gets the full plaintext, a redacted
+    selectively-disclosed view, or a signed denial receipt.
+
+    Example::
+
+        trust = ScoreAverageTrust()
+        priv = TrustGatedPrivacy(AgentId("alice"), trust, seed=b"a", deterministic=True)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        trust: Trust,
+        seed: bytes = b"",
+        *,
+        deterministic: bool = False,
+        policy: TierPolicy | None = None,
+        identity: Identity | None = None,
+        reveal_fields: frozenset[str] = frozenset(),
+    ) -> None:
+        self._agent_id = agent_id
+        self._trust = trust
+        self._seed = seed
+        self._deterministic = deterministic
+        self._policy = policy or TierPolicy()
+        self._identity = identity
+        self._reveal_fields = reveal_fields
+        self._inner = HybridX25519Privacy(agent_id, seed, deterministic=deterministic)
+        self._mac_key = hashlib.sha256(b"trust-gated-mac|" + seed).digest()
+        self._seq = 0
+
+    # -- composition passthroughs (key directory lives in the inner plugin) ---
+
+    @property
+    def inner(self) -> HybridX25519Privacy:
+        """The composed hybrid-encryption plugin (all cryptography lives here).
+
+        Example::
+
+            assert isinstance(priv.inner, HybridX25519Privacy)
+        """
+        return self._inner
+
+    @property
+    def policy(self) -> TierPolicy:
+        """The tier policy this gate enforces.
+
+        Example::
+
+            assert priv.policy.full >= priv.policy.partial
+        """
+        return self._policy
+
+    @property
+    def public_key(self) -> bytes:
+        """This agent's raw X25519 public key (from the composed plugin).
+
+        Example::
+
+            pk = priv.public_key
+        """
+        return self._inner.public_key
+
+    @property
+    def key_id(self) -> str:
+        """Short id of this agent's public key (matches inner wrap entries).
+
+        Example::
+
+            kid = priv.key_id
+        """
+        return self._inner.key_id
+
+    @property
+    def epoch(self) -> int:
+        """Current revocation epoch of the composed plugin.
+
+        Example::
+
+            assert priv.epoch >= 0
+        """
+        return self._inner.epoch
+
+    def register_peer(self, agent_id: AgentId, public_key: bytes) -> None:
+        """Register a peer's public key so envelopes can be wrapped for it.
+
+        Example::
+
+            priv.register_peer(AgentId("bob"), bob_public_key)
+        """
+        self._inner.register_peer(agent_id, public_key)
+
+    def revoke(self, agent_id: AgentId) -> int:
+        """Key-level revocation, delegated to the composed plugin.
+
+        Trust gating and revocation are complementary: the gate handles *low
+        trust*, revocation handles *expulsion*. Returns the new epoch.
+
+        Example::
+
+            new_epoch = priv.revoke(AgentId("mallory"))
+        """
+        return self._inner.revoke(agent_id)
+
+    # -- tier resolution -------------------------------------------------------
+
+    async def _tier_for(self, agent_id: AgentId) -> tuple[str, float]:
+        rep = await self._trust.score(agent_id)
+        score = rep.score
+        if not math.isfinite(score) or not 0.0 <= score <= 1.0:
+            # Fail closed: a trust layer emitting NaN/inf/out-of-range scores
+            # (a poisoned or Byzantine feed) grants NOTHING. The sentinel keeps
+            # the receipt canonical JSON instead of echoing the garbage value.
+            return _TIER_DENIED, _INVALID_SCORE
+        if score >= self._policy.full:
+            return _TIER_FULL, score
+        if score >= self._policy.partial:
+            return _TIER_PARTIAL, score
+        return _TIER_DENIED, score
+
+    # -- Privacy protocol: encryption ------------------------------------------
+
+    async def encrypt(self, data: bytes, audience: list[AgentId]) -> bytes:
+        """Encrypt *data* with per-recipient disclosure tiers.
+
+        Queries the trust layer for every distinct audience member and emits a
+        self-describing outer envelope containing: the gate table (agent, tier,
+        quantized score), at most one inner hybrid envelope for the full tier,
+        at most one for the partial tier (carrying the redacted view), and a
+        signed denial receipt per denied member. The gate table's digest is
+        sealed inside both inner plaintexts, so the table cannot be reworked
+        around the ciphertexts.
+
+        Example::
+
+            env = await alice.encrypt(b"secret", [AgentId("bob"), AgentId("carol")])
+        """
+        recipients: list[AgentId] = []
+        seen: set[AgentId] = set()
+        for aid in audience:
+            if aid not in seen:
+                seen.add(aid)
+                recipients.append(aid)
+
+        self._seq += 1
+        msg_id = f"{self._agent_id}:{self._inner.epoch}:{self._seq}"
+
+        full_tier: list[AgentId] = []
+        partial_tier: list[AgentId] = []
+        denied: list[tuple[AgentId, float]] = []
+        gate: list[dict[str, Any]] = []
+        for aid in recipients:
+            tier, score = await self._tier_for(aid)
+            gate.append({"agent": str(aid), "tier": tier, "score": _round_score(score)})
+            if tier == _TIER_FULL:
+                full_tier.append(aid)
+            elif tier == _TIER_PARTIAL:
+                partial_tier.append(aid)
+            else:
+                denied.append((aid, score))
+        gate.sort(key=lambda entry: str(entry["agent"]))
+
+        header: dict[str, Any] = {
+            "s": GATE_SCHEME,
+            "from": str(self._agent_id),
+            "msg": msg_id,
+            "policy": {"full": self._policy.full, "partial": self._policy.partial},
+            "gate": gate,
+        }
+        gate_digest = hashlib.sha256(_canon(header)).hexdigest()
+
+        full_blob: str | None = None
+        if full_tier:
+            full_plain = _canon({"d": gate_digest, "body": _b64(data)})
+            full_blob = _b64(await self._inner.encrypt(full_plain, full_tier))
+
+        partial_blob: str | None = None
+        if partial_tier:
+            package = await self._partial_package(data, gate_digest, msg_id)
+            partial_blob = _b64(await self._inner.encrypt(_canon(package), partial_tier))
+
+        denials = [self._denial_receipt(aid, score, msg_id) for aid, score in denied]
+
+        envelope: dict[str, Any] = {
+            "v": 1,
+            **header,
+            "full": full_blob,
+            "partial": partial_blob,
+            "denials": denials,
+        }
+        return _canon(envelope)
+
+    async def _partial_package(self, data: bytes, gate_digest: str, msg_id: str) -> dict[str, Any]:
+        """Build the redacted view for partial-tier recipients."""
+        fields = _as_str_fields(data)
+        if fields is None:
+            # Opaque payload: an honest commitment, never a pretend proof.
+            return {
+                "s": PARTIAL_SCHEME,
+                "d": gate_digest,
+                "kind": "digest",
+                "sha256": hashlib.sha256(data).hexdigest(),
+                "size": len(data),
+            }
+
+        salt_seed: bytes | None = None
+        if self._deterministic:
+            salt_seed = hashlib.sha256(
+                b"trust-gated-salt|" + self._seed + b"|" + msg_id.encode("utf-8")
+            ).digest()
+        root, salts = commit_credential(fields, salt_seed=salt_seed)
+        reveal = sorted(self._reveal_fields & set(fields))
+        statement = Statement(
+            predicate=DISCLOSURE_PREDICATE,
+            public_inputs={"root": root, "reveal": ",".join(reveal)},
+        )
+        witness = Witness(private_inputs={**fields, "__salts__": json.dumps(salts)})
+        proof = await self._inner.prove(statement, witness)
+        return {
+            "s": PARTIAL_SCHEME,
+            "d": gate_digest,
+            "kind": "selective",
+            "root": root,
+            "reveal": reveal,
+            "revealed": {name: fields[name] for name in reveal},
+            "proof": _b64(proof.data),
+        }
+
+    def _denial_payload(
+        self, agent_id: str, score: float, threshold: float, msg_id: str, epoch: int
+    ) -> bytes:
+        # The threshold is a parameter — NOT read from self._policy — so that
+        # verification authenticates the receipt's *claimed* threshold. Binding
+        # it to the verifier's live policy instead would let a forged threshold
+        # field slide through whenever the policy happened to agree.
+        return _canon(
+            {
+                "s": DENIAL_SCHEME,
+                "agent": agent_id,
+                "score": score,
+                "threshold": threshold,
+                "msg": msg_id,
+                "from": str(self._agent_id),
+                "epoch": epoch,
+            }
+        )
+
+    def _denial_receipt(self, agent_id: AgentId, score: float, msg_id: str) -> dict[str, Any]:
+        """Build a signed (or MAC'd) receipt naming the denial and its cause."""
+        quantized = _round_score(score)
+        epoch = self._inner.epoch
+        payload = self._denial_payload(
+            str(agent_id), quantized, self._policy.partial, msg_id, epoch
+        )
+        receipt: dict[str, Any] = {
+            "s": DENIAL_SCHEME,
+            "agent": str(agent_id),
+            "score": quantized,
+            "threshold": self._policy.partial,
+            "msg": msg_id,
+            "from": str(self._agent_id),
+            "epoch": epoch,
+        }
+        if self._identity is not None:
+            sig = self._identity.sign(payload)
+            receipt["alg"] = sig.algorithm
+            receipt["sig"] = _b64(sig.value)
+            receipt["signer"] = str(sig.signer)
+        else:
+            receipt["alg"] = "hmac-sha256"
+            receipt["mac"] = hmac.new(self._mac_key, payload, hashlib.sha256).hexdigest()
+        return receipt
+
+    def verify_denial(self, receipt: dict[str, Any]) -> bool:
+        """Verify a denial receipt's signature or MAC.
+
+        With an ``Identity`` plugin the check is third-party verifiable; the
+        HMAC fallback is verifiable only by the issuing sender (documented in
+        the module notes). Any edit to the subject, score, threshold, message
+        id, or epoch invalidates the receipt.
+
+        Example::
+
+            assert alice.verify_denial(receipt)
+        """
+        try:
+            payload = self._denial_payload(
+                str(receipt["agent"]),
+                float(receipt["score"]),
+                float(receipt["threshold"]),
+                str(receipt["msg"]),
+                int(receipt["epoch"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            return False
+        if receipt.get("from") != str(self._agent_id):
+            return False
+        alg = receipt.get("alg")
+        if alg == "hmac-sha256":
+            expected = hmac.new(self._mac_key, payload, hashlib.sha256).hexdigest()
+            return hmac.compare_digest(expected, str(receipt.get("mac", "")))
+        if self._identity is not None and "sig" in receipt:
+            sig = Signature(
+                signer=AgentId(str(receipt.get("signer", ""))),
+                value=_unb64(str(receipt["sig"])),
+                algorithm=str(alg),
+            )
+            return self._identity.verify(payload, sig, AgentId(str(receipt.get("signer", ""))))
+        return False
+
+    # -- Privacy protocol: decryption ------------------------------------------
+
+    async def decrypt(self, data: bytes) -> bytes:
+        """Decrypt a trust-gated envelope addressed to this agent.
+
+        Full-tier recipients get the original plaintext; partial-tier
+        recipients get the canonical redacted-view package (scheme
+        ``PARTIAL_SCHEME``) whose embedded proof they can check with
+        :meth:`verify_proof`. A denied agent raises :class:`TrustDeniedError`
+        carrying its receipt; an agent that was never addressed raises
+        :class:`NotInAudienceError`. A gate table that does not match the
+        digest sealed inside the inner plaintext raises :class:`TamperError`.
+
+        Example::
+
+            view = await bob.decrypt(env)
+        """
+        obj = _parse_object(data, "outer envelope")
+        if _require(obj, "s") != GATE_SCHEME:
+            raise MalformedEnvelopeError("unknown outer scheme")
+        header: dict[str, Any] = {
+            "s": GATE_SCHEME,
+            "from": _require(obj, "from"),
+            "msg": _require(obj, "msg"),
+            "policy": _require(obj, "policy"),
+            "gate": _require(obj, "gate"),
+        }
+        gate_digest = hashlib.sha256(_canon(header)).hexdigest()
+
+        full_blob = obj.get("full")
+        if isinstance(full_blob, str):
+            plaintext = await self._try_inner(full_blob)
+            if plaintext is not None:
+                wrapper = _parse_object(plaintext, "full-tier plaintext")
+                if _require(wrapper, "d") != gate_digest:
+                    raise TamperError("gate table does not match full-tier plaintext")
+                return _unb64(str(_require(wrapper, "body")))
+
+        partial_blob = obj.get("partial")
+        if isinstance(partial_blob, str):
+            plaintext = await self._try_inner(partial_blob)
+            if plaintext is not None:
+                package = _parse_object(plaintext, "partial-tier plaintext")
+                if _require(package, "s") != PARTIAL_SCHEME:
+                    raise MalformedEnvelopeError("unexpected partial-tier scheme")
+                if _require(package, "d") != gate_digest:
+                    raise TamperError("gate table does not match partial-tier plaintext")
+                return plaintext
+
+        raw_denials = obj.get("denials")
+        if isinstance(raw_denials, list):
+            for item in cast("list[Any]", raw_denials):
+                if isinstance(item, dict):
+                    receipt = cast("dict[str, Any]", item)
+                    if receipt.get("agent") == str(self._agent_id):
+                        raise TrustDeniedError(
+                            f"{self._agent_id} denied below trust threshold",
+                            receipt=receipt,
+                        )
+        raise NotInAudienceError(f"{self._agent_id} is not in the audience")
+
+    async def _try_inner(self, blob: str) -> bytes | None:
+        """Decrypt one inner envelope; ``None`` if we are not in its audience."""
+        try:
+            return await self._inner.decrypt(_unb64(blob))
+        except NotInAudienceError:
+            return None
+
+    # -- Privacy protocol: proofs (delegated) -----------------------------------
+
+    async def prove(self, statement: Statement, witness: Witness) -> Proof:
+        """Generate a selective-disclosure proof (delegates to the composed plugin).
+
+        Example::
+
+            proof = await priv.prove(stmt, witness)
+        """
+        return await self._inner.prove(statement, witness)
+
+    async def verify_proof(self, statement: Statement, proof: Proof) -> bool:
+        """Verify a selective-disclosure proof (delegates to the composed plugin).
+
+        Example::
+
+            ok = await priv.verify_proof(stmt, proof)
+        """
+        return await self._inner.verify_proof(statement, proof)

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -30,16 +30,28 @@ from nest_plugins_reference.validators.privacy_validators import (
     check_stale_revocation_blocked,
     corrupt_proof,
 )
+from nest_plugins_reference.validators.trust_gate_validators import (
+    check_denial_receipt_auditable,
+    check_gate_tamper_rejected,
+    check_low_trust_blocked,
+    check_partial_redaction_enforced,
+    forge_tier_upgrade,
+)
 
 __all__ = [
     "ConvergenceFailureError",
     "PartitionLeakError",
     "ValidatorReport",
     "check_converged",
+    "check_denial_receipt_auditable",
     "check_eavesdropper_blocked",
     "check_field_injection_rejected",
+    "check_gate_tamper_rejected",
+    "check_low_trust_blocked",
     "check_no_partition_view_leak",
+    "check_partial_redaction_enforced",
     "check_replay_rejected",
     "check_stale_revocation_blocked",
     "corrupt_proof",
+    "forge_tier_upgrade",
 ]

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/trust_gate_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/trust_gate_validators.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for the ``trust_gated`` privacy plugin.
+
+Four attack classes that **both** existing reference privacy plugins allow —
+``noop`` because it hands every byte to everyone, and ``hybrid_x25519``
+because it is deliberately trust-blind (any agent the sender lists in the
+audience gets the full plaintext, regardless of reputation):
+
+1. **Low-trust exfiltration.** A recipient below the trust floor recovers the
+   plaintext. :func:`check_low_trust_blocked` asserts the low-trust reader
+   cannot recover the payload and the payload never rides the wire in clear.
+2. **Partial-tier overexposure.** A mid-trust recipient sees fields the
+   policy says it must not. :func:`check_partial_redaction_enforced` asserts
+   the mid-trust reader receives *something* other than the full plaintext
+   and that no hidden field value reaches it (or the wire).
+3. **Gate laundering.** An attacker edits the gate table to upgrade a tier.
+   :func:`check_gate_tamper_rejected` asserts a doctored envelope (built with
+   :func:`forge_tier_upgrade`) never yields the plaintext. Against the
+   reference plugins the "forgery" is a no-op — their envelopes carry no gate
+   — so the plaintext flows and the check fails, which is the point.
+4. **Silent denial.** A gated-out agent is refused with no auditable trail.
+   :func:`check_denial_receipt_auditable` asserts the denial surfaces a
+   receipt bound to the message that the issuer verifies, and that a forged
+   copy of the receipt does not verify.
+
+Each validator is a pure ``async`` function on the
+:class:`~nest_core.layers.privacy.Privacy` protocol surface (receipt access is
+duck-typed via the exception's ``receipt`` attribute and the sender's
+``verify_denial`` callable, so no import of the plugin class is needed). The
+same check therefore runs against every privacy plugin:
+
+* against ``trust_gated`` every check **passes**;
+* against ``noop`` **and** ``hybrid_x25519`` every check **fails** — the
+  charter's bar for "adversarial", raised one notch: the attack class must be
+  one the *hardened* merged plugin also cannot catch.
+
+Example::
+
+    report = await check_low_trust_blocked(alice, mallory, payload=secret, audience=aud)
+    assert report.passed, report.detail
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, cast
+
+from nest_plugins_reference.validators.gossip_validators import ValidatorReport
+
+if TYPE_CHECKING:
+    from nest_core.layers.privacy import Privacy
+    from nest_core.types import AgentId
+
+
+async def _try_decrypt(
+    privacy: Privacy, envelope: bytes
+) -> tuple[bool, bytes | None, Exception | None]:
+    """Attempt a decrypt; return ``(ok, plaintext, exception)`` without raising.
+
+    Example::
+
+        ok, plaintext, exc = await _try_decrypt(reader, envelope)
+    """
+    try:
+        return True, await privacy.decrypt(envelope), None
+    except Exception as exc:  # noqa: BLE001 - refusal is a policy outcome here
+        return False, None, exc
+
+
+async def check_low_trust_blocked(
+    sender: Privacy, low_trust_reader: Privacy, *, payload: bytes, audience: list[AgentId]
+) -> ValidatorReport:
+    """Assert an audience member below the trust floor cannot read *payload*.
+
+    Passes iff the low-trust reader's decrypt does not yield the payload and
+    the payload does not appear verbatim in the envelope. ``noop`` fails both
+    conditions; ``hybrid_x25519`` fails the first — it encrypts *to* the
+    low-trust member because it never consults trust.
+
+    Example::
+
+        report = await check_low_trust_blocked(alice, mallory, payload=b"s", audience=aud)
+        assert report.passed, report.detail
+    """
+    envelope = await sender.encrypt(payload, audience)
+    if payload in envelope:
+        return ValidatorReport(passed=False, detail="payload rides the wire in clear")
+    ok, recovered, _ = await _try_decrypt(low_trust_reader, envelope)
+    if ok and recovered == payload:
+        return ValidatorReport(
+            passed=False,
+            detail="low-trust audience member recovered the full plaintext",
+            evidence={"recovered_bytes": len(recovered or b"")},
+        )
+    return ValidatorReport(passed=True, detail="low-trust member blocked from plaintext")
+
+
+async def check_partial_redaction_enforced(
+    sender: Privacy,
+    mid_trust_reader: Privacy,
+    *,
+    payload: bytes,
+    audience: list[AgentId],
+    hidden: list[bytes],
+) -> ValidatorReport:
+    """Assert a mid-trust member gets a redacted view, never the hidden fields.
+
+    Passes iff no ``hidden`` byte-string appears in the envelope, the reader's
+    recovered view is not the full payload, and no hidden value appears in
+    that view. ``noop`` and ``hybrid_x25519`` both hand the mid-trust member
+    the complete payload, so both fail.
+
+    Example::
+
+        report = await check_partial_redaction_enforced(
+            alice, carol, payload=doc, audience=aud, hidden=[b"250000"]
+        )
+        assert report.passed, report.detail
+    """
+    envelope = await sender.encrypt(payload, audience)
+    for secret in hidden:
+        if secret in envelope:
+            return ValidatorReport(passed=False, detail="hidden field rides the wire in clear")
+    ok, recovered, _ = await _try_decrypt(mid_trust_reader, envelope)
+    if ok and recovered == payload:
+        return ValidatorReport(
+            passed=False, detail="mid-trust member received the full, unredacted plaintext"
+        )
+    if ok and recovered is not None:
+        for secret in hidden:
+            if secret in recovered:
+                return ValidatorReport(
+                    passed=False, detail="hidden field leaked into the mid-trust view"
+                )
+    return ValidatorReport(passed=True, detail="mid-trust member confined to the redacted view")
+
+
+def forge_tier_upgrade(envelope: bytes, *, agent: str) -> bytes:
+    """Rewrite *envelope*'s gate table to claim *agent* deserves the full tier.
+
+    For envelopes without a gate table (``noop``, ``hybrid_x25519``) the input
+    is returned unchanged — the "attack" needs no forgery there, which is
+    exactly why those plugins fail :func:`check_gate_tamper_rejected`.
+
+    Example::
+
+        forged = forge_tier_upgrade(envelope, agent="mallory")
+    """
+    try:
+        loaded: Any = json.loads(envelope)
+    except (ValueError, TypeError):
+        return envelope
+    if not isinstance(loaded, dict):
+        return envelope
+    obj = cast("dict[str, Any]", loaded)
+    gate = obj.get("gate")
+    if not isinstance(gate, list):
+        return envelope
+    for item in cast("list[Any]", gate):
+        if isinstance(item, dict):
+            entry = cast("dict[str, Any]", item)
+            if entry.get("agent") == agent:
+                entry["tier"] = "full"
+                entry["score"] = 0.99
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+async def check_gate_tamper_rejected(
+    sender: Privacy,
+    reader: Privacy,
+    *,
+    payload: bytes,
+    audience: list[AgentId],
+    upgrade_agent: str,
+) -> ValidatorReport:
+    """Assert a doctored gate table never yields the plaintext to *reader*.
+
+    Builds the forgery with :func:`forge_tier_upgrade` and passes iff the
+    reader cannot recover the payload from the forged envelope. Reference
+    plugins carry no gate to authenticate, so the payload flows and the check
+    fails against them.
+
+    Example::
+
+        report = await check_gate_tamper_rejected(
+            alice, bob, payload=b"s", audience=aud, upgrade_agent="mallory"
+        )
+        assert report.passed, report.detail
+    """
+    envelope = await sender.encrypt(payload, audience)
+    forged = forge_tier_upgrade(envelope, agent=upgrade_agent)
+    ok, recovered, exc = await _try_decrypt(reader, forged)
+    if ok and recovered == payload:
+        return ValidatorReport(
+            passed=False,
+            detail="reader recovered plaintext from an envelope with a doctored gate table",
+            evidence={"forgery_changed_bytes": forged != envelope},
+        )
+    return ValidatorReport(
+        passed=True,
+        detail="doctored gate table rejected",
+        evidence={"refusal": type(exc).__name__ if exc is not None else "plaintext-mismatch"},
+    )
+
+
+async def check_denial_receipt_auditable(
+    sender: Privacy, denied_reader: Privacy, *, payload: bytes, audience: list[AgentId]
+) -> ValidatorReport:
+    """Assert a trust denial is refused *with* a verifiable receipt.
+
+    Passes iff the denied reader's decrypt raises an exception carrying a
+    ``receipt`` mapping, the sender's ``verify_denial`` accepts it, and a
+    score-forged copy is rejected. ``noop`` fails because the denied agent
+    simply reads the payload; ``hybrid_x25519`` fails because its refusal is
+    silent — no receipt, nothing to audit.
+
+    Example::
+
+        report = await check_denial_receipt_auditable(alice, mallory, payload=b"s", audience=aud)
+        assert report.passed, report.detail
+    """
+    envelope = await sender.encrypt(payload, audience)
+    ok, recovered, exc = await _try_decrypt(denied_reader, envelope)
+    if ok:
+        return ValidatorReport(
+            passed=False,
+            detail="denied agent was not refused",
+            evidence={"recovered_payload": recovered == payload},
+        )
+    receipt_obj: Any = getattr(exc, "receipt", None)
+    if not isinstance(receipt_obj, dict):
+        return ValidatorReport(
+            passed=False, detail="denial is silent: refusal carries no auditable receipt"
+        )
+    receipt = cast("dict[str, Any]", receipt_obj)
+    verify_attr: Any = getattr(sender, "verify_denial", None)
+    if not callable(verify_attr):
+        return ValidatorReport(passed=False, detail="sender cannot verify its own receipts")
+    if not bool(verify_attr(receipt)):
+        return ValidatorReport(passed=False, detail="issued receipt failed verification")
+    forged = dict(receipt)
+    forged["score"] = 0.99
+    if bool(verify_attr(forged)):
+        return ValidatorReport(passed=False, detail="score-forged receipt verified")
+    return ValidatorReport(
+        passed=True, detail="denial refused with a verifiable, unforgeable receipt"
+    )

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -41,6 +41,7 @@ lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
 
 [project.entry-points."nest.plugins.privacy"]
 hybrid_x25519 = "nest_plugins_reference.privacy.hybrid_x25519:HybridX25519Privacy"
+trust_gated = "nest_plugins_reference.privacy.trust_gated:TrustGatedPrivacy"
 
 [project.entry-points."nest.plugins.datafacts"]
 cid_facts = "nest_plugins_reference.datafacts.cid_facts:CidFacts"

--- a/packages/nest-plugins-reference/tests/test_trust_gated.py
+++ b/packages/nest-plugins-reference/tests/test_trust_gated.py
@@ -1,0 +1,576 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Example-based + adversarial tests for the ``trust_gated`` privacy plugin.
+
+Three layers of coverage (mirrors the ``hybrid_x25519`` test structure):
+
+1. **Disclosure tiers** — full plaintext for high trust, a redacted
+   selectively-disclosed view (with a *verifiable* Merkle proof) for medium
+   trust, a signed denial receipt for low trust, and inclusive threshold
+   boundaries.
+2. **Discrimination** — the gate invariant ("a low-trust audience member must
+   not recover the plaintext") FAILS against ``noop`` *and* against
+   ``hybrid_x25519`` (which is deliberately trust-blind), and PASSES only
+   against ``trust_gated``. This is the charter's bar: a check the existing
+   reference plugins cannot satisfy.
+3. **Byzantine behaviour** — poisoned trust scores (NaN/inf/out-of-range)
+   fail closed; gate-table tampering, tier-blob swapping, forged denial
+   receipts, and replay are all rejected; envelopes stay byte-deterministic.
+
+Example::
+
+    pytest packages/nest-plugins-reference/tests/test_trust_gated.py
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import math
+from typing import Any, cast
+
+import pytest
+from nest_core.layers.privacy import Privacy
+from nest_core.plugins import PluginRegistry
+from nest_core.types import (
+    AgentId,
+    AgentIdentity,
+    Attestation,
+    Claim,
+    Evidence,
+    Proof,
+    ReputationScore,
+    Signature,
+    Statement,
+)
+from nest_plugins_reference.privacy.hybrid_x25519 import (
+    PROOF_SCHEME,
+    HybridX25519Privacy,
+    MalformedEnvelopeError,
+    NotInAudienceError,
+    ReplayError,
+    TamperError,
+)
+from nest_plugins_reference.privacy.noop import NoopPrivacy
+from nest_plugins_reference.privacy.trust_gated import (
+    DENIAL_SCHEME,
+    DISCLOSURE_PREDICATE,
+    PARTIAL_SCHEME,
+    TierPolicy,
+    TrustDeniedError,
+    TrustGatedPrivacy,
+)
+from nest_plugins_reference.trust.score_average import ScoreAverageTrust
+from nest_plugins_reference.validators import (
+    check_denial_receipt_auditable,
+    check_gate_tamper_rejected,
+    check_low_trust_blocked,
+    check_partial_redaction_enforced,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+_HIDDEN_1 = "250000"
+_HIDDEN_2 = "123-45-6789"
+_PAYLOAD_FIELDS = {"dept": "finance", "region": "EU", "salary": _HIDDEN_1, "ssn": _HIDDEN_2}
+_PAYLOAD = json.dumps(_PAYLOAD_FIELDS, sort_keys=True).encode("utf-8")
+_REVEAL = frozenset({"dept", "region"})
+
+
+class StaticTrust:
+    """Trust stub returning preset scores (default 0.5); the other protocol
+    methods are inert. Deterministic by construction."""
+
+    def __init__(self, scores: dict[str, float] | None = None) -> None:
+        self._scores = dict(scores or {})
+
+    async def score(self, agent: AgentId) -> ReputationScore:
+        return ReputationScore(agent_id=agent, score=self._scores.get(str(agent), 0.5))
+
+    async def attest(self, agent: AgentId, claim: Claim) -> Attestation:
+        sig = Signature(signer=AgentId("static"), value=b"", algorithm="none")
+        return Attestation(issuer=AgentId("static"), claim=claim, signature=sig)
+
+    async def report(self, agent: AgentId, evidence: Evidence) -> None:
+        return None
+
+    async def stake(self, agent: AgentId, amount: int) -> None:
+        return None
+
+
+class StubIdentity:
+    """Deterministic shared-secret Identity stub (test-only, not real crypto)."""
+
+    def __init__(self, agent_id: AgentId, secret: bytes) -> None:
+        self._agent_id = agent_id
+        self._secret = secret
+
+    def sign(self, payload: bytes) -> Signature:
+        import hashlib
+        import hmac as _hmac
+
+        tag = _hmac.new(self._secret, payload, hashlib.sha256).digest()
+        return Signature(signer=self._agent_id, value=tag, algorithm="hmac-test")
+
+    def verify(self, payload: bytes, sig: Signature, agent: AgentId) -> bool:
+        import hashlib
+        import hmac as _hmac
+
+        expected = _hmac.new(self._secret, payload, hashlib.sha256).digest()
+        return _hmac.compare_digest(expected, sig.value)
+
+    async def resolve(self, agent: AgentId) -> AgentIdentity:
+        return AgentIdentity(agent_id=agent, public_key=b"", method="stub")
+
+
+_SCORES = {"bob": 0.9, "carol": 0.6, "mallory": 0.1}
+
+
+def _mk(
+    name: str,
+    trust: StaticTrust | ScoreAverageTrust,
+    *,
+    identity: StubIdentity | None = None,
+) -> TrustGatedPrivacy:
+    return TrustGatedPrivacy(
+        AgentId(name),
+        trust,
+        seed=name.encode("utf-8"),
+        deterministic=True,
+        identity=identity,
+        reveal_fields=_REVEAL,
+    )
+
+
+def _fleet(
+    trust: StaticTrust | ScoreAverageTrust,
+    *,
+    identity: StubIdentity | None = None,
+) -> tuple[TrustGatedPrivacy, TrustGatedPrivacy, TrustGatedPrivacy, TrustGatedPrivacy]:
+    """A wired (alice, bob, carol, mallory) fleet sharing one trust feed."""
+    alice = _mk("alice", trust, identity=identity)
+    bob = _mk("bob", trust)
+    carol = _mk("carol", trust)
+    mallory = _mk("mallory", trust)
+    for name, plugin in (("bob", bob), ("carol", carol), ("mallory", mallory)):
+        alice.register_peer(AgentId(name), plugin.public_key)
+    return alice, bob, carol, mallory
+
+
+_AUDIENCE = [AgentId("bob"), AgentId("carol"), AgentId("mallory")]
+
+
+def _view_of(plaintext: bytes) -> dict[str, Any]:
+    loaded: Any = json.loads(plaintext)
+    assert isinstance(loaded, dict)
+    return cast("dict[str, Any]", loaded)
+
+
+def _proof_from_view(view: dict[str, Any]) -> tuple[Statement, Proof]:
+    statement = Statement(
+        predicate=DISCLOSURE_PREDICATE,
+        public_inputs={
+            "root": str(view["root"]),
+            "reveal": ",".join(str(n) for n in cast("list[Any]", view["reveal"])),
+        },
+    )
+    proof = Proof(
+        statement=statement,
+        data=base64.b64decode(str(view["proof"])),
+        scheme=PROOF_SCHEME,
+    )
+    return statement, proof
+
+
+# ---------------------------------------------------------------------------
+# 1. Disclosure tiers
+# ---------------------------------------------------------------------------
+
+
+class TestDisclosureTiers:
+    async def test_full_tier_gets_plaintext(self) -> None:
+        alice, bob, _, _ = _fleet(StaticTrust(_SCORES))
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        assert await bob.decrypt(env) == _PAYLOAD
+
+    async def test_partial_tier_gets_redacted_view_with_valid_proof(self) -> None:
+        alice, _, carol, _ = _fleet(StaticTrust(_SCORES))
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        view = _view_of(await carol.decrypt(env))
+        assert view["s"] == PARTIAL_SCHEME
+        assert view["kind"] == "selective"
+        assert view["revealed"] == {"dept": "finance", "region": "EU"}
+        statement, proof = _proof_from_view(view)
+        assert await carol.verify_proof(statement, proof)
+
+    async def test_hidden_fields_never_reach_partial_tier_or_wire(self) -> None:
+        alice, _, carol, _ = _fleet(StaticTrust(_SCORES))
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        view_bytes = await carol.decrypt(env)
+        for secret in (_HIDDEN_1.encode(), _HIDDEN_2.encode()):
+            assert secret not in env, "hidden field leaked on the wire"
+            assert secret not in view_bytes, "hidden field leaked to partial tier"
+
+    async def test_denied_tier_raises_with_verifiable_receipt(self) -> None:
+        alice, _, _, mallory = _fleet(StaticTrust(_SCORES))
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        with pytest.raises(TrustDeniedError) as excinfo:
+            await mallory.decrypt(env)
+        receipt = excinfo.value.receipt
+        assert receipt is not None
+        assert receipt["s"] == DENIAL_SCHEME
+        assert receipt["agent"] == "mallory"
+        assert receipt["score"] == 0.1
+        assert receipt["threshold"] == alice.policy.partial
+        assert alice.verify_denial(receipt)
+
+    async def test_outsider_is_not_in_audience(self) -> None:
+        trust = StaticTrust(_SCORES)
+        alice, _, _, _ = _fleet(trust)
+        eve = _mk("eve", trust)
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        with pytest.raises(NotInAudienceError):
+            await eve.decrypt(env)
+
+    async def test_threshold_boundaries_are_inclusive(self) -> None:
+        trust = StaticTrust({"bob": 0.8, "carol": 0.5, "mallory": 0.4999})
+        alice, bob, carol, mallory = _fleet(trust)
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        assert await bob.decrypt(env) == _PAYLOAD, "score == full threshold must be full tier"
+        view = _view_of(await carol.decrypt(env))
+        assert view["kind"] == "selective", "score == partial threshold must be partial tier"
+        with pytest.raises(TrustDeniedError):
+            await mallory.decrypt(env)
+
+    async def test_opaque_payload_partial_tier_gets_honest_digest(self) -> None:
+        import hashlib
+
+        alice, _, carol, _ = _fleet(StaticTrust(_SCORES))
+        opaque = b"\x00\x01binary-blob\xff"
+        env = await alice.encrypt(opaque, _AUDIENCE)
+        view = _view_of(await carol.decrypt(env))
+        assert view["kind"] == "digest"
+        assert view["sha256"] == hashlib.sha256(opaque).hexdigest()
+        assert view["size"] == len(opaque)
+        assert opaque not in env
+
+    async def test_integrates_with_reference_score_average_trust(self) -> None:
+        trust = ScoreAverageTrust()
+        for _ in range(10):
+            await trust.report(
+                AgentId("bob"),
+                Evidence(reporter=AgentId("boss"), subject=AgentId("bob"), kind="positive"),
+            )
+            await trust.report(
+                AgentId("mallory"),
+                Evidence(reporter=AgentId("boss"), subject=AgentId("mallory"), kind="negative"),
+            )
+        alice, bob, carol, mallory = _fleet(trust)
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        assert await bob.decrypt(env) == _PAYLOAD  # mean 1.0 -> full
+        view = _view_of(await carol.decrypt(env))  # unknown agent -> 0.5 -> partial
+        assert view["s"] == PARTIAL_SCHEME
+        with pytest.raises(TrustDeniedError):  # mean 0.0 -> denied
+            await mallory.decrypt(env)
+
+    def test_policy_validation_rejects_nonsense(self) -> None:
+        with pytest.raises(ValueError, match="tier policy"):
+            TierPolicy(full=0.4, partial=0.6)
+        with pytest.raises(ValueError, match="tier policy"):
+            TierPolicy(full=1.2, partial=0.5)
+        with pytest.raises(ValueError, match="tier policy"):
+            TierPolicy(full=0.8, partial=-0.1)
+
+
+# ---------------------------------------------------------------------------
+# 2. Discrimination: the gate invariant vs. the existing reference plugins
+# ---------------------------------------------------------------------------
+
+
+async def _low_trust_reader_blocked(
+    sender: Privacy, low_trust_reader: Privacy, payload: bytes, audience: list[AgentId]
+) -> bool:
+    """The gate invariant: an audience member below the trust floor must not
+    recover the plaintext, and the plaintext must not ride the wire in clear."""
+    envelope = await sender.encrypt(payload, audience)
+    if payload in envelope:
+        return False
+    try:
+        recovered = await low_trust_reader.decrypt(envelope)
+    except Exception:  # noqa: BLE001 - any refusal satisfies the invariant
+        return True
+    return recovered != payload
+
+
+class TestGateInvariantDiscrimination:
+    """The check that FAILS without this plugin and PASSES with it."""
+
+    async def test_noop_fails_the_gate_invariant(self) -> None:
+        noop = NoopPrivacy()
+        assert not await _low_trust_reader_blocked(noop, noop, _PAYLOAD, [AgentId("mallory")]), (
+            "noop must fail: it hands every byte to everyone"
+        )
+
+    async def test_hybrid_x25519_fails_the_gate_invariant(self) -> None:
+        alice = HybridX25519Privacy(AgentId("alice"), seed=b"alice", deterministic=True)
+        mallory = HybridX25519Privacy(AgentId("mallory"), seed=b"mallory", deterministic=True)
+        alice.register_peer(AgentId("mallory"), mallory.public_key)
+        assert not await _low_trust_reader_blocked(
+            alice, mallory, _PAYLOAD, [AgentId("mallory")]
+        ), "hybrid_x25519 must fail: it is deliberately trust-blind"
+
+    async def test_trust_gated_passes_the_gate_invariant(self) -> None:
+        alice, _, _, mallory = _fleet(StaticTrust(_SCORES))
+        assert await _low_trust_reader_blocked(alice, mallory, _PAYLOAD, [AgentId("mallory")])
+
+
+# ---------------------------------------------------------------------------
+# 3. Byzantine behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestByzantineTrust:
+    async def test_poisoned_scores_fail_closed(self) -> None:
+        for poison in (math.nan, math.inf, -math.inf, 2.0, -3.0):
+            trust = StaticTrust({"bob": poison})
+            alice, bob, _, _ = _fleet(trust)
+            env = await alice.encrypt(_PAYLOAD, [AgentId("bob")])
+            with pytest.raises(TrustDeniedError) as excinfo:
+                await bob.decrypt(env)
+            receipt = excinfo.value.receipt
+            assert receipt is not None
+            assert receipt["score"] == -1.0, f"poison {poison!r} must record the sentinel"
+            assert _PAYLOAD not in env
+
+    async def test_gate_table_tamper_detected(self) -> None:
+        trust = StaticTrust(_SCORES)
+        alice, _, _, _ = _fleet(trust)
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        obj = cast("dict[str, Any]", json.loads(env))
+        for entry in cast("list[dict[str, Any]]", obj["gate"]):
+            if entry["agent"] == "mallory":
+                entry["tier"] = "full"
+                entry["score"] = 0.99
+        forged = json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        fresh_bob = _mk("bob", trust)  # same keys, empty replay set
+        with pytest.raises(TamperError):
+            await fresh_bob.decrypt(forged)
+
+    async def test_policy_tamper_detected(self) -> None:
+        trust = StaticTrust(_SCORES)
+        alice, _, _, _ = _fleet(trust)
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        obj = cast("dict[str, Any]", json.loads(env))
+        cast("dict[str, Any]", obj["policy"])["partial"] = 0.0
+        forged = json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        fresh_bob = _mk("bob", trust)
+        with pytest.raises(TamperError):
+            await fresh_bob.decrypt(forged)
+
+    async def test_tier_blob_swap_never_yields_plaintext(self) -> None:
+        trust = StaticTrust(_SCORES)
+        alice, _, _, _ = _fleet(trust)
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        obj = cast("dict[str, Any]", json.loads(env))
+        obj["full"], obj["partial"] = obj["partial"], obj["full"]
+        swapped = json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        for name in ("bob", "carol"):
+            reader = _mk(name, trust)
+            with pytest.raises(MalformedEnvelopeError):
+                await reader.decrypt(swapped)
+
+    async def test_forged_denial_receipts_rejected(self) -> None:
+        alice, _, _, mallory = _fleet(StaticTrust(_SCORES))
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        with pytest.raises(TrustDeniedError) as excinfo:
+            await mallory.decrypt(env)
+        receipt = excinfo.value.receipt
+        assert receipt is not None
+        for field, forged_value in (
+            ("score", 0.99),
+            ("agent", "bob"),
+            ("threshold", 0.0),
+            ("epoch", 42),
+        ):
+            forged = dict(receipt)
+            forged[field] = forged_value
+            assert not alice.verify_denial(forged), f"forged {field} accepted"
+
+    async def test_replay_rejected(self) -> None:
+        alice, bob, _, _ = _fleet(StaticTrust(_SCORES))
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        assert await bob.decrypt(env) == _PAYLOAD
+        with pytest.raises(ReplayError):
+            await bob.decrypt(env)
+
+    async def test_tampered_proof_fails_verification(self) -> None:
+        alice, _, carol, _ = _fleet(StaticTrust(_SCORES))
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        view = _view_of(await carol.decrypt(env))
+        statement, proof = _proof_from_view(view)
+        body = cast("dict[str, Any]", json.loads(proof.data))
+        disclosed = cast("dict[str, dict[str, Any]]", body["disclosed"])
+        disclosed["dept"]["value"] = "engineering"
+        tampered = Proof(
+            statement=statement,
+            data=json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8"),
+            scheme=PROOF_SCHEME,
+        )
+        assert not await carol.verify_proof(statement, tampered)
+
+    async def test_identity_signed_receipts(self) -> None:
+        identity = StubIdentity(AgentId("alice"), secret=b"alice-signing-secret")
+        alice, _, _, mallory = _fleet(StaticTrust(_SCORES), identity=identity)
+        env = await alice.encrypt(_PAYLOAD, _AUDIENCE)
+        with pytest.raises(TrustDeniedError) as excinfo:
+            await mallory.decrypt(env)
+        receipt = excinfo.value.receipt
+        assert receipt is not None
+        assert receipt["alg"] == "hmac-test"
+        assert alice.verify_denial(receipt)
+        forged = dict(receipt)
+        forged["score"] = 0.99
+        assert not alice.verify_denial(forged)
+
+
+# ---------------------------------------------------------------------------
+# 4. Determinism, registry, protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminismAndWiring:
+    async def test_envelopes_are_byte_deterministic(self) -> None:
+        envs: list[bytes] = []
+        for _ in range(2):
+            alice, _, _, _ = _fleet(StaticTrust(_SCORES))
+            envs.append(await alice.encrypt(_PAYLOAD, _AUDIENCE))
+        assert envs[0] == envs[1], "same seed + trust must yield byte-identical envelopes"
+
+    async def test_different_seeds_yield_different_envelopes(self) -> None:
+        trust = StaticTrust(_SCORES)
+        alice_a, _, _, _ = _fleet(trust)
+        alice_b = TrustGatedPrivacy(
+            AgentId("alice"), trust, seed=b"other", deterministic=True, reveal_fields=_REVEAL
+        )
+        bob = _mk("bob", trust)
+        alice_b.register_peer(AgentId("bob"), bob.public_key)
+        env_a = await alice_a.encrypt(_PAYLOAD, [AgentId("bob")])
+        env_b = await alice_b.encrypt(_PAYLOAD, [AgentId("bob")])
+        assert env_a != env_b
+
+    def test_registry_resolves_trust_gated(self) -> None:
+        cls = PluginRegistry().resolve("privacy", "trust_gated")
+        assert cls is TrustGatedPrivacy
+
+    def test_satisfies_privacy_protocol(self) -> None:
+        plugin = _mk("alice", StaticTrust())
+        assert isinstance(plugin, Privacy)
+
+
+# ---------------------------------------------------------------------------
+# 5. Adversarial validators: PASS vs trust_gated, FAIL vs noop AND hybrid_x25519
+# ---------------------------------------------------------------------------
+
+
+def _hybrid_pair(reader_name: str) -> tuple[HybridX25519Privacy, HybridX25519Privacy]:
+    """A wired (sender, reader) pair of trust-blind hybrid plugins."""
+    sender = HybridX25519Privacy(AgentId("alice"), seed=b"alice", deterministic=True)
+    reader = HybridX25519Privacy(
+        AgentId(reader_name), seed=reader_name.encode("utf-8"), deterministic=True
+    )
+    sender.register_peer(AgentId(reader_name), reader.public_key)
+    return sender, reader
+
+
+class TestAdversarialValidators:
+    """Charter bar: each check fails vs BOTH reference plugins, passes vs ours."""
+
+    async def test_low_trust_blocked_discriminates(self) -> None:
+        alice, _, _, mallory = _fleet(StaticTrust(_SCORES))
+        assert (
+            await check_low_trust_blocked(
+                alice, mallory, payload=_PAYLOAD, audience=[AgentId("mallory")]
+            )
+        ).passed
+        noop = NoopPrivacy()
+        assert not (
+            await check_low_trust_blocked(
+                noop, noop, payload=_PAYLOAD, audience=[AgentId("mallory")]
+            )
+        ).passed
+        h_sender, h_reader = _hybrid_pair("mallory")
+        assert not (
+            await check_low_trust_blocked(
+                h_sender, h_reader, payload=_PAYLOAD, audience=[AgentId("mallory")]
+            )
+        ).passed
+
+    async def test_partial_redaction_discriminates(self) -> None:
+        hidden = [_HIDDEN_1.encode(), _HIDDEN_2.encode()]
+        alice, _, carol, _ = _fleet(StaticTrust(_SCORES))
+        assert (
+            await check_partial_redaction_enforced(
+                alice, carol, payload=_PAYLOAD, audience=_AUDIENCE, hidden=hidden
+            )
+        ).passed
+        noop = NoopPrivacy()
+        assert not (
+            await check_partial_redaction_enforced(
+                noop, noop, payload=_PAYLOAD, audience=[AgentId("carol")], hidden=hidden
+            )
+        ).passed
+        h_sender, h_reader = _hybrid_pair("carol")
+        assert not (
+            await check_partial_redaction_enforced(
+                h_sender, h_reader, payload=_PAYLOAD, audience=[AgentId("carol")], hidden=hidden
+            )
+        ).passed
+
+    async def test_gate_tamper_discriminates(self) -> None:
+        trust = StaticTrust(_SCORES)
+        alice, _, _, _ = _fleet(trust)
+        fresh_bob = _mk("bob", trust)
+        assert (
+            await check_gate_tamper_rejected(
+                alice, fresh_bob, payload=_PAYLOAD, audience=_AUDIENCE, upgrade_agent="mallory"
+            )
+        ).passed
+        noop = NoopPrivacy()
+        assert not (
+            await check_gate_tamper_rejected(
+                noop, noop, payload=_PAYLOAD, audience=[AgentId("bob")], upgrade_agent="mallory"
+            )
+        ).passed
+        h_sender, h_reader = _hybrid_pair("bob")
+        assert not (
+            await check_gate_tamper_rejected(
+                h_sender,
+                h_reader,
+                payload=_PAYLOAD,
+                audience=[AgentId("bob")],
+                upgrade_agent="mallory",
+            )
+        ).passed
+
+    async def test_denial_receipt_discriminates(self) -> None:
+        alice, _, _, mallory = _fleet(StaticTrust(_SCORES))
+        assert (
+            await check_denial_receipt_auditable(
+                alice, mallory, payload=_PAYLOAD, audience=_AUDIENCE
+            )
+        ).passed
+        noop = NoopPrivacy()
+        assert not (
+            await check_denial_receipt_auditable(
+                noop, noop, payload=_PAYLOAD, audience=[AgentId("mallory")]
+            )
+        ).passed
+        # hybrid refuses the outsider but silently: no receipt, nothing to audit.
+        h_sender, _ = _hybrid_pair("bob")
+        h_outsider = HybridX25519Privacy(AgentId("mallory"), seed=b"mallory", deterministic=True)
+        assert not (
+            await check_denial_receipt_auditable(
+                h_sender, h_outsider, payload=_PAYLOAD, audience=[AgentId("bob")]
+            )
+        ).passed

--- a/packages/nest-plugins-reference/tests/test_trust_gated_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_trust_gated_scenario.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Full-simulator integration for the ``trust_gated`` privacy layer.
+
+Boots ``scenarios/trust_gated_exchange.yaml`` through the real
+:class:`~nest_core.runner.ScenarioRunner` to prove the plugin integrates into
+an end-to-end run without breaking the simulator, and that the run stays
+deterministic under replay (Tier-1). The tier *mechanics* and adversarial
+validators are exercised directly in ``test_trust_gated.py``; here we verify
+the plugin is discoverable and simulator-safe.
+
+Example::
+
+    pytest packages/nest-plugins-reference/tests/test_trust_gated_scenario.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_plugins_reference.privacy.trust_gated import TrustGatedPrivacy
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "trust_gated_exchange.yaml"
+
+
+def test_privacy_layer_resolves_to_trust_gated_plugin() -> None:
+    """The registry discovers ``trust_gated`` via the built-in map / entry point."""
+    cls = PluginRegistry().resolve("privacy", "trust_gated")
+    assert cls is TrustGatedPrivacy
+
+
+@pytest.mark.parametrize("seed", [42, 7])
+def test_scenario_boots_and_runs(seed: int) -> None:
+    """The scenario wiring the trust-gated privacy layer runs to completion."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    assert config.layers.privacy == "trust_gated"
+    config = config.model_copy(update={"seed": seed})
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"gated_{seed}.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        result = asyncio.run(runner.run())
+        assert result.exists()
+        assert result.stat().st_size > 0
+
+
+def test_scenario_is_deterministic_under_replay() -> None:
+    """Two seed-42 runs produce byte-identical traces (Tier-1 reproducibility)."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+
+    def run_once() -> bytes:
+        config = ScenarioConfig.from_yaml(str(SCENARIO_PATH)).model_copy(update={"seed": 42})
+        with tempfile.TemporaryDirectory() as tmp:
+            trace_path = Path(tmp) / "gated_replay.jsonl"
+            config = config.model_copy(
+                update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+            )
+            runner = ScenarioRunner(config, registry=PluginRegistry())
+            result = asyncio.run(runner.run())
+            return result.read_bytes()
+
+    assert run_once() == run_once()

--- a/scenarios/trust_gated_exchange.yaml
+++ b/scenarios/trust_gated_exchange.yaml
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Marketplace data exchange with a TRUST-GATED privacy layer.
+#
+# Identical to the `sealed_bid_with_privacy` wiring except the privacy layer
+# is `trust_gated` instead of `hybrid_x25519`. Where `hybrid_x25519` gives
+# every listed recipient the full plaintext (it is deliberately trust-blind),
+# `trust_gated` composes the same hybrid encryption with the live trust layer:
+# high-trust recipients decrypt everything, mid-trust recipients get a
+# redacted selectively-disclosed view, and low-trust recipients are refused
+# with a signed denial receipt.
+#
+# This file wires the capability into a full simulator run (see
+# `tests/test_trust_gated_scenario.py`, which boots it, asserts the layer
+# resolves to `TrustGatedPrivacy`, and checks the run is deterministic). The
+# tier *mechanics* — full/partial/denied disclosure under a shared trust feed,
+# plus the four adversarial validators — are exercised end-to-end in
+# `tests/test_trust_gated.py`.
+name: trust_gated_exchange
+description: "1 auctioneer and 7 bidders; disclosure gated per-recipient by live trust scores."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 8
+  brain: state-machine
+  roles:
+    - name: auctioneer
+      count: 1
+    - name: bidder
+      count: 7
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: trust_gated
+  datafacts: datafacts_v1
+
+task:
+  type: auction
+  config:
+    rounds: 3
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/trust_gated_exchange.jsonl


### PR DESCRIPTION
## Problem

The merged `hybrid_x25519` plugin (#28) answers *who* can read with a static, all-or-nothing audience — it is deliberately trust-blind. Meanwhile the trust layer computes reputation scores that no privacy plugin consumes. The two layers that most obviously belong together — *how much do I trust you* and *how much may you see* — are not connected anywhere in the stack. This PR connects them.

## Design

`("privacy", "trust_gated")` **composes** `hybrid_x25519` (re-implements **no** cryptography) with a live `Trust` feed. Per recipient, at encrypt time:

| Trust score | Tier | Recipient gets |
|---|---|---|
| >= 0.8 | full | complete plaintext (inner hybrid envelope #1) |
| 0.5 - 0.8 | partial | redacted view with salted-Merkle selective-disclosure proofs (inner envelope #2); opaque payloads get an honest SHA-256 commitment, never a pretend proof |
| < 0.5 | denied | no wrap entry anywhere — the cryptography enforces the gate; refusal carries a **signed denial receipt** naming score and threshold |

The gate table (agent → tier → score) is digest-sealed **inside** every AEAD-authenticated inner plaintext, so a doctored gate cannot be re-attached to real ciphertexts (`TamperError`). Poisoned trust scores (NaN/±inf/out-of-range) **fail closed** to denied. `deterministic=True` yields byte-identical Tier-1 traces.

## Adversarial validators (mandatory artifact)

`validators/trust_gate_validators.py` — four attack classes: **low-trust exfiltration, partial-tier overexposure, gate laundering** (via the `forge_tier_upgrade` helper), **silent denial**. Each check **fails against `noop` AND against `hybrid_x25519`** and passes against `trust_gated` — one notch above the charter bar, which only requires beating the default plugin. Scenario: `scenarios/trust_gated_exchange.yaml`, with a ScenarioRunner integration test proving byte-identical traces under seed replay.

## Results (measured, not simulated)

200 structured payloads (2 sensitive fields), audience trust 0.9 / 0.6 / 0.1:

| Plugin | Low-trust plaintext reads | Mid-trust hidden-field exposures | Auditable denials | Mean envelope | enc + 3×dec |
|---|---|---|---|---|---|
| `noop` | 200/200 | 200/200 | 0 | 82 B | ~0 ms |
| `hybrid_x25519` | 200/200 | 200/200 | 0 | 676 B | 0.76 ms |
| `trust_gated` | **0/200** | **0/200** | **200/200** | 3 558 B | 1.32 ms |

## Tradeoffs (full list in `docs/layers/trust_gated_privacy.md`)

- Gate-time trust, not read-time: a recipient whose score later collapses keeps envelopes it already received (same future-only stance as `hybrid_x25519` revocation; pair with `revoke()`).
- HMAC receipts are sender-verifiable only; supply an `Identity` for third-party verification.
- Merkle commitments, not ZK circuits (full zk-SNARKs are out of scope per the problem brief).
- ~5× envelope size vs plain `hybrid_x25519` for a 3-tier audience.

## Verification

Whole-repo `make ci-local` green: `uv sync`, `ruff check`, `ruff format --check`, `pyright` (strict), `pytest` — **977 passed**. 36 tests for this plugin: disclosure tiers (incl. inclusive boundaries and integration with the reference `score_average` trust plugin), discrimination invariant vs both reference plugins, Byzantine behaviour (poisoned scores, gate tamper, policy tamper, tier-blob swap, receipt forgery, replay, tampered proofs), byte-determinism, registry resolution via both `_BUILTINS` and the `nest.plugins.privacy` entry point, and full-simulator scenario integration.

```bash
uv run pytest packages/nest-plugins-reference/tests/test_trust_gated.py \
              packages/nest-plugins-reference/tests/test_trust_gated_scenario.py -v
uv run nest run trust_gated_exchange
```