### PR TITLE
[Hackathon] maharmuavia (distributed-systems-engineer): or_map -- add-wins observed-remove map CRDT (memory)

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -45,6 +45,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("negotiation", "pareto"): f"{_REF}.negotiation.pareto:ParetoNegotiation",
     ("memory", "blackboard"): f"{_REF}.memory.blackboard:Blackboard",
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
+    ("memory", "or_map"): f"{_REF}.memory.or_map:OrMapMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
     ("privacy", "hybrid_x25519"): f"{_REF}.privacy.hybrid_x25519:HybridX25519Privacy",
     ("privacy", "trust_gated"): f"{_REF}.privacy.trust_gated:TrustGatedPrivacy",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -109,6 +109,12 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("memory_concurrent_writers", memory_concurrent_writers_factory)
+    elif name == "memory_or_map_add_remove":
+        from nest_core.scenarios_builtin.memory_or_map_add_remove import (
+            memory_or_map_add_remove_factory,
+        )
+
+        register_scenario("memory_or_map_add_remove", memory_or_map_add_remove_factory)
     elif name == "comms_versioning":
         from nest_core.scenarios_builtin.comms_versioning import comms_versioning_factory
 

--- a/packages/nest-core/nest_core/scenarios_builtin/memory_or_map_add_remove.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/memory_or_map_add_remove.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OR-Map add/remove churn scenario -- prove add-wins convergence end-to-end.
+
+Every agent owns its **own replica** of the memory plugin (a per-agent plugin
+override) and, at start-up, writes a distinct value to the *same* shared key.
+A designated subset of agents then issues an observed-remove of that key one
+round later -- retiring only the adds they have gossiped so far, while other
+agents' concurrent adds are still in flight. Agents run a fixed number of
+full-state anti-entropy rounds (broadcasting ``export_all`` snapshots; peers
+``merge_all`` whatever they receive), so under a lossy network the redundant
+rounds still drive every replica to the same **add-wins** result: the key
+stays present, holding the deterministic winning add, because a remove can only
+erase adds it had already observed.
+
+On stop each agent broadcasts a ``final:<json>`` record carrying the *winning
+value* it reads for the key, so the ``memory_or_map_add_remove`` trace
+validator (:func:`nest_core.validators.validate_or_map_convergence`) can
+confirm the swarm converged to one value regardless of delivery order or loss.
+
+Example::
+
+    agents = memory_or_map_add_remove_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId
+
+_TICK = b"tick"
+_REMOVE_TICK = b"remove-tick"
+_SYNC_PREFIX = "sync:"
+_FINAL_PREFIX = "final:"
+
+
+class OrMapChurnAgent(StateMachineAgent):
+    """Writes one value to a shared key, optionally removes it, then gossips.
+
+    The agent reads its private replica from ``ctx.plugins["memory"]`` (a
+    per-agent override), so every agent merges independently and the scenario
+    exercises real conflict resolution rather than a single shared dict. A
+    ``remover`` schedules an observed-remove one round after its initial write,
+    modelling the add-wins race at swarm scale.
+
+    Example::
+
+        agent = OrMapChurnAgent(AgentId("w0"), key="shared", value=b"v0",
+                                rounds=20, remover=False)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        key: str,
+        value: bytes,
+        rounds: int,
+        remover: bool,
+    ) -> None:
+        self._id = agent_id
+        self._key = key
+        self._value = value
+        self._rounds = rounds
+        self._remover = remover
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Write this agent's value, schedule a remove (if remover) and all rounds.
+
+        Scheduling every gossip round up front (rather than chaining tick to
+        tick) means a dropped tick cannot halt the loop -- the remaining ticks
+        still fire, which is what makes convergence robust to loss.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        mem = ctx.plugins["memory"]
+        await mem.write(self._key, self._value)
+        if self._remover:
+            await ctx.schedule(1.0, _REMOVE_TICK)
+        for round_idx in range(self._rounds):
+            await ctx.schedule(float(round_idx + 2), _TICK)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Handle a gossip tick, a remove tick, or an incoming full-state sync.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("w1"), b"tick")
+        """
+        mem = ctx.plugins["memory"]
+        if payload == _REMOVE_TICK:
+            await mem.remove(self._key)
+            return
+        if payload == _TICK:
+            state = mem.export_all()
+            await ctx.broadcast(_SYNC_PREFIX.encode() + state)
+            return
+        text = payload.decode("utf-8", errors="replace")
+        if text.startswith(_SYNC_PREFIX):
+            state = text[len(_SYNC_PREFIX) :].encode("utf-8")
+            try:
+                await mem.merge_all(state)
+            except ValueError:
+                # Malformed / garbled state (e.g. byzantine corruption): ignore.
+                return
+
+    async def on_stop(self, ctx: AgentContext) -> None:
+        """Broadcast the winning value for the key for the convergence validator.
+
+        Example::
+
+            await agent.on_stop(ctx)
+        """
+        mem = ctx.plugins["memory"]
+        winner = await mem.read(self._key)
+        encoded = None if winner is None else base64.b64encode(winner).decode("ascii")
+        record = json.dumps({"key": self._key, "value": encoded}, sort_keys=True)
+        await ctx.broadcast(_FINAL_PREFIX.encode() + record.encode("utf-8"))
+
+
+def memory_or_map_add_remove_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create N churn agents, each with its own memory replica.
+
+    Every ``removers``-th agent (default every third) issues an observed-remove
+    after its initial write. Values are derived deterministically from the
+    agent index, and remover selection is index-based, so the scenario replays
+    byte-identically under a fixed seed.
+
+    Example::
+
+        agents = memory_or_map_add_remove_factory(config, plugins)
+    """
+    task_config = config.task.config
+    rounds = int(task_config.get("rounds", 20))
+    key = str(task_config.get("key", "shared"))
+    remover_stride = max(int(task_config.get("remover_stride", 3)), 2)
+    count = max(config.agents.count, 8)
+
+    memory_cls = plugins["memory"]
+    agent_ids = [AgentId(f"writer-{i}") for i in range(count)]
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    overrides: dict[AgentId, dict[str, Any]] = {}
+    for idx, aid in enumerate(agent_ids):
+        agents[aid] = OrMapChurnAgent(
+            aid,
+            key=key,
+            value=f"value-from-{aid}".encode(),
+            rounds=rounds,
+            remover=(idx % remover_stride == 0),
+        )
+        overrides[aid] = {"memory": memory_cls(str(aid))}
+
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1244,6 +1244,93 @@ def validate_memory_convergence(
     return results
 
 
+def validate_or_map_convergence(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Trace validator: every OR-Map replica agrees on the shared key's value.
+
+    The ``memory_or_map_add_remove`` scenario has each agent broadcast a
+    ``final:{"key": ..., "value": <base64 | null>}`` record on stop, carrying
+    the *winning value* it reads after add/remove churn and gossip. This
+    validator confirms every agent emitted exactly one such record and that all
+    of them report the same value -- i.e. the swarm converged despite removes,
+    reordering, and loss. A value of ``null`` (key absent) is a legitimate
+    converged outcome as long as every replica agrees on it.
+    """
+    finals: dict[str, str] = {}
+    duplicates: set[str] = set()
+    malformed: list[str] = []
+
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        msg = str(ev.get("msg", ""))
+        if not msg.startswith("final:"):
+            continue
+        agent = str(ev.get("agent", ""))
+        body = msg[len("final:") :]
+        try:
+            parsed = json.loads(body)
+            value = cast("dict[str, Any]", parsed).get("value")
+            canonical = json.dumps(value, sort_keys=True)
+        except (ValueError, TypeError, AttributeError):
+            malformed.append(agent)
+            continue
+        if agent in finals:
+            duplicates.add(agent)
+        finals[agent] = canonical
+
+    results: list[ValidationResult] = []
+
+    if malformed:
+        results.append(
+            ValidationResult(
+                "or_map_convergence_wellformed",
+                False,
+                f"{len(malformed)} malformed final record(s): {sorted(set(malformed))}",
+            )
+        )
+
+    if not finals:
+        results.append(
+            ValidationResult(
+                "or_map_convergence",
+                False,
+                "no final replica values found in trace",
+            )
+        )
+        return results
+
+    distinct = set(finals.values())
+    if len(distinct) == 1:
+        results.append(
+            ValidationResult(
+                "or_map_convergence",
+                True,
+                f"all {len(finals)} replicas converged to value {next(iter(distinct))}",
+            )
+        )
+    else:
+        results.append(
+            ValidationResult(
+                "or_map_convergence",
+                False,
+                f"{len(finals)} replicas hold {len(distinct)} distinct values: {sorted(distinct)}",
+            )
+        )
+
+    if duplicates:
+        results.append(
+            ValidationResult(
+                "or_map_convergence_one_final_per_agent",
+                False,
+                f"agents emitted multiple final records: {sorted(duplicates)}",
+            )
+        )
+
+    return results
+
+
 # ---------------------------------------------------------------------------
 # Streaming payments validators
 # ---------------------------------------------------------------------------
@@ -4975,6 +5062,10 @@ VALIDATORS: dict[str, list[Any]] = {
     ],
     "memory_concurrent_writers": [
         validate_memory_convergence,
+        validate_memory_liveness,
+    ],
+    "memory_or_map_add_remove": [
+        validate_or_map_convergence,
         validate_memory_liveness,
     ],
     "streaming_payments": [

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2000,6 +2000,7 @@ class TestValidatorRegistry:
             "identity_rotation",
             "attested_peering",
             "memory_concurrent_writers",
+            "memory_or_map_add_remove",
             "streaming_payments",
             "empic_payments",
             "comms_versioning",

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/or_map.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/or_map.py
@@ -1,0 +1,543 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OR-Map CRDT memory plugin -- add-wins, observed-remove shared state.
+
+This module implements a **state-based Observed-Remove Map** (an add-wins
+``ORSWOT``-style CvRDT, "OR-Set Without Tombstones" generalised from a set to
+a keyed map) for the Nanda Town memory layer. It exists to cover the one thing
+the merged ``lww_register`` plugin structurally *cannot* express: **deletion
+under concurrency**.
+
+``lww_register`` resolves every conflict -- including a delete modelled as an
+LWW write of a tombstone -- by the total order ``(lamport, node)``. That means
+a concurrent *add* can silently **lose** to a concurrent *remove* if the remove
+happens to carry the higher timestamp. For a register that is the correct,
+intended behaviour; for a shared *set/map* of live entries it is a lost update:
+an agent that re-advertises a catalogue entry at the same time another agent
+retires the old one should keep its entry, not have it deleted out from under
+it. The ``blackboard`` default is worse still -- a delete is just ``del`` on a
+shared dict, order-dependent and non-convergent.
+
+An OR-Map fixes this with the **add-wins** rule: an element survives iff it has
+at least one *add* that the remover had **not observed** at remove time. The
+mechanism is the classic "unique tag on add" (here called a *dot*
+``(node, counter)``) plus a per-replica **causal context** (a version vector of
+the highest counter seen per node). A remove drops only the dots the remover
+has actually seen; a concurrent add carries a fresh dot outside the remover's
+context and therefore wins. The merge of any two replica states is a genuine
+semilattice join -- **commutative, associative, and idempotent** -- so replicas
+that have observed the same operations converge to byte-identical state
+regardless of delivery order, duplication, or loss (*strong eventual
+consistency*), and the map needs **no tombstones** to do it.
+
+The read side keeps the base :class:`~nest_core.layers.memory.Memory` contract
+single-valued: when concurrent writes leave a key with several live dots, all
+of them are retained internally (so convergence and inspection are exact) but
+:meth:`read` returns the payload of the deterministic winner -- the dot that is
+largest under ``(counter, node)``. Reads are therefore total, deterministic,
+and replay-stable.
+
+State for a key is encoded as inspectable JSON so it stays grep-able inside a
+JSONL trace::
+
+    {"crdt": "or_map", "key": "cat", "dots":
+        [{"node": "agent-2", "counter": 3, "payload": "<base64>"}],
+     "context": {"agent-2": 3, "agent-5": 1}}
+
+Example::
+
+    a = OrMapMemory("a")
+    b = OrMapMemory("b")
+    await a.write("cat", b"apple")
+    await b.merge_all(a.export_all())        # b now observes a's add
+    await a.write("cat", b"apricot")         # concurrent re-add on a ...
+    await b.remove("cat")                    # ... while b removes what it saw
+    await a.merge_all(b.export_all())
+    await b.merge_all(a.export_all())
+    assert await a.read("cat") == b"apricot"  # add-wins: the entry survives
+    assert await b.read("cat") == b"apricot"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any, cast
+
+CRDT_KIND = "or_map"
+"""Schema tag stamped into every serialized state, used to detect and validate
+OR-Map state when it is read back from a trace or the wire."""
+
+
+class OrMapStateError(ValueError):
+    """Raised when a byte string is not valid serialized OR-Map state.
+
+    Subclasses :class:`ValueError` so existing ``except ValueError`` handlers
+    (such as the gossip loop in the concurrent-writers scenario) keep working,
+    while callers that care can catch the specific type.
+
+    Example::
+
+        try:
+            OrMapMemory._decode_key(b"not json")
+        except OrMapStateError:
+            ...
+    """
+
+
+@dataclass(frozen=True, order=True)
+class Dot:
+    """A unique per-write tag ``(counter, node)`` -- the OR-Set "unique tag".
+
+    Fields are declared ``counter`` first so the dataclass-generated ordering
+    is ``(counter, node)``: a higher counter wins, and the stable ``node`` id
+    breaks ties. Because a node's counter strictly increases on every local
+    write, a ``(node, counter)`` pair is globally unique across all writes, so
+    it can both identify an add and participate in the deterministic read
+    total order.
+
+    Example::
+
+        assert Dot(counter=2, node="a") > Dot(counter=1, node="z")
+        assert Dot(counter=1, node="b") > Dot(counter=1, node="a")
+    """
+
+    counter: int
+    node: str
+
+
+@dataclass(frozen=True)
+class _Add:
+    """A live entry: the dot that created it plus its payload.
+
+    Example::
+
+        e = _Add(Dot(1, "a"), b"apple")
+    """
+
+    dot: Dot
+    payload: bytes
+
+
+class OrMapMemory:
+    """An add-wins observed-remove map CRDT implementing the ``Memory`` protocol.
+
+    Each instance is an independent **replica**. Local writes mint a fresh dot
+    ``(node_id, counter+1)``; :meth:`remove` drops the dots this replica has
+    observed for a key; and replicas reconcile with :meth:`export_all` /
+    :meth:`merge_all` (full-state anti-entropy) or the per-key
+    :meth:`export` / :meth:`merge`. The merge is conflict-free and add-wins, so
+    any set of replicas that have observed the same operations read back
+    identical values no matter the order in which writes, removes, and merges
+    arrived.
+
+    The base :class:`~nest_core.layers.memory.Memory` surface
+    (``read`` / ``write`` / ``cas`` / ``subscribe``) treats values as opaque
+    user payloads; the CRDT machinery is internal. The additive
+    :meth:`remove` / :meth:`export` / :meth:`merge` / :meth:`export_all` /
+    :meth:`merge_all` methods are the delete verb and the replication channel --
+    a caller that only speaks the base protocol never has to know the values
+    are CRDT entries.
+
+    Example::
+
+        mem = OrMapMemory("agent-0")
+        await mem.write("counter", b"42")
+        assert await mem.read("counter") == b"42"
+        await mem.remove("counter")
+        assert await mem.read("counter") is None
+    """
+
+    def __init__(self, node_id: str = "node") -> None:
+        """Create a replica with a stable, unique ``node_id``.
+
+        The ``node_id`` must be stable for the replica's lifetime and unique
+        across replicas: it namespaces this replica's dots and breaks ties in
+        the read total order. Two replicas sharing a ``node_id`` would mint
+        colliding dots and break the convergence guarantee.
+
+        Example::
+
+            mem = OrMapMemory("agent-0")
+        """
+        self._node_id = str(node_id)
+        # key -> {dot: payload} for every currently-live add of that key.
+        self._entries: dict[str, dict[Dot, bytes]] = {}
+        # Causal context / version vector: node -> highest counter observed.
+        self._context: dict[str, int] = {}
+        self._subscribers: dict[str, list[asyncio.Queue[bytes]]] = {}
+
+    @property
+    def node_id(self) -> str:
+        """The stable node identifier that namespaces this replica's dots.
+
+        Example::
+
+            assert OrMapMemory("agent-0").node_id == "agent-0"
+        """
+        return self._node_id
+
+    @property
+    def context(self) -> dict[str, int]:
+        """A copy of this replica's causal context (version vector).
+
+        Example::
+
+            mem = OrMapMemory("a")
+            assert mem.context == {}
+        """
+        return dict(self._context)
+
+    # -- Memory protocol -------------------------------------------------
+
+    async def read(self, key: str) -> bytes | None:
+        """Read the winning payload for ``key`` or ``None`` if it has no live add.
+
+        When concurrent writes leave several live dots, the winner is the dot
+        that is largest under ``(counter, node)`` -- a deterministic, replay-
+        stable choice.
+
+        Example::
+
+            val = await mem.read("counter")
+        """
+        winner = self._winner(key)
+        return winner.payload if winner is not None else None
+
+    async def write(self, key: str, value: bytes) -> None:
+        """Locally add/replace ``key`` with ``value`` under a fresh dot.
+
+        The write mints ``(node_id, counter+1)`` and makes it the *only* live
+        dot this replica knows for ``key`` (a local write supersedes this
+        replica's own earlier writes); concurrent writes from other replicas
+        are preserved as separate dots at the next merge. Subscribers are
+        notified, matching the ``blackboard`` contract that every local write
+        is observable.
+
+        Example::
+
+            await mem.write("counter", b"42")
+        """
+        dot = self._next_dot()
+        self._entries[key] = {dot: value}
+        await self._notify(key, value)
+
+    async def subscribe(self, key: str) -> AsyncIterator[bytes]:
+        """Yield the winning payload for ``key`` each time it advances.
+
+        Removals are not delivered (the base protocol yields ``bytes`` values,
+        not tombstones); a subsequent re-add is delivered normally.
+
+        Example::
+
+            async for val in mem.subscribe("counter"):
+                print(val)
+        """
+        q: asyncio.Queue[bytes] = asyncio.Queue()
+        self._subscribers.setdefault(key, []).append(q)
+        try:
+            while True:
+                yield await q.get()
+        finally:
+            self._subscribers[key].remove(q)
+
+    async def cas(self, key: str, expected: bytes, new: bytes) -> bool:
+        """Compare-and-swap on this replica's winning payload.
+
+        Succeeds iff the current winning payload equals ``expected``, in which
+        case it performs a normal tagged :meth:`write` of ``new``. This is
+        linearizable *on this replica*; across replicas the CRDT merge -- not
+        CAS -- reconciles a swap that raced a concurrent write elsewhere.
+
+        Example::
+
+            ok = await mem.cas("counter", b"42", b"43")
+        """
+        winner = self._winner(key)
+        current = winner.payload if winner is not None else None
+        if current == expected:
+            await self.write(key, new)
+            return True
+        return False
+
+    # -- Additive delete verb -------------------------------------------
+
+    async def remove(self, key: str) -> bool:
+        """Observed-remove ``key``: drop every add this replica has seen.
+
+        Only the dots currently live at this replica are removed; because the
+        causal context retains their counters, a peer learns the removal at the
+        next merge. A concurrent add made elsewhere (a dot outside this
+        replica's context) is **not** removed -- that is the add-wins rule.
+        Returns ``True`` if a live value was actually dropped. Idempotent.
+
+        Example::
+
+            await mem.write("k", b"v")
+            assert await mem.remove("k") is True
+            assert await mem.remove("k") is False
+        """
+        if key not in self._entries:
+            return False
+        del self._entries[key]
+        await self._notify_removed(key)
+        return True
+
+    # -- CRDT replication channel ---------------------------------------
+
+    def export(self, key: str) -> bytes | None:
+        """Serialize the live dots and causal context for a single ``key``.
+
+        Returns ``None`` only if this replica has *never* observed ``key``.
+        A key that has been removed serializes with an empty ``dots`` list, so
+        the removal still propagates through :meth:`merge`. The result is valid
+        input to another replica's :meth:`merge`.
+
+        Example::
+
+            state = mem.export("counter")
+        """
+        if key not in self._entries and not self._seen_key(key):
+            return None
+        return self._encode_key(key, self._entries.get(key, {}))
+
+    def export_all(self) -> bytes:
+        """Serialize this replica's full state for a full-state anti-entropy push.
+
+        This is the correct channel for propagating **removals**: the snapshot
+        carries the complete live-key set plus the causal context, so a peer
+        can tell "never seen" (keep) from "seen and removed" (drop).
+
+        Example::
+
+            snapshot = mem.export_all()
+        """
+        keys: dict[str, list[dict[str, Any]]] = {
+            key: self._encode_dots(dots) for key, dots in sorted(self._entries.items())
+        }
+        data = {
+            "crdt": CRDT_KIND,
+            "keys": keys,
+            "context": dict(sorted(self._context.items())),
+        }
+        return json.dumps(data, sort_keys=True).encode("utf-8")
+
+    async def merge(self, key: str, state: bytes) -> bool:
+        """Merge a remote single-key state into this replica.
+
+        Applies the add-wins join for ``key`` using the incoming causal
+        context, advances this replica's context pointwise, and notifies
+        subscribers if the winning payload changed. Returns ``True`` on a
+        visible change. Idempotent: merging the same state twice is a no-op.
+
+        Example::
+
+            changed = await mem.merge("counter", other.export("counter"))
+        """
+        remote_key, remote_dots, remote_ctx = self._decode_key(state)
+        target = key if remote_key is None else remote_key
+        before = self._winner(target)
+        self._entries[target] = self._join_key(
+            self._entries.get(target, {}), remote_dots, remote_ctx
+        )
+        if not self._entries[target]:
+            del self._entries[target]
+        self._absorb_context(remote_ctx)
+        return await self._emit_if_changed(target, before)
+
+    async def merge_all(self, state: bytes) -> list[str]:
+        """Merge a full-state snapshot, returning the keys whose value changed.
+
+        Because the snapshot names every live key and the sender's context,
+        this reconciles adds *and* removals: a key the sender dropped is
+        removed here too unless this replica holds a concurrent add.
+
+        Example::
+
+            changed_keys = await mem.merge_all(other.export_all())
+        """
+        remote_keys, remote_ctx = self._decode_all(state)
+        before: dict[str, _Add | None] = {}
+        for key in set(self._entries) | set(remote_keys):
+            before[key] = self._winner(key)
+            merged = self._join_key(
+                self._entries.get(key, {}), remote_keys.get(key, {}), remote_ctx
+            )
+            if merged:
+                self._entries[key] = merged
+            else:
+                self._entries.pop(key, None)
+        self._absorb_context(remote_ctx)
+        changed: list[str] = []
+        for key in sorted(before):
+            if await self._emit_if_changed(key, before[key]):
+                changed.append(key)
+        return changed
+
+    # -- internals -------------------------------------------------------
+
+    def _next_dot(self) -> Dot:
+        counter = self._context.get(self._node_id, 0) + 1
+        self._context[self._node_id] = counter
+        return Dot(counter=counter, node=self._node_id)
+
+    def _winner(self, key: str) -> _Add | None:
+        dots = self._entries.get(key)
+        if not dots:
+            return None
+        best = max(dots)
+        return _Add(dot=best, payload=dots[best])
+
+    def _seen_key(self, key: str) -> bool:
+        # A key is "known" if it is live now; removed keys are indistinguishable
+        # from never-seen at the per-key granularity, which is why removals
+        # propagate through export_all (full state), not a bare export(key).
+        return key in self._entries
+
+    def _join_key(
+        self,
+        mine: dict[Dot, bytes],
+        theirs: dict[Dot, bytes],
+        their_ctx: dict[str, int],
+    ) -> dict[Dot, bytes]:
+        """Add-wins ORSWOT join of two dot sets for one key.
+
+        Keep one of my dots if the other side still has it, or if the other
+        side has never observed it (a concurrent local add). Symmetrically for
+        their dots against my context. The union of the survivors is the merged
+        live set.
+        """
+        kept: dict[Dot, bytes] = {}
+        for dot, payload in mine.items():
+            if dot in theirs or dot.counter > their_ctx.get(dot.node, 0):
+                kept[dot] = payload
+        for dot, payload in theirs.items():
+            if dot in mine or dot.counter > self._context.get(dot.node, 0):
+                kept[dot] = payload
+        return kept
+
+    def _absorb_context(self, other: dict[str, int]) -> None:
+        for node, counter in other.items():
+            if counter > self._context.get(node, 0):
+                self._context[node] = counter
+
+    async def _emit_if_changed(self, key: str, before: _Add | None) -> bool:
+        after = self._winner(key)
+        before_payload = before.payload if before is not None else None
+        after_payload = after.payload if after is not None else None
+        if after_payload == before_payload:
+            return False
+        if after_payload is None:
+            await self._notify_removed(key)
+        else:
+            await self._notify(key, after_payload)
+        return True
+
+    async def _notify(self, key: str, payload: bytes) -> None:
+        for q in self._subscribers.get(key, []):
+            await q.put(payload)
+
+    async def _notify_removed(self, key: str) -> None:
+        # Removals are not surfaced on the value stream; hook retained so the
+        # emit path is symmetric and easy to extend to tombstone-aware
+        # subscribers later.
+        return None
+
+    # -- serialization ---------------------------------------------------
+
+    @staticmethod
+    def _encode_dots(dots: dict[Dot, bytes]) -> list[dict[str, Any]]:
+        return [
+            {
+                "node": dot.node,
+                "counter": dot.counter,
+                "payload": base64.b64encode(payload).decode("ascii"),
+            }
+            for dot, payload in sorted(dots.items())
+        ]
+
+    def _encode_key(self, key: str, dots: dict[Dot, bytes]) -> bytes:
+        data = {
+            "crdt": CRDT_KIND,
+            "key": key,
+            "dots": self._encode_dots(dots),
+            "context": dict(sorted(self._context.items())),
+        }
+        return json.dumps(data, sort_keys=True).encode("utf-8")
+
+    @staticmethod
+    def _loads_object(state: bytes) -> dict[str, Any]:
+        try:
+            obj = json.loads(state)
+        except (ValueError, TypeError) as exc:
+            msg = "state is not valid JSON"
+            raise OrMapStateError(msg) from exc
+        if not isinstance(obj, dict):
+            msg = f"not {CRDT_KIND} state: {obj!r}"
+            raise OrMapStateError(msg)
+        data = cast("dict[str, Any]", obj)
+        if data.get("crdt") != CRDT_KIND:
+            msg = f"not {CRDT_KIND} state: {data!r}"
+            raise OrMapStateError(msg)
+        return data
+
+    @staticmethod
+    def _parse_dots(raw: Any) -> dict[Dot, bytes]:
+        if not isinstance(raw, list):
+            msg = "'dots' must be a list"
+            raise OrMapStateError(msg)
+        raw_list = cast("list[Any]", raw)
+        dots: dict[Dot, bytes] = {}
+        for item in raw_list:
+            if not isinstance(item, dict):
+                msg = f"dot entry must be an object: {item!r}"
+                raise OrMapStateError(msg)
+            fields = cast("dict[str, Any]", item)
+            try:
+                node = str(fields["node"])
+                counter = int(fields["counter"])
+                payload = base64.b64decode(fields["payload"])
+            except (KeyError, ValueError, TypeError) as exc:
+                msg = f"malformed dot entry: {fields!r}"
+                raise OrMapStateError(msg) from exc
+            dots[Dot(counter=counter, node=node)] = payload
+        return dots
+
+    @staticmethod
+    def _parse_context(raw: Any) -> dict[str, int]:
+        if raw is None:
+            return {}
+        if not isinstance(raw, dict):
+            msg = "'context' must be an object"
+            raise OrMapStateError(msg)
+        raw_ctx = cast("dict[str, Any]", raw)
+        try:
+            return {str(node): int(counter) for node, counter in raw_ctx.items()}
+        except (ValueError, TypeError) as exc:
+            msg = f"malformed context: {raw_ctx!r}"
+            raise OrMapStateError(msg) from exc
+
+    @classmethod
+    def _decode_key(cls, state: bytes) -> tuple[str | None, dict[Dot, bytes], dict[str, int]]:
+        data = cls._loads_object(state)
+        raw_key = data.get("key")
+        key = None if raw_key is None else str(raw_key)
+        dots = cls._parse_dots(data.get("dots", []))
+        ctx = cls._parse_context(data.get("context"))
+        return key, dots, ctx
+
+    @classmethod
+    def _decode_all(cls, state: bytes) -> tuple[dict[str, dict[Dot, bytes]], dict[str, int]]:
+        data = cls._loads_object(state)
+        raw_keys = data.get("keys", {})
+        if not isinstance(raw_keys, dict):
+            msg = "snapshot 'keys' must be an object"
+            raise OrMapStateError(msg)
+        raw_map = cast("dict[str, Any]", raw_keys)
+        keys: dict[str, dict[Dot, bytes]] = {
+            str(key): cls._parse_dots(dots) for key, dots in raw_map.items()
+        }
+        ctx = cls._parse_context(data.get("context"))
+        return keys, ctx

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -29,6 +29,11 @@ from nest_plugins_reference.validators.gossip_validators import (
     check_converged,
     check_no_partition_view_leak,
 )
+from nest_plugins_reference.validators.or_map_validators import (
+    AddWinsViolationError,
+    check_add_wins_survives_concurrent_remove,
+    check_convergence_under_churn,
+)
 from nest_plugins_reference.validators.privacy_validators import (
     check_eavesdropper_blocked,
     check_field_injection_rejected,
@@ -45,11 +50,14 @@ from nest_plugins_reference.validators.trust_gate_validators import (
 )
 
 __all__ = [
+    "AddWinsViolationError",
     "ConvergenceFailureError",
     "PartitionLeakError",
     "ValidatorReport",
+    "check_add_wins_survives_concurrent_remove",
     "check_audience_binding",
     "check_converged",
+    "check_convergence_under_churn",
     "check_denial_receipt_auditable",
     "check_eavesdropper_blocked",
     "check_field_injection_rejected",

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/or_map_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/or_map_validators.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for the OR-Map (observed-remove) memory plugin.
+
+Two properties the default ``blackboard`` and the merged ``lww_register`` plugin
+cannot satisfy for a shared *set/map of live entries*:
+
+1. **Add-wins under a concurrent remove.**  When one replica re-advertises an
+   entry at the same time another replica retires the copy it had seen, the
+   entry must survive -- an add the remover never observed is not deleted.
+   ``check_add_wins_survives_concurrent_remove`` builds exactly that race and
+   asserts both replicas converge to the *re-added* value.
+
+   * ``blackboard`` has no causal history: a delete is order-dependent ``del``
+     on a per-replica dict, so the two replicas diverge -- fails.
+   * ``lww_register`` resolves a delete (modelled as a tombstone write) by
+     ``(lamport, node)``; the race is arranged so the tombstone sorts *above*
+     the concurrent add, so the add is silently overwritten -- fails.
+   * ``or_map`` keeps the add via the add-wins rule -- passes.
+
+2. **Convergence under add/remove churn.**  Replicas that apply the same
+   multiset of adds and removes in **different delivery orders** must read back
+   identical state.  ``check_convergence_under_churn`` permutes the delivery
+   order per replica and asserts equality.  ``blackboard`` diverges the moment
+   two replicas see operations in different orders; ``or_map`` converges.
+
+Both validators are **capability-aware** pure functions over a replica factory,
+so a single call site discriminates all three plugins: they use the CRDT
+replication channel (``export_all`` / ``merge_all``) and the ``remove`` verb
+when present, and fall back to modelling "observe" as a ``write`` and "delete"
+as a tombstone ``write`` when they are not -- which is precisely what exposes
+the order-dependent plugins.
+
+Example::
+
+    from nest_plugins_reference.memory.or_map import OrMapMemory
+    from nest_plugins_reference.memory.blackboard import Blackboard
+
+    assert check_add_wins_survives_concurrent_remove(OrMapMemory).passed
+    assert not check_add_wins_survives_concurrent_remove(Blackboard).passed
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from nest_plugins_reference.validators.gossip_validators import ValidatorReport
+
+ReplicaFactory = Callable[[str], Any]
+"""A ``node_id -> memory replica`` constructor (e.g. ``OrMapMemory``)."""
+
+_TOMBSTONE = b"\x00__ormap_tombstone__"
+"""Sentinel used to model a delete on plugins that lack a ``remove`` verb."""
+
+
+class AddWinsViolationError(AssertionError):
+    """Raised when a concurrent add is lost to a concurrent remove.
+
+    Example::
+
+        raise AddWinsViolationError("re-added 'cat' was deleted by a stale remove")
+    """
+
+
+def _has_full_channel(replica: Any) -> bool:
+    return hasattr(replica, "export_all") and hasattr(replica, "merge_all")
+
+
+async def _observe(source: Any, target: Any, key: str) -> None:
+    """Make ``target`` observe ``source``'s current state for ``key``."""
+    if _has_full_channel(source) and _has_full_channel(target):
+        await target.merge_all(source.export_all())
+        return
+    if hasattr(source, "export") and hasattr(target, "merge"):
+        state = source.export(key)
+        if state is not None:
+            await target.merge(key, state)
+        return
+    # No replication channel (e.g. blackboard): model observation as adopting
+    # the source's currently-visible value via the base protocol.
+    value = await source.read(key)
+    if value is not None:
+        await target.write(key, value)
+
+
+async def _delete(replica: Any, key: str) -> None:
+    """Delete ``key`` at ``replica`` using ``remove`` if present, else a tombstone."""
+    if hasattr(replica, "remove"):
+        await replica.remove(key)
+    else:
+        await replica.write(key, _TOMBSTONE)
+
+
+async def _reconcile(a: Any, b: Any, key: str) -> None:
+    """Exchange state both ways so ``a`` and ``b`` see each other's operations."""
+    if _has_full_channel(a) and _has_full_channel(b):
+        state_a = a.export_all()
+        state_b = b.export_all()
+        await a.merge_all(state_b)
+        await b.merge_all(state_a)
+        return
+    if hasattr(a, "export") and hasattr(b, "export"):
+        state_a = a.export(key)
+        state_b = b.export(key)
+        if state_b is not None:
+            await a.merge(key, state_b)
+        if state_a is not None:
+            await b.merge(key, state_a)
+        return
+    # Blackboard fallback: each side delivers its current value to the other.
+    val_a = await a.read(key)
+    val_b = await b.read(key)
+    if val_b is not None:
+        await a.write(key, val_b)
+    if val_a is not None:
+        await b.write(key, val_a)
+
+
+async def _run_add_wins(make_replica: ReplicaFactory, key: str) -> ValidatorReport:
+    # Replica ids chosen so a modelled tombstone from the remover ("z") sorts
+    # ABOVE the concurrent add from the adder ("a") under an LWW register's
+    # (counter, node) order -- making the LWW failure deterministic rather than
+    # interleaving-dependent.
+    adder = make_replica("a")
+    remover = make_replica("z")
+
+    old = b"v-old"
+    new = b"v-new"
+
+    await adder.write(key, old)
+    await _observe(adder, remover, key)  # remover now knows the old add
+
+    # Concurrent operations: the adder re-advertises; the remover retires the
+    # copy it observed. Neither has seen the other's operation yet.
+    await adder.write(key, new)
+    await _delete(remover, key)
+
+    await _reconcile(adder, remover, key)
+
+    read_adder = await adder.read(key)
+    read_remover = await remover.read(key)
+
+    if read_adder != read_remover:
+        return ValidatorReport(
+            passed=False,
+            detail=(
+                f"replicas diverged after concurrent add/remove: "
+                f"adder={read_adder!r} remover={read_remover!r}"
+            ),
+            evidence={"adder": repr(read_adder), "remover": repr(read_remover)},
+        )
+    if read_adder != new:
+        return ValidatorReport(
+            passed=False,
+            detail=(
+                f"add-wins violated: concurrent re-add {new!r} was lost, "
+                f"replicas hold {read_adder!r}"
+            ),
+            evidence={"expected": repr(new), "actual": repr(read_adder)},
+        )
+    return ValidatorReport(
+        passed=True,
+        detail=f"add-wins holds: concurrent re-add {new!r} survived the remove",
+        evidence={"value": repr(read_adder)},
+    )
+
+
+def check_add_wins_survives_concurrent_remove(
+    make_replica: ReplicaFactory,
+    *,
+    key: str = "cat",
+) -> ValidatorReport:
+    """Assert a concurrent re-add survives a stale remove (the add-wins rule).
+
+    Drives the canonical race -- replica ``a`` re-adds ``key`` while replica
+    ``z`` removes the copy it had observed -- and returns ``passed=True`` iff
+    both replicas converge to the re-added value. Fails for ``blackboard``
+    (divergence) and ``lww_register`` (the tombstone overwrites the add).
+
+    Example::
+
+        report = check_add_wins_survives_concurrent_remove(OrMapMemory)
+        assert report.passed, report.detail
+    """
+    return asyncio.run(_run_add_wins(make_replica, key))
+
+
+async def _run_churn(
+    make_replica: ReplicaFactory,
+    ops: Sequence[tuple[str, str, bytes | None]],
+    delivery_orders: Sequence[Sequence[int]],
+    key: str,
+) -> ValidatorReport:
+    replica_count = len(delivery_orders)
+    replicas = [make_replica(f"node-{i}") for i in range(replica_count)]
+
+    # Phase 1: apply each op at its origin replica and snapshot the full state.
+    snapshots: list[bytes | None] = []
+    for origin_idx, verb, payload in ops:
+        origin = replicas[int(origin_idx.split("-")[-1])] if "-" in origin_idx else replicas[0]
+        if verb == "add" and payload is not None:
+            await origin.write(key, payload)
+        elif verb == "remove":
+            await _delete(origin, key)
+        if _has_full_channel(origin):
+            snapshots.append(origin.export_all())
+        else:
+            snapshots.append(None)
+
+    # Phase 2: deliver every op's resulting snapshot to each replica in its own
+    # order. Plugins without a replication channel replay the raw value/verb.
+    for r_idx, order in enumerate(delivery_orders):
+        for op_idx in order:
+            snap = snapshots[op_idx]
+            origin_idx, verb, payload = ops[op_idx]
+            if snap is not None and _has_full_channel(replicas[r_idx]):
+                await replicas[r_idx].merge_all(snap)
+            elif verb == "add" and payload is not None:
+                await replicas[r_idx].write(key, payload)
+            elif verb == "remove":
+                await _delete(replicas[r_idx], key)
+
+    finals = [await r.read(key) for r in replicas]
+    distinct = {repr(v) for v in finals}
+    if len(distinct) == 1:
+        return ValidatorReport(
+            passed=True,
+            detail=f"{replica_count} replicas converged to {finals[0]!r} under churn",
+            evidence={"value": repr(finals[0])},
+        )
+    return ValidatorReport(
+        passed=False,
+        detail=f"replicas diverged under churn into {len(distinct)} states: {sorted(distinct)}",
+        evidence={"states": sorted(distinct)},
+    )
+
+
+def check_convergence_under_churn(
+    make_replica: ReplicaFactory,
+    *,
+    key: str = "cat",
+) -> ValidatorReport:
+    """Assert replicas converge under add/remove operations delivered out of order.
+
+    Applies a fixed multiset of adds and removes, then delivers them to three
+    replicas in three different orders, and returns ``passed=True`` iff all
+    replicas read back the same value. Fails for ``blackboard`` (order
+    dependent); passes for ``or_map``.
+
+    Example::
+
+        report = check_convergence_under_churn(OrMapMemory)
+        assert report.passed, report.detail
+    """
+    ops: list[tuple[str, str, bytes | None]] = [
+        ("node-0", "add", b"a0"),
+        ("node-1", "add", b"a1"),
+        ("node-2", "add", b"a2"),
+        ("node-0", "remove", None),
+        ("node-1", "add", b"a1-again"),
+    ]
+    delivery_orders = [[0, 1, 2, 3, 4], [4, 3, 2, 1, 0], [2, 0, 4, 1, 3]]
+    return asyncio.run(_run_churn(make_replica, ops, delivery_orders, key))

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -38,6 +38,7 @@ authenticated = "nest_plugins_reference.comms.authenticated:AuthenticatedComms"
 
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
+or_map = "nest_plugins_reference.memory.or_map:OrMapMemory"
 
 [project.entry-points."nest.plugins.registry"]
 byzantine_gossip = "nest_plugins_reference.registry.byzantine_gossip:ByzantineGossipRegistry"

--- a/packages/nest-plugins-reference/tests/test_or_map.py
+++ b/packages/nest-plugins-reference/tests/test_or_map.py
@@ -1,0 +1,428 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the OR-Map (observed-remove, add-wins) CRDT memory plugin.
+
+Covers protocol conformance, the read/write/cas/subscribe surface, the
+additive ``remove`` verb, the per-key and full-state export/merge replication
+channel, the three CRDT algebraic laws (commutativity, associativity,
+idempotence) of the full-state join, convergence under arbitrary delivery
+order, determinism, malformed-input handling, registry wiring, the two
+adversarial validators (add-wins survival and churn convergence -- which must
+fail for ``blackboard`` and, for add-wins, for ``lww_register`` -- and pass for
+the OR-Map), and an end-to-end scenario run under message loss that is
+byte-deterministic across seeds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.layers.memory import Memory
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_crdt_convergence, validate_trace
+from nest_plugins_reference.memory.blackboard import Blackboard
+from nest_plugins_reference.memory.lww_register import LwwRegisterMemory
+from nest_plugins_reference.memory.or_map import (
+    CRDT_KIND,
+    Dot,
+    OrMapMemory,
+    OrMapStateError,
+)
+from nest_plugins_reference.validators import (
+    check_add_wins_survives_concurrent_remove,
+    check_convergence_under_churn,
+)
+
+# ---------------------------------------------------------------------------
+# Protocol conformance and base Memory surface
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_isinstance_memory(self) -> None:
+        assert isinstance(OrMapMemory("a"), Memory)
+
+    @pytest.mark.asyncio
+    async def test_read_missing_is_none(self) -> None:
+        assert await OrMapMemory("a").read("missing") is None
+
+    @pytest.mark.asyncio
+    async def test_write_read_roundtrip(self) -> None:
+        mem = OrMapMemory("a")
+        await mem.write("k", b"value")
+        assert await mem.read("k") == b"value"
+
+    @pytest.mark.asyncio
+    async def test_overwrite_keeps_latest(self) -> None:
+        mem = OrMapMemory("a")
+        await mem.write("k", b"old")
+        await mem.write("k", b"new")
+        assert await mem.read("k") == b"new"
+
+    @pytest.mark.asyncio
+    async def test_cas_success(self) -> None:
+        mem = OrMapMemory("a")
+        await mem.write("k", b"old")
+        assert await mem.cas("k", b"old", b"new") is True
+        assert await mem.read("k") == b"new"
+
+    @pytest.mark.asyncio
+    async def test_cas_failure_leaves_value(self) -> None:
+        mem = OrMapMemory("a")
+        await mem.write("k", b"current")
+        assert await mem.cas("k", b"wrong", b"new") is False
+        assert await mem.read("k") == b"current"
+
+    @pytest.mark.asyncio
+    async def test_cas_on_missing_key(self) -> None:
+        assert await OrMapMemory("a").cas("k", b"expected", b"new") is False
+
+    @pytest.mark.asyncio
+    async def test_binary_payload(self) -> None:
+        mem = OrMapMemory("a")
+        blob = bytes(range(256))
+        await mem.write("k", blob)
+        assert await mem.read("k") == blob
+
+    @pytest.mark.asyncio
+    async def test_subscribe_receives_writes(self) -> None:
+        mem = OrMapMemory("a")
+        sub = mem.subscribe("k")
+        fut = asyncio.ensure_future(anext(sub))
+        await asyncio.sleep(0)  # let the generator register its queue
+        await mem.write("k", b"first")
+        assert await asyncio.wait_for(fut, 5) == b"first"
+
+    @pytest.mark.asyncio
+    async def test_subscribe_receives_merges(self) -> None:
+        a = OrMapMemory("a")
+        b = OrMapMemory("b")
+        await a.write("k", b"v")
+        sub = b.subscribe("k")
+        fut = asyncio.ensure_future(anext(sub))
+        await asyncio.sleep(0)
+        await b.merge_all(a.export_all())
+        assert await asyncio.wait_for(fut, 5) == b"v"
+
+
+# ---------------------------------------------------------------------------
+# The additive remove verb
+# ---------------------------------------------------------------------------
+
+
+class TestRemove:
+    @pytest.mark.asyncio
+    async def test_remove_makes_key_absent(self) -> None:
+        mem = OrMapMemory("a")
+        await mem.write("k", b"v")
+        assert await mem.remove("k") is True
+        assert await mem.read("k") is None
+
+    @pytest.mark.asyncio
+    async def test_remove_missing_is_false(self) -> None:
+        assert await OrMapMemory("a").remove("k") is False
+
+    @pytest.mark.asyncio
+    async def test_remove_is_idempotent(self) -> None:
+        mem = OrMapMemory("a")
+        await mem.write("k", b"v")
+        assert await mem.remove("k") is True
+        assert await mem.remove("k") is False
+
+    @pytest.mark.asyncio
+    async def test_readd_after_remove(self) -> None:
+        mem = OrMapMemory("a")
+        await mem.write("k", b"v1")
+        await mem.remove("k")
+        await mem.write("k", b"v2")
+        assert await mem.read("k") == b"v2"
+
+
+# ---------------------------------------------------------------------------
+# Export / merge replication channel
+# ---------------------------------------------------------------------------
+
+
+class TestExportMerge:
+    @pytest.mark.asyncio
+    async def test_export_never_seen_is_none(self) -> None:
+        assert OrMapMemory("a").export("k") is None
+
+    @pytest.mark.asyncio
+    async def test_export_is_grep_able_json(self) -> None:
+        mem = OrMapMemory("a")
+        await mem.write("k", b"hi")
+        raw = mem.export("k")
+        assert raw is not None
+        assert CRDT_KIND.encode() in raw
+
+    @pytest.mark.asyncio
+    async def test_merge_into_empty_adopts_value(self) -> None:
+        a = OrMapMemory("a")
+        b = OrMapMemory("b")
+        await a.write("k", b"from-a")
+        state = a.export("k")
+        assert state is not None
+        assert await b.merge("k", state) is True
+        assert await b.read("k") == b"from-a"
+
+    @pytest.mark.asyncio
+    async def test_merge_is_idempotent(self) -> None:
+        a = OrMapMemory("a")
+        b = OrMapMemory("b")
+        await a.write("k", b"x")
+        state = a.export("k")
+        assert state is not None
+        assert await b.merge("k", state) is True
+        assert await b.merge("k", state) is False
+        assert await b.read("k") == b"x"
+
+    @pytest.mark.asyncio
+    async def test_full_state_removal_propagates(self) -> None:
+        a = OrMapMemory("a")
+        b = OrMapMemory("b")
+        await a.write("k", b"v")
+        await b.merge_all(a.export_all())
+        assert await b.read("k") == b"v"
+        await a.remove("k")
+        await b.merge_all(a.export_all())
+        assert await b.read("k") is None
+
+    @pytest.mark.asyncio
+    async def test_export_all_merge_all_roundtrip(self) -> None:
+        a = OrMapMemory("a")
+        await a.write("k1", b"v1")
+        await a.write("k2", b"v2")
+        b = OrMapMemory("b")
+        changed = await b.merge_all(a.export_all())
+        assert changed == ["k1", "k2"]
+        assert await b.read("k1") == b"v1"
+        assert await b.read("k2") == b"v2"
+
+
+# ---------------------------------------------------------------------------
+# Add-wins semantics (the headline novelty)
+# ---------------------------------------------------------------------------
+
+
+class TestAddWins:
+    @pytest.mark.asyncio
+    async def test_concurrent_add_survives_stale_remove(self) -> None:
+        a = OrMapMemory("a")
+        b = OrMapMemory("b")
+        await a.write("k", b"old")
+        await b.merge_all(a.export_all())  # b observes the old add
+        # Concurrent: a re-adds; b removes what it saw.
+        await a.write("k", b"new")
+        await b.remove("k")
+        await a.merge_all(b.export_all())
+        await b.merge_all(a.export_all())
+        assert await a.read("k") == b"new"
+        assert await b.read("k") == b"new"
+
+    @pytest.mark.asyncio
+    async def test_remove_of_fully_observed_add_wins(self) -> None:
+        # If the remover HAS observed every add, the key is genuinely removed.
+        a = OrMapMemory("a")
+        b = OrMapMemory("b")
+        await a.write("k", b"v")
+        await b.merge_all(a.export_all())
+        await b.remove("k")
+        await a.merge_all(b.export_all())
+        assert await a.read("k") is None
+        assert await b.read("k") is None
+
+
+# ---------------------------------------------------------------------------
+# Malformed input handling
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedState:
+    @pytest.mark.asyncio
+    async def test_merge_rejects_non_json(self) -> None:
+        with pytest.raises(OrMapStateError):
+            await OrMapMemory("a").merge("k", b"\xff\xfenot json")
+
+    @pytest.mark.asyncio
+    async def test_merge_rejects_wrong_kind(self) -> None:
+        with pytest.raises(OrMapStateError):
+            await OrMapMemory("a").merge("k", b'{"crdt": "other", "x": 1}')
+
+    @pytest.mark.asyncio
+    async def test_merge_all_rejects_bad_keys(self) -> None:
+        with pytest.raises(OrMapStateError):
+            await OrMapMemory("a").merge_all(b'{"crdt": "or_map", "keys": 5}')
+
+    def test_or_map_state_error_is_value_error(self) -> None:
+        assert issubclass(OrMapStateError, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# CRDT algebraic laws (property-based) over the full-state join
+# ---------------------------------------------------------------------------
+
+_verb = st.sampled_from(["w", "r"])
+_payload = st.binary(min_size=0, max_size=4)
+_program = st.lists(st.tuples(_verb, _payload), min_size=0, max_size=4)
+
+
+async def _state_from_program(node: str, program: list[tuple[str, bytes]]) -> bytes:
+    mem = OrMapMemory(node)
+    for verb, payload in program:
+        if verb == "w":
+            await mem.write("k", payload)
+        else:
+            await mem.remove("k")
+    return mem.export_all()
+
+
+async def _merged_export(states: list[bytes]) -> bytes:
+    merger = OrMapMemory("merger")
+    for s in states:
+        await merger.merge_all(s)
+    return merger.export_all()
+
+
+class TestCrdtLaws:
+    @settings(max_examples=60, deadline=None)
+    @given(p1=_program, p2=_program)
+    @pytest.mark.asyncio
+    async def test_merge_is_commutative(
+        self, p1: list[tuple[str, bytes]], p2: list[tuple[str, bytes]]
+    ) -> None:
+        s1 = await _state_from_program("a", p1)
+        s2 = await _state_from_program("b", p2)
+        assert await _merged_export([s1, s2]) == await _merged_export([s2, s1])
+
+    @settings(max_examples=60, deadline=None)
+    @given(p1=_program, p2=_program, p3=_program)
+    @pytest.mark.asyncio
+    async def test_merge_is_associative(
+        self,
+        p1: list[tuple[str, bytes]],
+        p2: list[tuple[str, bytes]],
+        p3: list[tuple[str, bytes]],
+    ) -> None:
+        s1 = await _state_from_program("a", p1)
+        s2 = await _state_from_program("b", p2)
+        s3 = await _state_from_program("c", p3)
+        assert await _merged_export([s1, s2, s3]) == await _merged_export([s3, s2, s1])
+
+    @settings(max_examples=60, deadline=None)
+    @given(p1=_program)
+    @pytest.mark.asyncio
+    async def test_merge_is_idempotent(self, p1: list[tuple[str, bytes]]) -> None:
+        s1 = await _state_from_program("a", p1)
+        assert await _merged_export([s1]) == await _merged_export([s1, s1])
+
+
+# ---------------------------------------------------------------------------
+# Convergence under arbitrary delivery order + determinism
+# ---------------------------------------------------------------------------
+
+
+class TestConvergence:
+    @settings(max_examples=40, deadline=None)
+    @given(data=st.data())
+    @pytest.mark.asyncio
+    async def test_replicas_converge_for_any_order(self, data: st.DataObject) -> None:
+        n_writes = data.draw(st.integers(min_value=2, max_value=6))
+        replicas = data.draw(st.integers(min_value=2, max_value=5))
+        writes = [
+            (data.draw(st.integers(min_value=0, max_value=replicas - 1)), f"v{i}".encode())
+            for i in range(n_writes)
+        ]
+        orders = [data.draw(st.permutations(list(range(n_writes)))) for _ in range(replicas)]
+        results = await validate_crdt_convergence(OrMapMemory, writes, orders)
+        assert all(r.passed for r in results), results[0].detail
+
+    @pytest.mark.asyncio
+    async def test_determinism_same_ops_same_state(self) -> None:
+        async def build() -> bytes:
+            a = OrMapMemory("a")
+            b = OrMapMemory("b")
+            await a.write("k", b"one")
+            await b.write("k", b"two")
+            await a.merge_all(b.export_all())
+            await a.remove("k")
+            await a.write("k", b"three")
+            return a.export_all()
+
+        assert await build() == await build()
+
+    @pytest.mark.asyncio
+    async def test_dot_ordering_is_deterministic(self) -> None:
+        assert Dot(counter=2, node="a") > Dot(counter=1, node="z")
+        assert Dot(counter=1, node="b") > Dot(counter=1, node="a")
+
+
+# ---------------------------------------------------------------------------
+# Adversarial validators: reference plugins must fail, OR-Map must pass
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialValidators:
+    def test_add_wins_passes_for_or_map(self) -> None:
+        report = check_add_wins_survives_concurrent_remove(OrMapMemory)
+        assert report.passed, report.detail
+
+    def test_add_wins_fails_for_blackboard(self) -> None:
+        report = check_add_wins_survives_concurrent_remove(lambda _n: Blackboard())
+        assert not report.passed
+
+    def test_add_wins_fails_for_lww_register(self) -> None:
+        report = check_add_wins_survives_concurrent_remove(LwwRegisterMemory)
+        assert not report.passed
+
+    def test_churn_convergence_passes_for_or_map(self) -> None:
+        report = check_convergence_under_churn(OrMapMemory)
+        assert report.passed, report.detail
+
+    def test_churn_convergence_fails_for_blackboard(self) -> None:
+        report = check_convergence_under_churn(lambda _n: Blackboard())
+        assert not report.passed
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_builtin_resolves(self) -> None:
+        assert PluginRegistry().resolve("memory", "or_map") is OrMapMemory
+
+    def test_listed_for_memory_layer(self) -> None:
+        assert ("memory", "or_map") in PluginRegistry().list_plugins("memory")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end scenario: convergence under loss, deterministic across seeds
+# ---------------------------------------------------------------------------
+
+
+class TestScenario:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("seed", [42, 7, 1337])
+    async def test_scenario_converges_and_is_deterministic(self, seed: int) -> None:
+        traces: list[bytes] = []
+        with tempfile.TemporaryDirectory() as tmp:
+            for run in range(2):
+                config = ScenarioConfig.from_yaml("scenarios/memory_or_map_add_remove.yaml")
+                config.seed = seed
+                out = Path(tmp) / f"run-{run}.jsonl"
+                config.output.trace = str(out)
+                trace_path = await ScenarioRunner(config).run()
+                traces.append(trace_path.read_bytes())
+                if run == 0:
+                    results = validate_trace(trace_path, "memory_or_map_add_remove")
+                    assert results, "validator produced no results"
+                    assert all(r.passed for r in results), [r.detail for r in results]
+        assert traces[0] == traces[1], "trace not byte-identical under same seed"

--- a/scenarios/memory_or_map_add_remove.yaml
+++ b/scenarios/memory_or_map_add_remove.yaml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# OR-Map add/remove churn: 9 agents each write the same key with their own
+# add-wins observed-remove (OR-Map) replica; every third agent also removes the
+# key one round after writing. Full-state gossip under 10% message drop drives
+# every replica to the same add-wins value -- a concurrent add always beats a
+# stale remove. Swap `memory: or_map` for `memory: blackboard` and the trace
+# validator fails (replicas diverge), which is the point.
+name: memory_or_map_add_remove
+description: "9 agents add/remove one shared key under 10% drop; OR-Map add-wins merge converges."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 9
+  brain: state-machine
+  roles:
+    - name: writer
+      count: 9
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: or_map
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: memory_or_map_add_remove
+  config:
+    rounds: 20
+    key: shared
+    remover_stride: 3
+
+failures:
+  message_drop: 0.1
+
+duration: "ticks: 100000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/memory_or_map_add_remove.jsonl


### PR DESCRIPTION
# memory: `or_map` — an add-wins observed-remove map CRDT (Problem 02)

**Persona:** distributed-systems engineer. The thing I care about is *causal*
consistency under concurrent delete — the failure mode that a plain register
hides.

## Motivation

`memory/lww_register` (merged) is a correct **LWW-Register**: it settles every
conflict by the total order `(lamport, node)`. That is exactly right for a
single-valued register — and exactly wrong for a shared **set/map of live
entries**, because a *delete* has to be modelled as a tombstone write, and a
tombstone that happens to carry the higher `(lamport, node)` **silently
overwrites a concurrent add**. An agent re-advertising a catalogue entry at the
same moment another agent retires the copy it had seen loses its entry. The
default `blackboard` is worse: delete is order-dependent `del` on a per-replica
dict, so replicas simply diverge.

There is no add-wins / observed-remove memory plugin in the tree, and
`docs/layers/memory.md` calls CRDTs out as wanted. This fills that gap with the
one capability `lww_register` structurally cannot express: **deletion under
concurrency**.

## Design

`OrMapMemory` is a **state-based ORSWOT** ("OR-Set Without Tombstones",
generalised from a set to a keyed map):

- every `write` mints a globally-unique **dot** `(node, counter)`;
- a per-replica **causal context** (a version vector: `node -> max counter
  seen`) records everything the replica has observed;
- `remove(key)` drops only the dots this replica has *observed* — a concurrent
  add carries a fresh dot **outside** the remover's context and therefore
  survives (**add-wins**);
- the full-state join keeps a dot iff the other side still has it *or* has never
  seen it, so the merge is **commutative, associative, and idempotent** — strong
  eventual consistency with **no tombstones**.

Reads stay single-valued and deterministic: when concurrent writes leave several
live dots, `read` returns the payload of the largest dot under `(counter,
node)`, while all concurrent dots are retained internally so convergence and
trace inspection are exact.

The base `Memory` surface (`read`/`write`/`cas`/`subscribe`) is unchanged; the
delete verb and replication channel (`remove` / `export` / `merge` /
`export_all` / `merge_all`) are **additive**, so a caller that only speaks the
base protocol never has to know the values are CRDT entries.

## Tradeoffs

- **State-based (CvRDT), not op-based.** Simpler to reason about and matches the
  problem brief ("pick state-based for this problem"); the cost is that a
  per-key `export` carries the causal context. Removal propagation uses the
  full-state `export_all`/`merge_all` channel, which is the correct anti-entropy
  path for observed-remove.
- **No context compaction.** The version vector is not garbage-collected across
  gossip rounds — fine at simulation scale, called out as future work.
- **Deterministic single-valued read** over a multi-value internal state: a
  deliberate choice so traces replay byte-identically; the concurrent values
  remain inspectable.

## Adversarial validators (the discriminating bar)

Two **capability-aware** validators in
`nest_plugins_reference/validators/or_map_validators.py`. They use the CRDT
channel + `remove` when present and otherwise model "observe" as a `write` and
"delete" as a tombstone `write`, so one call site discriminates all three
plugins:

| validator | `blackboard` | `lww_register` | `or_map` |
|---|---|---|---|
| `check_add_wins_survives_concurrent_remove` | **FAIL** (diverges) | **FAIL** (add lost to tombstone) | **PASS** |
| `check_convergence_under_churn` | **FAIL** (diverges) | PASS (converges, wrong value) | **PASS** |

`lww_register` passing churn-convergence but failing add-wins is the whole
point: it *is* a CRDT, so it converges — but it converges to the *deleted*
state, dropping the concurrent add. `or_map` keeps it.

## Scenario

`scenarios/memory_or_map_add_remove.yaml` — 9 replicas each write the same key
with their own `or_map` replica; every third also issues an observed-remove one
round later; full-state gossip under 10% message drop. The
`memory_or_map_add_remove` trace validators (`validate_or_map_convergence` +
`validate_memory_liveness`) confirm every replica converges to one value and
none dropped out. Byte-deterministic across seeds 42, 7, 1337.

## Verify it

```bash
uv sync
uv run pytest packages/nest-plugins-reference/tests/test_or_map.py -v   # 42 tests

# Watch the validators discriminate:
uv run python - <<'PY'
from nest_plugins_reference.memory.blackboard import Blackboard
from nest_plugins_reference.memory.lww_register import LwwRegisterMemory
from nest_plugins_reference.memory.or_map import OrMapMemory
from nest_plugins_reference.validators import check_add_wins_survives_concurrent_remove
for name, f in {"or_map": OrMapMemory, "lww_register": LwwRegisterMemory,
                "blackboard": lambda _n: Blackboard()}.items():
    r = check_add_wins_survives_concurrent_remove(f)
    print(f"{name:14s} {'PASS' if r.passed else 'FAIL'}  {r.detail}")
PY
```

## CI

All five checks green locally (`uv sync`, `ruff check`, `ruff format --check`,
`pyright` strict → 0 errors, `pytest` → **987 passed**, 1 pre-existing skip).

## Files

- `packages/nest-plugins-reference/nest_plugins_reference/memory/or_map.py` — plugin
- `packages/nest-plugins-reference/nest_plugins_reference/validators/or_map_validators.py` — adversarial validators
- `packages/nest-core/nest_core/scenarios_builtin/memory_or_map_add_remove.py` + `scenarios/memory_or_map_add_remove.yaml` — scenario
- `packages/nest-plugins-reference/tests/test_or_map.py` — 42 tests
- wiring: `plugins.py`, `scenarios.py`, `validators.py`, reference `pyproject.toml`, validators `__init__.py`
