### PR TITLE
[Hackathon] auth-engineer: delegatable capability tokens with cascading revocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ for r in validate_trace(Path("traces/auction.jsonl"), "auction"):
 | Supply chain | Delivered goods trace through all four hops; no materials lost. |
 | Reputation | Cheaters get bad reports; agents with score ≤ −3 are warned. |
 | Marketplace | No double-sell (same product to two buyers); every buy answered; sold price matches the offer. |
+| Delegated auth | Delegated scopes ⊆ the parent's (attenuation); no token verifies after an ancestor is revoked (cascading revocation); presenter must equal the token's audience. |
 
 > **Important.** Validators are property *checks*, not blessings of the
 > bundled scenarios. They inspect trace evidence and can still only verify

--- a/docs/layers/auth.md
+++ b/docs/layers/auth.md
@@ -21,6 +21,26 @@ shape (header.payload.sig), no claim validation beyond the signature.
 
 Source: [`nest_plugins_reference/auth/jwt_auth.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/jwt_auth.py).
 
+## Delegation plugin
+
+`delegatable` — macaroon-style capability tokens (Birgisson et al., 2014).
+Implements the two things `jwt` cannot: **capability delegation** and
+**revocation propagation**. A token carries its whole delegation chain plus one
+running HMAC signature (`s_i = HMAC(s_{i-1}, link_i)`), so any holder can mint a
+narrowed, shorter-lived sub-token for another agent *without the issuer*, and
+revoking a parent link's id invalidates every descendant at the next verify —
+no per-child revocation list.
+
+Adds `delegate(parent, audience, scopes_subset, ttl)` on top of the base `Auth`
+contract; `verify` takes an optional `presenter` (audience binding) and
+`context` (first-party caveats). Delegation is attenuation-only: child scopes
+must be a subset of the parent's and child TTL must be ≤ the parent's.
+
+Source: [`nest_plugins_reference/auth/delegatable.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py).
+Demo scenario: [`scenarios/delegated_auth.yaml`](../../scenarios/delegated_auth.yaml)
+with the `delegated_auth` validators (scope escalation, cascading revocation,
+audience binding).
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -26,6 +26,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
+    ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -145,3 +145,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("rogue_trusted_agent", rogue_trusted_agent_factory)
+    elif name == "delegated_auth":
+        from nest_core.scenarios_builtin.delegated_auth import (
+            delegated_auth_factory,
+        )
+
+        register_scenario("delegated_auth", delegated_auth_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
@@ -1,0 +1,387 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegated-auth scenario -- a coordinator, 3 intermediaries, 12 leaf agents.
+
+Drives the ``delegatable`` auth plugin through a real delegation tree and three
+adversarial probes, emitting one structured ``authz:<kind>:<fields>`` broadcast
+per lifecycle event. The three ``delegated_auth`` validators (see
+:mod:`nest_core.validators`) read those broadcasts and confirm:
+
+* every delegated token's scopes are a subset of its parent's (attenuation);
+* no token verifies OK once an ancestor has been revoked (cascading revocation);
+* no token verifies OK when presented by an agent that is not its audience
+  (audience binding).
+
+Flow (all timings are logical sim ticks; the auth clock is *fixed* so tokens are
+byte-identical across replays):
+
+* The coordinator issues a root token and delegates a narrowed token to each of
+  the three intermediaries.
+* Each intermediary delegates a further-narrowed token to its four leaves, which
+  verify and report ``authz:verified:result=ok``.
+* ``intermediary-0`` runs two live attacks the plugin rejects: a **scope
+  escalation** (delegating a scope it does not hold) and an **audience
+  confusion** (handing ``leaf-0``'s token to ``leaf-1``, which tries to present
+  it).
+* The coordinator **revokes** ``intermediary-2``; every leaf re-verifies later,
+  and the four under ``intermediary-2`` now fail with a revoked ancestor.
+* The coordinator presents a pre-minted **expired** token to exercise the
+  time-expiry branch deterministically.
+
+If the configured auth plugin lacks ``delegate`` (e.g. the default ``jwt``),
+the agents skip the entire tree, no ``authz:delegated`` / ``authz:verified``
+events reach the trace, and the validators report "no delegation observed" --
+exactly the adversarial discrimination the charter asks for.
+
+Example::
+
+    agents = delegated_auth_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId
+
+# Fixed auth clock -- every issued/delegated token gets deterministic iat/exp.
+_CLOCK = 100.0
+_SECRET = b"delegated-auth-scenario-secret"
+
+# Logical tick schedule. Delegation cascades at BOOT via zero-latency sends;
+# revocation and re-verification are spaced strictly after it so ordering in
+# the trace is unambiguous.
+_TICK_BOOT = 1.0
+_TICK_REVOKE = 5.0
+_TICK_STALE = 6.0
+_TICK_RECHECK = 8.0
+
+# Attenuating scope sets: root -> intermediary -> leaf, each a strict subset.
+_ROOT_SCOPES = ["read", "write", "exec"]
+_MID_SCOPES = ["read", "write"]
+_LEAF_SCOPES = ["read"]
+
+_MID_TTL = 500.0  # intermediary exp = 600 (<= root exp)
+_LEAF_TTL = 200.0  # leaf exp = 300 (<= intermediary exp)
+
+# Control-message opcodes (point-to-point). Prefixed so agents ignore the
+# ``authz:*`` broadcasts that also arrive in ``on_message``.
+_GRANT = b"grant"
+_IMPERSONATE = b"impersonate"
+_OP_BOOT = b"op:boot"
+_OP_REVOKE = b"op:revoke"
+_OP_STALE = b"op:stale"
+_OP_RECHECK = b"op:recheck"
+
+_REVOKED_INTERMEDIARY = "intermediary-2"
+
+
+def _emit(fields: dict[str, str]) -> bytes:
+    """Build a structured ``authz:<kind>:k=v:...`` broadcast payload.
+
+    Scope lists are ``|``-joined so no value contains the ``:`` or ``=``
+    separators the validator parser splits on.
+    """
+    kind = fields.pop("kind")
+    body = ":".join(f"{k}={v}" for k, v in fields.items())
+    return (f"authz:{kind}:{body}" if body else f"authz:{kind}").encode()
+
+
+def _supports_delegation(auth: Any) -> bool:
+    """Whether the resolved auth plugin is delegatable (has ``delegate``)."""
+    return hasattr(auth, "delegate")
+
+
+class CoordinatorAgent(StateMachineAgent):
+    """Root of trust: issues the root token and delegates to intermediaries.
+
+    Also drives the two coordinator-owned probes -- revoking
+    ``intermediary-2`` (cascading revocation) and presenting a pre-minted
+    expired token (time-expiry).
+
+    Example::
+
+        agent = CoordinatorAgent(AgentId("coordinator"), ["intermediary-0"], stale_token=None)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        intermediaries: list[AgentId],
+        auth_cls: Any,
+    ) -> None:
+        self._id = agent_id
+        self._intermediaries = intermediaries
+        self._auth_cls = auth_cls
+        self._root: str | None = None
+        self._mid_tokens: dict[str, str] = {}
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        await ctx.schedule(_TICK_BOOT, _OP_BOOT)
+        await ctx.schedule(_TICK_REVOKE, _OP_REVOKE)
+        await ctx.schedule(_TICK_STALE, _OP_STALE)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        auth = ctx.plugins["auth"]
+        if payload == _OP_BOOT:
+            await self._boot(ctx, auth)
+        elif payload == _OP_REVOKE:
+            await self._revoke(ctx, auth)
+        elif payload == _OP_STALE:
+            await self._present_stale(ctx, auth)
+
+    async def _boot(self, ctx: AgentContext, auth: Any) -> None:
+        root = await auth.issue(self._id, _ROOT_SCOPES)
+        self._root = str(root)
+        await ctx.broadcast(
+            _emit(
+                {
+                    "kind": "issued",
+                    "holder": str(self._id),
+                    "scopes": "|".join(_ROOT_SCOPES),
+                }
+            )
+        )
+        if not _supports_delegation(auth):
+            return  # default jwt: no delegation surface -> tree never forms.
+        for mid in self._intermediaries:
+            child = await auth.delegate(root, mid, _MID_SCOPES, _MID_TTL)
+            self._mid_tokens[str(mid)] = str(child)
+            await ctx.broadcast(
+                _emit(
+                    {
+                        "kind": "delegated",
+                        "by": str(self._id),
+                        "aud": str(mid),
+                        "parent": str(self._id),
+                        "scopes": "|".join(_MID_SCOPES),
+                    }
+                )
+            )
+            await ctx.send(mid, _GRANT + b"|" + child.encode())
+
+    async def _revoke(self, ctx: AgentContext, auth: Any) -> None:
+        token = self._mid_tokens.get(_REVOKED_INTERMEDIARY)
+        if token is None:
+            return
+        await auth.revoke(token)
+        await ctx.broadcast(
+            _emit({"kind": "revoked", "by": str(self._id), "aud": _REVOKED_INTERMEDIARY})
+        )
+
+    async def _present_stale(self, ctx: AgentContext, auth: Any) -> None:
+        if not _supports_delegation(auth):
+            return
+        stale_token = await self._mint_stale_token()
+        if stale_token is None:
+            return
+        try:
+            await auth.verify(stale_token, presenter=self._id)
+        except Exception as exc:  # noqa: BLE001 -- report any rejection class
+            await ctx.broadcast(
+                _emit(
+                    {
+                        "kind": "denied",
+                        "by": str(self._id),
+                        "attack": "expired_parent",
+                        "reason": type(exc).__name__,
+                    }
+                )
+            )
+
+    async def _mint_stale_token(self) -> str | None:
+        """Pre-mint an already-expired delegated token via a past-clock instance.
+
+        The throwaway instance shares ``_SECRET`` (so the signature verifies
+        under the live clock) but sits far enough in the past that both links'
+        ``exp`` are below ``_CLOCK`` -- making the time-expiry attack
+        deterministic without moving any clock.
+        """
+        try:
+            stale = self._auth_cls(secret=_SECRET, clock=10.0, default_ttl=20.0)
+        except TypeError:
+            return None
+        if not _supports_delegation(stale):
+            return None
+        root = await stale.issue(AgentId("stale-root"), _MID_SCOPES)
+        child = await stale.delegate(root, self._id, _LEAF_SCOPES, 10.0)
+        return str(child)
+
+
+class IntermediaryAgent(StateMachineAgent):
+    """Delegates a narrowed token to each of its leaves; optionally runs attacks.
+
+    ``intermediary-0`` additionally probes scope escalation and audience
+    confusion, both of which the plugin must reject.
+
+    Example::
+
+        agent = IntermediaryAgent(AgentId("intermediary-0"), ["leaf-0"], attacker=True)
+    """
+
+    def __init__(self, agent_id: AgentId, leaves: list[AgentId], attacker: bool) -> None:
+        self._id = agent_id
+        self._leaves = leaves
+        self._attacker = attacker
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        if not payload.startswith(_GRANT + b"|"):
+            return
+        auth = ctx.plugins["auth"]
+        my_token = payload[len(_GRANT) + 1 :].decode()
+        first_leaf_token: str | None = None
+        for leaf in self._leaves:
+            child = await auth.delegate(my_token, leaf, _LEAF_SCOPES, _LEAF_TTL)
+            if first_leaf_token is None:
+                first_leaf_token = str(child)
+            await ctx.broadcast(
+                _emit(
+                    {
+                        "kind": "delegated",
+                        "by": str(self._id),
+                        "aud": str(leaf),
+                        "parent": str(self._id),
+                        "scopes": "|".join(_LEAF_SCOPES),
+                    }
+                )
+            )
+            await ctx.send(leaf, _GRANT + b"|" + child.encode())
+        if self._attacker:
+            await self._attack(ctx, auth, my_token, first_leaf_token)
+
+    async def _attack(
+        self,
+        ctx: AgentContext,
+        auth: Any,
+        my_token: str,
+        first_leaf_token: str | None,
+    ) -> None:
+        # Attack 1 -- scope escalation: delegate a scope not held by this token.
+        try:
+            await auth.delegate(my_token, AgentId("phantom"), ["exec"], _LEAF_TTL)
+        except Exception as exc:  # noqa: BLE001
+            await ctx.broadcast(
+                _emit(
+                    {
+                        "kind": "denied",
+                        "by": str(self._id),
+                        "attack": "scope_escalation",
+                        "reason": type(exc).__name__,
+                    }
+                )
+            )
+        # Attack 2 -- audience confusion: hand leaf-0's token to leaf-1.
+        if first_leaf_token is not None and len(self._leaves) >= 2:
+            await ctx.send(self._leaves[1], _IMPERSONATE + b"|" + first_leaf_token.encode())
+
+
+class LeafAgent(StateMachineAgent):
+    """Verifies its granted token, re-verifies after revocation, resists replay.
+
+    On the honest path it reports ``authz:verified:result=ok``. If handed a
+    foreign token it reports ``authz:denied:attack=audience_confusion``. On the
+    scheduled recheck, a leaf whose intermediary was revoked reports
+    ``authz:denied:attack=revoked_parent``.
+
+    Example::
+
+        agent = LeafAgent(AgentId("leaf-0"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+        self._token: str | None = None
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        auth = ctx.plugins["auth"]
+        if payload.startswith(_GRANT + b"|"):
+            self._token = payload[len(_GRANT) + 1 :].decode()
+            await self._verify(ctx, auth, self._token, attack=None)
+            await ctx.schedule(_TICK_RECHECK - ctx.time, _OP_RECHECK)
+        elif payload.startswith(_IMPERSONATE + b"|"):
+            foreign = payload[len(_IMPERSONATE) + 1 :].decode()
+            await self._verify(ctx, auth, foreign, attack="audience_confusion")
+        elif payload == _OP_RECHECK and self._token is not None:
+            await self._verify(ctx, auth, self._token, attack="revoked_parent")
+
+    async def _verify(
+        self,
+        ctx: AgentContext,
+        auth: Any,
+        token: str,
+        attack: str | None,
+    ) -> None:
+        try:
+            authctx = await auth.verify(token, presenter=self._id)
+        except Exception as exc:  # noqa: BLE001
+            await ctx.broadcast(
+                _emit(
+                    {
+                        "kind": "denied",
+                        "by": str(self._id),
+                        "attack": attack or "verify",
+                        "presenter": str(self._id),
+                        "reason": type(exc).__name__,
+                    }
+                )
+            )
+            return
+        await ctx.broadcast(
+            _emit(
+                {
+                    "kind": "verified",
+                    "by": str(self._id),
+                    "aud": str(authctx.subject),
+                    "presenter": str(self._id),
+                    "result": "ok",
+                }
+            )
+        )
+
+
+def delegated_auth_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Build the 16-agent delegation tree and wire one shared auth instance.
+
+    Every agent receives the *same* ``DelegatableAuth`` instance (fixed clock,
+    shared secret + revoked set) via the ``_agent_plugins`` override channel, so
+    a revocation on the coordinator's instance is visible to every leaf's
+    verify. For a non-delegatable auth class the shared instance is still wired,
+    but the agents detect the missing ``delegate`` surface and the tree never
+    forms.
+
+    Example::
+
+        agents = delegated_auth_factory(config, plugins)
+    """
+    auth_cls = plugins["auth"]
+    shared_revoked: set[str] = set()
+    try:
+        shared_auth = auth_cls(secret=_SECRET, clock=_CLOCK, revoked=shared_revoked)
+    except TypeError:
+        # Non-delegatable auth (e.g. jwt) -- best-effort shared instance.
+        try:
+            shared_auth = auth_cls(secret=_SECRET, clock=_CLOCK)
+        except TypeError:
+            shared_auth = auth_cls()
+
+    intermediaries = [AgentId(f"intermediary-{i}") for i in range(3)]
+    agents: dict[AgentId, StateMachineAgent] = {}
+
+    coordinator_id = AgentId("coordinator")
+    agents[coordinator_id] = CoordinatorAgent(coordinator_id, intermediaries, auth_cls=auth_cls)
+
+    leaf_index = 0
+    for i, mid in enumerate(intermediaries):
+        leaves = [AgentId(f"leaf-{leaf_index + k}") for k in range(4)]
+        leaf_index += 4
+        agents[mid] = IntermediaryAgent(mid, leaves, attacker=(i == 0))
+        for leaf in leaves:
+            agents[leaf] = LeafAgent(leaf)
+
+    overrides: dict[AgentId, dict[str, Any]] = {aid: {"auth": shared_auth} for aid in agents}
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -3036,6 +3036,214 @@ def validate_escrow_no_payout_without_delivery(
     ]
 
 
+# ---------------------------------------------------------------------------
+# Delegated-auth validators (adversarial)
+# ---------------------------------------------------------------------------
+
+
+def _parse_authz_events(
+    events: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    """Parse trace broadcasts of the form ``authz:<kind>:k=v:k=v...``.
+
+    Returns one dict per matching event, in trace (emission) order, with
+    ``kind``, the broadcasting ``agent``, and the parsed ``key=value`` fields.
+    Only sender-recorded ``broadcast`` events are inspected, so a broadcast is
+    counted once rather than once per recipient. Non-matching broadcasts are
+    skipped silently.
+    """
+    out: list[dict[str, str]] = []
+    for ev in events:
+        if ev.get("kind") != "broadcast":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("authz:"):
+            continue
+        parts = msg.split(":")
+        if len(parts) < 2:
+            continue
+        parsed: dict[str, str] = {"kind": parts[1], "agent": str(ev.get("agent", ""))}
+        for piece in parts[2:]:
+            if "=" in piece:
+                key, _, value = piece.partition("=")
+                parsed[key] = value
+        out.append(parsed)
+    return out
+
+
+def _authz_scope_map(parsed: list[dict[str, str]]) -> tuple[dict[str, set[str]], dict[str, str]]:
+    """Build ``audience -> scopes`` and ``audience -> parent-audience`` maps.
+
+    Each token is keyed by the audience it was minted for (unique in a strict
+    delegation tree). Root tokens come from ``issued`` events, delegated tokens
+    from ``delegated`` events.
+    """
+    scopes: dict[str, set[str]] = {}
+    parent: dict[str, str] = {}
+    for ev in parsed:
+        if ev["kind"] == "issued":
+            holder = ev.get("holder", "")
+            scopes[holder] = {s for s in ev.get("scopes", "").split("|") if s}
+        elif ev["kind"] == "delegated":
+            aud = ev.get("aud", "")
+            scopes[aud] = {s for s in ev.get("scopes", "").split("|") if s}
+            parent[aud] = ev.get("parent", "")
+    return scopes, parent
+
+
+def validate_authz_no_scope_escalation(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every delegated token's scopes are a subset of its parent's scopes.
+
+    Delegation must only *attenuate*. A child token that holds a scope its
+    parent never held is a privilege escalation -- the confused-deputy /
+    scope-widening attack. This reads the ``authz:delegated`` events, reconstructs
+    the token tree by audience, and flags any child whose scope set is not a
+    subset of its parent's.
+
+    The default ``jwt`` plugin has no ``delegate`` surface, so the tree never
+    forms and no ``authz:delegated`` events reach the trace -- reported here as
+    "no delegation observed" (the adversarial discrimination the charter asks
+    for).
+    """
+    parsed = _parse_authz_events(events)
+    scopes, parent = _authz_scope_map(parsed)
+    violations: list[str] = []
+    for aud, parent_aud in parent.items():
+        child_scopes = scopes.get(aud, set())
+        parent_scopes = scopes.get(parent_aud, set())
+        extra = child_scopes - parent_scopes
+        if extra:
+            violations.append(
+                f"{aud!r} holds {sorted(extra)} not held by parent {parent_aud!r} "
+                f"{sorted(parent_scopes)}"
+            )
+    if violations:
+        return [ValidationResult("authz_no_scope_escalation", False, "; ".join(violations))]
+    if not parent:
+        return [
+            ValidationResult(
+                "authz_no_scope_escalation",
+                False,
+                "no delegation observed in trace -- plugin lacks the delegate surface",
+            )
+        ]
+    return [
+        ValidationResult(
+            "authz_no_scope_escalation",
+            True,
+            f"{len(parent)} delegated tokens all attenuate their parent's scopes",
+        )
+    ]
+
+
+def validate_authz_cascading_revocation(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """No token verifies OK once any ancestor in its chain has been revoked.
+
+    Revoking a parent capability must invalidate every descendant. The check
+    walks the trace in order, tracking which audiences have been revoked
+    (``authz:revoked`` events), and flags any ``authz:verified:result=ok`` for a
+    token whose audience *or any ancestor audience* is already revoked.
+
+    Because verifications that happened **before** the revocation are legitimate,
+    ordering matters -- the check only faults an OK verification that occurs
+    after the revoke. A plugin that keeps honoring descendants of a revoked
+    parent (e.g. ``jwt``, which revokes by exact string with no parent-child
+    link) is caught here; ``jwt`` additionally emits no delegation lifecycle at
+    all, so this reports "no verifications observed".
+    """
+    parsed = _parse_authz_events(events)
+    _, parent = _authz_scope_map(parsed)
+
+    def _ancestors(aud: str) -> set[str]:
+        chain: set[str] = set()
+        cur = aud
+        seen: set[str] = set()
+        while cur in parent and cur not in seen:
+            seen.add(cur)
+            cur = parent[cur]
+            chain.add(cur)
+        return chain
+
+    revoked: set[str] = set()
+    violations: list[str] = []
+    saw_verified = False
+    for ev in parsed:
+        if ev["kind"] == "revoked":
+            revoked.add(ev.get("aud", ""))
+        elif ev["kind"] == "verified" and ev.get("result") == "ok":
+            saw_verified = True
+            aud = ev.get("aud", "")
+            compromised = ({aud} | _ancestors(aud)) & revoked
+            if compromised:
+                violations.append(
+                    f"{aud!r} verified OK after ancestor(s) {sorted(compromised)} revoked"
+                )
+    if violations:
+        return [ValidationResult("authz_cascading_revocation", False, "; ".join(violations))]
+    if not saw_verified:
+        return [
+            ValidationResult(
+                "authz_cascading_revocation",
+                False,
+                "no verifications observed in trace -- plugin lacks the delegate surface",
+            )
+        ]
+    return [
+        ValidationResult(
+            "authz_cascading_revocation",
+            True,
+            "no token verified OK after an ancestor was revoked",
+        )
+    ]
+
+
+def validate_authz_audience_binding(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """No token verifies OK when presented by an agent other than its audience.
+
+    A capability minted for agent B must not be usable by agent C (a
+    confused-deputy replay). Every ``authz:verified:result=ok`` event must carry
+    ``presenter == aud``; a mismatch means the plugin honored a token for the
+    wrong holder.
+
+    The default ``jwt`` plugin binds no audience and never delegates, so it
+    emits no verifications -- reported here as "no verifications observed".
+    """
+    parsed = _parse_authz_events(events)
+    violations: list[str] = []
+    saw_verified = False
+    for ev in parsed:
+        if ev["kind"] != "verified" or ev.get("result") != "ok":
+            continue
+        saw_verified = True
+        presenter = ev.get("presenter", "")
+        aud = ev.get("aud", "")
+        if presenter != aud:
+            violations.append(f"token for {aud!r} verified OK when presented by {presenter!r}")
+    if violations:
+        return [ValidationResult("authz_audience_binding", False, "; ".join(violations))]
+    if not saw_verified:
+        return [
+            ValidationResult(
+                "authz_audience_binding",
+                False,
+                "no verifications observed in trace -- plugin lacks the delegate surface",
+            )
+        ]
+    return [
+        ValidationResult(
+            "authz_audience_binding",
+            True,
+            "every OK verification was presented by the token's declared audience",
+        )
+    ]
+
+
 def validate_receipt_reputation_ring_severed(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
@@ -4705,5 +4913,10 @@ VALIDATORS: dict[str, list[Any]] = {
     "rogue_trusted_agent": [
         validate_rogue_trusted_agent_blocked,
         validate_rogue_trusted_agent_reputation,
+    ],
+    "delegated_auth": [
+        validate_authz_no_scope_escalation,
+        validate_authz_cascading_revocation,
+        validate_authz_audience_binding,
     ],
 }

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -1911,6 +1911,7 @@ class TestValidatorRegistry:
             "failure_detection",
             "parc_migration",
             "rogue_trusted_agent",
+            "delegated_auth",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
@@ -1,0 +1,419 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegatable capability tokens — macaroon-style HMAC chains with cascading revocation.
+
+The default :class:`~nest_plugins_reference.auth.jwt_auth.JwtAuth` plugin issues
+flat HMAC tokens and revokes by exact token string. It cannot model the most
+common multi-agent authorization pattern: an orchestrator hands out
+narrowly-scoped, time-bounded sub-capabilities to workers *without going back to
+the issuer*, and withdrawing the orchestrator's own token silently withdraws
+every sub-capability underneath it.
+
+This plugin implements that pattern with the macaroon construction
+(Birgisson et al., 2014). A token is not a flat blob: it carries its **entire
+delegation chain** (root → leaf) plus a single running HMAC signature where each
+link is keyed on its parent's signature::
+
+    s0  = HMAC(secret, link0)
+    s1  = HMAC(s0,     link1)      # the previous signature is the next key
+    ...
+    sig = s_n
+
+Two properties fall out of that construction, and they are the whole point:
+
+* **Tamper-evidence.** Changing any byte of any link (a widened scope, a
+  stretched expiry, a swapped audience) breaks the recomputed ``sig``.
+* **Cascading revocation by construction.** Every descendant token embeds its
+  ancestors' links, so :meth:`DelegatableAuth.verify` can walk the whole
+  ancestry offline. Revoking a parent link's id invalidates every descendant at
+  the next verify — no per-child revocation list.
+
+Delegation only ever **attenuates**: a child's scopes must be a subset of its
+parent's, its expiry must be no later than its parent's, and any first-party
+caveats are additive constraints. Issuing a child that broadens either raises a
+typed :class:`DelegationError`.
+
+Determinism: like ``JwtAuth`` the plugin takes a fixed ``clock`` so simulated
+traces are byte-identical across replays; there is no wall-clock or unseeded
+randomness on any code path.
+
+Example::
+
+    auth = DelegatableAuth(secret=b"secret", clock=0.0)
+    root = await auth.issue(AgentId("coordinator"), ["read", "write", "exec"])
+    sub = await auth.delegate(root, AgentId("worker-1"), ["read"], ttl=600)
+    ctx = await auth.verify(sub, presenter=AgentId("worker-1"))
+    assert ctx.scopes == ["read"]
+    await auth.revoke(root)              # cascades: sub now fails to verify
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, TypedDict, cast
+
+from nest_core.types import AgentId, AuthContext, Token
+
+_DEFAULT_TTL = 3600.0
+
+
+class DelegationError(ValueError):
+    """Base class for every delegation/authorization failure.
+
+    Catching :class:`DelegationError` catches all of the specific subclasses
+    below in one ``except``.
+
+    Example::
+
+        try:
+            await auth.delegate(parent, AgentId("b"), ["admin"], ttl=60)
+        except DelegationError as exc:
+            print(exc)
+    """
+
+
+class InvalidTokenError(DelegationError):
+    """The token is malformed or its chain signature does not verify.
+
+    Example::
+
+        raise InvalidTokenError("chain signature mismatch")
+    """
+
+
+class ScopeEscalationError(DelegationError):
+    """A child requested a scope its parent does not hold.
+
+    Example::
+
+        raise ScopeEscalationError("child scope 'admin' not in parent scopes")
+    """
+
+
+class TtlExpansionError(DelegationError):
+    """A child's expiry would outlive its parent's expiry.
+
+    Example::
+
+        raise TtlExpansionError("child exp 200 > parent exp 100")
+    """
+
+
+class ExpiredTokenError(DelegationError):
+    """A link in the chain (leaf or ancestor) has passed its expiry.
+
+    Example::
+
+        raise ExpiredTokenError("link for 'worker-1' expired at 50.0")
+    """
+
+
+class RevokedAncestorError(DelegationError):
+    """A link in the chain has been revoked, so the whole token is invalid.
+
+    Raised for both a directly-revoked leaf and any revoked ancestor — the
+    cascading-revocation guarantee.
+
+    Example::
+
+        raise RevokedAncestorError("ancestor link 'coordinator' revoked")
+    """
+
+
+class AudienceMismatchError(DelegationError):
+    """The presenter is not the audience the leaf token was minted for.
+
+    Blocks a confused-deputy replay where agent C presents a token issued to
+    agent B.
+
+    Example::
+
+        raise AudienceMismatchError("presented by 'c' but audience is 'b'")
+    """
+
+
+class CaveatUnsatisfiedError(DelegationError):
+    """A first-party caveat attached to a link is not satisfied at verify time.
+
+    Example::
+
+        raise CaveatUnsatisfiedError("caveat 'resource=jobs' not satisfied")
+    """
+
+
+class _Link(TypedDict):
+    """One rung of a delegation chain (serialized inside the token).
+
+    ``sub`` delegated to ``aud`` the given ``scopes`` from ``iat`` until ``exp``,
+    subject to ``caveats``. The link ``id`` is derived (not stored) so it cannot
+    be forged independently of the link's content.
+    """
+
+    sub: str
+    aud: str
+    scopes: list[str]
+    iat: float
+    exp: float
+    caveats: list[str]
+
+
+def _canonical(link: _Link) -> bytes:
+    """Serialize a link to canonical bytes for hashing/signing.
+
+    Sorted keys + tight separators make the encoding reproducible, so link ids
+    and chain signatures are byte-stable across runs.
+    """
+    return json.dumps(link, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _link_id(link: _Link) -> str:
+    """Return the stable, content-derived id of a link.
+
+    The id is a hash of the link's canonical bytes, so it is impossible to keep
+    a link's id while altering its content. Revocation targets this id.
+
+    Example::
+
+        rid = _link_id(link)
+    """
+    return hashlib.sha256(_canonical(link)).hexdigest()[:16]
+
+
+class DelegatableAuth:
+    """Macaroon-style delegatable auth with attenuation and cascading revocation.
+
+    Satisfies the :class:`~nest_core.layers.auth.Auth` protocol
+    (``issue`` / ``verify`` / ``revoke``) and adds :meth:`delegate`. ``verify``
+    keeps the base signature but accepts two optional keyword arguments
+    (``presenter`` and ``context``), so it remains protocol-compatible.
+
+    All instances that must recognise the same tokens and revocations should
+    share one ``secret`` and one ``revoked`` set — pass the same instance to
+    every agent (see the ``delegated_auth`` scenario factory).
+
+    Example::
+
+        auth = DelegatableAuth(secret=b"secret", clock=0.0)
+        root = await auth.issue(AgentId("a"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("b"), ["read"], ttl=60)
+    """
+
+    def __init__(
+        self,
+        secret: bytes = b"nest-delegatable-secret",
+        clock: float | None = None,
+        default_ttl: float = _DEFAULT_TTL,
+        revoked: set[str] | None = None,
+    ) -> None:
+        self._secret = secret
+        self._clock = clock
+        self._default_ttl = default_ttl
+        self._revoked: set[str] = revoked if revoked is not None else set()
+
+    def _now(self) -> float:
+        if self._clock is not None:
+            return self._clock
+        return time.time()
+
+    def _chain_sig(self, links: list[_Link]) -> str:
+        """Compute the running macaroon signature over a chain of links.
+
+        Each link is HMAC'd with the *previous* link's signature as the key,
+        anchoring the whole chain to ``self._secret``.
+        """
+        running = self._secret
+        for link in links:
+            running = hmac.new(running, _canonical(link), hashlib.sha256).digest()
+        return running.hex()
+
+    def _encode(self, links: list[_Link]) -> Token:
+        """Serialize a signed chain into an opaque token string."""
+        envelope = {"links": links, "sig": self._chain_sig(links)}
+        return Token(json.dumps(envelope, sort_keys=True))
+
+    def _decode(self, token: Token) -> tuple[list[_Link], str]:
+        """Parse a token into its links and signature (no verification yet).
+
+        Raises :class:`InvalidTokenError` if the envelope is not well-formed.
+        """
+        try:
+            data: Any = json.loads(str(token))
+            links_raw = data["links"]
+            sig = data["sig"]
+        except (ValueError, KeyError, TypeError) as exc:
+            msg = f"malformed delegatable token: {exc}"
+            raise InvalidTokenError(msg) from exc
+        if not isinstance(links_raw, list) or not links_raw or not isinstance(sig, str):
+            msg = "token carries no delegation links"
+            raise InvalidTokenError(msg)
+        return cast("list[_Link]", links_raw), sig
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Issue a root capability token held by ``subject`` itself.
+
+        The root link's audience equals its subject: the issuer is the first
+        holder and may delegate onward from here.
+
+        Example::
+
+            root = await auth.issue(AgentId("coordinator"), ["read", "write"])
+        """
+        now = self._now()
+        link: _Link = {
+            "sub": str(subject),
+            "aud": str(subject),
+            "scopes": list(scopes),
+            "iat": now,
+            "exp": now + self._default_ttl,
+            "caveats": [],
+        }
+        return self._encode([link])
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+        caveats: list[str] | None = None,
+    ) -> Token:
+        """Mint a narrowed child token for ``audience`` — no issuer involved.
+
+        The child is appended to the parent's chain by the current holder. It
+        must **attenuate**:
+
+        * ``scopes_subset`` must be a subset of the parent leaf's scopes, else
+          :class:`ScopeEscalationError`.
+        * ``now + ttl`` must not exceed the parent leaf's expiry, else
+          :class:`TtlExpansionError`.
+        * ``caveats`` are additive first-party constraints re-checked at verify.
+
+        The parent is verified first, so you cannot delegate from an expired or
+        revoked token.
+
+        Example::
+
+            child = await auth.delegate(root, AgentId("worker-1"), ["read"], ttl=600)
+        """
+        await self.verify(parent_token)
+        links, _ = self._decode(parent_token)
+        parent_leaf = links[-1]
+        parent_scopes = set(parent_leaf["scopes"])
+        requested = list(scopes_subset)
+        extra = set(requested) - parent_scopes
+        if extra:
+            msg = f"child scopes {sorted(extra)} not held by parent {sorted(parent_scopes)}"
+            raise ScopeEscalationError(msg)
+        now = self._now()
+        child_exp = now + ttl
+        if child_exp > parent_leaf["exp"]:
+            msg = f"child exp {child_exp} exceeds parent exp {parent_leaf['exp']}"
+            raise TtlExpansionError(msg)
+        child: _Link = {
+            "sub": parent_leaf["aud"],
+            "aud": str(audience),
+            "scopes": requested,
+            "iat": now,
+            "exp": child_exp,
+            "caveats": list(caveats or []),
+        }
+        return self._encode([*links, child])
+
+    def _check_caveat(self, caveat: str, chain_depth: int, context: dict[str, str]) -> bool:
+        """Return whether a single first-party caveat holds.
+
+        Supported vocabulary (deterministic, self-contained):
+
+        * ``max_depth=<int>`` — satisfied iff the total chain length is within
+          the bound (an intrinsic check needing no external context).
+        * ``<key>=<value>`` — satisfied iff ``context[key] == value``. A missing
+          key fails closed.
+        """
+        key, sep, value = caveat.partition("=")
+        if not sep:
+            return False
+        if key == "max_depth":
+            try:
+                return chain_depth <= int(value)
+            except ValueError:
+                return False
+        return context.get(key) == value
+
+    async def verify(
+        self,
+        token: Token,
+        presenter: AgentId | None = None,
+        context: dict[str, str] | None = None,
+    ) -> AuthContext:
+        """Verify a token end-to-end and return the leaf holder's auth context.
+
+        Checks, in order: the chain signature; then for every link (root → leaf)
+        revocation, expiry, scope monotonicity, expiry monotonicity, and
+        caveats; then — if ``presenter`` is given — that it matches the leaf
+        audience. Any failure raises the matching :class:`DelegationError`.
+
+        Because ancestors are embedded in the token, a revoked *parent* fails a
+        *child*'s verify: that is the cascading-revocation guarantee.
+
+        Example::
+
+            ctx = await auth.verify(child, presenter=AgentId("worker-1"))
+        """
+        links, sig = self._decode(token)
+        if not hmac.compare_digest(sig, self._chain_sig(links)):
+            msg = "chain signature mismatch — token tampered or wrong secret"
+            raise InvalidTokenError(msg)
+
+        now = self._now()
+        ctx = context or {}
+        prev_scopes: set[str] | None = None
+        prev_exp: float | None = None
+        for link in links:
+            lid = _link_id(link)
+            if lid in self._revoked:
+                msg = f"link {lid} for {link['aud']!r} has been revoked"
+                raise RevokedAncestorError(msg)
+            if link["exp"] < now:
+                msg = f"link for {link['aud']!r} expired at {link['exp']} (now={now})"
+                raise ExpiredTokenError(msg)
+            scopes = set(link["scopes"])
+            if prev_scopes is not None and not scopes <= prev_scopes:
+                widened = sorted(scopes - prev_scopes)
+                msg = f"link for {link['aud']!r} widened scopes {widened} mid-chain"
+                raise ScopeEscalationError(msg)
+            if prev_exp is not None and link["exp"] > prev_exp:
+                msg = f"link for {link['aud']!r} extended expiry {link['exp']} > {prev_exp}"
+                raise TtlExpansionError(msg)
+            for caveat in link["caveats"]:
+                if not self._check_caveat(caveat, len(links), ctx):
+                    msg = f"caveat {caveat!r} not satisfied"
+                    raise CaveatUnsatisfiedError(msg)
+            prev_scopes = scopes
+            prev_exp = link["exp"]
+
+        leaf = links[-1]
+        if presenter is not None and str(presenter) != leaf["aud"]:
+            msg = f"presented by {presenter!r} but leaf audience is {leaf['aud']!r}"
+            raise AudienceMismatchError(msg)
+        return AuthContext(
+            subject=AgentId(leaf["aud"]),
+            scopes=list(leaf["scopes"]),
+            issued_at=leaf["iat"],
+            expires_at=leaf["exp"],
+        )
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke a token by adding its leaf link id to the shared revoked set.
+
+        Because every descendant embeds this link, revoking a token here
+        invalidates the token and everything delegated from it at the next
+        verify — one O(1) call collapses an entire subtree.
+
+        Example::
+
+            await auth.revoke(root)   # every child of root now fails verify
+        """
+        links, _ = self._decode(token)
+        self._revoked.add(_link_id(links[-1]))

--- a/packages/nest-plugins-reference/tests/test_delegatable.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the delegatable (macaroon-style) auth plugin.
+
+Cover the core contract: attenuating delegation, cascading revocation, audience
+binding, expiry, tamper resistance, caveats, and byte-determinism.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.delegatable import (
+    AudienceMismatchError,
+    CaveatUnsatisfiedError,
+    DelegatableAuth,
+    ExpiredTokenError,
+    InvalidTokenError,
+    RevokedAncestorError,
+    ScopeEscalationError,
+    TtlExpansionError,
+)
+
+_SECRET = b"unit-test-secret"
+
+
+def _auth(clock: float = 100.0, **kwargs: object) -> DelegatableAuth:
+    return DelegatableAuth(secret=_SECRET, clock=clock, **kwargs)  # type: ignore[arg-type]
+
+
+async def test_issue_and_verify_root() -> None:
+    auth = _auth()
+    root = await auth.issue(AgentId("coordinator"), ["read", "write", "exec"])
+    ctx = await auth.verify(root)
+    assert ctx.subject == AgentId("coordinator")
+    assert set(ctx.scopes) == {"read", "write", "exec"}
+
+
+async def test_delegate_narrows_scopes_and_binds_audience() -> None:
+    auth = _auth()
+    root = await auth.issue(AgentId("a"), ["read", "write", "exec"])
+    child = await auth.delegate(root, AgentId("b"), ["read"], ttl=600)
+    ctx = await auth.verify(child, presenter=AgentId("b"))
+    assert ctx.subject == AgentId("b")
+    assert ctx.scopes == ["read"]
+
+
+async def test_delegate_scope_escalation_raises() -> None:
+    auth = _auth()
+    root = await auth.issue(AgentId("a"), ["read"])
+    with pytest.raises(ScopeEscalationError):
+        await auth.delegate(root, AgentId("b"), ["read", "write"], ttl=60)
+
+
+async def test_delegate_ttl_expansion_raises() -> None:
+    auth = _auth()
+    # Root expiry is clock + default_ttl; a child asking for more must fail.
+    root = await auth.issue(AgentId("a"), ["read"])
+    with pytest.raises(TtlExpansionError):
+        await auth.delegate(root, AgentId("b"), ["read"], ttl=10_000_000)
+
+
+async def test_cascading_revocation_three_deep() -> None:
+    auth = _auth()
+    root = await auth.issue(AgentId("a"), ["read", "write"])
+    child = await auth.delegate(root, AgentId("b"), ["read"], ttl=600)
+    grand = await auth.delegate(child, AgentId("c"), ["read"], ttl=300)
+    # All verify before revocation.
+    await auth.verify(grand, presenter=AgentId("c"))
+    await auth.revoke(root)
+    for token, holder in ((root, "a"), (child, "b"), (grand, "c")):
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify(token, presenter=AgentId(holder))
+
+
+async def test_revoke_middle_spares_root_and_siblings() -> None:
+    auth = _auth()
+    root = await auth.issue(AgentId("a"), ["read", "write"])
+    branch = await auth.delegate(root, AgentId("b"), ["read"], ttl=600)
+    sibling = await auth.delegate(root, AgentId("s"), ["read"], ttl=600)
+    leaf = await auth.delegate(branch, AgentId("b1"), ["read"], ttl=300)
+    await auth.revoke(branch)
+    # Revoked branch and its descendant fail.
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify(branch, presenter=AgentId("b"))
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify(leaf, presenter=AgentId("b1"))
+    # Root and unrelated sibling are untouched.
+    assert (await auth.verify(root)).subject == AgentId("a")
+    assert (await auth.verify(sibling, presenter=AgentId("s"))).subject == AgentId("s")
+
+
+async def test_audience_mismatch_raises() -> None:
+    auth = _auth()
+    root = await auth.issue(AgentId("a"), ["read"])
+    child = await auth.delegate(root, AgentId("b"), ["read"], ttl=600)
+    with pytest.raises(AudienceMismatchError):
+        await auth.verify(child, presenter=AgentId("attacker"))
+    # No presenter given -> audience is not checked.
+    assert (await auth.verify(child)).subject == AgentId("b")
+
+
+async def test_expiry_raises_under_advanced_clock() -> None:
+    shared_revoked: set[str] = set()
+    past = DelegatableAuth(secret=_SECRET, clock=100.0, revoked=shared_revoked)
+    root = await past.issue(AgentId("a"), ["read"])
+    child = await past.delegate(root, AgentId("b"), ["read"], ttl=10)  # exp = 110
+    # A verifier whose clock is past the expiry rejects the token.
+    future = DelegatableAuth(secret=_SECRET, clock=200.0, revoked=shared_revoked)
+    with pytest.raises(ExpiredTokenError):
+        await future.verify(child, presenter=AgentId("b"))
+
+
+async def test_delegate_from_expired_parent_raises() -> None:
+    past = DelegatableAuth(secret=_SECRET, clock=100.0, default_ttl=10.0)
+    root = await past.issue(AgentId("a"), ["read"])  # exp = 110
+    future = DelegatableAuth(secret=_SECRET, clock=200.0)
+    with pytest.raises(ExpiredTokenError):
+        await future.delegate(root, AgentId("b"), ["read"], ttl=1)
+
+
+async def test_delegate_from_revoked_parent_raises() -> None:
+    auth = _auth()
+    root = await auth.issue(AgentId("a"), ["read"])
+    await auth.revoke(root)
+    with pytest.raises(RevokedAncestorError):
+        await auth.delegate(root, AgentId("b"), ["read"], ttl=60)
+
+
+async def test_tampered_token_fails_signature() -> None:
+    auth = _auth()
+    root = await auth.issue(AgentId("a"), ["read"])
+    tampered = Token(str(root).replace('"read"', '"admin"'))
+    assert tampered != root
+    with pytest.raises(InvalidTokenError):
+        await auth.verify(tampered)
+
+
+async def test_malformed_token_raises() -> None:
+    auth = _auth()
+    for bad in ("not json", "{}", '{"links": [], "sig": "x"}'):
+        with pytest.raises(InvalidTokenError):
+            await auth.verify(Token(bad))
+
+
+async def test_determinism_same_inputs_same_bytes() -> None:
+    a = await _auth().issue(AgentId("x"), ["read", "write"])
+    b = await _auth().issue(AgentId("x"), ["read", "write"])
+    assert a == b
+    child_a = await _auth().delegate(a, AgentId("y"), ["read"], ttl=60)
+    child_b = await _auth().delegate(b, AgentId("y"), ["read"], ttl=60)
+    assert child_a == child_b
+
+
+async def test_caveat_context_enforced() -> None:
+    auth = _auth()
+    root = await auth.issue(AgentId("a"), ["read"])
+    child = await auth.delegate(root, AgentId("b"), ["read"], ttl=60, caveats=["resource=jobs"])
+    # Satisfied when context matches.
+    assert (await auth.verify(child, context={"resource": "jobs"})).subject == AgentId("b")
+    # Fails closed when context is missing or mismatched.
+    with pytest.raises(CaveatUnsatisfiedError):
+        await auth.verify(child, context={"resource": "secrets"})
+    with pytest.raises(CaveatUnsatisfiedError):
+        await auth.verify(child)
+
+
+async def test_max_depth_caveat_bounds_chain_length() -> None:
+    auth = _auth()
+    root = await auth.issue(AgentId("a"), ["read"])
+    # Caveat added at depth 2 permits at most a 2-link chain.
+    child = await auth.delegate(root, AgentId("b"), ["read"], ttl=600, caveats=["max_depth=2"])
+    assert (await auth.verify(child, presenter=AgentId("b"))).subject == AgentId("b")
+    # Delegating once more makes the chain length 3 -> the caveat now fails.
+    grand = await auth.delegate(child, AgentId("c"), ["read"], ttl=300)
+    with pytest.raises(CaveatUnsatisfiedError):
+        await auth.verify(grand, presenter=AgentId("c"))
+
+
+async def test_verify_rejects_hand_forged_scope_widening() -> None:
+    """A token whose leaf widens scope (bypassing delegate) fails verify."""
+    import json
+
+    auth = _auth()
+    root = await auth.issue(AgentId("a"), ["read"])
+    child = await auth.delegate(root, AgentId("b"), ["read"], ttl=60)
+    data = json.loads(str(child))
+    data["links"][-1]["scopes"] = ["read", "admin"]  # widen without re-signing
+    from nest_core.types import Token
+
+    forged = Token(json.dumps(data, sort_keys=True))
+    # The chain signature no longer matches the mutated link.
+    with pytest.raises(InvalidTokenError):
+        await auth.verify(forged)

--- a/packages/nest-plugins-reference/tests/test_delegatable_properties.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable_properties.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Property tests for the delegated_auth adversarial validators.
+
+Feed the validators hand-crafted event streams -- an honest tree and one stream
+per attack class -- and assert they PASS the honest case and FAIL each attack.
+This proves the validators actually catch a buggy plugin that lets an attack
+through, independent of the reference scenario.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.validators import validate_events
+
+
+def _bcast(agent: str, msg: str) -> dict[str, Any]:
+    """Build a sender-recorded broadcast event as the trace writer would."""
+    return {"kind": "broadcast", "agent": agent, "msg": msg}
+
+
+def _issued(holder: str, scopes: list[str]) -> dict[str, Any]:
+    return _bcast(holder, f"authz:issued:holder={holder}:scopes={'|'.join(scopes)}")
+
+
+def _delegated(by: str, aud: str, parent: str, scopes: list[str]) -> dict[str, Any]:
+    joined = "|".join(scopes)
+    return _bcast(by, f"authz:delegated:by={by}:aud={aud}:parent={parent}:scopes={joined}")
+
+
+def _verified(aud: str, presenter: str) -> dict[str, Any]:
+    return _bcast(aud, f"authz:verified:by={aud}:aud={aud}:presenter={presenter}:result=ok")
+
+
+def _revoked(by: str, aud: str) -> dict[str, Any]:
+    return _bcast(by, f"authz:revoked:by={by}:aud={aud}")
+
+
+def _honest_tree() -> list[dict[str, Any]]:
+    """A minimal honest delegation tree: root -> mid -> leaf, all attenuating."""
+    return [
+        _issued("coordinator", ["read", "write", "exec"]),
+        _delegated("coordinator", "mid", "coordinator", ["read", "write"]),
+        _delegated("mid", "leaf", "mid", ["read"]),
+        _verified("leaf", "leaf"),
+    ]
+
+
+def _names(results: list[Any]) -> dict[str, Any]:
+    return {r.name: r for r in results}
+
+
+# --- Honest baseline -------------------------------------------------------
+
+
+def test_honest_tree_passes_all_validators() -> None:
+    results = validate_events(_honest_tree(), "delegated_auth")
+    assert results, "expected validators registered for delegated_auth"
+    assert all(r.passed for r in results), [
+        f"{r.name}: {r.detail}" for r in results if not r.passed
+    ]
+
+
+# --- Attack 1: scope escalation --------------------------------------------
+
+
+def test_scope_escalation_is_caught() -> None:
+    events = [
+        _issued("coordinator", ["read", "write"]),
+        _delegated("coordinator", "mid", "coordinator", ["read"]),
+        # Child grabs 'exec', which neither parent ever held.
+        _delegated("mid", "leaf", "mid", ["read", "exec"]),
+        _verified("leaf", "leaf"),
+    ]
+    r = _names(validate_events(events, "delegated_auth"))["authz_no_scope_escalation"]
+    assert not r.passed
+    assert "exec" in r.detail
+
+
+# --- Attack 2: cascading revocation (stale parent) -------------------------
+
+
+def test_verify_after_ancestor_revoked_is_caught() -> None:
+    events = [
+        *_honest_tree(),
+        _revoked("coordinator", "mid"),
+        # A buggy plugin still honors the leaf after its parent 'mid' is revoked.
+        _verified("leaf", "leaf"),
+    ]
+    r = _names(validate_events(events, "delegated_auth"))["authz_cascading_revocation"]
+    assert not r.passed
+    assert "mid" in r.detail
+
+
+def test_verify_before_revocation_is_allowed() -> None:
+    """An OK verification that precedes the revoke is legitimate, not a fault."""
+    events = [
+        *_honest_tree(),  # leaf verified here, before any revoke
+        _revoked("coordinator", "mid"),
+    ]
+    r = _names(validate_events(events, "delegated_auth"))["authz_cascading_revocation"]
+    assert r.passed
+
+
+# --- Attack 3: audience confusion ------------------------------------------
+
+
+def test_audience_confusion_is_caught() -> None:
+    events = [
+        *_honest_tree(),
+        # 'attacker' presents leaf's token and the plugin honors it.
+        _bcast("attacker", "authz:verified:by=attacker:aud=leaf:presenter=attacker:result=ok"),
+    ]
+    r = _names(validate_events(events, "delegated_auth"))["authz_audience_binding"]
+    assert not r.passed
+    assert "attacker" in r.detail
+
+
+# --- Discrimination: an empty / non-delegating trace fails all three -------
+
+
+def test_no_delegation_fails_all_validators() -> None:
+    """The jwt-shaped trace: a root issue but no delegation or verification."""
+    events = [_issued("coordinator", ["read", "write", "exec"])]
+    results = validate_events(events, "delegated_auth")
+    assert not any(r.passed for r in results)
+    assert all("no " in r.detail for r in results)

--- a/packages/nest-plugins-reference/tests/test_delegated_auth_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_delegated_auth_scenario.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end scenario test for the delegatable auth plugin.
+
+Boots the ``delegated_auth`` scenario through the real ``Simulator`` twice --
+once with ``auth: delegatable`` and once with ``auth: jwt`` -- and proves the
+three validators discriminate: ALL PASS under the delegatable plugin, ALL FAIL
+under the default plugin (which has no delegate surface).
+
+Also pins determinism: same seed -> byte-identical trace.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "delegated_auth.yaml"
+
+
+def _swap_auth(config: ScenarioConfig, plugin_name: str) -> ScenarioConfig:
+    new_layers = config.layers.model_copy(update={"auth": plugin_name})
+    return config.model_copy(update={"layers": new_layers})
+
+
+def _run(plugin_name: str, seed: int = 42) -> Path:
+    """Run the scenario with the chosen auth plugin; return the trace path."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    config = _swap_auth(config, plugin_name)
+    config = config.model_copy(update={"seed": seed})
+    tmp = Path(tempfile.mkdtemp())
+    trace_path = tmp / f"delegated_auth_{plugin_name}_{seed}.jsonl"
+    config = config.model_copy(
+        update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+    )
+    runner = ScenarioRunner(config, registry=PluginRegistry())
+    asyncio.run(runner.run())
+    return trace_path
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_delegatable_passes_all_three_validators() -> None:
+    """The delegatable plugin satisfies attenuation, cascading revocation, audience binding."""
+    results = validate_trace(_run("delegatable"), "delegated_auth")
+    summary = [f"{'PASS' if r.passed else 'FAIL'} {r.name}: {r.detail}" for r in results]
+    assert results and all(r.passed for r in results), (
+        "expected all validators to pass under delegatable:\n" + "\n".join(summary)
+    )
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_jwt_fails_all_three_validators() -> None:
+    """The default ``jwt`` plugin has no delegate surface, so the tree never forms."""
+    results = validate_trace(_run("jwt"), "delegated_auth")
+    assert results and not any(r.passed for r in results), [
+        f"{r.name}: {r.detail}" for r in results if r.passed
+    ]
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_scenario_deterministic_under_replay() -> None:
+    """Two runs with the same seed produce byte-identical traces."""
+    assert _run("delegatable", seed=42).read_bytes() == _run("delegatable", seed=42).read_bytes()
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_validator_discrimination_holds_across_seeds(seed: int) -> None:
+    """Validator discrimination is seed-independent (message ordering aside)."""
+    results = validate_trace(_run("delegatable", seed=seed), "delegated_auth")
+    assert all(r.passed for r in results), [
+        f"{r.name}: {r.detail}" for r in results if not r.passed
+    ]
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_scenario_exercises_every_attack_class() -> None:
+    """The trace must contain each denied-attack class plus a cascading revoke."""
+    trace = _run("delegatable")
+    text = trace.read_text()
+    for marker in (
+        "attack=scope_escalation",
+        "attack=audience_confusion",
+        "attack=revoked_parent",
+        "attack=expired_parent",
+        "authz:revoked",
+    ):
+        assert marker in text, f"missing {marker!r} in trace"

--- a/scenarios/delegated_auth.yaml
+++ b/scenarios/delegated_auth.yaml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegated-auth tree: 1 coordinator + 3 intermediaries + 12 leaves drive the
+# delegatable auth plugin through a full delegation tree plus three adversarial
+# probes (scope escalation, stale parent, audience confusion). The three
+# delegated_auth validators must all PASS under `auth: delegatable` and all FAIL
+# under `auth: jwt` (no delegate surface, so no delegation events are emitted).
+
+name: delegated_auth
+description: |
+  A coordinator issues a root capability, delegates narrowed tokens to three
+  intermediaries, and each intermediary delegates further-narrowed tokens to
+  four leaves. intermediary-0 attempts a scope escalation and an audience
+  confusion; the coordinator revokes intermediary-2 (cascading to its four
+  leaves) and presents a pre-minted expired token. All three delegated_auth
+  validators (no-scope-escalation, cascading-revocation, audience-binding)
+  must pass under the delegatable plugin.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 16
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+      config: {}
+    - name: intermediary
+      count: 3
+      config: {}
+    - name: leaf
+      count: 12
+      config: {}
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: delegatable
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: delegated_auth
+  config: {}
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+# Event budget (max_ticks counts processed events). Each broadcast fans out to
+# all 16 agents, so the tree + revoke/recheck/expired probes need headroom.
+duration: "ticks: 5000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/delegated_auth.jsonl


### PR DESCRIPTION
## Problem 04 — Delegatable capability tokens with cascading revocation

The default `auth` plugin (`jwt_auth.py`) issues flat HMAC tokens and revokes by
*exact token string* (`JwtAuth._revoked: set[str]`). It cannot model the most
common multi-agent authorization pattern: an orchestrator hands a worker a
**narrowed, time-bounded sub-capability without going back to the issuer**, and
revoking the orchestrator's own token silently withdraws every sub-capability
underneath it.

This PR ships `delegatable` — a macaroon-style auth plugin (Birgisson et al.,
2014) that does exactly that.

### How it works

A token is not a flat blob: it carries its **entire delegation chain**
(root → leaf) plus a single running HMAC signature where each link is keyed on
its parent's signature:

```
s0  = HMAC(secret, link0)
s1  = HMAC(s0,     link1)      # the previous signature is the next key
sig = s_n
```

Two properties fall out of that construction — and they are the whole point:

- **Tamper-evidence.** Changing any byte of any link (a widened scope, a
  stretched expiry, a swapped audience) breaks the recomputed `sig`.
- **Cascading revocation by construction.** Every descendant embeds its
  ancestors' links, so `verify` walks the whole ancestry offline. Revoking a
  parent link's id invalidates every descendant at the next verify — **no
  per-child revocation list.**

### API (extends `Auth`, stays protocol-compatible)

- `delegate(parent, audience, scopes_subset, ttl, caveats=None) -> Token` — any
  holder mints a child **without the issuer**. Attenuation-only: child scopes
  must be a subset of the parent's (`ScopeEscalationError` otherwise) and child
  TTL must be ≤ the parent's (`TtlExpansionError`).
- `verify(token, presenter=None, context=None) -> AuthContext` — checks the
  chain signature, then per link: revocation (`RevokedAncestorError`), expiry
  (`ExpiredTokenError`), scope/expiry monotonicity, and first-party caveats
  (`CaveatUnsatisfiedError`); binds the presenter to the leaf audience
  (`AudienceMismatchError`).
- `revoke(token)` — O(1); adds the leaf link id to the shared revoked set, which
  collapses the entire subtree beneath it.

All errors subclass one `DelegationError(ValueError)`, mirroring
`EscrowError` in the escrow plugin.

### Adversarial validators (`delegated_auth`)

Three validators, each derived purely from trace evidence so they catch a
*buggy plugin that lets an attack through*, not just self-reported denials:

| Validator | Catches |
|---|---|
| `authz_no_scope_escalation` | a delegated token holding a scope its parent never held |
| `authz_cascading_revocation` | a token that verifies OK **after** an ancestor was revoked (order-aware) |
| `authz_audience_binding` | a token that verifies OK when presented by an agent other than its audience |

**All three PASS under `delegatable` and all three FAIL under the default `jwt`
plugin** (no `delegate` surface → the tree never forms → "no delegation
observed"). Same discrimination model as the merged escrow PR.

### Scenario `scenarios/delegated_auth.yaml`

Coordinator → 3 intermediaries → 12 leaves, exactly as the problem's success
criteria require, plus adversarial probes that the plugin rejects:

- **scope escalation** — an intermediary delegates a scope it does not hold;
- **stale parent** — both an **expired** parent (deterministic via a fixed
  clock and a pre-minted past-dated token) and a **revoked** parent (the
  coordinator revokes `intermediary-2`, cascading to its four leaves);
- **audience confusion** — `leaf-0`'s token is handed to `leaf-1`, which tries
  to present it.

### Determinism

No wall clock, no unseeded RNG. Like `JwtAuth`, the plugin takes a fixed
`clock`; the scenario pins it so **same seed → byte-identical trace** (asserted
in the test suite, verified across seeds `[42, 7, 1337]`).

### Tests

- `test_delegatable.py` — 16 unit tests: attenuation, 3-deep cascading revoke,
  sibling isolation, audience mismatch, expiry, delegate-from-dead-parent,
  tamper/forgery, caveats, determinism.
- `test_delegatable_properties.py` — 8 property tests feeding hand-crafted
  attack traces to each validator (honest → PASS, each attack → FAIL).
- `test_delegated_auth_scenario.py` — 6 e2e tests: `delegatable` passes all
  validators, `jwt` fails all, byte-determinism, cross-seed discrimination,
  and every attack class present in the trace.

### CI

`make ci-local` is green: `uv sync`, `ruff check`, `ruff format --check`,
`pyright` (strict), `pytest -v` → **765 passed, 1 skipped**.

### Files

**New:** `auth/delegatable.py`, `scenarios_builtin/delegated_auth.py`,
`scenarios/delegated_auth.yaml`, three test modules.
**Edited:** `plugins.py` (+1 entry), `scenarios.py` (+1 branch), `validators.py`
(parser + 3 validators + registry), `tests/test_validators.py` (registry set),
`docs/layers/auth.md`, `README.md` (validators table). No changes outside the
auth layer / its scenario / its validators.

### Out of scope

DAG delegation (strict tree only), OAuth2/network endpoints, hardware key
attestation. This is **not** PR #9's DPoP — that is sender-constraint; this is
delegation + cascading revocation, a different problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
