### PR TITLE
[Hackathon] Harden LWW register state validation

### DIFF
--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -109,6 +109,12 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("memory_concurrent_writers", memory_concurrent_writers_factory)
+    elif name == "memory_byzantine_state":
+        from nest_core.scenarios_builtin.memory_byzantine_state import (
+            memory_byzantine_state_factory,
+        )
+
+        register_scenario("memory_byzantine_state", memory_byzantine_state_factory)
     elif name == "comms_versioning":
         from nest_core.scenarios_builtin.comms_versioning import comms_versioning_factory
 

--- a/packages/nest-core/nest_core/scenarios_builtin/memory_byzantine_state.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/memory_byzantine_state.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Byzantine-state memory scenario -- reject malformed CRDT gossip.
+
+This scenario is a hostile variant of ``memory_concurrent_writers``. Each
+honest agent owns a private LWW-register replica, writes a local value, and
+gossips normally. One byzantine agent then broadcasts malformed serialized
+register state with an artificially high Lamport clock. A hardened CRDT must
+raise at the merge boundary and leave the trusted local value unchanged; an
+unsafe decoder can accept the poison and spread it by later gossip rounds.
+
+Example::
+
+    agents = memory_byzantine_state_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId
+
+_TICK = b"tick"
+_ATTACK = b"attack"
+_SYNC_PREFIX = "sync:"
+_ATTACK_PREFIX = "attack:"
+_FINAL_PREFIX = "final:"
+_REJECTED_PREFIX = "rejected:"
+_ACCEPTED_PREFIX = "accepted:"
+
+
+class ByzantineStateAgent(StateMachineAgent):
+    """Write one CRDT value, gossip it, and reject malformed remote state.
+
+    Example::
+
+        agent = ByzantineStateAgent(AgentId("writer-1"), "shared", b"value", 20, False)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        key: str,
+        value: bytes,
+        rounds: int,
+        is_attacker: bool,
+        malicious_state: bytes,
+    ) -> None:
+        self._id = agent_id
+        self._key = key
+        self._value = value
+        self._rounds = rounds
+        self._is_attacker = is_attacker
+        self._malicious_state = malicious_state
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Write the local value and schedule deterministic gossip rounds.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        mem = ctx.plugins["memory"]
+        await mem.write(self._key, self._value)
+        for round_idx in range(self._rounds):
+            await ctx.schedule(float(round_idx + 1), _TICK)
+        if self._is_attacker:
+            await ctx.schedule(2.5, _ATTACK)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Handle gossip ticks, normal sync state, and byzantine attack state.
+
+        Example::
+
+            await agent.on_message(ctx, AgentId("writer-0"), b"tick")
+        """
+        mem = ctx.plugins["memory"]
+        if payload == _TICK:
+            state = mem.export(self._key)
+            if state is not None:
+                await ctx.broadcast(_SYNC_PREFIX.encode() + state)
+            return
+        if payload == _ATTACK:
+            await ctx.broadcast(_ATTACK_PREFIX.encode() + self._malicious_state)
+            return
+
+        text = payload.decode("utf-8", errors="replace")
+        if text.startswith(_SYNC_PREFIX):
+            state = text[len(_SYNC_PREFIX) :].encode("utf-8")
+            try:
+                await mem.merge(self._key, state)
+            except ValueError:
+                return
+            return
+        if text.startswith(_ATTACK_PREFIX):
+            if self._is_attacker:
+                return
+            state = text[len(_ATTACK_PREFIX) :].encode("utf-8")
+            before = mem.export(self._key)
+            try:
+                await mem.merge(self._key, state)
+            except ValueError:
+                await ctx.broadcast(f"{_REJECTED_PREFIX}{sender}".encode())
+                return
+            if mem.export(self._key) != before:
+                await ctx.broadcast(f"{_ACCEPTED_PREFIX}{sender}".encode())
+
+    async def on_stop(self, ctx: AgentContext) -> None:
+        """Broadcast the terminal register state for validators.
+
+        Example::
+
+            await agent.on_stop(ctx)
+        """
+        mem = ctx.plugins["memory"]
+        state = mem.export(self._key)
+        if state is not None:
+            await ctx.broadcast(_FINAL_PREFIX.encode() + state)
+
+
+def memory_byzantine_state_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create writer replicas plus one deterministic malformed-state attacker.
+
+    Example::
+
+        agents = memory_byzantine_state_factory(config, plugins)
+    """
+    task_config = config.task.config
+    rounds = int(task_config.get("rounds", 20))
+    key = str(task_config.get("key", "shared"))
+    count = max(config.agents.count, 8)
+    attacker_index = int(task_config.get("attacker_index", 0))
+    malicious_state = str(
+        task_config.get(
+            "malicious_state",
+            '{"crdt":"lww_register","payload":"@@@","lamport":999,"node":"evil"}',
+        )
+    ).encode("utf-8")
+
+    memory_cls = plugins["memory"]
+    agent_ids = [AgentId(f"writer-{i}") for i in range(count)]
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    overrides: dict[AgentId, dict[str, Any]] = {}
+    for idx, aid in enumerate(agent_ids):
+        agents[aid] = ByzantineStateAgent(
+            aid,
+            key=key,
+            value=f"value-from-{aid}".encode(),
+            rounds=rounds,
+            is_attacker=idx == attacker_index,
+            malicious_state=malicious_state,
+        )
+        overrides[aid] = {"memory": memory_cls(str(aid))}
+
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1244,6 +1244,108 @@ def validate_memory_convergence(
     return results
 
 
+def validate_memory_byzantine_state_rejected(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Trace validator: malformed byzantine CRDT state is rejected.
+
+    The ``memory_byzantine_state`` scenario emits one ``attack:<json>``
+    broadcast. Honest replicas must answer with ``rejected:<attacker>`` and
+    must not emit ``accepted:<attacker>``. Final CRDT states must also avoid
+    the attacker's ``node`` id and empty payload, so a pre-fix decoder that
+    accepts ``payload:"@@@"`` with a high Lamport clock is caught even if the
+    poisoned state later converges.
+
+    Example::
+
+        results = validate_memory_byzantine_state_rejected(events)
+    """
+    attacks: list[str] = []
+    rejected: set[str] = set()
+    accepted: set[str] = set()
+    poisoned: list[str] = []
+
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        agent = str(ev.get("agent", ""))
+        msg = str(ev.get("msg", ""))
+        if msg.startswith("attack:"):
+            attacks.append(agent)
+        elif msg.startswith("rejected:"):
+            rejected.add(agent)
+        elif msg.startswith("accepted:"):
+            accepted.add(agent)
+        elif msg.startswith("final:"):
+            body = msg[len("final:") :]
+            with contextlib.suppress(ValueError, TypeError):
+                parsed = json.loads(body)
+                if parsed.get("node") == "evil" or parsed.get("payload") == "":
+                    poisoned.append(agent)
+
+    results: list[ValidationResult] = []
+    if not attacks:
+        results.append(
+            ValidationResult(
+                "memory_byzantine_state_attack_present",
+                False,
+                "no malformed attack state was observed",
+            )
+        )
+    else:
+        results.append(
+            ValidationResult(
+                "memory_byzantine_state_attack_present",
+                True,
+                f"{len(attacks)} malformed attack broadcast(s) observed",
+            )
+        )
+
+    if accepted:
+        results.append(
+            ValidationResult(
+                "memory_byzantine_state_rejected",
+                False,
+                f"malformed state accepted by {sorted(accepted)}",
+            )
+        )
+    elif rejected:
+        results.append(
+            ValidationResult(
+                "memory_byzantine_state_rejected",
+                True,
+                f"{len(rejected)} honest replica(s) rejected malformed state",
+            )
+        )
+    else:
+        results.append(
+            ValidationResult(
+                "memory_byzantine_state_rejected",
+                False,
+                "no honest replica rejection records found",
+            )
+        )
+
+    if poisoned:
+        results.append(
+            ValidationResult(
+                "memory_byzantine_state_not_poisoned",
+                False,
+                f"poisoned final state observed at {sorted(poisoned)}",
+            )
+        )
+    else:
+        results.append(
+            ValidationResult(
+                "memory_byzantine_state_not_poisoned",
+                True,
+                "no final replica state used the malformed attack register",
+            )
+        )
+
+    return results
+
+
 # ---------------------------------------------------------------------------
 # Streaming payments validators
 # ---------------------------------------------------------------------------
@@ -4976,6 +5078,11 @@ VALIDATORS: dict[str, list[Any]] = {
     "memory_concurrent_writers": [
         validate_memory_convergence,
         validate_memory_liveness,
+    ],
+    "memory_byzantine_state": [
+        validate_memory_convergence,
+        validate_memory_liveness,
+        validate_memory_byzantine_state_rejected,
     ],
     "streaming_payments": [
         validate_streaming_conservation,

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2000,6 +2000,7 @@ class TestValidatorRegistry:
             "identity_rotation",
             "attested_peering",
             "memory_concurrent_writers",
+            "memory_byzantine_state",
             "streaming_payments",
             "empic_payments",
             "comms_versioning",

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/lww_register.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/lww_register.py
@@ -384,11 +384,29 @@ class LwwRegisterMemory:
 
     @staticmethod
     def _register_from_fields(fields: dict[str, Any]) -> Register:
+        raw_payload = fields.get("payload")
+        raw_lamport = fields.get("lamport")
+        raw_node = fields.get("node")
+        if not isinstance(raw_payload, str):
+            msg = f"payload must be a base64 string: {fields!r}"
+            raise CrdtStateError(msg)
+        if not isinstance(raw_lamport, int) or isinstance(raw_lamport, bool):
+            msg = f"lamport clock must be an integer: {fields!r}"
+            raise CrdtStateError(msg)
+        if not isinstance(raw_node, str):
+            msg = f"node id must be a string: {fields!r}"
+            raise CrdtStateError(msg)
         try:
-            payload = base64.b64decode(fields["payload"])
-            lamport = int(fields["lamport"])
-            node = str(fields["node"])
-        except (KeyError, ValueError, TypeError) as exc:
+            payload = base64.b64decode(raw_payload, validate=True)
+        except (ValueError, TypeError) as exc:
             msg = f"malformed register fields: {fields!r}"
             raise CrdtStateError(msg) from exc
+        lamport = raw_lamport
+        node = raw_node
+        if lamport < 0:
+            msg = f"lamport clock must be non-negative: {fields!r}"
+            raise CrdtStateError(msg)
+        if not node:
+            msg = f"node id must be non-empty: {fields!r}"
+            raise CrdtStateError(msg)
         return Register(payload=payload, lamport=lamport, node=node)

--- a/packages/nest-plugins-reference/tests/test_lww_register.py
+++ b/packages/nest-plugins-reference/tests/test_lww_register.py
@@ -204,8 +204,88 @@ class TestMalformedState:
         with pytest.raises(CrdtStateError):
             await LwwRegisterMemory("a").merge("k", b'{"crdt": "lww_register"}')
 
+    @pytest.mark.asyncio
+    async def test_merge_rejects_invalid_base64_payload(self) -> None:
+        with pytest.raises(CrdtStateError):
+            await LwwRegisterMemory("a").merge(
+                "k",
+                b'{"crdt": "lww_register", "payload": "@@@", "lamport": 1, "node": "a"}',
+            )
+
+    @pytest.mark.asyncio
+    async def test_merge_rejects_non_string_payload(self) -> None:
+        with pytest.raises(CrdtStateError):
+            await LwwRegisterMemory("a").merge(
+                "k",
+                b'{"crdt": "lww_register", "payload": 123, "lamport": 1, "node": "a"}',
+            )
+
+    @pytest.mark.asyncio
+    async def test_merge_rejects_negative_lamport(self) -> None:
+        with pytest.raises(CrdtStateError):
+            await LwwRegisterMemory("a").merge(
+                "k",
+                b'{"crdt": "lww_register", "payload": "eA==", "lamport": -1, "node": "a"}',
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("lamport", [b"2.9", b'"7"', b"true", b"1e400"])
+    async def test_merge_rejects_non_integer_lamport(self, lamport: bytes) -> None:
+        with pytest.raises(CrdtStateError):
+            await LwwRegisterMemory("a").merge(
+                "k",
+                b'{"crdt": "lww_register", "payload": "eA==", "lamport": '
+                + lamport
+                + b', "node": "a"}',
+            )
+
+    @pytest.mark.asyncio
+    async def test_merge_rejects_empty_node_id(self) -> None:
+        with pytest.raises(CrdtStateError):
+            await LwwRegisterMemory("a").merge(
+                "k",
+                b'{"crdt": "lww_register", "payload": "eA==", "lamport": 1, "node": ""}',
+            )
+
+    @pytest.mark.asyncio
+    async def test_merge_rejects_non_string_node_id(self) -> None:
+        with pytest.raises(CrdtStateError):
+            await LwwRegisterMemory("a").merge(
+                "k",
+                b'{"crdt": "lww_register", "payload": "eA==", "lamport": 1, "node": 123}',
+            )
+
+    @pytest.mark.asyncio
+    async def test_malformed_merge_does_not_poison_existing_value(self) -> None:
+        mem = LwwRegisterMemory("a")
+        await mem.write("k", b"trusted")
+        before = mem.export("k")
+
+        with pytest.raises(CrdtStateError):
+            await mem.merge(
+                "k",
+                b'{"crdt": "lww_register", "payload": "@@@", "lamport": 99, "node": "evil"}',
+            )
+
+        assert await mem.read("k") == b"trusted"
+        assert mem.export("k") == before
+
     def test_crdt_state_error_is_value_error(self) -> None:
         assert issubclass(CrdtStateError, ValueError)
+
+    @settings(max_examples=80, deadline=None)
+    @given(state=st.binary(max_size=128))
+    @pytest.mark.asyncio
+    async def test_failed_merge_never_mutates_existing_state(self, state: bytes) -> None:
+        mem = LwwRegisterMemory("a")
+        await mem.write("k", b"trusted")
+        before = mem.export("k")
+
+        try:
+            await mem.merge("k", state)
+        except CrdtStateError:
+            assert await mem.read("k") == b"trusted"
+            assert mem.export("k") == before
 
 
 # ---------------------------------------------------------------------------
@@ -342,3 +422,15 @@ class TestScenario:
                     assert results, "validator produced no results"
                     assert all(r.passed for r in results), [r.detail for r in results]
         assert traces[0] == traces[1], "trace not byte-identical under same seed"
+
+    @pytest.mark.asyncio
+    async def test_byzantine_state_scenario_rejects_malformed_gossip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config = ScenarioConfig.from_yaml("scenarios/memory_byzantine_state.yaml")
+            out = Path(tmp) / "memory-byzantine-state.jsonl"
+            config.output.trace = str(out)
+            trace_path = await ScenarioRunner(config).run()
+
+            results = validate_trace(trace_path, "memory_byzantine_state")
+            assert results, "validator produced no results"
+            assert all(r.passed for r in results), [r.detail for r in results]

--- a/scenarios/memory_byzantine_state.yaml
+++ b/scenarios/memory_byzantine_state.yaml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# Byzantine-state scenario: 8 CRDT memory replicas gossip normally while one
+# replica injects malformed serialized register state with a high Lamport clock.
+name: memory_byzantine_state
+description: "8 memory replicas reject malformed CRDT state and keep converging."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 8
+  brain: state-machine
+  roles:
+    - name: writer
+      count: 7
+    - name: byzantine
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: lww_register
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: memory_byzantine_state
+  config:
+    rounds: 20
+    key: shared
+    attacker_index: 0
+    malicious_state: '{"crdt":"lww_register","payload":"@@@","lamport":999,"node":"evil"}'
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 100000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/memory_byzantine_state.jsonl


### PR DESCRIPTION
## Summary

Harden the memory layer's LWW-register CRDT merge boundary against malformed or adversarial replica state.

This rejects:
- invalid base64 payloads
- non-string payload fields
- negative Lamport clocks
- empty node IDs
- non-string node IDs

It also adds regression coverage proving malformed remote CRDT state cannot poison an existing trusted replica value.

**Problem:** `02-memory-crdt-lww`  
**Layer:** `memory`

## Validation

Ran the required CI sequence locally:

- `uv sync`
- `uv run ruff check .`