### PR TITLE
[Hackathon] audit-engineer: intent-gated datafacts — pre-publication intent gate (problem 08)

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -50,6 +50,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("privacy", "trust_gated"): f"{_REF}.privacy.trust_gated:TrustGatedPrivacy",
     ("datafacts", "datafacts_v1"): f"{_REF}.datafacts.datafacts_v1:DataFactsV1",
     ("datafacts", "cid_facts"): f"{_REF}.datafacts.cid_facts:CidFacts",
+    ("datafacts", "intent_facts"): f"{_REF}.datafacts.intent_facts:IntentGatedFacts",
     ("failure_detector", "heartbeat"): (
         f"{_REF}.failure_detection.heartbeat:HeartbeatFailureDetector"
     ),

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -175,3 +175,9 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.sybil_bond import sybil_bond_factory
 
         register_scenario("sybil_bond", sybil_bond_factory)
+    elif name == "intent_gated_datafacts":
+        from nest_core.scenarios_builtin.intent_gated_datafacts import (
+            intent_gated_datafacts_factory,
+        )
+
+        register_scenario("intent_gated_datafacts", intent_gated_datafacts_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/intent_gated_datafacts.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/intent_gated_datafacts.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Intent-gated datafacts scenario: publish only after a pre-declared intent.
+
+Three honest agents each **register a publish intent** for their dataset and then
+publish it; a fourth agent is an **attacker** that skips the intent step and tries
+to publish a surprise dataset directly. Every step is reported as a ``|``-delimited
+trace message so ``validate_trace(..., "intent_gated_datafacts")`` can read it.
+
+The scenario is a discriminator. Point ``layers.datafacts`` at ``intent_facts``
+(the ``IntentGatedFacts`` plugin) and both validators pass: honest publishes are
+each preceded by a registered intent, and the attacker's un-declared publish is
+blocked. Point it at ``datafacts_v1`` -- which has no intent concept -- and both
+flip to FAIL: there is no intent gate, so the attacker's surprise publication
+succeeds silently and no publish is backed by a declared intent.
+
+Example::
+
+    agents = intent_gated_datafacts_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, DatasetMetadata
+
+
+class HonestPublisher(StateMachineAgent):
+    """Declares a publish intent, then publishes its dataset within the TTL.
+
+    Against a gated plugin the intent is registered first (emitting
+    ``intent_registered``) and the publish then consumes it (``publish_ok``).
+    Against a plugin with no intent concept the registration is silently
+    skipped -- the ``publish_ok`` then has no backing intent, which is exactly
+    what the validator catches.
+
+    Example::
+
+        pub = HonestPublisher(AgentId("supplier-0"), name="prices")
+    """
+
+    def __init__(self, agent_id: AgentId, name: str) -> None:
+        self._id = agent_id
+        self._name = name
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Register intent (if the plugin supports it), then publish the dataset.
+
+        Example::
+
+            await pub.on_start(ctx)
+        """
+        facts = ctx.plugins.get("datafacts")
+        if facts is None:
+            return
+        register = getattr(facts, "register_publish_intent", None)
+        if callable(register):
+            register(self._name)
+            await ctx.send(self._id, f"intent_registered|honest|{self._name}|{self._id}".encode())
+        dataset = DatasetMetadata(name=self._name, owner=self._id)
+        try:
+            url = await facts.publish(dataset)
+        except ValueError as exc:  # IntentError (a ValueError) if the gate blocks it
+            await ctx.send(
+                self._id, f"publish_blocked|honest|{self._name}|{self._id}|{exc}".encode()
+            )
+            return
+        await ctx.send(self._id, f"publish_ok|honest|{self._name}|{self._id}|{url}".encode())
+
+
+class AttackerPublisher(StateMachineAgent):
+    """Skips the intent step and attempts a surprise publication.
+
+    A gated plugin raises (a ``ValueError``) because no intent was declared, and
+    the attempt is reported as ``publish_blocked``. A plugin with no gate lets
+    the surprise land as ``publish_ok`` -- the failure the discriminator surfaces.
+
+    Example::
+
+        atk = AttackerPublisher(AgentId("attacker-0"), name="surprise_release")
+    """
+
+    def __init__(self, agent_id: AgentId, name: str) -> None:
+        self._id = agent_id
+        self._name = name
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Attempt to publish without declaring any intent first.
+
+        Example::
+
+            await atk.on_start(ctx)
+        """
+        facts = ctx.plugins.get("datafacts")
+        if facts is None:
+            return
+        dataset = DatasetMetadata(name=self._name, owner=self._id)
+        try:
+            url = await facts.publish(dataset)
+        except ValueError as exc:  # IntentError (a ValueError) when the gate blocks it
+            await ctx.send(
+                self._id, f"publish_blocked|attacker|{self._name}|{self._id}|{exc}".encode()
+            )
+            return
+        await ctx.send(self._id, f"publish_ok|attacker|{self._name}|{self._id}|{url}".encode())
+
+
+def _build_datafacts_handles(
+    datafacts_cls: type[Any],
+    identities: dict[AgentId, Any],
+    all_ids: list[AgentId],
+) -> dict[AgentId, Any]:
+    """Give each agent its own datafacts handle over shared storage where possible.
+
+    Plugins that take an ``Identity`` plus ``datasets``/``proofs``/``clock``
+    keyword arguments (``intent_facts``, ``cid_facts``) get one handle per agent
+    over the same dicts and logical clock, so each agent signs and registers
+    intents as itself while sharing the published-dataset store. Plugins with a
+    no-argument constructor (``datafacts_v1``) get a single shared instance.
+
+    Example::
+
+        handles = _build_datafacts_handles(cls, identities, all_ids)
+    """
+    shared_datasets: dict[Any, Any] = {}
+    shared_proofs: dict[Any, Any] = {}
+    shared_clock: Any = None
+    shared_instance: Any = None
+    handles: dict[AgentId, Any] = {}
+
+    for aid in all_ids:
+        try:
+            kwargs: dict[str, Any] = {"datasets": shared_datasets, "proofs": shared_proofs}
+            if shared_clock is not None:
+                kwargs["clock"] = shared_clock
+            handle = datafacts_cls(identities[aid], **kwargs)
+            shared_clock = getattr(handle, "clock", shared_clock)
+            handles[aid] = handle
+        except TypeError:
+            if shared_instance is None:
+                shared_instance = datafacts_cls()
+            handles[aid] = shared_instance
+    return handles
+
+
+def intent_gated_datafacts_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create three honest publishers plus one surprise-publishing attacker.
+
+    Instantiates per-agent identities (so each agent registers and signs as
+    itself) and wires the resolved ``datafacts`` plugin class into per-agent
+    handles via :func:`_build_datafacts_handles`.
+
+    Example::
+
+        agents = intent_gated_datafacts_factory(config, plugins)
+    """
+    supplier = AgentId("supplier-0")
+    manufacturer = AgentId("manufacturer-0")
+    retailer = AgentId("retailer-0")
+    attacker = AgentId("attacker-0")
+    all_ids = [supplier, manufacturer, retailer, attacker]
+
+    identity_cls = plugins.get("identity")
+    identities: dict[AgentId, Any] = {}
+    if identity_cls is not None and isinstance(identity_cls, type):
+        for aid in all_ids:
+            identities[aid] = identity_cls(aid, seed=b"sim-seed")
+        for aid, ident in identities.items():
+            for peer_id, peer_ident in identities.items():
+                if peer_id != aid:
+                    ident.register_peer(peer_id, peer_ident.public_key)
+
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+    datafacts_cls = plugins.get("datafacts")
+    if datafacts_cls is not None and isinstance(datafacts_cls, type) and identities:
+        handles = _build_datafacts_handles(datafacts_cls, identities, all_ids)
+        for aid, handle in handles.items():
+            agent_plugins.setdefault(aid, {})["datafacts"] = handle
+    plugins.pop("datafacts", None)
+    plugins.pop("identity", None)
+
+    return {
+        supplier: HonestPublisher(supplier, name="raw_materials"),
+        manufacturer: HonestPublisher(manufacturer, name="assembled_goods"),
+        retailer: HonestPublisher(retailer, name="retail_inventory"),
+        attacker: AttackerPublisher(attacker, name="surprise_release"),
+    }

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -4793,6 +4793,120 @@ def validate_attested_sybil_quarantined(
 
 
 # ---------------------------------------------------------------------------
+# Intent-gated datafacts validators
+# ---------------------------------------------------------------------------
+
+
+def _intent_field_msg(events: list[dict[str, Any]], prefix: str) -> list[list[str]]:
+    """Collect ``|``-delimited fields from every send whose message starts with *prefix*.
+
+    Example::
+
+        rows = _intent_field_msg(events, "publish_ok|")
+    """
+    rows: list[list[str]] = []
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = str(ev.get("msg", ""))
+        if msg.startswith(prefix):
+            rows.append(msg.split("|"))
+    return rows
+
+
+def validate_intent_no_surprise_publication(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every successful publish must be backed by a previously declared intent.
+
+    Reads the trace in order: an ``intent_registered|role|name|agent`` message
+    records a live intent for ``(agent, name)``; a ``publish_ok|role|name|agent|url``
+    message must find that pair already registered. A gated plugin
+    (``intent_facts``) declares intent before every honest publish and blocks the
+    attacker outright, so every ``publish_ok`` is backed. A plugin with no gate
+    (``datafacts_v1``) skips registration and lets every publish through, so the
+    surprise publications are unbacked and this validator fails.
+
+    Example::
+
+        results = validate_intent_no_surprise_publication(events)
+    """
+    registered: set[tuple[str, str]] = set()
+    unbacked: list[str] = []
+    publishes = 0
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = str(ev.get("msg", ""))
+        if msg.startswith("intent_registered|"):
+            parts = msg.split("|")
+            if len(parts) >= 4:
+                registered.add((parts[3], parts[2]))
+        elif msg.startswith("publish_ok|"):
+            parts = msg.split("|")
+            if len(parts) >= 4:
+                publishes += 1
+                if (parts[3], parts[2]) not in registered:
+                    unbacked.append(f"{parts[3]} published {parts[2]!r} with no declared intent")
+    if publishes == 0:
+        return [
+            ValidationResult(
+                "intent_no_surprise_publication", False, "no successful publication recorded"
+            )
+        ]
+    if unbacked:
+        return [ValidationResult("intent_no_surprise_publication", False, "; ".join(unbacked))]
+    return [
+        ValidationResult(
+            "intent_no_surprise_publication",
+            True,
+            f"all {publishes} publications were backed by a declared intent",
+        )
+    ]
+
+
+def validate_intent_gate_blocks_attacker(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """The attacker's un-declared publish must be blocked, never succeed.
+
+    A gated plugin (``intent_facts``) raises on the attacker's intent-less
+    publish, recorded as ``publish_blocked|attacker|...`` and never as
+    ``publish_ok|attacker|...``. A plugin with no gate (``datafacts_v1``) lets the
+    surprise land, producing ``publish_ok|attacker|...`` and no block -- which
+    this validator fails on.
+
+    Example::
+
+        results = validate_intent_gate_blocks_attacker(events)
+    """
+    slipped = _intent_field_msg(events, "publish_ok|attacker|")
+    blocked = _intent_field_msg(events, "publish_blocked|attacker|")
+    if slipped:
+        name = slipped[0][2] if len(slipped[0]) >= 3 else "?"
+        return [
+            ValidationResult(
+                "intent_gate_blocks_attacker",
+                False,
+                f"attacker published {name!r} with no declared intent",
+            )
+        ]
+    if not blocked:
+        return [
+            ValidationResult(
+                "intent_gate_blocks_attacker", False, "no attacker publish attempt recorded"
+            )
+        ]
+    return [
+        ValidationResult(
+            "intent_gate_blocks_attacker",
+            True,
+            "attacker's intent-less publish was blocked by the gate",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -5038,5 +5152,9 @@ VALIDATORS: dict[str, list[Any]] = {
     "rogue_trusted_agent": [
         validate_rogue_trusted_agent_blocked,
         validate_rogue_trusted_agent_reputation,
+    ],
+    "intent_gated_datafacts": [
+        validate_intent_no_surprise_publication,
+        validate_intent_gate_blocks_attacker,
     ],
 }

--- a/packages/nest-core/tests/test_intent_gated_datafacts_scenario.py
+++ b/packages/nest-core/tests/test_intent_gated_datafacts_scenario.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the intent_gated_datafacts discriminator scenario and validators.
+
+The core claim under test: both adversarial validators PASS against the
+``intent_facts`` layer (publish is gated on a pre-declared intent) and FAIL
+against the default ``datafacts_v1`` layer (no intent concept) -- driven both
+from synthetic traces and from a real simulator run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import (
+    validate_intent_gate_blocks_attacker,
+    validate_intent_no_surprise_publication,
+    validate_trace,
+)
+
+type Event = dict[str, Any]
+
+
+def _send(msg: str, agent: str = "supplier-0") -> Event:
+    return {"ts": 0.0, "agent": agent, "kind": "send", "to": agent, "msg": msg}
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests (synthetic traces)
+# ---------------------------------------------------------------------------
+
+
+class TestNoSurprisePublication:
+    def test_pass_when_publish_backed_by_intent(self) -> None:
+        events = [
+            _send("intent_registered|honest|prices|supplier-0"),
+            _send("publish_ok|honest|prices|supplier-0|df://sha256-x"),
+        ]
+        results = validate_intent_no_surprise_publication(events)
+        assert results[0].passed is True
+
+    def test_fail_when_publish_has_no_intent(self) -> None:
+        # datafacts_v1 behaviour: publish succeeds with no intent declared.
+        events = [_send("publish_ok|honest|prices|supplier-0|df://prices")]
+        results = validate_intent_no_surprise_publication(events)
+        assert results[0].passed is False
+
+    def test_fail_when_nothing_published(self) -> None:
+        results = validate_intent_no_surprise_publication([])
+        assert results[0].passed is False
+
+
+class TestGateBlocksAttacker:
+    def test_pass_when_attacker_blocked(self) -> None:
+        events = [_send("publish_blocked|attacker|surprise_release|attacker-0|no intent")]
+        results = validate_intent_gate_blocks_attacker(events)
+        assert results[0].passed is True
+
+    def test_fail_when_attacker_slips_through(self) -> None:
+        # datafacts_v1 behaviour: surprise publication lands.
+        events = [_send("publish_ok|attacker|surprise_release|attacker-0|df://surprise_release")]
+        results = validate_intent_gate_blocks_attacker(events)
+        assert results[0].passed is False
+
+    def test_fail_when_no_attack_recorded(self) -> None:
+        results = validate_intent_gate_blocks_attacker([])
+        assert results[0].passed is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real simulator run (the discriminator)
+# ---------------------------------------------------------------------------
+
+
+def _run(datafacts: str, out: Path, seed: int = 42) -> None:
+    cfg = ScenarioConfig.from_yaml("scenarios/intent_gated_datafacts.yaml")
+    cfg.layers.datafacts = datafacts
+    cfg.seed = seed
+    cfg.output.trace = str(out)
+    asyncio.run(ScenarioRunner(cfg).run())
+
+
+class TestScenarioEndToEnd:
+    def test_intent_facts_passes_all(self, tmp_path: Path) -> None:
+        out = tmp_path / "intent_facts.jsonl"
+        _run("intent_facts", out)
+        results = validate_trace(out, "intent_gated_datafacts")
+        assert results, "expected validators to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_datafacts_v1_fails_all(self, tmp_path: Path) -> None:
+        out = tmp_path / "v1.jsonl"
+        _run("datafacts_v1", out)
+        results = {r.name: r.passed for r in validate_trace(out, "intent_gated_datafacts")}
+        assert results["intent_no_surprise_publication"] is False
+        assert results["intent_gate_blocks_attacker"] is False
+
+    def test_deterministic_across_required_seeds(self, tmp_path: Path) -> None:
+        for seed in (42, 7, 1337):
+            a, b = tmp_path / f"{seed}a.jsonl", tmp_path / f"{seed}b.jsonl"
+            _run("intent_facts", a, seed=seed)
+            _run("intent_facts", b, seed=seed)
+            assert a.read_bytes() == b.read_bytes(), f"seed {seed} not deterministic"
+            assert all(r.passed for r in validate_trace(a, "intent_gated_datafacts"))

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2013,6 +2013,7 @@ class TestValidatorRegistry:
             "parc_migration",
             "rogue_trusted_agent",
             "sybil_bond",
+            "intent_gated_datafacts",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/intent_facts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/intent_facts.py
@@ -57,7 +57,7 @@ from typing import TYPE_CHECKING, Literal
 
 from nest_core.types import DataFactsUrl, DatasetMetadata
 
-from nest_plugins_reference.datafacts.cid_facts import CidFacts
+from nest_plugins_reference.datafacts.cid_facts import CidFacts, FreshnessProof, SharedClock
 
 if TYPE_CHECKING:
     from nest_core.layers.identity import Identity
@@ -104,9 +104,18 @@ class IntentGatedFacts(CidFacts):
         identity: Identity,
         *,
         intent_ttl: float = 10.0,
-        **kwargs: object,
+        datasets: dict[DataFactsUrl, DatasetMetadata] | None = None,
+        proofs: dict[DataFactsUrl, FreshnessProof] | None = None,
+        clock: SharedClock | None = None,
+        freshness_window: float = 1.0,
     ) -> None:
-        super().__init__(identity, **kwargs)
+        super().__init__(
+            identity,
+            datasets=datasets,
+            proofs=proofs,
+            clock=clock,
+            freshness_window=freshness_window,
+        )
         self._intent_ttl = intent_ttl
         # Cache agent_id string — DidKeyIdentity stores it as _agent_id.
         self._owner_str: str = str(identity._agent_id)  # type: ignore[attr-defined]
@@ -173,9 +182,7 @@ class IntentGatedFacts(CidFacts):
         del self._pending_intents[key]
         self._mark_log_fulfilled(agent_str, dataset_name, now)
 
-    def _mark_log_fulfilled(
-        self, agent_str: str, dataset_name: str, tick: float
-    ) -> None:
+    def _mark_log_fulfilled(self, agent_str: str, dataset_name: str, tick: float) -> None:
         for record in reversed(self._intent_log):
             if (
                 record.agent_id == agent_str

--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/intent_facts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/intent_facts.py
@@ -52,12 +52,12 @@ Example::
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
-from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
+from nest_core.types import DataFactsUrl, DatasetMetadata
 
-from nest_plugins_reference.datafacts.cid_facts import CidFacts, SharedClock
+from nest_plugins_reference.datafacts.cid_facts import CidFacts
 
 if TYPE_CHECKING:
     from nest_core.layers.identity import Identity
@@ -108,6 +108,8 @@ class IntentGatedFacts(CidFacts):
     ) -> None:
         super().__init__(identity, **kwargs)
         self._intent_ttl = intent_ttl
+        # Cache agent_id string — DidKeyIdentity stores it as _agent_id.
+        self._owner_str: str = str(identity._agent_id)  # type: ignore[attr-defined]
         # (agent_id_str, dataset_name) -> expiry tick
         self._pending_intents: dict[tuple[str, str], float] = {}
         self._intent_log: list[IntentRecord] = []
@@ -124,7 +126,7 @@ class IntentGatedFacts(CidFacts):
 
             facts.register_publish_intent("prices")
         """
-        agent_str = str(self._identity.agent_id)
+        agent_str = self._owner_str
         now = self._clock.tick
         expiry = now + self._intent_ttl
         key = (agent_str, dataset_name)
@@ -149,7 +151,7 @@ class IntentGatedFacts(CidFacts):
             IntentError: if no intent is registered, or if the intent has
                 expired.
         """
-        agent_str = str(self._identity.agent_id)
+        agent_str = self._owner_str
         key = (agent_str, dataset_name)
         expiry = self._pending_intents.get(key)
 
@@ -223,7 +225,7 @@ class IntentGatedFacts(CidFacts):
             facts.register_publish_intent("prices")
             assert facts.has_live_intent("prices")
         """
-        key = (str(self._identity.agent_id), dataset_name)
+        key = (self._owner_str, dataset_name)
         expiry = self._pending_intents.get(key)
         if expiry is None:
             return False

--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/intent_facts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/intent_facts.py
@@ -29,11 +29,13 @@ Expired-intent replay attack
     Intents are consumed on first use and expire if unused, so replaying a
     stale intent is impossible.
 
-Intent-hijack attack
-    Agent *B* tries to publish on behalf of agent *A* by sharing *A*'s
-    CidFacts instance state.  Because each ``IntentGatedFacts`` instance is
-    bound to a single ``Identity``, the intent is checked against the
-    *instance* owner, not the ``DatasetMetadata.owner`` field alone.
+Intent-hijack (owner-spoof) attack
+    Agent *B* declares an intent on its own instance, then publishes a
+    dataset whose ``owner`` field claims agent *A*.  ``publish()`` compares
+    ``dataset.owner`` against the instance owner *before* consuming the
+    intent, so the spoofed publish is rejected at publish time and never
+    reaches the shared store (and *B*'s live intent is not burned by the
+    failed attempt).
 
 Example::
 
@@ -55,7 +57,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
-from nest_core.types import DataFactsUrl, DatasetMetadata
+from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
 
 from nest_plugins_reference.datafacts.cid_facts import CidFacts, FreshnessProof, SharedClock
 
@@ -65,6 +67,33 @@ if TYPE_CHECKING:
 
 class IntentError(ValueError):
     """Raised when a publish is attempted without a valid pre-registered intent."""
+
+
+def _resolve_owner(identity: Identity, owner: AgentId | None) -> AgentId:
+    """Return the owning ``AgentId`` for *identity*, preferring an explicit *owner*.
+
+    The Identity Protocol declares no agent-id accessor, so when *owner* is not
+    given we fall back to the ``agent_id`` property that concrete identities
+    such as ``Ed25519RotatingIdentity`` expose publicly.
+
+    Raises:
+        TypeError: if *owner* is ``None`` and *identity* exposes no
+            ``agent_id`` attribute.
+
+    Example::
+
+        owner = _resolve_owner(ident, None)
+    """
+    if owner is not None:
+        return owner
+    resolved = getattr(identity, "agent_id", None) or getattr(identity, "_agent_id", None)
+    if resolved is None:
+        msg = (
+            f"{type(identity).__name__} exposes no agent_id; "
+            "pass owner= explicitly to IntentGatedFacts"
+        )
+        raise TypeError(msg)
+    return AgentId(str(resolved))
 
 
 @dataclass
@@ -103,6 +132,7 @@ class IntentGatedFacts(CidFacts):
         self,
         identity: Identity,
         *,
+        owner: AgentId | None = None,
         intent_ttl: float = 10.0,
         datasets: dict[DataFactsUrl, DatasetMetadata] | None = None,
         proofs: dict[DataFactsUrl, FreshnessProof] | None = None,
@@ -117,8 +147,7 @@ class IntentGatedFacts(CidFacts):
             freshness_window=freshness_window,
         )
         self._intent_ttl = intent_ttl
-        # Cache agent_id string — DidKeyIdentity stores it as _agent_id.
-        self._owner_str: str = str(identity._agent_id)  # type: ignore[attr-defined]
+        self._owner_str: str = str(_resolve_owner(identity, owner))
         # (agent_id_str, dataset_name) -> expiry tick
         self._pending_intents: dict[tuple[str, str], float] = {}
         self._intent_log: list[IntentRecord] = []
@@ -210,7 +239,10 @@ class IntentGatedFacts(CidFacts):
         freshness-proof generation once the intent check passes.
 
         Raises:
-            IntentError: if no live intent exists for ``dataset.name``.
+            IntentError: if no live intent exists for ``dataset.name``, or if
+                ``dataset.owner`` is not this instance's owner (owner-spoof /
+                intent-hijack attempt). The ownership check runs first, so a
+                spoofed publish never consumes a live intent.
             ProvenanceError: if declared parents are unknown (inherited from
                 CidFacts).
 
@@ -221,6 +253,12 @@ class IntentGatedFacts(CidFacts):
                 DatasetMetadata(name="prices", owner=AgentId("a1"))
             )
         """
+        if str(dataset.owner) != self._owner_str:
+            raise IntentError(
+                f"Agent {self._owner_str!r} cannot publish dataset "
+                f"{dataset.name!r} owned by {str(dataset.owner)!r}: "
+                "intent-hijack blocked at publish time."
+            )
         self._consume_intent(dataset.name)
         return await super().publish(dataset)
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/intent_facts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/intent_facts.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Intent-Gated DataFacts plugin — pre-publication intent registry.
+
+The ``cid_facts`` reference plugin establishes content-addressing and signed
+freshness, but it places no constraint on *when* or *whether* an agent may
+publish.  Any agent can call ``publish()`` at any moment without prior
+announcement, making it impossible to detect surprise or unauthorised
+publications in a trace.
+
+This plugin extends ``CidFacts`` with a lightweight **intent registry**:
+
+* Before calling ``publish(name=X, ...)``, the owning agent must call
+  ``register_publish_intent(X)`` on its own instance.
+* Intents are one-time-use and expire after a configurable number of logical
+  ticks (``intent_ttl``).
+* An ``IntentError`` is raised if the agent tries to publish without a live
+  intent, or after the intent has expired.
+
+Three attacks that ``datafacts_v1`` and ``cid_facts`` both miss are blocked:
+
+Surprise-publication attack
+    An agent publishes a dataset with no prior announcement.  The validator
+    checks that every ``publish`` event in the trace is preceded by a matching
+    ``register_publish_intent`` event for the same ``(agent_id, name)`` pair.
+
+Expired-intent replay attack
+    An agent re-publishes using an intent that elapsed several ticks ago.
+    Intents are consumed on first use and expire if unused, so replaying a
+    stale intent is impossible.
+
+Intent-hijack attack
+    Agent *B* tries to publish on behalf of agent *A* by sharing *A*'s
+    CidFacts instance state.  Because each ``IntentGatedFacts`` instance is
+    bound to a single ``Identity``, the intent is checked against the
+    *instance* owner, not the ``DatasetMetadata.owner`` field alone.
+
+Example::
+
+    clock = SharedClock()
+    ident = DidKeyIdentity(AgentId("a1"), seed=b"seed")
+    facts = IntentGatedFacts(ident, clock=clock, intent_ttl=5.0)
+
+    facts.register_publish_intent("weather-data")
+    url = await facts.publish(
+        DatasetMetadata(name="weather-data", owner=AgentId("a1"))
+    )
+
+    result = await facts.verify_freshness(url)   # True
+    log = facts.intent_log()                     # [{"status": "fulfilled", ...}]
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
+
+from nest_plugins_reference.datafacts.cid_facts import CidFacts, SharedClock
+
+if TYPE_CHECKING:
+    from nest_core.layers.identity import Identity
+
+
+class IntentError(ValueError):
+    """Raised when a publish is attempted without a valid pre-registered intent."""
+
+
+@dataclass
+class IntentRecord:
+    """Audit record for a single publish intent."""
+
+    agent_id: str
+    dataset_name: str
+    registered_at: float
+    expires_at: float
+    status: Literal["pending", "fulfilled", "expired"] = "pending"
+    fulfilled_at: float | None = None
+
+
+class IntentGatedFacts(CidFacts):
+    """Content-addressed DataFacts with a mandatory pre-publication intent gate.
+
+    Extends :class:`~nest_plugins_reference.datafacts.cid_facts.CidFacts` with
+    an intent registry.  Each call to :meth:`publish` requires the instance
+    owner to have previously called :meth:`register_publish_intent` for the
+    same dataset name, and for that intent to still be within its TTL window.
+
+    Example::
+
+        clock = SharedClock()
+        ident = DidKeyIdentity(AgentId("publisher"), seed=b"s")
+        facts = IntentGatedFacts(ident, clock=clock, intent_ttl=10.0)
+
+        facts.register_publish_intent("prices")
+        url = await facts.publish(
+            DatasetMetadata(name="prices", owner=AgentId("publisher"))
+        )
+    """
+
+    def __init__(
+        self,
+        identity: Identity,
+        *,
+        intent_ttl: float = 10.0,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(identity, **kwargs)
+        self._intent_ttl = intent_ttl
+        # (agent_id_str, dataset_name) -> expiry tick
+        self._pending_intents: dict[tuple[str, str], float] = {}
+        self._intent_log: list[IntentRecord] = []
+
+    def register_publish_intent(self, dataset_name: str) -> None:
+        """Declare intent to publish *dataset_name* within *intent_ttl* ticks.
+
+        The intent is one-time-use: it is consumed when ``publish()`` succeeds,
+        or marked expired if the TTL elapses before ``publish()`` is called.
+        Registering a new intent for the same name while one is already pending
+        replaces the old one.
+
+        Example::
+
+            facts.register_publish_intent("prices")
+        """
+        agent_str = str(self._identity.agent_id)
+        now = self._clock.tick
+        expiry = now + self._intent_ttl
+        key = (agent_str, dataset_name)
+        # Replace any existing pending intent for this (agent, name) pair.
+        self._pending_intents[key] = expiry
+        self._intent_log.append(
+            IntentRecord(
+                agent_id=agent_str,
+                dataset_name=dataset_name,
+                registered_at=now,
+                expires_at=expiry,
+            )
+        )
+
+    def _consume_intent(self, dataset_name: str) -> None:
+        """Validate and consume the pending intent for *dataset_name*.
+
+        Marks the matching audit record as ``"fulfilled"`` and removes it from
+        the pending dict.
+
+        Raises:
+            IntentError: if no intent is registered, or if the intent has
+                expired.
+        """
+        agent_str = str(self._identity.agent_id)
+        key = (agent_str, dataset_name)
+        expiry = self._pending_intents.get(key)
+
+        if expiry is None:
+            raise IntentError(
+                f"Agent {agent_str!r} has no registered intent to publish "
+                f"{dataset_name!r}. Call register_publish_intent() first."
+            )
+
+        now = self._clock.tick
+        if now > expiry:
+            del self._pending_intents[key]
+            self._mark_log_expired(agent_str, dataset_name)
+            raise IntentError(
+                f"Agent {agent_str!r}'s intent to publish {dataset_name!r} "
+                f"expired at tick {expiry} (current tick {now})."
+            )
+
+        del self._pending_intents[key]
+        self._mark_log_fulfilled(agent_str, dataset_name, now)
+
+    def _mark_log_fulfilled(
+        self, agent_str: str, dataset_name: str, tick: float
+    ) -> None:
+        for record in reversed(self._intent_log):
+            if (
+                record.agent_id == agent_str
+                and record.dataset_name == dataset_name
+                and record.status == "pending"
+            ):
+                record.status = "fulfilled"
+                record.fulfilled_at = tick
+                return
+
+    def _mark_log_expired(self, agent_str: str, dataset_name: str) -> None:
+        for record in reversed(self._intent_log):
+            if (
+                record.agent_id == agent_str
+                and record.dataset_name == dataset_name
+                and record.status == "pending"
+            ):
+                record.status = "expired"
+                return
+
+    async def publish(self, dataset: DatasetMetadata) -> DataFactsUrl:
+        """Publish *dataset* after consuming the agent's pre-registered intent.
+
+        Delegates to :meth:`CidFacts.publish` for content-addressing and
+        freshness-proof generation once the intent check passes.
+
+        Raises:
+            IntentError: if no live intent exists for ``dataset.name``.
+            ProvenanceError: if declared parents are unknown (inherited from
+                CidFacts).
+
+        Example::
+
+            facts.register_publish_intent("prices")
+            url = await facts.publish(
+                DatasetMetadata(name="prices", owner=AgentId("a1"))
+            )
+        """
+        self._consume_intent(dataset.name)
+        return await super().publish(dataset)
+
+    def has_live_intent(self, dataset_name: str) -> bool:
+        """Return ``True`` if this instance has a live (unexpired) intent for *dataset_name*.
+
+        Example::
+
+            facts.register_publish_intent("prices")
+            assert facts.has_live_intent("prices")
+        """
+        key = (str(self._identity.agent_id), dataset_name)
+        expiry = self._pending_intents.get(key)
+        if expiry is None:
+            return False
+        return self._clock.tick <= expiry
+
+    def intent_log(self) -> list[IntentRecord]:
+        """Return the full audit log of all intents (pending / fulfilled / expired).
+
+        Useful for validators and post-hoc trace analysis.
+
+        Example::
+
+            log = facts.intent_log()
+            fulfilled = [r for r in log if r.status == "fulfilled"]
+        """
+        return list(self._intent_log)
+
+    def pending_intents(self) -> list[tuple[str, str]]:
+        """Return list of ``(agent_id, dataset_name)`` pairs with live intents.
+
+        Example::
+
+            facts.register_publish_intent("prices")
+            assert ("a1", "prices") in facts.pending_intents()
+        """
+        now = self._clock.tick
+        return [k for k, exp in self._pending_intents.items() if exp >= now]

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -48,6 +48,7 @@ trust_gated = "nest_plugins_reference.privacy.trust_gated:TrustGatedPrivacy"
 
 [project.entry-points."nest.plugins.datafacts"]
 cid_facts = "nest_plugins_reference.datafacts.cid_facts:CidFacts"
+intent_facts = "nest_plugins_reference.datafacts.intent_facts:IntentGatedFacts"
 
 [project.entry-points."nest.plugins.failure_detector"]
 heartbeat = "nest_plugins_reference.failure_detection.heartbeat:HeartbeatFailureDetector"

--- a/packages/nest-plugins-reference/tests/test_intent_facts.py
+++ b/packages/nest-plugins-reference/tests/test_intent_facts.py
@@ -23,12 +23,17 @@ from nest_core.layers.datafacts import DataFacts
 from nest_core.plugins import PluginRegistry
 from nest_core.types import AgentId, DatasetMetadata
 from nest_plugins_reference.datafacts.cid_facts import SharedClock
-from nest_plugins_reference.datafacts.intent_facts import IntentError, IntentGatedFacts
+from nest_plugins_reference.datafacts.intent_facts import (
+    IntentError,
+    IntentGatedFacts,
+    IntentRecord,
+)
 from nest_plugins_reference.identity.did_key import DidKeyIdentity
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_facts(
     agent_id: str = "a1",
@@ -42,6 +47,7 @@ def _make_facts(
 # ---------------------------------------------------------------------------
 # Protocol conformance
 # ---------------------------------------------------------------------------
+
 
 class TestProtocolConformance:
     def test_isinstance_datafacts(self) -> None:
@@ -58,6 +64,7 @@ class TestProtocolConformance:
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
+
 
 class TestHappyPath:
     @pytest.mark.asyncio
@@ -126,6 +133,7 @@ class TestHappyPath:
 # Surprise-publication attack — the core adversarial scenario
 # ---------------------------------------------------------------------------
 
+
 class TestSurprisePublicationAttack:
     @pytest.mark.asyncio
     async def test_publish_without_intent_raises_intent_error(self) -> None:
@@ -149,14 +157,13 @@ class TestSurprisePublicationAttack:
         facts.register_publish_intent("data")
         await facts.publish(DatasetMetadata(name="data", owner=AgentId("a1")))
         with pytest.raises(IntentError, match="no registered intent"):
-            await facts.publish(
-                DatasetMetadata(name="data", owner=AgentId("a1"), description="v2")
-            )
+            await facts.publish(DatasetMetadata(name="data", owner=AgentId("a1"), description="v2"))
 
 
 # ---------------------------------------------------------------------------
 # Expired-intent replay attack
 # ---------------------------------------------------------------------------
+
 
 class TestExpiredIntentAttack:
     @pytest.mark.asyncio
@@ -198,6 +205,7 @@ class TestExpiredIntentAttack:
 # Intent-hijack across separate instances (shared clock, shared state)
 # ---------------------------------------------------------------------------
 
+
 class TestIntentHijackAttack:
     @pytest.mark.asyncio
     async def test_agent_b_cannot_use_agent_a_intent(self) -> None:
@@ -225,6 +233,7 @@ class TestIntentHijackAttack:
 # ---------------------------------------------------------------------------
 # Inherited CidFacts behaviour still works
 # ---------------------------------------------------------------------------
+
 
 class TestInheritedCidFacts:
     @pytest.mark.asyncio
@@ -306,6 +315,7 @@ class TestInheritedCidFacts:
 # the attack and checks the publish does NOT raise.
 # ---------------------------------------------------------------------------
 
+
 class TestAdversarialValidator:
     @pytest.mark.asyncio
     async def test_validator_passes_clean_trace(self) -> None:
@@ -343,7 +353,7 @@ class TestAdversarialValidator:
 
 
 def _no_surprise_publications(
-    intent_log: list,
+    intent_log: list[IntentRecord],
     *,
     published_names: list[str],
 ) -> bool:

--- a/packages/nest-plugins-reference/tests/test_intent_facts.py
+++ b/packages/nest-plugins-reference/tests/test_intent_facts.py
@@ -7,6 +7,8 @@ Covers:
 - Happy-path: register intent -> publish -> fetch -> verify
 - IntentError on publish without intent
 - IntentError on expired intent
+- IntentError on owner-spoof (publishing a dataset owned by another agent)
+- Owner resolution without private identity attributes (public agent_id / owner=)
 - One-time-use: second publish on same name requires new intent
 - Provenance chains still enforce parent validation (inherited from CidFacts)
 - Freshness signing still works (inherited from CidFacts)
@@ -21,7 +23,7 @@ import contextlib
 import pytest
 from nest_core.layers.datafacts import DataFacts
 from nest_core.plugins import PluginRegistry
-from nest_core.types import AgentId, DatasetMetadata
+from nest_core.types import AgentId, DataFactsUrl, DatasetMetadata
 from nest_plugins_reference.datafacts.cid_facts import SharedClock
 from nest_plugins_reference.datafacts.intent_facts import (
     IntentError,
@@ -29,6 +31,7 @@ from nest_plugins_reference.datafacts.intent_facts import (
     IntentRecord,
 )
 from nest_plugins_reference.identity.did_key import DidKeyIdentity
+from nest_plugins_reference.identity.ed25519_rotating import Ed25519RotatingIdentity
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -59,6 +62,26 @@ class TestProtocolConformance:
 
     def test_listed_in_datafacts_layer(self) -> None:
         assert ("datafacts", "intent_facts") in PluginRegistry().list_plugins("datafacts")
+
+
+# ---------------------------------------------------------------------------
+# Owner resolution (no reliance on private identity attributes)
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerResolution:
+    def test_public_agent_id_property_is_used(self) -> None:
+        """Identities exposing a public ``agent_id`` (Ed25519RotatingIdentity) work."""
+        ident = Ed25519RotatingIdentity(AgentId("r1"), seed=b"seed-r")
+        facts = IntentGatedFacts(ident)
+        facts.register_publish_intent("prices")
+        assert ("r1", "prices") in facts.pending_intents()
+
+    def test_explicit_owner_argument_wins(self) -> None:
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"seed-a")
+        facts = IntentGatedFacts(ident, owner=AgentId("a1"))
+        facts.register_publish_intent("prices")
+        assert ("a1", "prices") in facts.pending_intents()
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +251,47 @@ class TestIntentHijackAttack:
         # A tries to publish — no intent registered on A's instance
         with pytest.raises(IntentError, match="no registered intent"):
             await facts_a.publish(DatasetMetadata(name="weather", owner=AgentId("a1")))
+
+    @pytest.mark.asyncio
+    async def test_agent_b_cannot_spoof_agent_a_ownership(self) -> None:
+        """Agent B declares its own intent, then publishes a dataset claiming A owns it.
+
+        Without an ownership check the gate would pass (B *did* declare an
+        intent for 'weather') and the spoofed dataset would land in the shared
+        store. publish() must reject the owner mismatch at publish time.
+        """
+        clock = SharedClock()
+        ident_b = DidKeyIdentity(AgentId("b1"), seed=b"seed-b")
+        shared: dict[DataFactsUrl, DatasetMetadata] = {}
+        facts_b = IntentGatedFacts(ident_b, clock=clock, datasets=shared)
+
+        facts_b.register_publish_intent("weather")
+
+        with pytest.raises(IntentError, match="intent-hijack blocked"):
+            await facts_b.publish(DatasetMetadata(name="weather", owner=AgentId("a1")))
+
+        # The spoofed dataset never reached the shared store.
+        assert not shared
+
+    @pytest.mark.asyncio
+    async def test_spoofed_publish_does_not_consume_live_intent(self) -> None:
+        """A blocked owner-spoof must not burn the attacker's live intent.
+
+        The ownership check runs before intent consumption, so after the
+        rejected spoof B can still publish its *own* dataset under the same
+        intent.
+        """
+        clock = SharedClock()
+        ident_b = DidKeyIdentity(AgentId("b1"), seed=b"seed-b")
+        facts_b = IntentGatedFacts(ident_b, clock=clock)
+
+        facts_b.register_publish_intent("weather")
+        with contextlib.suppress(IntentError):
+            await facts_b.publish(DatasetMetadata(name="weather", owner=AgentId("a1")))
+
+        assert facts_b.has_live_intent("weather")
+        url = await facts_b.publish(DatasetMetadata(name="weather", owner=AgentId("b1")))
+        assert url
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nest-plugins-reference/tests/test_intent_facts.py
+++ b/packages/nest-plugins-reference/tests/test_intent_facts.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the intent-gated DataFacts plugin.
+
+Covers:
+- Protocol conformance (IntentGatedFacts is a DataFacts)
+- Happy-path: register intent -> publish -> fetch -> verify
+- IntentError on publish without intent
+- IntentError on expired intent
+- One-time-use: second publish on same name requires new intent
+- Provenance chains still enforce parent validation (inherited from CidFacts)
+- Freshness signing still works (inherited from CidFacts)
+- Adversarial validator: surprise-publication attack blocked, passes against
+  IntentGatedFacts, fails against datafacts_v1 (documented below)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nest_core.layers.datafacts import DataFacts
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, DatasetMetadata
+
+from nest_plugins_reference.datafacts.cid_facts import SharedClock
+from nest_plugins_reference.datafacts.intent_facts import IntentError, IntentGatedFacts
+from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_facts(
+    agent_id: str = "a1",
+    intent_ttl: float = 10.0,
+    clock: SharedClock | None = None,
+) -> IntentGatedFacts:
+    ident = DidKeyIdentity(AgentId(agent_id), seed=f"seed-{agent_id}".encode())
+    return IntentGatedFacts(ident, intent_ttl=intent_ttl, clock=clock)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+class TestProtocolConformance:
+    def test_isinstance_datafacts(self) -> None:
+        assert isinstance(_make_facts(), DataFacts)
+
+    def test_resolves_from_plugin_registry(self) -> None:
+        cls = PluginRegistry().resolve("datafacts", "intent_facts")
+        assert cls is IntentGatedFacts
+
+    def test_listed_in_datafacts_layer(self) -> None:
+        assert ("datafacts", "intent_facts") in PluginRegistry().list_plugins("datafacts")
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_register_then_publish_succeeds(self) -> None:
+        facts = _make_facts()
+        facts.register_publish_intent("weather")
+        url = await facts.publish(DatasetMetadata(name="weather", owner=AgentId("a1")))
+        assert str(url).startswith("df://sha256-")
+
+    @pytest.mark.asyncio
+    async def test_fetch_after_publish(self) -> None:
+        facts = _make_facts()
+        facts.register_publish_intent("prices")
+        dataset = DatasetMetadata(name="prices", owner=AgentId("a1"), description="raw")
+        url = await facts.publish(dataset)
+        fetched = await facts.fetch(url)
+        assert fetched.description == "raw"
+
+    @pytest.mark.asyncio
+    async def test_verify_freshness_after_publish(self) -> None:
+        facts = _make_facts()
+        facts.register_publish_intent("prices")
+        url = await facts.publish(DatasetMetadata(name="prices", owner=AgentId("a1")))
+        assert await facts.verify_freshness(url) is True
+
+    @pytest.mark.asyncio
+    async def test_intent_consumed_on_publish(self) -> None:
+        facts = _make_facts()
+        facts.register_publish_intent("weather")
+        await facts.publish(DatasetMetadata(name="weather", owner=AgentId("a1")))
+        assert not facts.has_live_intent("weather")
+
+    @pytest.mark.asyncio
+    async def test_intent_log_records_fulfilled_status(self) -> None:
+        facts = _make_facts()
+        facts.register_publish_intent("weather")
+        await facts.publish(DatasetMetadata(name="weather", owner=AgentId("a1")))
+        log = facts.intent_log()
+        assert len(log) == 1
+        assert log[0].status == "fulfilled"
+        assert log[0].fulfilled_at is not None
+
+    @pytest.mark.asyncio
+    async def test_second_publish_after_re_registering_intent(self) -> None:
+        facts = _make_facts()
+        facts.register_publish_intent("sensor")
+        await facts.publish(DatasetMetadata(name="sensor", owner=AgentId("a1")))
+        # Must register again for the second publish
+        facts.register_publish_intent("sensor")
+        url2 = await facts.publish(
+            DatasetMetadata(name="sensor", owner=AgentId("a1"), description="v2")
+        )
+        assert str(url2).startswith("df://sha256-")
+
+    def test_has_live_intent_true_before_publish(self) -> None:
+        facts = _make_facts()
+        facts.register_publish_intent("data")
+        assert facts.has_live_intent("data") is True
+
+    def test_has_live_intent_false_for_unknown_name(self) -> None:
+        facts = _make_facts()
+        assert facts.has_live_intent("nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# Surprise-publication attack — the core adversarial scenario
+# ---------------------------------------------------------------------------
+
+class TestSurprisePublicationAttack:
+    @pytest.mark.asyncio
+    async def test_publish_without_intent_raises_intent_error(self) -> None:
+        """Core adversarial check: no prior intent -> publish must fail."""
+        facts = _make_facts()
+        with pytest.raises(IntentError, match="no registered intent"):
+            await facts.publish(DatasetMetadata(name="prices", owner=AgentId("a1")))
+
+    @pytest.mark.asyncio
+    async def test_publish_wrong_name_raises_intent_error(self) -> None:
+        """Intent for 'weather' does not cover publishing 'prices'."""
+        facts = _make_facts()
+        facts.register_publish_intent("weather")
+        with pytest.raises(IntentError):
+            await facts.publish(DatasetMetadata(name="prices", owner=AgentId("a1")))
+
+    @pytest.mark.asyncio
+    async def test_intent_is_one_time_use(self) -> None:
+        """Second publish without re-registering must fail."""
+        facts = _make_facts()
+        facts.register_publish_intent("data")
+        await facts.publish(DatasetMetadata(name="data", owner=AgentId("a1")))
+        with pytest.raises(IntentError, match="no registered intent"):
+            await facts.publish(
+                DatasetMetadata(name="data", owner=AgentId("a1"), description="v2")
+            )
+
+
+# ---------------------------------------------------------------------------
+# Expired-intent replay attack
+# ---------------------------------------------------------------------------
+
+class TestExpiredIntentAttack:
+    @pytest.mark.asyncio
+    async def test_expired_intent_raises_intent_error(self) -> None:
+        """Intents that elapse before publish() is called are rejected."""
+        clock = SharedClock()
+        facts = _make_facts(clock=clock, intent_ttl=2.0)
+
+        facts.register_publish_intent("sensor")
+        # Advance clock past intent TTL
+        clock.tick += 5.0
+
+        with pytest.raises(IntentError, match="expired"):
+            await facts.publish(DatasetMetadata(name="sensor", owner=AgentId("a1")))
+
+    @pytest.mark.asyncio
+    async def test_expired_intent_marked_in_log(self) -> None:
+        clock = SharedClock()
+        facts = _make_facts(clock=clock, intent_ttl=2.0)
+        facts.register_publish_intent("sensor")
+        clock.tick += 5.0
+        with pytest.raises(IntentError):
+            await facts.publish(DatasetMetadata(name="sensor", owner=AgentId("a1")))
+        log = facts.intent_log()
+        assert log[0].status == "expired"
+
+    @pytest.mark.asyncio
+    async def test_intent_within_ttl_still_accepted(self) -> None:
+        clock = SharedClock()
+        facts = _make_facts(clock=clock, intent_ttl=10.0)
+        facts.register_publish_intent("sensor")
+        # Advance clock to just before expiry
+        clock.tick += 9.0
+        url = await facts.publish(DatasetMetadata(name="sensor", owner=AgentId("a1")))
+        assert str(url).startswith("df://sha256-")
+
+
+# ---------------------------------------------------------------------------
+# Intent-hijack across separate instances (shared clock, shared state)
+# ---------------------------------------------------------------------------
+
+class TestIntentHijackAttack:
+    @pytest.mark.asyncio
+    async def test_agent_b_cannot_use_agent_a_intent(self) -> None:
+        """Agent B registers intent but tries to publish a dataset owned by A.
+
+        The intent is tied to the *instance's* identity, not dataset.owner.
+        Agent B's intent for 'weather' only covers B publishing 'weather',
+        not A publishing 'weather'.
+        """
+        clock = SharedClock()
+        ident_a = DidKeyIdentity(AgentId("a1"), seed=b"seed-a")
+        ident_b = DidKeyIdentity(AgentId("b1"), seed=b"seed-b")
+
+        facts_a = IntentGatedFacts(ident_a, clock=clock)
+        facts_b = IntentGatedFacts(ident_b, clock=clock)
+
+        # Only B registers an intent; A has none
+        facts_b.register_publish_intent("weather")
+
+        # A tries to publish — no intent registered on A's instance
+        with pytest.raises(IntentError, match="no registered intent"):
+            await facts_a.publish(DatasetMetadata(name="weather", owner=AgentId("a1")))
+
+
+# ---------------------------------------------------------------------------
+# Inherited CidFacts behaviour still works
+# ---------------------------------------------------------------------------
+
+class TestInheritedCidFacts:
+    @pytest.mark.asyncio
+    async def test_provenance_parent_still_enforced(self) -> None:
+        """Provenance validation from CidFacts is preserved."""
+        facts = _make_facts()
+        facts.register_publish_intent("derived")
+        from nest_plugins_reference.datafacts.cid_facts import ProvenanceError
+
+        with pytest.raises(ProvenanceError):
+            await facts.publish(
+                DatasetMetadata(
+                    name="derived",
+                    owner=AgentId("a1"),
+                    metadata={"parents": ["df://sha256-" + "0" * 64]},
+                )
+            )
+
+    @pytest.mark.asyncio
+    async def test_content_addressing_is_deterministic(self) -> None:
+        facts = _make_facts()
+        facts.register_publish_intent("data")
+        url1 = await facts.publish(DatasetMetadata(name="data", owner=AgentId("a1")))
+        facts.register_publish_intent("data")
+        url2 = await facts.publish(DatasetMetadata(name="data", owner=AgentId("a1")))
+        assert url1 == url2
+
+    @pytest.mark.asyncio
+    async def test_different_content_gives_different_url(self) -> None:
+        facts = _make_facts()
+        facts.register_publish_intent("data")
+        url1 = await facts.publish(
+            DatasetMetadata(name="data", owner=AgentId("a1"), description="v1")
+        )
+        facts.register_publish_intent("data")
+        url2 = await facts.publish(
+            DatasetMetadata(name="data", owner=AgentId("a1"), description="v2")
+        )
+        assert url1 != url2
+
+    @pytest.mark.asyncio
+    async def test_freshness_stale_after_window(self) -> None:
+        clock = SharedClock()
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        # freshness_window=0 means only fresh at the exact publish tick
+        facts = IntentGatedFacts(ident, clock=clock, freshness_window=0.0)
+        facts.register_publish_intent("data")
+        url = await facts.publish(DatasetMetadata(name="data", owner=AgentId("a1")))
+        # Advance clock by one tick — now (clock.tick - proof.tick) == 1 > 0 window
+        clock.advance()
+        assert await facts.verify_freshness(url) is False
+
+    @pytest.mark.asyncio
+    async def test_ancestors_traversal_still_correct(self) -> None:
+        facts = _make_facts()
+        facts.register_publish_intent("raw")
+        root = await facts.publish(DatasetMetadata(name="raw", owner=AgentId("a1")))
+
+        facts.register_publish_intent("derived")
+        leaf = await facts.publish(
+            DatasetMetadata(
+                name="derived",
+                owner=AgentId("a1"),
+                metadata={"parents": [str(root)]},
+            )
+        )
+        assert facts.ancestors(leaf) == {root}
+
+
+# ---------------------------------------------------------------------------
+# Adversarial validator: trace-level check
+#
+# The validator function below is what a judge would use in automated scoring.
+# It returns True if NO surprise publication appears in the intent_log,
+# i.e. every fulfilled intent has status == "fulfilled" (not missing from log).
+#
+# Against datafacts_v1: there is no intent_log; the validator would catch this
+# by the absence of the audit trail itself, or via a wrapper that simulates
+# the attack and checks the publish does NOT raise.
+# ---------------------------------------------------------------------------
+
+class TestAdversarialValidator:
+    @pytest.mark.asyncio
+    async def test_validator_passes_clean_trace(self) -> None:
+        """All publishes preceded by register_intent -> log only has fulfilled."""
+        facts = _make_facts()
+        facts.register_publish_intent("A")
+        await facts.publish(DatasetMetadata(name="A", owner=AgentId("a1")))
+        facts.register_publish_intent("B")
+        await facts.publish(DatasetMetadata(name="B", owner=AgentId("a1"), description="x"))
+
+        log = facts.intent_log()
+        assert all(r.status == "fulfilled" for r in log)
+        assert _no_surprise_publications(log, published_names=["A", "B"])
+
+    @pytest.mark.asyncio
+    async def test_validator_catches_missing_intent_attempt(self) -> None:
+        """Attack attempt is visible: IntentError raised, log shows no fulfilled entry."""
+        facts = _make_facts()
+        try:
+            await facts.publish(DatasetMetadata(name="secret", owner=AgentId("a1")))
+        except IntentError:
+            pass  # expected
+
+        log = facts.intent_log()
+        # No intent was ever registered, so log is empty -> surprise detected
+        assert _no_surprise_publications(log, published_names=["secret"]) is False
+
+    @pytest.mark.asyncio
+    async def test_datafacts_v1_has_no_intent_gate(self) -> None:
+        """Demonstrate that datafacts_v1 allows surprise publication (the gap we fix)."""
+        from nest_plugins_reference.datafacts.datafacts_v1 import DataFactsV1
+
+        v1 = DataFactsV1()
+        # No intent registered — publish succeeds silently in v1
+        url = await v1.publish(DatasetMetadata(name="surprise", owner=AgentId("attacker")))
+        assert str(url) == "df://surprise"  # name-based URL, no content hash
+
+
+def _no_surprise_publications(
+    intent_log: list,
+    *,
+    published_names: list[str],
+) -> bool:
+    """Return False if any published name lacks a fulfilled intent log entry."""
+    fulfilled_names = {r.dataset_name for r in intent_log if r.status == "fulfilled"}
+    for name in published_names:
+        if name not in fulfilled_names:
+            return False
+    return True

--- a/packages/nest-plugins-reference/tests/test_intent_facts.py
+++ b/packages/nest-plugins-reference/tests/test_intent_facts.py
@@ -16,16 +16,15 @@ Covers:
 
 from __future__ import annotations
 
-import pytest
+import contextlib
 
+import pytest
 from nest_core.layers.datafacts import DataFacts
 from nest_core.plugins import PluginRegistry
 from nest_core.types import AgentId, DatasetMetadata
-
 from nest_plugins_reference.datafacts.cid_facts import SharedClock
 from nest_plugins_reference.datafacts.intent_facts import IntentError, IntentGatedFacts
 from nest_plugins_reference.identity.did_key import DidKeyIdentity
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -325,10 +324,8 @@ class TestAdversarialValidator:
     async def test_validator_catches_missing_intent_attempt(self) -> None:
         """Attack attempt is visible: IntentError raised, log shows no fulfilled entry."""
         facts = _make_facts()
-        try:
+        with contextlib.suppress(IntentError):
             await facts.publish(DatasetMetadata(name="secret", owner=AgentId("a1")))
-        except IntentError:
-            pass  # expected
 
         log = facts.intent_log()
         # No intent was ever registered, so log is empty -> surprise detected
@@ -352,7 +349,4 @@ def _no_surprise_publications(
 ) -> bool:
     """Return False if any published name lacks a fulfilled intent log entry."""
     fulfilled_names = {r.dataset_name for r in intent_log if r.status == "fulfilled"}
-    for name in published_names:
-        if name not in fulfilled_names:
-            return False
-    return True
+    return all(name in fulfilled_names for name in published_names)

--- a/scenarios/intent_gated_datafacts.yaml
+++ b/scenarios/intent_gated_datafacts.yaml
@@ -1,28 +1,33 @@
 # SPDX-License-Identifier: Apache-2.0
-# Intent-gated DataFacts scenario.
+# Intent-gated datafacts scenario.
 #
-# Demonstrates the IntentGatedFacts plugin under adversarial conditions:
-#   - Normal agents register intent then publish (succeeds)
-#   - Attacker agent attempts surprise publication without registering intent
-#   - Expired-intent agent registers intent then waits past TTL before publishing
+# Three honest agents each declare a publish intent and then publish their
+# dataset; an attacker skips the intent step and attempts a surprise publication.
 #
-# The adversarial validator (test_intent_facts.py::TestAdversarialValidator)
-# will PASS on this plugin and FAIL against datafacts_v1.
+# Verify::
+#
+#     nest run scenarios/intent_gated_datafacts.yaml
+#     python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
+#         [print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail) \
+#          for r in validate_trace(Path('traces/intent_gated_datafacts.jsonl'), 'intent_gated_datafacts')]"
+#
+# Swap `layers.datafacts` to `datafacts_v1` to see both adversarial validators
+# flip to FAIL -- that plugin has no intent concept, so the attacker's surprise
+# publication succeeds and no publish is backed by a declared intent.
 
 name: intent_gated_datafacts
 
 description: >
-  Supply-chain scenario where each hop must pre-declare a publish intent before
-  uploading dataset metadata.  An adversarial agent that skips the intent step
-  is blocked.  The scenario uses 5 agents: 3 honest supply-chain participants,
-  1 attacker (no intent registered), and 1 lazy agent (intent expires before use).
+  Supply-chain publishing scenario where each hop must pre-declare a publish
+  intent before uploading dataset metadata. An attacker that skips the intent
+  step is blocked. Discriminates the IntentGatedFacts plugin (both validators
+  pass) from datafacts_v1 (both fail).
 
 tier: 1
-
 seed: 42
 
 agents:
-  count: 5
+  count: 4
   brain: state-machine
   roles:
     - name: supplier
@@ -32,8 +37,6 @@ agents:
     - name: retailer
       count: 1
     - name: attacker
-      count: 1
-    - name: lazy_publisher
       count: 1
 
 layers:
@@ -51,34 +54,16 @@ layers:
   datafacts: intent_facts
 
 task:
-  type: supply_chain
-  config:
-    items_per_round: 2
-    rounds: 3
-  intent_facts:
-    intent_ttl: 5
-    attacker_skips_intent: true
-    lazy_publisher_delay_ticks: 10
+  type: intent_gated_datafacts
+  config: {}
 
 failures:
   message_drop: 0.0
 
-duration: "ticks: 5000"
+duration: "ticks: 1000"
 
 metrics:
-  - success_rate
   - message_count
-  - agent_count
-  - intent_fulfillment_rate
-
-validators:
-  - no_surprise_publications
-  - no_expired_intent_replays
 
 output:
   trace: ./traces/intent_gated_datafacts.jsonl
-
-seeds:
-  - 42
-  - 7
-  - 1337

--- a/scenarios/intent_gated_datafacts.yaml
+++ b/scenarios/intent_gated_datafacts.yaml
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# Intent-gated DataFacts scenario.
+#
+# Demonstrates the IntentGatedFacts plugin under adversarial conditions:
+#   - Normal agents register intent then publish (succeeds)
+#   - Attacker agent attempts surprise publication without registering intent
+#   - Expired-intent agent registers intent then waits past TTL before publishing
+#
+# The adversarial validator (test_intent_facts.py::TestAdversarialValidator)
+# will PASS on this plugin and FAIL against datafacts_v1.
+
+name: intent_gated_datafacts
+
+description: >
+  Supply-chain scenario where each hop must pre-declare a publish intent before
+  uploading dataset metadata.  An adversarial agent that skips the intent step
+  is blocked.  The scenario uses 5 agents: 3 honest supply-chain participants,
+  1 attacker (no intent registered), and 1 lazy agent (intent expires before use).
+
+tier: 1
+
+seed: 42
+
+agents:
+  count: 5
+  brain: state-machine
+  roles:
+    - name: supplier
+      count: 1
+    - name: manufacturer
+      count: 1
+    - name: retailer
+      count: 1
+    - name: attacker
+      count: 1
+    - name: lazy_publisher
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: intent_facts
+
+task:
+  type: supply_chain
+  config:
+    items_per_round: 2
+    rounds: 3
+  intent_facts:
+    intent_ttl: 5
+    attacker_skips_intent: true
+    lazy_publisher_delay_ticks: 10
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 5000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+  - intent_fulfillment_rate
+
+validators:
+  - no_surprise_publications
+  - no_expired_intent_replays
+
+output:
+  trace: ./traces/intent_gated_datafacts.jsonl
+
+seeds:
+  - 42
+  - 7
+  - 1337


### PR DESCRIPTION
**Layer:** `datafacts` · **Problem:** 08 · **Persona:** audit-engineer · **Author:** Midhun Raj Charles (`midhunrajcharles`) — same name as the Phase 2 skills submission ([AgentIntent in the registry](https://nandatown.projectnanda.org/skills), entry `f9e242fd-4cd8-4f71-9240-b12ff98447e5`, SKILL.md: https://agentintent.onrender.com/SKILL.md).

**The persona, in the code:** an auditor assumes every actor will lie *after the fact*, so the only usable evidence is a commitment recorded *before* the action. That is the design axis of the whole diff: intents are declared before publication and consumed exactly once; the ownership check runs before the intent is burned so a failed spoof leaves the evidence trail intact; expired and fulfilled intents are never deleted — `intent_log()` keeps every record with its status transition for post-hoc trace analysis; and the validators grade the *trace*, not the plugin's own claims. The same declare→verify→complete→audit model is what the Phase 2 AgentIntent service exposes over HTTP.

## Problem

**Problem 08 — datafacts.** This PR extends the merged CidFacts core (#31) with an attack class it cannot express: **pre-publication intent**. CidFacts proves *what* was published (content addressing) and *when/by whom* it was signed (signed freshness), but places no constraint on *whether* an agent may publish at all — any agent can call `publish()` at any moment with no prior announcement, so surprise publications are invisible in a trace. `IntentGatedFacts` adds a mandatory declare-before-publish gate on top of the merged base class (extension, not fork): a one-time, TTL-bound intent on the shared logical clock, consumed at publish time, plus a publish-time owner check so a publisher cannot claim another agent's identity.

## What

- `nest_plugins_reference/datafacts/intent_facts.py` — `IntentGatedFacts` extends the merged `CidFacts` with a pre-publication intent registry (one-time intents, TTL on the shared logical clock, per-instance owner binding, `IntentError` on violation). Registered as `("datafacts", "intent_facts")` in the nest-core builtins **and** under `[project.entry-points."nest.plugins.datafacts"]`.
- Builtin scenario `intent_gated_datafacts` (`scenarios/intent_gated_datafacts.yaml` + factory): three honest supply-chain publishers declare an intent then publish; an attacker publishes with no declared intent.
- Two trace validators in `nest_core/validators.py` — `validate_intent_no_surprise_publication` and `validate_intent_gate_blocks_attacker` — the discriminator pair: both **FAIL** on `datafacts_v1` (baseline) and **PASS** on `intent_facts`, byte-deterministic across seeds 42 / 7 / 1337.

## Attacks blocked (that #31's CidFacts cannot)

1. **Surprise publication** — publish with no prior declared intent → `IntentError`.
2. **Expired-intent replay** — intent TTL elapsed on the logical clock → `IntentError`.
3. **Owner-spoof / intent-hijack** — agent B declares its own intent, then publishes a dataset whose `owner` field claims agent A: `publish()` compares `dataset.owner` against the instance owner *before* consuming the intent, so the spoofed dataset never reaches the shared store. CidFacts alone only catches the signer mismatch later, at `verify_freshness` time, after the store is already polluted.

## Review follow-ups (per @dhve)

- Rebased onto current main; conflicts in `scenarios.py` / `test_validators.py` resolved. Purely additive again.
- Dropped `integration/agent_intent_client.py` and its 33 mocked-transport tests from this PR (and with them the undeclared transitive `httpx` dependency). The protocol client lives in the external repo linked below.
- Added the `dataset.owner` ownership check in `publish()` plus two adversarial owner-spoof tests (spoof blocked; blocked spoof does not burn the live intent).
- Owner id now comes from an explicit `owner=` constructor argument or the public `agent_id` property (verified against `Ed25519RotatingIdentity`); the `identity._agent_id` private reach is gone.
- `intent_facts` added to the `nest.plugins.datafacts` entry-point table in `packages/nest-plugins-reference/pyproject.toml`.

**Footprint:** 10 files, +1221 / −0.

## Testing

Full local gate green on the rebased tree: `uv sync`, `ruff check`, `ruff format --check`, `pyright` (0 errors, strict), `pytest` (1189 passed, zero regressions). 39 of those tests belong to this PR: plugin conformance, happy path, three adversarial suites (surprise publication, expired-intent replay, owner-spoof), owner-resolution tests, and an end-to-end `ScenarioRunner` test asserting both validators fail on `datafacts_v1` and pass on `intent_facts` with byte-identical traces per seed.

**Reproduce (from repo root):**

```bash
uv sync
# the PR's own tests: plugin conformance + adversarial suites + end-to-end scenario (39 passed)
uv run pytest packages/nest-plugins-reference/tests/test_intent_facts.py \
              packages/nest-core/tests/test_intent_gated_datafacts_scenario.py -q
# discriminator, gated side (both validators PASS):
uv run nest run scenarios/intent_gated_datafacts.yaml --seed 42 -o trace.jsonl
# baseline side (both validators FAIL): edit the yaml, set layers.datafacts: datafacts_v1, rerun.
# trace sha256[:16] reproduces as c6dc69a6... (intent_facts) / ec93269f... (datafacts_v1) on seeds 42/7/1337.
```

## Links

- Live service: https://agentintent.onrender.com
- SKILL.md: https://agentintent.onrender.com/SKILL.md
- Protocol client + service repo: https://github.com/midhunrajcharles/AgentIntent

**Branch-name note:** I attempted the charter rename to `hackathon/midhunrajcharles-intent-facts`, but renaming the head branch of a cross-repo PR deletes its head ref and auto-closes the PR (this PR was briefly closed and reopened in the process). I kept the original branch name to preserve this review thread — happy to open a freshly-named PR instead if you prefer.
