### PR TITLE
[Hackathon] LasaKaru : delegatable capability tokens with cascading revocation

### DIFF
--- a/docs/layers/auth.md
+++ b/docs/layers/auth.md
@@ -21,6 +21,40 @@ shape (header.payload.sig), no claim validation beyond the signature.
 
 Source: [`nest_plugins_reference/auth/jwt_auth.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/jwt_auth.py).
 
+## Delegatable plugin
+
+`delegatable` — macaroon-style capability tokens with **cascading
+revocation**. On top of the base `Auth` surface it adds:
+
+```python
+async def delegate(
+    self, parent_token: Token, audience: AgentId,
+    scopes_subset: list[str], ttl: float,
+) -> Token: ...
+
+async def verify(self, token: Token, *, presenter: AgentId | None = None) -> AuthContext: ...
+```
+
+A holder mints a narrower, shorter-lived child token **without going back
+to the issuer**. Each token carries its whole root→leaf chain, and each
+link's HMAC is keyed by the previous link's signature (Birgisson et al.,
+2014). Because a link's intermediate signature equals the outer signature
+of the corresponding ancestor token, revoking an ancestor invalidates
+every descendant at the next `verify` — no per-child revocation list.
+`delegate` enforces scope subsetting and TTL ≤ parent; the optional
+`presenter` argument binds a token to its audience (an impostor is
+rejected) while leaving `verify(token)` — the base contract — unchanged.
+
+Source: [`nest_plugins_reference/auth/delegatable.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py).
+
+**Adversarial validators** (`nest_plugins_reference.validators`):
+`check_scope_escalation_rejected`, `check_stale_parent_rejected`,
+`check_audience_confusion_rejected` — each FAILS against `jwt` and PASSES
+against `delegatable`. The [`delegated_auth`](../../scenarios/delegated_auth.yaml)
+scenario (a coordinator + 3 intermediaries + 12 leaves) drives a full
+cascading-revocation run whose trace is checked by
+`validate_delegated_auth_*`.
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -26,6 +26,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
+    ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -111,6 +111,10 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("multi_attribute_market", multi_attribute_market_factory)
+    elif name == "delegated_auth":
+        from nest_core.scenarios_builtin.delegated_auth import delegated_auth_factory
+
+        register_scenario("delegated_auth", delegated_auth_factory)
     elif name == "provenance_supply_chain":
         from nest_core.scenarios_builtin.provenance_supply_chain import (
             provenance_supply_chain_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegated-auth scenario: a coordinator hands out cascading capability tokens.
+
+A three-level delegation tree exercises the delegatable auth plugin end to end:
+
+    coordinator ──delegate──▶ 3 intermediaries ──delegate──▶ 12 leaves (4 each)
+
+The coordinator holds a root token and, without going back to any issuer, mints
+narrower sub-tokens for the intermediaries; each intermediary mints still
+narrower tokens for its leaves. The coordinator then runs a **verify sweep**
+(every leaf presents its own token — all accepted; impostors presenting someone
+else's token — all rejected), **revokes one intermediary**, and runs the sweep
+again: the revoked intermediary's whole subtree now fails to verify while every
+other agent is untouched. That is cascading revocation.
+
+Every delegation, revocation, and verify outcome is written to the trace so the
+offline validators (`validate_delegated_auth_*`) can reconstruct the tree and
+check scope narrowing, cascading revocation, and audience binding. Frame grammar
+(scopes are ``|``-joined so they never collide with the ``:`` delimiter)::
+
+    dauth:issue:<owner>:<scope|scope|...>
+    dauth:delegate:<parent>:<child>:<scope|scope|...>
+    dauth:verify:<presenter>:<owner>:<ok|fail>:<pre|post>
+    dauth:revoke:<owner>
+
+The coordinator drives the whole exchange synchronously in ``on_start`` against a
+single auth instance seeded with ``clock=0.0``, so the same seed yields a
+byte-identical trace.
+
+Example::
+
+    from nest_core.runner import ScenarioRunner
+    from nest_core.scenario import ScenarioConfig
+
+    runner = ScenarioRunner(ScenarioConfig.from_yaml("scenarios/delegated_auth.yaml"))
+    await runner.run()
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Token
+
+N_INTERMEDIARIES = 3
+"""Number of intermediary agents directly under the coordinator."""
+
+LEAVES_PER_INTERMEDIARY = 4
+"""Leaf agents delegated from each intermediary (3 x 4 = 12 leaves)."""
+
+ROOT_SCOPES = ["admin", "pay", "read", "write"]
+"""The coordinator's root capabilities (sorted; the widest scope set)."""
+
+INTERMEDIARY_SCOPES = [
+    ["read", "write", "pay"],
+    ["read", "write"],
+    ["read", "pay"],
+]
+"""Scope grant for each intermediary — each a strict subset of ``ROOT_SCOPES``."""
+
+CHILD_TTL = 600.0
+"""Lifetime (seconds) of an intermediary token; leaves clamp to <= this."""
+
+LEAF_TTL = 300.0
+"""Requested lifetime (seconds) of a leaf token; clamped to its parent's expiry."""
+
+REVOKED_INTERMEDIARY = 1
+"""Index of the intermediary the coordinator revokes to demonstrate cascading."""
+
+
+def _scopes_frame(scopes: list[str]) -> str:
+    """Join scopes with ``|`` for embedding in a ``:``-delimited trace frame."""
+    return "|".join(scopes)
+
+
+class TreeAgent(StateMachineAgent):
+    """A passive node (intermediary or leaf) that only needs to be addressable.
+
+    The coordinator drives all delegation and verification; these agents exist so
+    the coordinator's ``ctx.send`` frames have real destinations.
+
+    Example::
+
+        agent = TreeAgent(AgentId("int-0"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+
+
+class CoordinatorAgent(StateMachineAgent):
+    """Root of the delegation tree; builds it, sweeps it, revokes, sweeps again.
+
+    Holds a single delegatable auth instance and the deterministic per-leaf scope
+    choices, and performs the whole protocol in ``on_start`` so the trace is a
+    faithful, replayable record of a cascading-revocation run.
+
+    Example::
+
+        agent = CoordinatorAgent(AgentId("coordinator"), auth, leaf_scopes)
+    """
+
+    def __init__(
+        self,
+        coordinator_id: AgentId,
+        auth: Any,
+        leaf_scopes: dict[AgentId, list[str]],
+    ) -> None:
+        self._id = coordinator_id
+        self._auth = auth
+        self._leaf_scopes = leaf_scopes
+
+    def _intermediary_id(self, idx: int) -> AgentId:
+        return AgentId(f"int-{idx}")
+
+    def _leaf_id(self, idx: int, jdx: int) -> AgentId:
+        return AgentId(f"leaf-{idx}-{jdx}")
+
+    async def _emit(self, ctx: AgentContext, to: AgentId, frame: str) -> None:
+        await ctx.send(to, frame.encode())
+
+    async def _verify_probe(
+        self, ctx: AgentContext, token: Token, presenter: AgentId, owner: AgentId, phase: str
+    ) -> None:
+        """Verify *token* as *presenter* and record the ok/fail outcome to the trace."""
+        try:
+            await self._auth.verify(token, presenter=presenter)
+            outcome = "ok"
+        except Exception:  # noqa: BLE001 - any failure is recorded as a rejected verify
+            outcome = "fail"
+        await self._emit(ctx, owner, f"dauth:verify:{presenter}:{owner}:{outcome}:{phase}")
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Build the delegation tree, sweep it, revoke one branch, sweep again.
+
+        Example::
+
+            await coordinator.on_start(ctx)
+        """
+        # Root token: the coordinator's full capability set.
+        root = await self._auth.issue(self._id, ROOT_SCOPES)
+        await self._emit(ctx, self._id, f"dauth:issue:{self._id}:{_scopes_frame(ROOT_SCOPES)}")
+
+        int_tokens: dict[AgentId, Token] = {}
+        leaf_tokens: dict[AgentId, tuple[AgentId, Token]] = {}
+
+        # Level 1: delegate a narrower token to each intermediary.
+        for i in range(N_INTERMEDIARIES):
+            int_id = self._intermediary_id(i)
+            scopes = sorted(set(INTERMEDIARY_SCOPES[i]))
+            token = await self._auth.delegate(root, int_id, scopes, CHILD_TTL)
+            int_tokens[int_id] = token
+            await self._emit(
+                ctx, int_id, f"dauth:delegate:{self._id}:{int_id}:{_scopes_frame(scopes)}"
+            )
+
+            # Level 2: each intermediary delegates to its leaves.
+            for j in range(LEAVES_PER_INTERMEDIARY):
+                leaf_id = self._leaf_id(i, j)
+                leaf_scopes = self._leaf_scopes[leaf_id]
+                leaf_token = await self._auth.delegate(token, leaf_id, leaf_scopes, LEAF_TTL)
+                leaf_tokens[leaf_id] = (int_id, leaf_token)
+                await self._emit(
+                    ctx,
+                    leaf_id,
+                    f"dauth:delegate:{int_id}:{leaf_id}:{_scopes_frame(leaf_scopes)}",
+                )
+
+        # Pre-revocation sweep: every leaf presents its own token (accepted) and
+        # an impostor presents it (rejected by audience binding).
+        for leaf_id, (_int_id, leaf_token) in leaf_tokens.items():
+            await self._verify_probe(ctx, leaf_token, leaf_id, leaf_id, "pre")
+            impostor = AgentId(f"impostor-of-{leaf_id}")
+            await self._verify_probe(ctx, leaf_token, impostor, leaf_id, "pre")
+
+        # Revoke one intermediary; its whole subtree should die.
+        revoked_id = self._intermediary_id(REVOKED_INTERMEDIARY)
+        await self._auth.revoke(int_tokens[revoked_id])
+        await self._emit(ctx, revoked_id, f"dauth:revoke:{revoked_id}")
+
+        # Post-revocation sweep: intermediaries first, then leaves.
+        for int_id, token in int_tokens.items():
+            await self._verify_probe(ctx, token, int_id, int_id, "post")
+        for leaf_id, (_int_id, leaf_token) in leaf_tokens.items():
+            await self._verify_probe(ctx, leaf_token, leaf_id, leaf_id, "post")
+
+
+def delegated_auth_factory(config: ScenarioConfig, plugins: dict[str, Any]) -> dict[AgentId, Any]:
+    """Build the coordinator + 3 intermediaries + 12 leaves for the delegation tree.
+
+    Instantiates the configured ``auth`` plugin with ``clock=0.0`` for
+    determinism, derives each leaf's scope subset from a generator seeded only
+    from ``config.seed``, and hands the auth instance to the coordinator, which
+    drives the whole run in ``on_start``.
+
+    Example::
+
+        agents = delegated_auth_factory(config, plugins)
+    """
+    auth_cls = plugins["auth"]
+    auth = auth_cls(clock=0.0)
+
+    coordinator_id = AgentId("coordinator")
+    rng = random.Random(str(config.seed))
+
+    agents: dict[AgentId, Any] = {}
+    leaf_scopes: dict[AgentId, list[str]] = {}
+
+    for i in range(N_INTERMEDIARIES):
+        int_id = AgentId(f"int-{i}")
+        agents[int_id] = TreeAgent(int_id)
+        parent_scopes = sorted(set(INTERMEDIARY_SCOPES[i]))
+        for j in range(LEAVES_PER_INTERMEDIARY):
+            leaf_id = AgentId(f"leaf-{i}-{j}")
+            agents[leaf_id] = TreeAgent(leaf_id)
+            # "read" is always kept; a deterministic extra scope may be added if
+            # the parent holds one, so leaves narrow but stay non-trivial.
+            chosen = {"read"} if "read" in parent_scopes else {parent_scopes[0]}
+            extras = [s for s in parent_scopes if s not in chosen]
+            if extras and rng.random() < 0.5:
+                chosen.add(rng.choice(extras))
+            leaf_scopes[leaf_id] = sorted(chosen)
+
+    agents[coordinator_id] = CoordinatorAgent(coordinator_id, auth, leaf_scopes)
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -4595,6 +4595,212 @@ def validate_parc_stale_key_rejected(events: list[dict[str, Any]]) -> list[Valid
 
 
 # ---------------------------------------------------------------------------
+# Delegated-auth validators
+# ---------------------------------------------------------------------------
+
+
+def _delegated_auth_frames(events: list[dict[str, Any]]) -> list[list[str]]:
+    """Return every ``dauth:`` trace frame, colon-split into its fields.
+
+    Example::
+
+        frames = _delegated_auth_frames(events)
+    """
+    frames: list[list[str]] = []
+    for ev in events:
+        # Each frame is recorded once as a "send" and again as a "receive"; take
+        # the send as the canonical single source so counts are not doubled.
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        body = _message_body(ev)
+        if body.startswith("dauth:"):
+            frames.append(body.split(":"))
+    return frames
+
+
+def _delegated_auth_subtree(children: dict[str, list[str]], root: str) -> set[str]:
+    """Return *root* and all its transitive delegatees (inclusive subtree)."""
+    seen: set[str] = set()
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node in seen:
+            continue
+        seen.add(node)
+        stack.extend(children.get(node, []))
+    return seen
+
+
+def validate_delegated_auth_scope_narrowing(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every delegated child holds a strict subset of its parent's scopes.
+
+    Reconstructs each token's granted scopes from the ``issue`` / ``delegate``
+    frames and FAILS if any child carries a scope its parent never held (scope
+    escalation). The default ``jwt`` plugin, which re-issues unrelated tokens
+    with whatever scopes are asked for, cannot uphold this.
+
+    Example::
+
+        results = validate_delegated_auth_scope_narrowing(events)
+    """
+    scopes_of: dict[str, set[str]] = {}
+    violations: list[str] = []
+    delegations = 0
+    for frame in _delegated_auth_frames(events):
+        if frame[1] == "issue" and len(frame) >= 4:
+            owner, scope_str = frame[2], frame[3]
+            scopes_of[owner] = set(scope_str.split("|")) if scope_str else set[str]()
+        elif frame[1] == "delegate" and len(frame) >= 5:
+            parent, child, scope_str = frame[2], frame[3], frame[4]
+            child_scopes = set(scope_str.split("|")) if scope_str else set[str]()
+            scopes_of[child] = child_scopes
+            delegations += 1
+            parent_scopes = scopes_of.get(parent)
+            if parent_scopes is None:
+                violations.append(f"{child} delegated from unknown parent {parent}")
+            elif not child_scopes.issubset(parent_scopes):
+                extra = sorted(child_scopes - parent_scopes)
+                violations.append(f"{child} widened scopes by {extra} beyond parent {parent}")
+    if delegations == 0:
+        return [
+            ValidationResult("delegated_auth_scope_narrowing", False, "no delegations observed")
+        ]
+    if violations:
+        return [ValidationResult("delegated_auth_scope_narrowing", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "delegated_auth_scope_narrowing",
+            True,
+            f"{delegations} delegation(s) narrow scopes",
+        )
+    ]
+
+
+def validate_delegated_auth_cascading_revocation(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Revoking a token invalidates its whole subtree — and nothing else.
+
+    Builds the delegation tree from ``delegate`` frames, then checks the verify
+    sweeps: pre-revocation, every legitimate holder verifies; post-revocation,
+    every token in a revoked node's subtree FAILS and every unrelated token still
+    verifies. FAILS if a revoked descendant still verifies (stale parent) or an
+    unrelated token is wrongly rejected. The default ``jwt`` plugin revokes only
+    exact strings, so a revoked parent leaves its children valid.
+
+    Example::
+
+        results = validate_delegated_auth_cascading_revocation(events)
+    """
+    children: dict[str, list[str]] = defaultdict(list)
+    revoked: list[str] = []
+    for frame in _delegated_auth_frames(events):
+        if frame[1] == "delegate" and len(frame) >= 4:
+            children[frame[2]].append(frame[3])
+        elif frame[1] == "revoke" and len(frame) >= 3:
+            revoked.append(frame[2])
+
+    if not revoked:
+        return [
+            ValidationResult("delegated_auth_cascading_revocation", False, "no revocation observed")
+        ]
+
+    dead: set[str] = set()
+    for node in revoked:
+        dead |= _delegated_auth_subtree(children, node)
+    if not (dead - set(revoked)):
+        return [
+            ValidationResult(
+                "delegated_auth_cascading_revocation",
+                False,
+                "revoked token had no descendants; cascade not exercised",
+            )
+        ]
+
+    pre_ok = 0
+    post_checked = 0
+    violations: list[str] = []
+    for frame in _delegated_auth_frames(events):
+        if frame[1] != "verify" or len(frame) < 6:
+            continue
+        presenter, owner, outcome, phase = frame[2], frame[3], frame[4], frame[5]
+        if presenter != owner:
+            continue  # audience-binding validator owns impostor probes
+        if phase == "pre":
+            if outcome != "ok":
+                violations.append(f"pre-revocation verify for {owner} was {outcome}")
+            else:
+                pre_ok += 1
+        elif phase == "post":
+            post_checked += 1
+            if owner in dead and outcome != "fail":
+                violations.append(f"revoked-subtree {owner} still verified after revocation")
+            if owner not in dead and outcome != "ok":
+                violations.append(f"unrelated {owner} wrongly failed after revocation")
+
+    if pre_ok == 0 or post_checked == 0:
+        return [
+            ValidationResult(
+                "delegated_auth_cascading_revocation", False, "no pre/post verify sweep observed"
+            )
+        ]
+    if violations:
+        return [
+            ValidationResult("delegated_auth_cascading_revocation", False, "; ".join(violations))
+        ]
+    return [
+        ValidationResult(
+            "delegated_auth_cascading_revocation",
+            True,
+            f"revoking {sorted(revoked)} killed a subtree of {len(dead)} token(s)",
+        )
+    ]
+
+
+def validate_delegated_auth_audience_binding(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """A token presented by anyone other than its audience is rejected.
+
+    Checks every impostor verify probe (presenter != owner) and FAILS if any
+    succeeded. The default ``jwt`` plugin has no audience binding, so any holder
+    of the token string verifies.
+
+    Example::
+
+        results = validate_delegated_auth_audience_binding(events)
+    """
+    impostor_probes = 0
+    violations: list[str] = []
+    for frame in _delegated_auth_frames(events):
+        if frame[1] != "verify" or len(frame) < 6:
+            continue
+        presenter, owner, outcome = frame[2], frame[3], frame[4]
+        if presenter == owner:
+            continue
+        impostor_probes += 1
+        if outcome != "fail":
+            violations.append(f"impostor {presenter} verified {owner}'s token")
+    if impostor_probes == 0:
+        return [
+            ValidationResult(
+                "delegated_auth_audience_binding", False, "no impostor probes observed"
+            )
+        ]
+    if violations:
+        return [ValidationResult("delegated_auth_audience_binding", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "delegated_auth_audience_binding",
+            True,
+            f"{impostor_probes} impostor probe(s) rejected",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -4671,6 +4877,11 @@ VALIDATORS: dict[str, list[Any]] = {
     "multi_attribute_market": [
         validate_multi_attribute_pareto_optimal,
         validate_multi_attribute_individually_rational,
+    ],
+    "delegated_auth": [
+        validate_delegated_auth_scope_narrowing,
+        validate_delegated_auth_cascading_revocation,
+        validate_delegated_auth_audience_binding,
     ],
     "provenance_supply_chain": [
         validate_provenance_chain_integrity,

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -1905,6 +1905,7 @@ class TestValidatorRegistry:
             "comms_downgrade",
             "receipt_reputation",
             "multi_attribute_market",
+            "delegated_auth",
             "provenance_supply_chain",
             "bft_hotstuff",
             "escrow_marketplace",

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
@@ -1,0 +1,344 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegatable capability tokens with cascading revocation (macaroon-style).
+
+The default :class:`~nest_plugins_reference.auth.jwt_auth.JwtAuth` can only
+*issue* and *revoke by exact string*. It cannot model the most common
+multi-agent pattern: an orchestrator holds a long-lived root token, mints a
+narrowly-scoped, short-lived sub-token for a worker **without going back to the
+issuer**, and later revokes the root so every descendant token dies at once.
+
+``DelegatableAuth`` adds exactly that. It borrows the HMAC chaining from
+macaroons (Birgisson et al., 2014): each token carries the full chain of *links*
+from root to leaf, and each link's signature is keyed by the previous link's
+signature::
+
+    s_0 = HMAC(secret,   link_0)
+    s_1 = HMAC(s_0,       link_1)
+    ...
+    s_n = HMAC(s_{n-1},   link_n)          # the token's outer signature
+
+Two properties fall straight out of this construction:
+
+* **Transitive revocation for free.** ``s_k`` depends only on ``secret`` and
+  ``link_0..link_k``, so the intermediate signature at step *k* of a long chain
+  is *byte-identical* to the outer signature of the length-*k* ancestor token.
+  Revoking an ancestor records its outer signature; verifying any descendant
+  recomputes the same value mid-chain and rejects it — no per-child revocation
+  list, and siblings/cousins are untouched.
+* **Tamper-evidence.** Broadening a child's scopes or extending its expiry after
+  the fact breaks the signature chain, so :meth:`verify` re-checks scope
+  narrowing and TTL monotonicity as a belt-and-braces guard even though a forged
+  chain would already fail the signature check.
+
+The base :class:`~nest_core.layers.auth.Auth` surface (``issue`` / ``verify`` /
+``revoke``) is preserved; delegation adds :meth:`delegate` and an *optional*
+keyword-only ``presenter`` argument to :meth:`verify` for audience binding.
+``verify(token)`` — the base contract — still works unchanged.
+
+Example::
+
+    auth = DelegatableAuth(secret=b"orchestrator-secret")
+    root = await auth.issue(AgentId("coordinator"), ["read", "write", "pay"])
+    child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=600)
+    ctx = await auth.verify(child, presenter=AgentId("worker"))
+    assert ctx.scopes == ["read"]
+    await auth.revoke(root)              # cascades
+    await auth.verify(child)             # raises RevokedAncestorError
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, cast
+
+from nest_core.types import AgentId, AuthContext, Token
+
+ROOT_TTL = 3600.0
+"""Default lifetime (seconds) of a freshly issued root token."""
+
+
+class DelegationError(ValueError):
+    """Base class for delegation/verification failures.
+
+    Subclasses :class:`ValueError` so callers written against the ``jwt``
+    plugin's ``ValueError`` contract keep working while gaining typed granularity.
+
+    Example::
+
+        try:
+            await auth.verify(tok)
+        except DelegationError as exc:
+            log.warning("token rejected: %s", exc)
+    """
+
+
+class MalformedTokenError(DelegationError):
+    """The token string is not a well-formed delegatable token.
+
+    Example::
+
+        raise MalformedTokenError("token has no signature delimiter")
+    """
+
+
+class InvalidSignatureError(DelegationError):
+    """The recomputed chain signature does not match the token's outer signature.
+
+    Example::
+
+        raise InvalidSignatureError("chain signature mismatch")
+    """
+
+
+class RevokedAncestorError(DelegationError):
+    """Some link in the chain (this token or an ancestor) has been revoked.
+
+    Example::
+
+        raise RevokedAncestorError("ancestor at depth 1 is revoked")
+    """
+
+
+class ExpiredTokenError(DelegationError):
+    """A link in the chain (this token or an ancestor) has expired.
+
+    Example::
+
+        raise ExpiredTokenError("token expired at t=600.0")
+    """
+
+
+class ScopeEscalationError(DelegationError):
+    """A child link claims a scope its parent does not hold.
+
+    Raised by :meth:`delegate` when the requested subset is not a subset, and by
+    :meth:`verify` if a forged chain widens scopes mid-way.
+
+    Example::
+
+        raise ScopeEscalationError("child requested {'write'} beyond parent")
+    """
+
+
+class AudienceMismatchError(DelegationError):
+    """The presenter is not the audience the leaf token was minted for.
+
+    Example::
+
+        raise AudienceMismatchError("token minted for 'bob', presented by 'mallory'")
+    """
+
+
+def _link_bytes(link: dict[str, Any]) -> bytes:
+    """Serialize one chain link canonically so signatures are byte-deterministic."""
+    return json.dumps(link, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _chain_sigs(secret: bytes, links: list[dict[str, Any]]) -> list[str]:
+    """Return the running HMAC signatures ``s_0..s_n`` for a chain of links.
+
+    ``s_i`` is ``HMAC(key_i, link_i)`` where ``key_0`` is *secret* and each
+    subsequent key is the previous signature. The last element is the token's
+    outer signature; every earlier element equals the outer signature of the
+    corresponding ancestor token, which is what makes revocation transitive.
+
+    Example::
+
+        sigs = _chain_sigs(b"secret", [root_link, child_link])
+    """
+    sigs: list[str] = []
+    key = secret
+    for link in links:
+        sig = hmac.new(key, _link_bytes(link), hashlib.sha256).hexdigest()
+        sigs.append(sig)
+        key = sig.encode()
+    return sigs
+
+
+class DelegatableAuth:
+    """Macaroon-style auth: delegatable capability tokens, cascading revocation.
+
+    Example::
+
+        auth = DelegatableAuth(secret=b"secret")
+        root = await auth.issue(AgentId("a1"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("a2"), ["read"], ttl=300)
+    """
+
+    def __init__(
+        self, secret: bytes = b"nest-delegatable-secret", clock: float | None = None
+    ) -> None:
+        self._secret = secret
+        self._clock = clock
+        self._revoked: set[str] = set()
+
+    def _now(self) -> float:
+        if self._clock is not None:
+            return self._clock
+        return time.time()
+
+    def _parse(self, token: Token) -> tuple[list[dict[str, Any]], str]:
+        """Split a token into its ``(links, outer_signature)`` without validating."""
+        raw = str(token)
+        parts = raw.rsplit("|", 1)
+        if len(parts) != 2:
+            msg = "Token has no signature delimiter"
+            raise MalformedTokenError(msg)
+        payload_str, sig = parts
+        try:
+            data: Any = json.loads(payload_str)
+        except (ValueError, TypeError) as exc:
+            msg = "Token payload is not valid JSON"
+            raise MalformedTokenError(msg) from exc
+        if not isinstance(data, dict):
+            msg = "Token payload has no chain"
+            raise MalformedTokenError(msg)
+        chain = cast("dict[str, Any]", data).get("chain")
+        if not isinstance(chain, list) or not chain:
+            msg = "Token chain is empty"
+            raise MalformedTokenError(msg)
+        return list(cast("list[dict[str, Any]]", chain)), sig
+
+    def _encode(self, links: list[dict[str, Any]]) -> Token:
+        """Sign *links* and serialize them into a wire token string."""
+        sigs = _chain_sigs(self._secret, links)
+        payload = json.dumps({"chain": links}, sort_keys=True)
+        return Token(f"{payload}|{sigs[-1]}")
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Issue a root token granting *scopes* to *subject*.
+
+        The root's audience is the subject itself, so only the subject can
+        present it (once audience binding is checked).
+
+        Example::
+
+            root = await auth.issue(AgentId("coordinator"), ["read", "write"])
+        """
+        now = self._now()
+        link = {
+            "sub": str(subject),
+            "aud": str(subject),
+            "scopes": sorted(set(scopes)),
+            "iat": now,
+            "exp": now + ROOT_TTL,
+        }
+        return self._encode([link])
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token:
+        """Mint a child token for *audience* with a strict subset of parent scopes.
+
+        No round trip to the issuer: the holder of *parent_token* signs the child
+        with the parent's own signature as the HMAC key. The child's scopes must
+        be a subset of the parent's leaf scopes (else
+        :class:`ScopeEscalationError`) and its expiry is clamped to ``≤`` the
+        parent's (TTL never widens down the chain). The parent is verified first,
+        so delegating from a revoked or expired parent fails.
+
+        Example::
+
+            child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=600)
+        """
+        # Verify the parent (rejects revoked/expired/forged parents up front).
+        await self.verify(parent_token)
+        parent_links, _ = self._parse(parent_token)
+        parent_leaf = parent_links[-1]
+        parent_scopes = set(parent_leaf["scopes"])
+        requested = set(scopes_subset)
+        if not requested.issubset(parent_scopes):
+            extra = requested - parent_scopes
+            msg = f"child requested {sorted(extra)} beyond parent scopes {sorted(parent_scopes)}"
+            raise ScopeEscalationError(msg)
+        now = self._now()
+        child_exp = min(now + ttl, float(parent_leaf["exp"]))
+        child_link = {
+            "sub": str(audience),
+            "aud": str(audience),
+            "scopes": sorted(requested),
+            "iat": now,
+            "exp": child_exp,
+        }
+        return self._encode([*parent_links, child_link])
+
+    async def verify(self, token: Token, *, presenter: AgentId | None = None) -> AuthContext:
+        """Verify a token end-to-end and return the leaf's :class:`AuthContext`.
+
+        Checks, in order: the outer signature; that no link in the chain is
+        revoked (transitive — a revoked ancestor sinks the whole subtree); that
+        no link has expired; that scopes narrow monotonically and TTLs never
+        widen down the chain (tamper guard); and, when *presenter* is supplied,
+        that it matches the leaf's audience.
+
+        Passing *presenter* is optional so the base ``verify(token)`` contract is
+        preserved; omit it to skip audience binding (e.g. when the holder
+        delegates onward rather than presents).
+
+        Example::
+
+            ctx = await auth.verify(child, presenter=AgentId("worker"))
+        """
+        links, sig = self._parse(token)
+        sigs = _chain_sigs(self._secret, links)
+        if not hmac.compare_digest(sigs[-1], sig):
+            msg = "chain signature mismatch"
+            raise InvalidSignatureError(msg)
+
+        for depth, link_sig in enumerate(sigs):
+            if link_sig in self._revoked:
+                msg = f"ancestor at depth {depth} is revoked"
+                raise RevokedAncestorError(msg)
+
+        now = self._now()
+        prev_scopes: set[str] | None = None
+        prev_exp: float | None = None
+        for depth, link in enumerate(links):
+            exp = float(link["exp"])
+            if exp < now:
+                msg = f"link at depth {depth} expired at t={exp}"
+                raise ExpiredTokenError(msg)
+            scopes = set(link["scopes"])
+            if prev_scopes is not None and not scopes.issubset(prev_scopes):
+                widened = scopes - prev_scopes
+                msg = f"link at depth {depth} widened scopes by {sorted(widened)}"
+                raise ScopeEscalationError(msg)
+            if prev_exp is not None and exp > prev_exp:
+                msg = f"link at depth {depth} extends TTL beyond its parent"
+                raise DelegationError(msg)
+            prev_scopes = scopes
+            prev_exp = exp
+
+        leaf = links[-1]
+        if presenter is not None and str(presenter) != leaf["aud"]:
+            msg = f"token minted for {leaf['aud']!r}, presented by {str(presenter)!r}"
+            raise AudienceMismatchError(msg)
+
+        return AuthContext(
+            subject=AgentId(leaf["sub"]),
+            scopes=list(leaf["scopes"]),
+            issued_at=leaf["iat"],
+            expires_at=leaf["exp"],
+        )
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke *token*; every descendant delegated from it dies too.
+
+        Records the token's outer signature. Because that value reappears as an
+        intermediate signature in every descendant's chain, the next
+        :meth:`verify` of any descendant raises :class:`RevokedAncestorError`.
+        Siblings and ancestors are unaffected.
+
+        Example::
+
+            await auth.revoke(root)
+        """
+        _, sig = self._parse(token)
+        self._revoked.add(sig)

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -16,6 +16,11 @@ Example::
 
 from __future__ import annotations
 
+from nest_plugins_reference.validators.auth_validators import (
+    check_audience_confusion_rejected,
+    check_scope_escalation_rejected,
+    check_stale_parent_rejected,
+)
 from nest_plugins_reference.validators.gossip_validators import (
     ConvergenceFailureError,
     PartitionLeakError,
@@ -35,8 +40,11 @@ __all__ = [
     "ConvergenceFailureError",
     "PartitionLeakError",
     "ValidatorReport",
+    "check_audience_confusion_rejected",
     "check_converged",
     "check_eavesdropper_blocked",
+    "check_scope_escalation_rejected",
+    "check_stale_parent_rejected",
     "check_field_injection_rejected",
     "check_no_partition_view_leak",
     "check_replay_rejected",

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/auth_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/auth_validators.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for delegatable auth — three attacks on capability tokens.
+
+The default ``jwt`` plugin issues independent HMAC tokens with no parent-child
+relationship, no audience binding, and revocation by exact string only. That
+makes it silently vulnerable to the three attacks a delegation scheme must
+resist:
+
+1. **Scope escalation.** A "child" is minted with a scope its parent never held.
+   :func:`check_scope_escalation_rejected` asserts the escalated scope is never
+   granted — either the delegation is refused or the verified context omits it.
+2. **Stale parent.** A parent token is revoked (or expires) but a child minted
+   from it still verifies. :func:`check_stale_parent_rejected` asserts revoking
+   the parent transitively invalidates the child.
+3. **Audience confusion.** A child token bound to agent *bob* is presented by
+   *mallory*. :func:`check_audience_confusion_rejected` asserts the impostor is
+   rejected while the legitimate audience is accepted.
+
+Each validator drives only the public auth surface, so the *same* check runs
+against both plugins. A plugin with no ``delegate`` method (the ``jwt`` default)
+can only model "delegation" as re-issuance by the authority — exactly the
+anti-pattern the charter names — so :func:`_delegate` falls back to ``issue``.
+Under that fallback every check **fails** against ``jwt`` and **passes** against
+:class:`~nest_plugins_reference.auth.delegatable.DelegatableAuth`, which is the
+charter's bar for "adversarial": the reference plugin literally cannot satisfy
+them.
+
+Example::
+
+    from nest_plugins_reference.auth.delegatable import DelegatableAuth
+
+    report = await check_stale_parent_rejected(DelegatableAuth(), scopes=["read"])
+    assert report.passed, report.detail
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING, Any
+
+from nest_core.types import AgentId
+
+from nest_plugins_reference.validators.gossip_validators import ValidatorReport
+
+if TYPE_CHECKING:
+    from nest_core.types import Token
+
+
+def _supports_presenter(auth: Any) -> bool:
+    """Return ``True`` if ``auth.verify`` accepts a ``presenter`` keyword."""
+    try:
+        params = inspect.signature(auth.verify).parameters
+    except (TypeError, ValueError):
+        return False
+    return "presenter" in params
+
+
+async def _delegate(
+    auth: Any, parent: Token, audience: AgentId, scopes: list[str], ttl: float
+) -> Token:
+    """Delegate a child token, falling back to re-issuance for non-delegating plugins.
+
+    A real delegation plugin exposes ``delegate(parent, audience, scopes, ttl)``.
+    A plugin without it (the ``jwt`` default) can only re-issue a fresh,
+    unrelated token — which is precisely why it fails these validators.
+
+    Example::
+
+        child = await _delegate(auth, root, AgentId("bob"), ["read"], 600)
+    """
+    if hasattr(auth, "delegate"):
+        result: Token = await auth.delegate(parent, audience, scopes, ttl)
+        return result
+    reissued: Token = await auth.issue(audience, scopes)
+    return reissued
+
+
+async def _verify_ok(auth: Any, token: Token, presenter: AgentId | None = None) -> bool:
+    """Return ``True`` iff *token* verifies, honouring *presenter* when supported."""
+    try:
+        if presenter is not None and _supports_presenter(auth):
+            await auth.verify(token, presenter=presenter)
+        else:
+            await auth.verify(token)
+    except Exception:  # noqa: BLE001 - any failure is, for policy purposes, "rejected"
+        return False
+    return True
+
+
+async def check_scope_escalation_rejected(
+    auth: Any, *, root_scopes: list[str], escalated_scope: str
+) -> ValidatorReport:
+    """Assert a child never obtains a scope its parent does not hold.
+
+    Issues a root limited to *root_scopes* (which must exclude *escalated_scope*),
+    then attempts to delegate the escalated scope. Passes iff delegation is
+    refused, or the resulting context does not carry the escalated scope. Against
+    ``jwt`` the re-issued token simply grants it.
+
+    Example::
+
+        report = await check_scope_escalation_rejected(
+            auth, root_scopes=["read"], escalated_scope="write"
+        )
+        assert report.passed, report.detail
+    """
+    root = await auth.issue(AgentId("esc-root"), root_scopes)
+    try:
+        child = await _delegate(auth, root, AgentId("esc-child"), [escalated_scope], 600.0)
+    except Exception:  # noqa: BLE001 - refusing to broaden scope is the correct behaviour
+        return ValidatorReport(passed=True, detail="delegation refused scope escalation")
+    try:
+        ctx = await auth.verify(child, presenter=AgentId("esc-child"))
+    except TypeError:
+        ctx = await auth.verify(child)
+    if escalated_scope in ctx.scopes:
+        return ValidatorReport(
+            passed=False,
+            detail=f"child obtained scope {escalated_scope!r} its parent never held",
+            evidence={"granted_scopes": list(ctx.scopes)},
+        )
+    return ValidatorReport(passed=True, detail="escalated scope was not granted")
+
+
+async def check_stale_parent_rejected(auth: Any, *, scopes: list[str]) -> ValidatorReport:
+    """Assert revoking a parent transitively invalidates a child delegated from it.
+
+    Delegates a child, confirms it verifies, revokes the *parent*, then re-checks
+    the child. Passes iff the child verifies before revocation and fails after.
+    Against ``jwt`` the child is an unrelated token, so revoking the parent leaves
+    it valid.
+
+    Example::
+
+        report = await check_stale_parent_rejected(auth, scopes=["read"])
+        assert report.passed, report.detail
+    """
+    parent = await auth.issue(AgentId("stale-parent"), scopes)
+    child = await _delegate(auth, parent, AgentId("stale-child"), scopes, 600.0)
+    if not await _verify_ok(auth, child, AgentId("stale-child")):
+        return ValidatorReport(passed=False, detail="child failed to verify before revocation")
+    await auth.revoke(parent)
+    if await _verify_ok(auth, child, AgentId("stale-child")):
+        return ValidatorReport(
+            passed=False, detail="child still verifies after its parent was revoked"
+        )
+    return ValidatorReport(passed=True, detail="child invalidated by parent revocation")
+
+
+async def check_audience_confusion_rejected(auth: Any, *, scopes: list[str]) -> ValidatorReport:
+    """Assert a child token is rejected when presented by an agent other than its audience.
+
+    Delegates a child bound to *bob*, confirms *bob* can present it, then has
+    *mallory* present the same token. Passes iff the legitimate audience is
+    accepted and the impostor is rejected. Against ``jwt`` (no audience binding)
+    the impostor is accepted.
+
+    Example::
+
+        report = await check_audience_confusion_rejected(auth, scopes=["read"])
+        assert report.passed, report.detail
+    """
+    if not _supports_presenter(auth):
+        return ValidatorReport(
+            passed=False,
+            detail="verify() has no audience binding; any holder can present the token",
+        )
+    root = await auth.issue(AgentId("aud-root"), scopes)
+    child = await _delegate(auth, root, AgentId("aud-bob"), scopes, 600.0)
+    if not await _verify_ok(auth, child, AgentId("aud-bob")):
+        return ValidatorReport(passed=False, detail="legitimate audience could not present token")
+    if await _verify_ok(auth, child, AgentId("aud-mallory")):
+        return ValidatorReport(
+            passed=False, detail="impostor presented another agent's token successfully"
+        )
+    return ValidatorReport(passed=True, detail="impostor rejected; audience binding enforced")

--- a/packages/nest-plugins-reference/tests/test_delegatable_auth.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable_auth.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the delegatable auth plugin and its three adversarial validators.
+
+Three layers:
+
+1. **Plugin unit tests**, drive ``DelegatableAuth`` directly: root issuance,
+   subset-enforced delegation, TTL clamping, transitive (cascading) revocation,
+   sibling isolation, audience binding, and tamper resistance.
+2. **Adversarial-validator discrimination** (the core deliverable), the same
+   three checks — scope escalation, stale parent, audience confusion — **FAIL**
+   against the reference ``jwt`` plugin and **PASS** against ``DelegatableAuth``.
+   Without the delegatable plugin these assertions cannot hold.
+3. **End-to-end scenario**, boot the real ``delegated_auth`` scenario through
+   ``ScenarioRunner`` and confirm the trace validators pass on the produced
+   cascading-revocation trace.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.types import AgentId, Token
+from nest_core.validators import (
+    validate_delegated_auth_audience_binding,
+    validate_delegated_auth_cascading_revocation,
+    validate_delegated_auth_scope_narrowing,
+    validate_trace,
+)
+from nest_plugins_reference.auth.delegatable import (
+    AudienceMismatchError,
+    DelegatableAuth,
+    ExpiredTokenError,
+    InvalidSignatureError,
+    MalformedTokenError,
+    RevokedAncestorError,
+    ScopeEscalationError,
+)
+from nest_plugins_reference.auth.jwt_auth import JwtAuth
+from nest_plugins_reference.validators import (
+    check_audience_confusion_rejected,
+    check_scope_escalation_rejected,
+    check_stale_parent_rejected,
+)
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "delegated_auth.yaml"
+
+
+@pytest.fixture
+def auth() -> DelegatableAuth:
+    """A delegatable auth instance with a frozen clock for determinism."""
+    return DelegatableAuth(secret=b"test-secret", clock=0.0)
+
+
+class TestDelegatableAuthPlugin:
+    """Direct unit tests of the plugin surface."""
+
+    async def test_issue_and_verify_root(self, auth: DelegatableAuth) -> None:
+        root = await auth.issue(AgentId("coord"), ["read", "write"])
+        ctx = await auth.verify(root)
+        assert ctx.subject == AgentId("coord")
+        assert sorted(ctx.scopes) == ["read", "write"]
+        assert ctx.expires_at == 3600.0
+
+    async def test_delegate_narrows_scopes(self, auth: DelegatableAuth) -> None:
+        root = await auth.issue(AgentId("coord"), ["read", "write", "pay"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=600)
+        ctx = await auth.verify(child, presenter=AgentId("worker"))
+        assert ctx.scopes == ["read"]
+        assert ctx.subject == AgentId("worker")
+
+    async def test_delegate_rejects_scope_escalation(self, auth: DelegatableAuth) -> None:
+        root = await auth.issue(AgentId("coord"), ["read"])
+        with pytest.raises(ScopeEscalationError):
+            await auth.delegate(root, AgentId("worker"), ["write"], ttl=600)
+
+    async def test_delegate_clamps_ttl_to_parent(self, auth: DelegatableAuth) -> None:
+        root = await auth.issue(AgentId("coord"), ["read"])  # exp = 3600
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=999_999)
+        ctx = await auth.verify(child, presenter=AgentId("worker"))
+        assert ctx.expires_at == 3600.0
+
+    async def test_cascading_revocation(self, auth: DelegatableAuth) -> None:
+        root = await auth.issue(AgentId("coord"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=600)
+        grandchild = await auth.delegate(child, AgentId("sub"), ["read"], ttl=300)
+        # All verify before revocation.
+        await auth.verify(child)
+        await auth.verify(grandchild)
+        # Revoking the root sinks the whole subtree.
+        await auth.revoke(root)
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify(child)
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify(grandchild)
+
+    async def test_revocation_does_not_affect_siblings(self, auth: DelegatableAuth) -> None:
+        root = await auth.issue(AgentId("coord"), ["read"])
+        child_a = await auth.delegate(root, AgentId("a"), ["read"], ttl=600)
+        child_b = await auth.delegate(root, AgentId("b"), ["read"], ttl=600)
+        await auth.revoke(child_a)
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify(child_a)
+        # Sibling is untouched.
+        ctx = await auth.verify(child_b, presenter=AgentId("b"))
+        assert ctx.subject == AgentId("b")
+
+    async def test_audience_binding(self, auth: DelegatableAuth) -> None:
+        root = await auth.issue(AgentId("coord"), ["read"])
+        child = await auth.delegate(root, AgentId("bob"), ["read"], ttl=600)
+        # Correct audience is accepted.
+        await auth.verify(child, presenter=AgentId("bob"))
+        # An impostor is rejected.
+        with pytest.raises(AudienceMismatchError):
+            await auth.verify(child, presenter=AgentId("mallory"))
+        # Omitting the presenter preserves the base contract (no audience check).
+        await auth.verify(child)
+
+    async def test_delegate_from_revoked_parent_fails(self, auth: DelegatableAuth) -> None:
+        root = await auth.issue(AgentId("coord"), ["read"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=600)
+        await auth.revoke(root)
+        with pytest.raises(RevokedAncestorError):
+            await auth.delegate(child, AgentId("sub"), ["read"], ttl=300)
+
+    async def test_tampered_scope_fails_signature(self, auth: DelegatableAuth) -> None:
+        root = await auth.issue(AgentId("coord"), ["read"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=600)
+        tampered = Token(str(child).replace('"read"', '"read","write"'))
+        with pytest.raises(InvalidSignatureError):
+            await auth.verify(tampered)
+
+    async def test_expired_token_rejected(self) -> None:
+        issuer = DelegatableAuth(secret=b"s", clock=0.0)
+        root = await issuer.issue(AgentId("coord"), ["read"])  # exp = 3600
+        # A verifier whose clock is past the root's 1-hour lifetime rejects it.
+        later = DelegatableAuth(secret=b"s", clock=4000.0)
+        with pytest.raises(ExpiredTokenError):
+            await later.verify(root)
+
+    async def test_malformed_token_rejected(self, auth: DelegatableAuth) -> None:
+        with pytest.raises(MalformedTokenError):
+            await auth.verify(Token("not-a-token"))
+
+
+class TestAdversarialValidators:
+    """The three attacks FAIL against jwt and PASS against delegatable."""
+
+    async def test_scope_escalation_discriminates(self) -> None:
+        jwt_report = await check_scope_escalation_rejected(
+            JwtAuth(clock=0.0), root_scopes=["read"], escalated_scope="write"
+        )
+        assert not jwt_report.passed, jwt_report.detail
+        good_report = await check_scope_escalation_rejected(
+            DelegatableAuth(clock=0.0), root_scopes=["read"], escalated_scope="write"
+        )
+        assert good_report.passed, good_report.detail
+
+    async def test_stale_parent_discriminates(self) -> None:
+        jwt_report = await check_stale_parent_rejected(JwtAuth(clock=0.0), scopes=["read"])
+        assert not jwt_report.passed, jwt_report.detail
+        good_report = await check_stale_parent_rejected(DelegatableAuth(clock=0.0), scopes=["read"])
+        assert good_report.passed, good_report.detail
+
+    async def test_audience_confusion_discriminates(self) -> None:
+        jwt_report = await check_audience_confusion_rejected(JwtAuth(clock=0.0), scopes=["read"])
+        assert not jwt_report.passed, jwt_report.detail
+        good_report = await check_audience_confusion_rejected(
+            DelegatableAuth(clock=0.0), scopes=["read"]
+        )
+        assert good_report.passed, good_report.detail
+
+
+class TestDelegatedAuthScenario:
+    """The shipped scenario produces a trace all delegated_auth validators pass."""
+
+    async def test_scenario_trace_validates(self) -> None:
+        config = ScenarioConfig.from_yaml(SCENARIO_PATH)
+        with tempfile.TemporaryDirectory() as tmp:
+            config.output.trace = str(Path(tmp) / "delegated_auth.jsonl")
+            runner = ScenarioRunner(config)
+            trace_path = await runner.run()
+            results = validate_trace(Path(trace_path), "delegated_auth")
+
+        assert results, "no validators ran for delegated_auth"
+        for result in results:
+            assert result.passed, f"{result.name}: {result.detail}"
+        names = {r.name for r in results}
+        assert names == {
+            "delegated_auth_scope_narrowing",
+            "delegated_auth_cascading_revocation",
+            "delegated_auth_audience_binding",
+        }
+
+    async def test_scenario_is_deterministic(self) -> None:
+        traces: list[str] = []
+        for _ in range(2):
+            config = ScenarioConfig.from_yaml(SCENARIO_PATH)
+            with tempfile.TemporaryDirectory() as tmp:
+                config.output.trace = str(Path(tmp) / "run.jsonl")
+                trace_path = await ScenarioRunner(config).run()
+                traces.append(Path(trace_path).read_text())
+        assert traces[0] == traces[1]
+
+
+def _send(msg: str) -> dict[str, object]:
+    """A minimal send event carrying a colon-delimited dauth frame."""
+    return {"kind": "send", "msg": msg, "agent": "coordinator", "to": "peer"}
+
+
+class TestDelegatedAuthTraceValidators:
+    """Direct-call tests exercising each FAIL branch of the trace validators."""
+
+    def test_scope_narrowing_flags_escalation(self) -> None:
+        events = [
+            _send("dauth:issue:coord:read"),
+            _send("dauth:delegate:coord:child:read|write"),  # widened beyond parent
+        ]
+        result = validate_delegated_auth_scope_narrowing(events)[0]
+        assert not result.passed
+        assert "widened" in result.detail
+
+    def test_scope_narrowing_passes_clean_tree(self) -> None:
+        events = [
+            _send("dauth:issue:coord:read|write"),
+            _send("dauth:delegate:coord:child:read"),
+        ]
+        result = validate_delegated_auth_scope_narrowing(events)[0]
+        assert result.passed
+
+    def test_cascading_revocation_flags_surviving_descendant(self) -> None:
+        events = [
+            _send("dauth:issue:coord:read"),
+            _send("dauth:delegate:coord:child:read"),
+            _send("dauth:verify:child:child:ok:pre"),
+            _send("dauth:revoke:coord"),
+            # child is in the revoked subtree but still verified -> stale parent
+            _send("dauth:verify:child:child:ok:post"),
+        ]
+        result = validate_delegated_auth_cascading_revocation(events)[0]
+        assert not result.passed
+        assert "still verified" in result.detail
+
+    def test_cascading_revocation_passes_when_subtree_dies(self) -> None:
+        events = [
+            _send("dauth:issue:coord:read"),
+            _send("dauth:delegate:coord:child:read"),
+            _send("dauth:verify:child:child:ok:pre"),
+            _send("dauth:revoke:coord"),
+            _send("dauth:verify:child:child:fail:post"),
+        ]
+        result = validate_delegated_auth_cascading_revocation(events)[0]
+        assert result.passed
+
+    def test_audience_binding_flags_accepted_impostor(self) -> None:
+        events = [
+            _send("dauth:verify:mallory:bob:ok:pre"),  # impostor accepted
+        ]
+        result = validate_delegated_auth_audience_binding(events)[0]
+        assert not result.passed
+        assert "impostor" in result.detail
+
+    def test_audience_binding_passes_when_impostor_rejected(self) -> None:
+        events = [
+            _send("dauth:verify:mallory:bob:fail:pre"),
+        ]
+        result = validate_delegated_auth_audience_binding(events)[0]
+        assert result.passed

--- a/scenarios/delegated_auth.yaml
+++ b/scenarios/delegated_auth.yaml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegated-auth scenario: a three-level capability-delegation tree.
+#
+# A coordinator holds a root token and delegates narrower, shorter-lived
+# sub-tokens to 3 intermediaries, each of which delegates to 4 leaves (16 agents
+# total). The coordinator verifies every token, revokes ONE intermediary, and
+# re-verifies: the revoked intermediary's whole subtree fails while every other
+# agent is untouched (cascading revocation). Impostor probes present each token
+# under the wrong identity to exercise audience binding.
+#
+# Every delegation, revocation, and verify outcome is written to the trace so the
+# validators (validate_delegated_auth_*) can reconstruct the tree and check scope
+# narrowing, cascading revocation, and audience binding offline.
+#
+# Deterministic: the auth instance is seeded with clock=0.0 and per-leaf scope
+# choices are drawn from a generator seeded only from `seed`, so the same seed
+# yields a byte-identical trace.
+name: delegated_auth
+description: "Coordinator + 3 intermediaries + 12 leaves; cascading capability revocation."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 16
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+    - name: intermediary
+      count: 3
+    - name: leaf
+      count: 12
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: delegatable
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: delegated_auth
+
+duration: "ticks: 10000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/delegated_auth.jsonl


### PR DESCRIPTION
Add a macaroon-style auth plugin that lets an agent delegate a strict subset of its capabilities to another agent without going back to the issuer, and that revokes an entire delegation subtree transitively when any ancestor token is revoked.

- `DelegatableAuth` plugin (registered as ("auth", "delegatable")): each token carries its full root->leaf chain; each link's HMAC is keyed by the previous link's signature, so a link's intermediate signature equals the outer signature of the corresponding ancestor token. Revoking an ancestor records that signature and every descendant fails at the next verify -- no per-child revocation list. `delegate()` enforces scope subsetting and TTL <= parent; verify() gains an optional keyword-only `presenter` for audience binding while keeping the base `verify(token)` contract unchanged.
- Three adversarial validators (scope escalation, stale parent, audience confusion) that FAIL against the default `jwt` plugin and PASS against `delegatable`.
- `delegated_auth` scenario + builtin factory: a coordinator, 3 intermediaries, and 12 leaves in a delegation tree; revoking one intermediary cascades to its whole subtree. Trace validators check scope narrowing, cascading revocation, and audience binding.
- Tests covering the plugin surface, validator discrimination, and a deterministic end-to-end scenario run.