### PR TITLE
hackathon/implement NANDA Simulation Sandbox API and serve SKILL.md phase 2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git/
+.venv/
+**/__pycache__/
+**/*.pyc
+node_modules/
+.pytest_cache/
+.ruff_cache/
+traces/
+jwt_test.jsonl
+run1.jsonl
+run2.jsonl
+marketplace.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-slim
+
+# Pin specific stable uv tool version for reproducible builds
+COPY --from=ghcr.io/astral-sh/uv:0.3.0 /uv /uvx /bin/
+
+# Create a non-privileged system user for executing sandbox tasks
+RUN useradd -m -u 1000 appuser
+
+WORKDIR /app
+
+# Copy the workspace files
+COPY . .
+
+# Set correct read/write permissions for the non-root execution context
+RUN chown -R appuser:appuser /app
+
+USER appuser
+
+# Synchronize the workspace dependencies programmatically
+RUN uv sync --no-dev
+
+# Install sandbox app runtime dependencies
+RUN uv pip install -r apps/nanda-sandbox/requirements.txt
+
+EXPOSE 8000
+
+# Run uvicorn server in the workspace virtual environment, binding dynamically to the Railway assigned port
+CMD ["sh", "-c", ".venv/bin/uvicorn apps.nanda-sandbox.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/apps/nanda-sandbox/main.py
+++ b/apps/nanda-sandbox/main.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportUnknownMemberType=false
+# pyright: reportUnknownVariableType=false
+# pyright: reportUnknownArgumentType=false
+# pyright: reportUnusedImport=false
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import tempfile
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+from pydantic import ValidationError
+
+app = FastAPI(
+    title="NANDA Simulation Sandbox",
+    description="Simulation-as-a-Service (SaaS) for running and validating NANDA Town scenarios.",
+    openapi_url=None,
+    docs_url=None,
+    redoc_url=None,
+)
+
+# API Authentication Configuration - Environment Variable Driven
+API_KEY_NAME = "X-API-Key"
+API_KEY = os.environ["SANDBOX_API_KEY"]
+
+
+class SafeNoAnchorLoader(yaml.SafeLoader):
+    """YAML Loader that forbids anchors and aliases to prevent CPU/memory amplification."""
+
+    def compose_node(self, parent: Any, index: Any) -> Any:
+        if self.check_event(yaml.AliasEvent):
+            raise yaml.YAMLError("YAML aliases are disabled")
+        event = self.peek_event()
+        if event is not None and getattr(event, "anchor", None) is not None:
+            raise yaml.YAMLError("YAML anchors are disabled")
+        return super().compose_node(parent, index)
+
+
+BUILTIN_SCENARIOS = [
+    "marketplace",
+    "auction",
+    "voting",
+    "consensus",
+    "supply_chain",
+    "reputation",
+    "identity_rotation",
+    "gossip_registry",
+    "memory_concurrent_writers",
+    "comms_versioning",
+    "receipt_reputation",
+    "empic_payments",
+    "multi_attribute_market",
+    "provenance_supply_chain",
+    "bft_hotstuff",
+    "escrow_marketplace",
+    "failure_detection",
+]
+
+# Strict Allow-lists for Configuration Validation
+ALLOWED_BRAINS = {"state-machine", "llm", "shell"}
+ALLOWED_PLUGINS = {
+    "transport": {"in_memory"},
+    "comms": {"nest_native", "versioned"},
+    "identity": {"did_key", "ed25519_rotating"},
+    "registry": {"in_memory", "gossip"},
+    "auth": {"jwt", "delegatable"},
+    "trust": {"score_average", "agent_receipts"},
+    "payments": {"prepaid_credits", "streaming", "escrow", "empic_escrow"},
+    "coordination": {"contract_net", "hotstuff"},
+    "negotiation": {"alternating_offers", "pareto"},
+    "memory": {"blackboard", "lww_register"},
+    "privacy": {"noop", "hybrid_x25519"},
+    "datafacts": {"datafacts_v1", "cid_facts"},
+}
+
+
+class InMemoryRateLimiter:
+    """Rate limiter using Token Bucket algorithm in-memory per IP."""
+
+    def __init__(self, requests_per_minute: int = 15) -> None:
+        self.limit = requests_per_minute
+        self.tokens: dict[str, float] = defaultdict(lambda: float(requests_per_minute))
+        self.last_updated: dict[str, float] = defaultdict(time.time)
+
+    def is_allowed(self, ip: str) -> bool:
+        now = time.time()
+        elapsed = now - self.last_updated[ip]
+        self.last_updated[ip] = now
+
+        refill = elapsed * (self.limit / 60.0)
+        self.tokens[ip] = min(float(self.limit), self.tokens[ip] + refill)
+
+        if self.tokens[ip] >= 1.0:
+            self.tokens[ip] -= 1.0
+            return True
+        return False
+
+
+rate_limiter = InMemoryRateLimiter()
+
+
+@app.get("/")
+async def root() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/scenarios")
+async def get_scenarios() -> dict[str, list[str]]:
+    return {"scenarios": BUILTIN_SCENARIOS}
+
+
+@app.post("/simulate")
+async def simulate(request: Request) -> JSONResponse:
+    # 1. Enforce Rate Limiting (Handle reverse proxy X-Forwarded-For header safely)
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        client_ip = forwarded_for.split(",")[0].strip()
+    else:
+        client_ip = request.client.host if request.client else "unknown"
+
+    if not rate_limiter.is_allowed(client_ip):
+        return JSONResponse(
+            status_code=429, content={"success": False, "errors": ["Rate limit exceeded"]}
+        )
+
+    # 2. Enforce Authentication
+    api_key = request.headers.get(API_KEY_NAME)
+    if api_key != API_KEY:
+        return JSONResponse(
+            status_code=401,
+            content={"success": False, "errors": ["Unauthorized: Invalid API Key"]},
+        )
+
+    # 3. Enforce Request Body Size Limit (1 MB)
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > 1024 * 1024:
+                return JSONResponse(
+                    status_code=413, content={"success": False, "errors": ["Payload too large"]}
+                )
+        except ValueError:
+            pass
+
+    body_bytes = b""
+    async for chunk in request.stream():
+        body_bytes += chunk
+        if len(body_bytes) > 1024 * 1024:
+            return JSONResponse(
+                status_code=413, content={"success": False, "errors": ["Payload too large"]}
+            )
+
+    # 4. Parse YAML Off the Event Loop (using a loader that forbids anchors/aliases)
+    try:
+        data = await asyncio.to_thread(yaml.load, body_bytes, Loader=SafeNoAnchorLoader)
+    except yaml.YAMLError:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "success": False,
+                "errors": ["Invalid YAML syntax or contains disabled anchors/aliases"],
+            },
+        )
+
+    if not isinstance(data, dict):
+        return JSONResponse(
+            status_code=400,
+            content={"success": False, "errors": ["Root of scenario must be a dictionary"]},
+        )
+
+    data_dict: dict[str, Any] = data
+
+    # 6. Sanitize and Validate Config Settings
+    agents_section = data_dict.get("agents")
+    if isinstance(agents_section, dict):
+        agent_count = agents_section.get("count")
+        if isinstance(agent_count, int) and agent_count > 100:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "success": False,
+                    "errors": ["Simulation agent count exceeds maximum limit (100)"],
+                },
+            )
+
+        brain_val = agents_section.get("brain")
+        if brain_val and brain_val not in ALLOWED_BRAINS:
+            return JSONResponse(
+                status_code=400,
+                content={"success": False, "errors": [f"Unsupported brain type: {brain_val}"]},
+            )
+
+    duration_val = data_dict.get("duration")
+    if isinstance(duration_val, str) and duration_val.startswith("ticks:"):
+        try:
+            ticks = int(duration_val.split(":")[1].strip())
+            if ticks > 2000:
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "success": False,
+                        "errors": ["Simulation duration ticks exceed maximum limit (2000)"],
+                    },
+                )
+        except ValueError:
+            pass
+
+    # Validate layer plugin choices against allow-list
+    layers_section = data_dict.get("layers")
+    if isinstance(layers_section, dict):
+        for layer_name, plugin_name in layers_section.items():
+            if layer_name not in ALLOWED_PLUGINS:
+                return JSONResponse(
+                    status_code=400,
+                    content={"success": False, "errors": [f"Unknown layer: {layer_name}"]},
+                )
+            if plugin_name not in ALLOWED_PLUGINS[layer_name]:
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "success": False,
+                        "errors": [f"Unknown plugin {plugin_name} for layer {layer_name}"],
+                    },
+                )
+
+    # Set default values for mandatory keys
+    if "name" not in data_dict:
+        data_dict["name"] = "sandbox_sim"
+    if "description" not in data_dict:
+        data_dict["description"] = "Autogenerated sandbox simulation run"
+
+    # 7. Execute Simulation with Timeouts
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trace_file = Path(tmpdir) / "trace.jsonl"
+
+            # Reconstruct output configuration server-side to prevent path traversal writes
+            data_dict["output"] = {"trace": str(trace_file), "report": None}
+
+            # Model validate parsed configuration off event loop
+            config = await asyncio.to_thread(ScenarioConfig.model_validate, data_dict)
+
+            # Initialize ScenarioRunner
+            runner = ScenarioRunner(config)
+
+            # Run with a strict timeout limit to prevent CPU lockups
+            try:
+                await asyncio.wait_for(runner.run(), timeout=30.0)
+            except TimeoutError:
+                return JSONResponse(
+                    status_code=504,
+                    content={"success": False, "errors": ["Simulation execution timed out"]},
+                )
+
+            # Read simulation metrics
+            metrics = runner.metrics
+
+            # Run adversarial validators off event loop
+            val_results = await asyncio.to_thread(validate_trace, trace_file, config.task.type)
+            validation = [
+                {"name": r.name, "passed": r.passed, "detail": r.detail} for r in val_results
+            ]
+
+            # Read trace events with UTF-8 encoding
+            returned_events = []
+            total_events = 0
+            if trace_file.exists():
+                with trace_file.open(encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if line:
+                            total_events += 1
+                            if len(returned_events) < 100:
+                                with contextlib.suppress(json.JSONDecodeError):
+                                    returned_events.append(json.loads(line))
+
+            return JSONResponse(
+                content={
+                    "success": True,
+                    "metrics": metrics,
+                    "validation": validation,
+                    "trace_summary": {
+                        "total_events": total_events,
+                        "returned_events": returned_events,
+                    },
+                }
+            )
+
+    except ValidationError:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "success": False,
+                "errors": ["Invalid scenario configuration parameters"],
+            },
+        )
+    except Exception:
+        # Return generic error and hide filesystem/version/library traces
+        return JSONResponse(
+            status_code=500,
+            content={
+                "success": False,
+                "errors": ["Simulation failed due to an internal execution error"],
+            },
+        )
+
+
+@app.get("/skill.md")
+async def get_skill_md() -> Response:
+    skill_file = (
+        Path(__file__).parent.parent.parent / "docs/hackathon/solutions/nanda-sandbox-skill.md"
+    )
+    if skill_file.exists():
+        content = skill_file.read_text(encoding="utf-8")
+    else:
+        content = "SKILL.md file not found"
+    return Response(content=content, media_type="text/markdown")

--- a/apps/nanda-sandbox/requirements.txt
+++ b/apps/nanda-sandbox/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.139.0
+uvicorn==0.51.0
+PyYAML==6.0.3
+pydantic==2.13.4

--- a/apps/nanda-sandbox/tests/test_main.py
+++ b/apps/nanda-sandbox/tests/test_main.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportUnknownMemberType=false
+# pyright: reportUnknownVariableType=false
+# pyright: reportUnknownArgumentType=false
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Add app directory to sys.path so we can import main
+sys.path.append(str(Path(__file__).parent.parent))
+
+# Inject default dev key into environment before importing app to allow tests to run fail-closed
+os.environ["SANDBOX_API_KEY"] = "nanda-sandbox-local-dev-fallback"
+
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+TEST_API_KEY = os.environ["SANDBOX_API_KEY"]
+HEADERS = {"X-API-Key": TEST_API_KEY}
+
+
+def test_root() -> None:
+    response: Any = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_health() -> None:
+    response: Any = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_scenarios() -> None:
+    response: Any = client.get("/scenarios")
+    assert response.status_code == 200
+    scenarios = response.json()["scenarios"]
+    assert "marketplace" in scenarios
+    assert "auction" in scenarios
+
+
+def test_simulate_unauthorized() -> None:
+    response: Any = client.post("/simulate", content="name: test")
+    assert response.status_code == 401
+    assert "Unauthorized" in response.json()["errors"][0]
+
+
+def test_simulate_valid() -> None:
+    yaml_content = """
+name: test_sandbox_sim
+description: "A minimal sandbox simulation run"
+tier: 1
+seed: 42
+agents:
+  count: 2
+  brain: state-machine
+  roles: []
+layers:
+  transport: in_memory
+  comms: nest_native
+task:
+  type: marketplace
+  config: {}
+duration: "ticks: 10"
+metrics:
+  - message_count
+output:
+  trace: ./traces/sandbox_test.jsonl
+"""
+    response: Any = client.post("/simulate", content=yaml_content, headers=HEADERS)
+    assert response.status_code == 200
+    data: dict[str, Any] = response.json()
+    assert data["success"] is True
+    assert "metrics" in data
+    assert "validation" in data
+    assert "trace_summary" in data
+
+
+def test_simulate_invalid_yaml() -> None:
+    response: Any = client.post("/simulate", content="bad: [yaml: structure", headers=HEADERS)
+    assert response.status_code == 400
+    data: dict[str, Any] = response.json()
+    assert data["success"] is False
+    assert any("Invalid YAML syntax" in err for err in data["errors"])
+
+
+def test_simulate_invalid_config() -> None:
+    # A config with invalid fields (e.g. tier 99) will fail pydantic parsing
+    yaml_content = """
+name: invalid_config_sim
+tier: 99
+duration: "ticks: 10"
+"""
+    response: Any = client.post("/simulate", content=yaml_content, headers=HEADERS)
+    assert response.status_code == 400
+    data: dict[str, Any] = response.json()
+    assert data["success"] is False
+    assert any("Invalid scenario configuration parameters" in err for err in data["errors"])
+
+
+def test_get_skill_md() -> None:
+    response: Any = client.get("/skill.md")
+    assert response.status_code == 200
+    assert "NANDA Simulation Sandbox" in response.text
+
+
+def test_simulate_yaml_anchors_rejected() -> None:
+    # A config containing anchors or aliases will be rejected
+    yaml_content = """
+name: &anchor_name anchor_sim
+tier: 1
+duration: "ticks: 10"
+"""
+    response: Any = client.post("/simulate", content=yaml_content, headers=HEADERS)
+    assert response.status_code == 400
+    data: dict[str, Any] = response.json()
+    assert data["success"] is False
+    assert any("anchors/aliases" in err for err in data["errors"])

--- a/docs/hackathon/solutions/nanda-sandbox-skill.md
+++ b/docs/hackathon/solutions/nanda-sandbox-skill.md
@@ -1,0 +1,86 @@
+# NANDA Simulation Sandbox
+
+Hosted sandbox service that runs and validates NANDA Town agent simulation configurations remotely.
+
+https://renewed-truth-production-71f6.up.railway.app
+
+## Endpoints
+
+### GET /health
+Checks if the sandbox service is online and active.
+```bash
+curl https://renewed-truth-production-71f6.up.railway.app/health
+```
+```json
+{"status": "ok"}
+```
+
+### GET /scenarios
+Lists all built-in simulation scenarios supported by the registry.
+```bash
+curl https://renewed-truth-production-71f6.up.railway.app/scenarios
+```
+```json
+{
+  "scenarios": [
+    "marketplace",
+    "auction",
+    "voting",
+    "consensus",
+    "supply_chain",
+    "reputation",
+    "identity_rotation",
+    "gossip_registry",
+    "memory_concurrent_writers",
+    "comms_versioning",
+    "receipt_reputation",
+    "empic_payments",
+    "multi_attribute_market",
+    "provenance_supply_chain",
+    "bft_hotstuff",
+    "escrow_marketplace",
+    "failure_detection"
+  ]
+}
+```
+
+### POST /simulate
+Executes a simulation scenario YAML string and returns metrics, adversarial validator reports, and trace logs. Requires the header `X-API-Key` to contain your deployed API key.
+```bash
+curl -X POST -H "Content-Type: text/yaml" -H "X-API-Key: <YOUR_SANDBOX_API_KEY>" --data-binary @scenarios/marketplace.yaml https://renewed-truth-production-71f6.up.railway.app/simulate
+```
+```json
+{
+  "success": true,
+  "metrics": {
+    "message_count": 82.0,
+    "deal_rate": 0.8
+  },
+  "validation": [
+    {
+      "name": "double_spend_prevention",
+      "passed": true,
+      "detail": "Verified 10/10 transaction attempts"
+    }
+  ],
+  "trace_summary": {
+    "total_events": 100,
+    "returned_events": [
+      {
+        "tick": 0.0,
+        "event": "simulation_started",
+        "seed": 42
+      }
+    ]
+  }
+}
+```
+
+## How the agent should use this
+
+1. Retrieve the list of supported simulation task types by calling `GET /scenarios`.
+2. Construct or modify a NANDA Town scenario configuration in YAML format (defining agent counts, plugin layers, and logical durations). Keep `agents.count` under 100 and duration ticks under 2000.
+3. Submit the raw YAML string to `POST /simulate` including the `X-API-Key` header with your deployed API key.
+4. Parse the output JSON to check if `"success"` is `true`.
+5. Read the `"validation"` results to inspect which adversarial checks passed or failed.
+6. Analyze the `"metrics"` and `"trace_summary.returned_events"` to optimize your custom layer configurations.

--- a/packages/nest-cli/pyproject.toml
+++ b/packages/nest-cli/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 7 - Inactive",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
 ]

--- a/packages/nest-core/pyproject.toml
+++ b/packages/nest-core/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/packages/nest-marketplace/pyproject.toml
+++ b/packages/nest-marketplace/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Testing",

--- a/packages/nest-mocks/pyproject.toml
+++ b/packages/nest-mocks/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/packages/nest-scenarios/pyproject.toml
+++ b/packages/nest-scenarios/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/packages/nest-sdk/pyproject.toml
+++ b/packages/nest-sdk/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/packages/nest-shell/pyproject.toml
+++ b/packages/nest-shell/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -78,6 +77,9 @@ dev-dependencies = [
     # nest-cli is a deprecated shim — only installed for the dev test suite
     # so the shim's smoke tests can import it.
     "nest-cli",
+    "fastapi==0.139.0",
+    "uvicorn==0.51.0",
+    "httpx==0.28.1",
 ]
 
 [tool.uv.sources]
@@ -101,6 +103,14 @@ ignore = ["TC001", "TC002", "TC003", "A002"]
 [tool.pyright]
 pythonVersion = "3.12"
 typeCheckingMode = "strict"
+exclude = [
+    "**/node_modules",
+    "**/.venv",
+    "**/venv",
+    "**/.git",
+    "**/.next",
+    "**/__pycache__",
+]
 venvPath = "."
 venv = ".venv"
 extraPaths = [

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  }
+}


### PR DESCRIPTION
# Summary
Implementation of **NANDA Simulation Sandbox (SaaS)**. This service allows remote or lightweight AI agents (e.g., OpenClaw agents) to run full NANDA Town simulations, calculate performance metrics, and retrieve adversarial validator results via a single HTTP request without installing Python 3.12 or simulator packages locally.

All changes are fully verified, linted, typechecked, and pass the local CI checklist.

---

## 1. File Changes & Architecture

### Sandbox Service
* `apps/nanda-sandbox/main.py`:
  - FastAPI application implementing `/health`, `/scenarios`, `/simulate`, and `/skill.md`.
  - Runs simulations programmatically using `ScenarioRunner` and `validate_trace` from `nest_core` inside secure temporary directories.
* `apps/nanda-sandbox/requirements.txt`:
  - Web service dependencies.
* `Dockerfile` (Root):
  - Builds and synchronizes the entire workspace using `uv sync` to make all local NANDA Town packages natively importable.
* `railway.json` (Root):
  - Wires the build provider to the Dockerfile builder context.

### SkillMD Documentation
* `docs/hackathon/solutions/nanda-sandbox-skill.md`:
  - OpenClaw-compatible `SKILL.md` documenting curl invocation formats, YAML payload schemas, and agent walkthrough steps.
  - The API also dynamically serves this file at `/skill.md` as requested by the guidelines.

### Unit Tests
* `apps/nanda-sandbox/tests/test_main.py`:
  - Unit tests verifying endpoints, valid scenario runs, validation checks, and `/skill.md` exposure.

---

## 2. Verification

Run local checks:
```bash
# Run sandbox unit tests
uv run pytest apps/nanda-sandbox/tests/test_main.py -v

# Run full project checks
make ci-local