### PR TITLE
Remove dead code from reputation scoring validator

### DIFF
--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -787,7 +787,7 @@ def validate_supply_chain_no_lost(
 def validate_reputation_scoring(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """Reputation scores decrease for agents that cheat."""
+    """Validate that every cheating agent receives a corresponding bad report."""
     # Track scores: agent -> score
     scores: dict[str, int] = defaultdict(int)
     cheaters: set[str] = set()
@@ -809,9 +809,8 @@ def validate_reputation_scoring(
 
     violations: list[str] = []
 
-    # The core invariant: agents with bad reports should have lower scores
-    # than they would without those reports.  We verify that at least one
-    # "bad" report exists for every cheater.
+   # The core invariant: every agent that emits a "cheat:" event should
+   # receive at least one corresponding "report:...:bad" event.
     bad_agents_with_reports: set[str] = set()
     for ev in events:
         if ev.get("kind") != "send":

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -809,8 +809,8 @@ def validate_reputation_scoring(
 
     violations: list[str] = []
 
-   # The core invariant: every agent that emits a "cheat:" event should
-   # receive at least one corresponding "report:...:bad" event.
+    # The core invariant: every agent that emits a "cheat:" event should
+    # receive at least one corresponding "report:...:bad" event.
     bad_agents_with_reports: set[str] = set()
     for ev in events:
         if ev.get("kind") != "send":

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -808,12 +808,6 @@ def validate_reputation_scoring(
                     cheaters.add(agent_str)
 
     violations: list[str] = []
-    for cheater in cheaters:
-        if scores[cheater] >= 0:
-            # If a cheater has never had their score go negative from cheating
-            # that's fine — they might have enough good trades.  We check that
-            # at least one bad report actually decremented the score.
-            pass
 
     # The core invariant: agents with bad reports should have lower scores
     # than they would without those reports.  We verify that at least one

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -602,20 +602,7 @@ class TestReputationScoring:
         ]
         results = validate_reputation_scoring(events)
         assert results[0].passed is True
-    
-    def test_cheater_can_recover_with_good_reports(self) -> None:
-        events = [
-            _send("malicious-0", "honest-0", "cheat:1:malicious-0"),
-            _send("honest-0", "observer-0", "report:1:malicious-0:bad"),
-
-            _send("honest-1", "observer-0", "report:2:malicious-0:good"),
-            _send("honest-2", "observer-0", "report:3:malicious-0:good"),
-            _send("honest-3", "observer-0", "report:4:malicious-0:good"),
-        ]
-        results = validate_reputation_scoring(events)
-        assert results[0].passed is True
-
-
+        
 class TestReputationWarnings:
     def test_pass_warning_issued(self) -> None:
         events = [

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -602,7 +602,8 @@ class TestReputationScoring:
         ]
         results = validate_reputation_scoring(events)
         assert results[0].passed is True
-        
+
+
 class TestReputationWarnings:
     def test_pass_warning_issued(self) -> None:
         events = [

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -602,6 +602,18 @@ class TestReputationScoring:
         ]
         results = validate_reputation_scoring(events)
         assert results[0].passed is True
+    
+    def test_cheater_can_recover_with_good_reports(self) -> None:
+        events = [
+            _send("malicious-0", "honest-0", "cheat:1:malicious-0"),
+            _send("honest-0", "observer-0", "report:1:malicious-0:bad"),
+
+            _send("honest-1", "observer-0", "report:2:malicious-0:good"),
+            _send("honest-2", "observer-0", "report:3:malicious-0:good"),
+            _send("honest-3", "observer-0", "report:4:malicious-0:good"),
+        ]
+        results = validate_reputation_scoring(events)
+        assert results[0].passed is True
 
 
 class TestReputationWarnings:


### PR DESCRIPTION
## Summary

This PR removes the unused dead loop in `validate_reputation_scoring` and updates the related comments to reflect the validator's current behavior.

## Changes

- Removed the unused dead loop in `validate_reputation_scoring`
- Updated comments to match the implemented validation logic
- Verified that the existing `TestReputationScoring` tests continue to pass