### PR TITLE
auth: macaroon-style delegatable capability tokens with cascading revocation

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -26,6 +26,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
+    ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -145,3 +145,7 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("rogue_trusted_agent", rogue_trusted_agent_factory)
+    elif name == "delegation_tree":
+        from nest_core.scenarios_builtin.delegation_tree import delegation_tree_factory
+
+        register_scenario("delegation_tree", delegation_tree_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/delegation_tree.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegation_tree.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegation-tree scenario -- capability delegation with cascading revocation.
+
+A coordinator issues a root capability token and delegates a narrower,
+shorter-lived token to each of 3 intermediaries; each intermediary
+delegates a further-narrowed token to 4 leaves. Strict tree, one parent per
+token: coordinator -> 3 intermediaries -> 12 leaves.
+
+Midway through the run the coordinator revokes exactly one intermediary's
+token. All 4 leaves under that branch must fail re-verification with
+``RevokedAncestorError`` on their *next* verify -- no leaf token is ever
+revoked directly, demonstrating cascading revocation "by construction". The
+other 8 leaves, under the two untouched branches, keep verifying.
+
+Example::
+
+    agents = delegation_tree_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from nest_plugins_reference.auth.delegatable import RevokedAncestorError
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Token
+
+if TYPE_CHECKING:
+    from nest_plugins_reference.auth.delegatable import DelegatableAuth
+
+GRANT_PREFIX = b"grant:"
+RESULT_PREFIX = b"result:"
+REVERIFY = b"reverify"
+REVOKE_TICK = b"COORD_REVOKE_TICK"
+REVERIFY_TICK = b"COORD_REVERIFY_TICK"
+
+#: Scopes narrow strictly at every hop: root -> intermediary -> leaf.
+ROOT_SCOPES = ["read", "write", "admin"]
+INTERMEDIARY_SCOPES = ["read", "write"]
+LEAF_SCOPES = ["read"]
+
+#: TTLs narrow at every hop too, so a child never risks outliving its parent.
+INTERMEDIARY_TTL = 1800.0
+LEAF_TTL = 900.0
+
+
+class CoordinatorAgent(StateMachineAgent):
+    """Root of the delegation tree.
+
+    Issues the root token, delegates one child per intermediary, then --
+    on a scheduled tick -- revokes exactly one intermediary's token and
+    asks every leaf to re-verify, collecting the outcomes into a shared
+    report dict for the scenario factory (and tests) to inspect.
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        intermediary_ids: list[AgentId],
+        all_leaf_ids: list[AgentId],
+        revoke_intermediary: AgentId,
+        revoke_delay: float,
+        reverify_delay: float,
+        report: dict[str, str],
+    ) -> None:
+        self._id = agent_id
+        self._intermediary_ids = intermediary_ids
+        self._all_leaf_ids = all_leaf_ids
+        self._revoke_intermediary = revoke_intermediary
+        self._revoke_delay = revoke_delay
+        self._reverify_delay = reverify_delay
+        self._report = report
+        self._intermediary_tokens: dict[AgentId, Token] = {}
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        auth = cast("DelegatableAuth", ctx.plugins["auth"])
+        root_token = await auth.issue(self._id, list(ROOT_SCOPES))
+        for inter_id in self._intermediary_ids:
+            child = await auth.delegate(
+                root_token, inter_id, list(INTERMEDIARY_SCOPES), INTERMEDIARY_TTL
+            )
+            self._intermediary_tokens[inter_id] = child
+            await ctx.send(inter_id, GRANT_PREFIX + str(child).encode())
+        await ctx.schedule(self._revoke_delay, REVOKE_TICK)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        if sender == ctx.agent_id and payload == REVOKE_TICK:
+            auth = cast("DelegatableAuth", ctx.plugins["auth"])
+            await auth.revoke(self._intermediary_tokens[self._revoke_intermediary])
+            await ctx.schedule(self._reverify_delay, REVERIFY_TICK)
+            return
+        if sender == ctx.agent_id and payload == REVERIFY_TICK:
+            for leaf_id in self._all_leaf_ids:
+                await ctx.send(leaf_id, REVERIFY)
+            return
+        if payload.startswith(RESULT_PREFIX):
+            _, status, leaf_id = payload.decode("utf-8").split(":", 2)
+            self._report[leaf_id] = status
+
+
+class IntermediaryAgent(StateMachineAgent):
+    """Receives a delegated token from the coordinator and re-delegates to its leaves."""
+
+    def __init__(self, agent_id: AgentId, *, leaf_ids: list[AgentId]) -> None:
+        self._id = agent_id
+        self._leaf_ids = leaf_ids
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        if not payload.startswith(GRANT_PREFIX):
+            return
+        token = Token(payload[len(GRANT_PREFIX) :].decode("utf-8"))
+        auth = cast("DelegatableAuth", ctx.plugins["auth"])
+        await auth.verify_presented_by(token, ctx.agent_id)
+        for leaf_id in self._leaf_ids:
+            child = await auth.delegate(token, leaf_id, list(LEAF_SCOPES), LEAF_TTL)
+            await ctx.send(leaf_id, GRANT_PREFIX + str(child).encode())
+
+
+class LeafAgent(StateMachineAgent):
+    """Holds a delegated token and reports its verification status on request."""
+
+    def __init__(self, agent_id: AgentId, *, coordinator_id: AgentId) -> None:
+        self._id = agent_id
+        self._coordinator_id = coordinator_id
+        self._token: Token | None = None
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        if payload.startswith(GRANT_PREFIX):
+            self._token = Token(payload[len(GRANT_PREFIX) :].decode("utf-8"))
+            return
+        if payload == REVERIFY:
+            token = self._token
+            if token is None:
+                return
+            auth = cast("DelegatableAuth", ctx.plugins["auth"])
+            status = await self._check(auth, token, ctx.agent_id)
+            await ctx.send(
+                self._coordinator_id,
+                RESULT_PREFIX + f"{status}:{ctx.agent_id}".encode(),
+            )
+
+    async def _check(self, auth: DelegatableAuth, token: Token, presenter: AgentId) -> str:
+        try:
+            await auth.verify_presented_by(token, presenter)
+        except RevokedAncestorError:
+            return "revoked"
+        except Exception:  # noqa: BLE001 - any other failure is a distinct, reportable status
+            return "error"
+        return "ok"
+
+
+def _instantiate_auth(plugins: dict[str, Any]) -> None:
+    """Replace the resolved ``auth`` plugin class with one shared instance.
+
+    Mirrors ``marketplace._instantiate_plugins``'s shared-instance pattern:
+    every agent in the tree needs to verify tokens signed by the same
+    secret and see the same revocation state, so one instance is
+    constructed and handed to every agent context.
+
+    Pins the plugin's clock (if it accepts one -- ``DelegatableAuth`` and
+    ``JwtAuth`` both do) to a fixed value instead of leaving it on
+    wall-clock time, so every ``issue``/``delegate`` call produces
+    byte-identical caveat timestamps run over run. Falls back to the bare
+    constructor for a plugin that does not accept ``clock``.
+
+    Example::
+
+        _instantiate_auth(plugins)
+    """
+    auth_cls = plugins.get("auth")
+    if auth_cls is not None and isinstance(auth_cls, type):
+        try:
+            plugins["auth"] = auth_cls(clock=0.0)
+        except TypeError:
+            plugins["auth"] = auth_cls()
+
+
+def delegation_tree_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create a coordinator -> 3 intermediaries -> 12 leaves delegation tree.
+
+    ``config.task.config`` accepts ``revoke_intermediary_index`` (which of
+    the 3 intermediary branches gets revoked, default 1),
+    ``revoke_delay`` (ticks after start before revocation, default 50), and
+    ``reverify_delay`` (ticks after revocation before leaves re-verify,
+    default 100).
+
+    Exposes ``plugins["_delegation_report"]`` (leaf id -> ``"ok"`` /
+    ``"revoked"`` / ``"error"``, populated as the run progresses),
+    ``plugins["_delegation_leaf_ids"]`` (all 12 leaf ids), and
+    ``plugins["_delegation_revoked_leaf_ids"]`` (the 4 leaf ids under the
+    revoked branch) so tests can inspect the outcome without parsing the
+    trace.
+
+    Example::
+
+        agents = delegation_tree_factory(config, plugins)
+    """
+    task_config = config.task.config
+    revoke_index = int(task_config.get("revoke_intermediary_index", 1))
+    revoke_delay = float(task_config.get("revoke_delay", 50.0))
+    reverify_delay = float(task_config.get("reverify_delay", 100.0))
+
+    coordinator_id = AgentId("coordinator-0")
+    intermediary_ids = [AgentId(f"intermediary-{i}") for i in range(3)]
+    leaves_by_intermediary: dict[AgentId, list[AgentId]] = {
+        inter_id: [AgentId(f"leaf-{i}-{j}") for j in range(4)]
+        for i, inter_id in enumerate(intermediary_ids)
+    }
+    all_leaf_ids = [leaf_id for leaves in leaves_by_intermediary.values() for leaf_id in leaves]
+
+    _instantiate_auth(plugins)
+
+    report: dict[str, str] = {}
+    revoked_intermediary = intermediary_ids[revoke_index]
+    plugins["_delegation_report"] = report
+    plugins["_delegation_leaf_ids"] = [str(a) for a in all_leaf_ids]
+    plugins["_delegation_revoked_leaf_ids"] = [
+        str(a) for a in leaves_by_intermediary[revoked_intermediary]
+    ]
+
+    agents: dict[AgentId, StateMachineAgent] = {
+        coordinator_id: CoordinatorAgent(
+            coordinator_id,
+            intermediary_ids=intermediary_ids,
+            all_leaf_ids=all_leaf_ids,
+            revoke_intermediary=revoked_intermediary,
+            revoke_delay=revoke_delay,
+            reverify_delay=reverify_delay,
+            report=report,
+        ),
+    }
+    for inter_id in intermediary_ids:
+        agents[inter_id] = IntermediaryAgent(inter_id, leaf_ids=leaves_by_intermediary[inter_id])
+    for leaf_id in all_leaf_ids:
+        agents[leaf_id] = LeafAgent(leaf_id, coordinator_id=coordinator_id)
+
+    return agents

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
@@ -1,0 +1,483 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Macaroon-style delegatable capability tokens with cascading revocation.
+
+``JwtAuth`` (``nest_plugins_reference.auth.jwt_auth``) signs a flat claim set
+with one HMAC and tracks revocation in ``_revoked: set[str]`` keyed by the
+*exact* token string. There is no parent-child relationship between tokens at
+all, so it cannot model the most common real-world capability pattern: agent
+A holds a long-lived token, mints a narrower, shorter-lived token for agent B
+*without contacting the issuer*, and revoking A's token must invalidate B's
+at the next verification -- automatically, transitively, and without anyone
+having to remember to revoke B too.
+
+This plugin borrows the caveat-chaining trick from macaroons (Birgisson et
+al., 2014): a token is not one HMAC over one payload, it is an ordered chain
+of *caveats*, each signed with the *previous caveat's own signature* as the
+HMAC key rather than the root secret::
+
+    sig_0 = HMAC(root_secret,      caveat_0)              # issue()
+    sig_1 = HMAC(sig_0,            caveat_1)               # delegate()
+    sig_2 = HMAC(sig_1,            caveat_2)               # delegate() again
+    ...
+
+Two properties fall out of that construction for free:
+
+1. **Delegation needs no issuer round-trip.** :meth:`DelegatableAuth.delegate`
+   never reads ``self._secret``. It only needs the parent token's own
+   trailing signature (which travels with the token, in plain sight) to key
+   the next caveat. Any agent holding a valid token can attenuate it into a
+   narrower child; the anti-pattern this avoids is re-issuance-by-authority
+   dressed up as "delegation".
+2. **Revocation is transitive by construction.** Every token is
+   self-contained -- it carries its *entire* ancestor chain, not just a
+   pointer to one. :meth:`DelegatableAuth.verify` replays the whole chain
+   from ``self._secret`` and, at every level, recomputes that ancestor's
+   exact original token string and checks it against
+   ``self._revoked: dict[str, bool]``. That dict only ever gains an entry
+   for a token *directly* passed to :meth:`revoke` -- a child's entry is
+   never written. Revoking a parent invalidates every descendant the next
+   time any of them is verified, with zero bookkeeping proportional to the
+   size of the subtree.
+
+Attenuation is enforced at delegation time, not just checked cosmetically:
+a child's scopes must be a **strict** (proper) subset of its parent's --
+delegation can only narrow, never hold steady or widen -- and a child's TTL
+can never let it outlive its parent (``child.exp <= parent.exp``). Both are
+enforced inside :meth:`delegate` and raise a typed error immediately; no
+invalid token is ever minted.
+
+Delegated tokens also carry a declared **audience** -- the agent they were
+minted for. :meth:`verify` alone (matching the base ``Auth`` protocol
+signature) cannot check *who* is presenting a token, since the protocol
+gives it only the token. :meth:`verify_presented_by` is the audience-aware
+sibling: it does everything ``verify`` does and additionally rejects a token
+presented by any agent other than its declared audience.
+
+Example::
+
+    auth = DelegatableAuth(secret=b"town-secret", clock=1000.0)
+    root = await auth.issue(AgentId("orchestrator"), ["read", "write", "admin"])
+
+    # orchestrator delegates a narrower, shorter-lived capability to a worker
+    # -- no call back to the issuer, just the root token orchestrator holds.
+    worker_token = await auth.delegate(
+        root, AgentId("worker-1"), ["read", "write"], ttl=300.0
+    )
+    ctx = await auth.verify_presented_by(worker_token, AgentId("worker-1"))
+    assert ctx.scopes == ["read", "write"]
+
+    # Revoking the root invalidates worker_token transitively -- no separate
+    # revocation entry for worker_token was ever written.
+    await auth.revoke(root)
+    try:
+        await auth.verify(worker_token)
+    except RevokedAncestorError:
+        pass  # cascading revocation, by construction
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, cast
+
+from nest_core.types import AgentId, AuthContext, Token
+
+#: Default HMAC key used when no secret is supplied. Matches the naming
+#: convention of ``JwtAuth``'s default; the two plugins do not interoperate
+#: (different wire formats), so sharing the literal is cosmetic only.
+_DEFAULT_SECRET = b"nest-default-secret"
+
+#: Default lifetime, in seconds, of a root token minted by :meth:`issue`.
+_DEFAULT_ROOT_TTL = 3600.0
+
+
+class DelegationError(ValueError):
+    """Base class for every capability-delegation failure this plugin raises.
+
+    Subclasses :class:`ValueError` so call sites that only guard against the
+    base ``Auth`` protocol's ``ValueError``-raising ``verify`` (see
+    ``JwtAuth``) keep working unchanged against the richer plugin.
+
+    Example::
+
+        try:
+            await auth.delegate(parent, audience, ["admin"], ttl=60.0)
+        except DelegationError as exc:
+            print(f"delegation refused: {exc}")
+    """
+
+
+class InvalidTokenError(DelegationError):
+    """Raised when a token is malformed, tampered with, or expired.
+
+    Covers structural corruption (not valid JSON, missing caveat chain),
+    a signature that does not match its caveat at any level of the chain
+    (tamper detection -- any rewritten byte anywhere in the chain breaks
+    every signature computed after it), and plain expiry.
+
+    Example::
+
+        try:
+            await auth.verify(Token("not-json"))
+        except InvalidTokenError as exc:
+            assert "malformed" in str(exc)
+    """
+
+
+class ScopeEscalationError(DelegationError):
+    """Raised when a delegated scope set is not a strict subset of the parent's.
+
+    "Strict" is enforced literally: a child requesting the *same* scopes as
+    its parent is refused, not just a child requesting a superset. Every
+    hop down the delegation tree must shed at least one capability -- that
+    is what keeps a delegation chain from being usable as a way to launder
+    a token's original authority forever.
+
+    Example::
+
+        try:
+            await auth.delegate(parent, audience, ["read", "write", "admin"], ttl=60.0)
+        except ScopeEscalationError:
+            pass  # parent only held ["read", "write"]
+    """
+
+
+class DelegationTtlError(DelegationError):
+    """Raised when a requested child TTL is non-positive or outlives its parent.
+
+    A child's expiry (``now + ttl``) must land at or before the parent's own
+    expiry -- a delegated capability can never outlive the authority it was
+    carved from.
+
+    Example::
+
+        try:
+            await auth.delegate(parent, audience, ["read"], ttl=10_000.0)
+        except DelegationTtlError:
+            pass  # parent expires in under 10,000 seconds
+    """
+
+
+class RevokedAncestorError(DelegationError):
+    """Raised when any ancestor in a token's chain has been directly revoked.
+
+    Raised by :meth:`DelegatableAuth.verify` (and therefore also by
+    :meth:`DelegatableAuth.verify_presented_by`, which calls it) when the
+    transitive parent walk finds a revoked entry anywhere between the root
+    and the presented token -- including the presented token itself. This
+    is the cascading-revocation contract: revoking one ancestor is enough,
+    no descendant token's own digest ever needs a revocation entry.
+
+    Example::
+
+        await auth.revoke(root_token)
+        try:
+            await auth.verify(child_token)
+        except RevokedAncestorError as exc:
+            print(f"cascaded: {exc}")
+    """
+
+
+class AudienceMismatchError(DelegationError):
+    """Raised when a token is presented by an agent other than its declared audience.
+
+    A token minted via :meth:`DelegatableAuth.delegate` declares the
+    ``AgentId`` it was minted for. :meth:`DelegatableAuth.verify_presented_by`
+    checks the presenter against that declaration; :meth:`DelegatableAuth.verify`
+    alone cannot, since the base ``Auth`` protocol does not pass a presenter.
+
+    Example::
+
+        try:
+            await auth.verify_presented_by(worker_token, AgentId("attacker"))
+        except AudienceMismatchError:
+            pass  # worker_token was minted for "worker-1", not "attacker"
+    """
+
+
+def _canonical(obj: object) -> str:
+    """Serialize *obj* to canonical (sorted-key, whitespace-free) JSON.
+
+    Used for every HMAC input and every digest input in this module so that
+    the exact same Python structure always serializes to the exact same
+    bytes, regardless of insertion order -- required for the signature
+    chain and the revocation digests to be reproducible on replay.
+
+    Example::
+
+        assert _canonical({"b": 1, "a": 2}) == '{"a":2,"b":1}'
+    """
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def _hmac_hex(key: bytes, message: str) -> str:
+    """Compute the hex HMAC-SHA256 of *message* under *key*.
+
+    Example::
+
+        sig = _hmac_hex(b"secret", '{"a":1}')
+    """
+    return hmac.new(key, message.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _digest(token_str: str) -> str:
+    """Compute the revocation-table key for a full token string.
+
+    Example::
+
+        key = _digest(str(token))
+    """
+    return hashlib.sha256(token_str.encode("utf-8")).hexdigest()
+
+
+class DelegatableAuth:
+    """Capability tokens as macaroon-style HMAC caveat chains.
+
+    Implements the ``Auth`` protocol (``issue``/``verify``/``revoke``)
+    exactly, and adds :meth:`delegate` and :meth:`verify_presented_by` on
+    top. A single instance is meant to be shared by every agent in a
+    scenario (mirroring how ``JwtAuth`` shares one signing secret) --
+    ``delegate`` and ``verify`` are ordinary methods any holder of a valid
+    token can call.
+
+    Example::
+
+        auth = DelegatableAuth(secret=b"secret")
+        root = await auth.issue(AgentId("root"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("child"), ["read"], ttl=60.0)
+        ctx = await auth.verify(child)
+        assert ctx.scopes == ["read"]
+    """
+
+    def __init__(
+        self,
+        secret: bytes = _DEFAULT_SECRET,
+        clock: float | None = None,
+        default_root_ttl: float = _DEFAULT_ROOT_TTL,
+    ) -> None:
+        self._secret = secret
+        self._clock = clock
+        self._default_root_ttl = default_root_ttl
+        self._revoked: dict[str, bool] = {}
+
+    def _now(self) -> float:
+        if self._clock is not None:
+            return self._clock
+        return time.time()
+
+    def _parse_chain(self, token: Token) -> list[dict[str, Any]]:
+        """Parse and structurally validate a token string into its caveat chain.
+
+        Example::
+
+            chain = auth._parse_chain(token)
+            assert chain[0]["depth"] == 0
+        """
+        try:
+            obj = json.loads(str(token))
+        except (json.JSONDecodeError, TypeError) as exc:
+            msg = "malformed token: not valid JSON"
+            raise InvalidTokenError(msg) from exc
+        if not isinstance(obj, dict):
+            msg = "malformed token: expected a JSON object"
+            raise InvalidTokenError(msg)
+        raw_chain = cast("dict[str, Any]", obj).get("chain")
+        if not isinstance(raw_chain, list) or not raw_chain:
+            msg = "malformed token: missing or empty caveat chain"
+            raise InvalidTokenError(msg)
+        chain = cast("list[Any]", raw_chain)
+        for entry in chain:
+            if not isinstance(entry, dict) or "sig" not in entry:
+                msg = "malformed token: caveat entry missing a signature"
+                raise InvalidTokenError(msg)
+        return cast("list[dict[str, Any]]", chain)
+
+    def _reject_if_any_ancestor_revoked(self, chain: list[dict[str, Any]]) -> None:
+        """Raise :class:`RevokedAncestorError` if any prefix of *chain* was directly revoked.
+
+        A pure revocation-table lookup -- reconstructs each ancestor's exact
+        original token string from the structure already embedded in
+        *chain* and hashes it, needing no secret and no signature check.
+        Shared by :meth:`delegate` (which cannot verify signatures without
+        the root secret) and :meth:`verify` (which does both).
+
+        Example::
+
+            auth._reject_if_any_ancestor_revoked(chain)
+        """
+        for idx in range(len(chain)):
+            ancestor_str = _canonical({"chain": chain[: idx + 1]})
+            if self._revoked.get(_digest(ancestor_str), False):
+                subject = chain[idx].get("subject")
+                msg = f"ancestor at depth {idx} (subject={subject!r}) has been revoked"
+                raise RevokedAncestorError(msg)
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Issue a root token for *subject* with *scopes*, signed with the root secret.
+
+        The root caveat has no declared audience (``None``) and sits at
+        chain depth 0. Its expiry ceils every capability later delegated
+        from it, since no descendant's TTL may exceed its parent's.
+
+        Example::
+
+            token = await auth.issue(AgentId("orchestrator"), ["read", "write"])
+        """
+        now = self._now()
+        caveat: dict[str, Any] = {
+            "subject": str(subject),
+            "scopes": list(scopes),
+            "iat": now,
+            "exp": now + self._default_root_ttl,
+            "audience": None,
+            "depth": 0,
+        }
+        sig = _hmac_hex(self._secret, _canonical(caveat))
+        entry = {**caveat, "sig": sig}
+        return Token(_canonical({"chain": [entry]}))
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token:
+        """Mint a narrower, shorter-lived child token from *parent_token*.
+
+        *scopes_subset* must be a strict subset of the parent's current
+        scopes (:class:`ScopeEscalationError` otherwise) and *ttl* must be
+        positive and land the child's expiry at or before the parent's own
+        expiry (:class:`DelegationTtlError` otherwise, which also catches
+        delegating from an already-expired parent -- its expiry can never
+        be met by a positive-ttl child). Every ancestor's revocation status
+        is checked locally against the revocation table
+        (:class:`RevokedAncestorError` if any is revoked).
+
+        Crucially, this method never reads the root secret and never
+        verifies a signature -- unlike :meth:`verify`, it needs no
+        cryptographic material beyond the parent token's own trailing
+        signature (used only as the next HMAC *key*, never inspected).
+        That is what lets any agent holding a valid-looking token delegate
+        immediately, without a round trip to the issuer. A parent token
+        that was tampered with or forged is not rejected here; it is
+        rejected the next time anyone calls :meth:`verify` on a
+        descendant, when the real root secret replays the whole chain.
+
+        Example::
+
+            child = await auth.delegate(root, AgentId("worker-1"), ["read"], ttl=60.0)
+        """
+        chain = self._parse_chain(parent_token)
+        self._reject_if_any_ancestor_revoked(chain)
+        parent_entry = chain[-1]
+        parent_scopes = set(cast("list[str]", parent_entry["scopes"]))
+        requested = set(scopes_subset)
+        if not requested < parent_scopes:
+            msg = (
+                f"delegated scopes {sorted(requested)} must be a strict subset "
+                f"of parent scopes {sorted(parent_scopes)}"
+            )
+            raise ScopeEscalationError(msg)
+        if ttl <= 0:
+            msg = f"ttl must be positive, got {ttl}"
+            raise DelegationTtlError(msg)
+        now = self._now()
+        parent_exp = float(parent_entry["exp"])
+        child_exp = now + ttl
+        if child_exp > parent_exp:
+            msg = (
+                f"child ttl={ttl} would expire at {child_exp}, after the "
+                f"parent's own expiry {parent_exp}"
+            )
+            raise DelegationTtlError(msg)
+        caveat: dict[str, Any] = {
+            "subject": str(audience),
+            "scopes": list(scopes_subset),
+            "iat": now,
+            "exp": child_exp,
+            "audience": str(audience),
+            "depth": int(parent_entry["depth"]) + 1,
+        }
+        key = bytes.fromhex(str(parent_entry["sig"]))
+        sig = _hmac_hex(key, _canonical(caveat))
+        new_chain = [*chain, {**caveat, "sig": sig}]
+        return Token(_canonical({"chain": new_chain}))
+
+    async def verify(self, token: Token) -> AuthContext:
+        """Verify a token by replaying its entire caveat chain.
+
+        Walks the chain from the root, recomputing each level's signature
+        (tamper anywhere breaks every signature after it), checking each
+        ancestor's exact original token string against the revocation
+        table, and checking each ancestor's expiry. Raises
+        :class:`RevokedAncestorError` the moment any ancestor -- including
+        the token itself -- is found directly revoked, and
+        :class:`InvalidTokenError` for a bad signature, malformed token, or
+        expiry. On success, returns the context for the *leaf* caveat.
+
+        Example::
+
+            ctx = await auth.verify(token)
+            assert ctx.subject == AgentId("worker-1")
+        """
+        chain = self._parse_chain(token)
+        self._reject_if_any_ancestor_revoked(chain)
+        now = self._now()
+        key = self._secret
+        for idx, entry in enumerate(chain):
+            caveat = {k: v for k, v in entry.items() if k != "sig"}
+            carried_sig = str(entry["sig"])
+            expected_sig = _hmac_hex(key, _canonical(caveat))
+            if not hmac.compare_digest(carried_sig, expected_sig):
+                msg = f"invalid signature at chain depth {idx}"
+                raise InvalidTokenError(msg)
+            if float(caveat["exp"]) < now:
+                msg = f"ancestor at depth {idx} (subject={caveat['subject']!r}) has expired"
+                raise InvalidTokenError(msg)
+            key = bytes.fromhex(carried_sig)
+        leaf = chain[-1]
+        return AuthContext(
+            subject=AgentId(str(leaf["subject"])),
+            scopes=list(cast("list[str]", leaf["scopes"])),
+            issued_at=float(leaf["iat"]),
+            expires_at=float(leaf["exp"]),
+        )
+
+    async def verify_presented_by(self, token: Token, presenter: AgentId) -> AuthContext:
+        """Verify *token* and additionally check it was presented by its declared audience.
+
+        Performs the full :meth:`verify` chain walk, then compares
+        *presenter* against the leaf caveat's declared ``audience``. A root
+        token (``audience is None``) falls back to comparing *presenter*
+        against its own subject. Raises :class:`AudienceMismatchError` on a
+        mismatch.
+
+        Example::
+
+            ctx = await auth.verify_presented_by(child, AgentId("worker-1"))
+        """
+        ctx = await self.verify(token)
+        chain = self._parse_chain(token)
+        declared_audience = chain[-1].get("audience")
+        expected = str(declared_audience) if declared_audience is not None else str(ctx.subject)
+        if str(presenter) != expected:
+            msg = f"token declares audience {expected!r} but was presented by {presenter!r}"
+            raise AudienceMismatchError(msg)
+        return ctx
+
+    async def revoke(self, token: Token) -> None:
+        """Directly revoke *token*.
+
+        Only records *this exact token's* digest. Descendants are never
+        touched -- they are invalidated transitively the next time
+        :meth:`verify` walks a chain that passes through this digest.
+
+        Example::
+
+            await auth.revoke(root_token)
+        """
+        self._revoked[_digest(str(token))] = True

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -16,6 +16,11 @@ Example::
 
 from __future__ import annotations
 
+from nest_plugins_reference.validators.auth_delegation_validators import (
+    check_audience_confusion_rejected,
+    check_scope_escalation_rejected,
+    check_stale_parent_rejected,
+)
 from nest_plugins_reference.validators.gossip_validators import (
     ConvergenceFailureError,
     PartitionLeakError,
@@ -35,11 +40,14 @@ __all__ = [
     "ConvergenceFailureError",
     "PartitionLeakError",
     "ValidatorReport",
+    "check_audience_confusion_rejected",
     "check_converged",
     "check_eavesdropper_blocked",
     "check_field_injection_rejected",
     "check_no_partition_view_leak",
     "check_replay_rejected",
+    "check_scope_escalation_rejected",
+    "check_stale_parent_rejected",
     "check_stale_revocation_blocked",
     "corrupt_proof",
 ]

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/auth_delegation_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/auth_delegation_validators.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for capability-delegation auth plugins.
+
+Three attacks the default ``jwt`` plugin
+(``nest_plugins_reference.auth.jwt_auth.JwtAuth``) has no defense against,
+because it has no concept of a parent-child relationship between tokens at
+all -- "delegation" on top of it can only mean calling ``issue`` again,
+which is exactly the re-issuance-by-authority anti-pattern the
+``04-auth-capability-delegation`` problem doc warns against:
+
+1. **Scope escalation.** A child token claims broader scopes than whatever
+   it was "delegated" from. ``jwt``'s ``issue`` takes any scope list from
+   any caller -- there is no parent to compare against, so nothing can be
+   escalated *past*, but nothing is enforced *either*.
+   ``check_scope_escalation_rejected`` drives an attempted mint of an
+   over-scoped child and asserts the attempt is refused, either at mint
+   time or at verification time.
+2. **Stale parent.** A parent token is revoked (or expired) after a child
+   was minted from it, and the child still verifies. ``jwt``'s
+   ``_revoked: set[str]`` is keyed by exact token string with no chain, so
+   revoking a "parent" token never touches an independently-issued "child"
+   token. ``check_stale_parent_rejected`` revokes the parent *after* the
+   child already exists and asserts the child stops verifying.
+3. **Audience confusion.** A token minted for one agent is presented (and
+   accepted) by a different agent. ``jwt``'s ``verify`` takes only the
+   token -- there is no audience field and no presenter argument, so any
+   holder of any token can present it as anyone.
+   ``check_audience_confusion_rejected`` presents a token as the wrong
+   agent and asserts it is refused.
+
+Each validator is deliberately **plugin-agnostic**: it takes async
+callables the caller constructs however that plugin exposes the relevant
+operation, and only inspects the *outcome* (did the attack succeed or was
+it blocked). That is what lets the exact same validator function run
+against two structurally different plugins and produce the charter's
+required differential result:
+
+* against ``nest_plugins_reference.auth.delegatable.DelegatableAuth``,
+  wired through its real ``delegate`` / ``verify`` /
+  ``verify_presented_by`` surface, all three checks **pass** -- every
+  attack is rejected with a typed exception
+  (``ScopeEscalationError`` / ``RevokedAncestorError`` /
+  ``AudienceMismatchError``);
+* against ``JwtAuth``, wired through the only surface it has (``issue`` /
+  ``verify``, with no parent-aware delegation at all), all three checks
+  **fail** -- the validators literally cannot be satisfied by the
+  reference plugin, which is the charter's bar for "adversarial". See
+  ``packages/nest-plugins-reference/tests/test_delegatable_auth.py`` for
+  the differential proof wired against both plugins side by side.
+
+Example::
+
+    report = await check_scope_escalation_rejected(
+        attempt_mint=lambda: auth.delegate(parent, audience, ["read", "admin"], ttl=60.0),
+        verify=auth.verify,
+    )
+    assert report.passed, report.detail
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from nest_plugins_reference.validators.gossip_validators import ValidatorReport
+
+if TYPE_CHECKING:
+    from nest_core.types import AgentId, AuthContext, Token
+
+
+async def check_scope_escalation_rejected(
+    attempt_mint: Callable[[], Awaitable[Token]],
+    *,
+    verify: Callable[[Token], Awaitable[AuthContext]] | None = None,
+) -> ValidatorReport:
+    """Assert an attempt to mint an over-scoped child token does not succeed.
+
+    Calls *attempt_mint* (the caller's plugin-specific way of trying to
+    obtain a token with escalated scopes) and treats any exception as the
+    attack being rejected at mint time. If minting does not raise and
+    *verify* is supplied, the resulting token is also verified -- a plugin
+    that mints an escalated token but then refuses to verify it still
+    counts as rejecting the attack. Only a token that is both minted *and*
+    verified counts as a successful escalation.
+
+    Against ``DelegatableAuth.delegate``, an over-scoped request raises
+    ``ScopeEscalationError`` immediately. Against ``JwtAuth.issue`` (the
+    only "delegation" surface it has), the call has no parent to compare
+    against and always succeeds -- so does the subsequent verify -- and the
+    attack goes through uncaught.
+
+    Example::
+
+        report = await check_scope_escalation_rejected(
+            attempt_mint=lambda: auth.delegate(parent, aud, ["read", "admin"], ttl=60.0),
+            verify=auth.verify,
+        )
+        assert report.passed, report.detail
+    """
+    try:
+        token = await attempt_mint()
+    except Exception as exc:  # noqa: BLE001 - any failure is a rejected attack
+        return ValidatorReport(
+            passed=True, detail=f"escalated scope request rejected at mint time ({exc})"
+        )
+    if verify is None:
+        return ValidatorReport(
+            passed=False,
+            detail="escalated token was minted without error and no verify step was supplied",
+            evidence={"token": str(token)},
+        )
+    try:
+        ctx = await verify(token)
+    except Exception as exc:  # noqa: BLE001 - any failure is a rejected attack
+        return ValidatorReport(passed=True, detail=f"escalated token failed verification ({exc})")
+    return ValidatorReport(
+        passed=False,
+        detail=f"escalated token verified successfully with scopes {ctx.scopes}",
+        evidence={"scopes": ctx.scopes},
+    )
+
+
+async def check_stale_parent_rejected(
+    child_token: Token,
+    revoke_parent: Callable[[], Awaitable[None]],
+    verify: Callable[[Token], Awaitable[AuthContext]],
+) -> ValidatorReport:
+    """Assert a child token stops verifying once its parent is revoked.
+
+    *child_token* must already exist (legitimately minted while its parent
+    was still valid). *revoke_parent* is called first -- exercising the
+    revocation *after* the fact, the realistic ordering -- then *verify* is
+    attempted on the child. Any exception counts as the attack being
+    rejected.
+
+    Against ``DelegatableAuth``, the chain walk in ``verify`` finds the
+    revoked ancestor and raises ``RevokedAncestorError``. Against ``JwtAuth``,
+    a "child" token has no structural link to its "parent" (there is no
+    chain to walk), so revoking the parent token's own string never touches
+    the child's, and the child keeps verifying.
+
+    Example::
+
+        report = await check_stale_parent_rejected(
+            child_token, revoke_parent=lambda: auth.revoke(parent), verify=auth.verify
+        )
+        assert report.passed, report.detail
+    """
+    await revoke_parent()
+    try:
+        ctx = await verify(child_token)
+    except Exception as exc:  # noqa: BLE001 - any failure is a rejected attack
+        return ValidatorReport(
+            passed=True, detail=f"child rejected after parent was revoked ({exc})"
+        )
+    return ValidatorReport(
+        passed=False,
+        detail=f"child verified after its parent was revoked (subject={ctx.subject})",
+        evidence={"subject": str(ctx.subject)},
+    )
+
+
+async def check_audience_confusion_rejected(
+    present: Callable[[AgentId], Awaitable[AuthContext]],
+    wrong_presenter: AgentId,
+) -> ValidatorReport:
+    """Assert a token is refused when presented by an agent other than its audience.
+
+    *present* is the caller's plugin-specific way of "presenting" a token
+    as a given agent (e.g. ``lambda presenter: auth.verify_presented_by(token, presenter)``).
+    It is called with *wrong_presenter*, an agent that is not the token's
+    declared audience. Any exception counts as the attack being rejected.
+
+    Against ``DelegatableAuth.verify_presented_by``, the audience check
+    raises ``AudienceMismatchError``. Against ``JwtAuth.verify``, there is no
+    audience field and no presenter argument at all -- the caller's
+    ``present`` callable can only ignore *wrong_presenter* and verify the
+    bare token, which always succeeds regardless of who "presents" it.
+
+    Example::
+
+        report = await check_audience_confusion_rejected(
+            present=lambda p: auth.verify_presented_by(token, p),
+            wrong_presenter=AgentId("attacker"),
+        )
+        assert report.passed, report.detail
+    """
+    try:
+        ctx = await present(wrong_presenter)
+    except Exception as exc:  # noqa: BLE001 - any failure is a rejected attack
+        return ValidatorReport(
+            passed=True, detail=f"presentation by non-audience agent rejected ({exc})"
+        )
+    return ValidatorReport(
+        passed=False,
+        detail=(f"token presented by {wrong_presenter!r} verified anyway (subject={ctx.subject})"),
+        evidence={"presenter": str(wrong_presenter), "subject": str(ctx.subject)},
+    )

--- a/packages/nest-plugins-reference/tests/test_delegatable_auth.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable_auth.py
@@ -1,0 +1,458 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``delegatable`` capability-delegation auth plugin.
+
+Six layers of coverage:
+
+1. **Base ``Auth`` protocol conformance** -- issue/verify/revoke round-trip,
+   tamper and malformed-token handling, cross-instance signature mismatch.
+2. **Successful delegation** -- scopes narrow correctly, multi-level chains
+   (grandchild) resolve back to the root.
+3. **The three attacks the problem doc names** -- scope escalation, TTL
+   violation, and audience confusion are each individually rejected with
+   their typed exception.
+4. **Cascading revocation** -- revoking a parent (or grandparent) fails a
+   descendant's *next* verification, and does so while writing exactly one
+   entry into the revocation table (no per-descendant bookkeeping), and
+   without touching a sibling branch.
+5. **Adversarial validator differential proof** -- each of the three
+   ``nest_plugins_reference.validators.auth_delegation_validators`` checks
+   is run against both ``JwtAuth`` (must fail) and ``DelegatableAuth``
+   (must pass), proving the validator is genuinely adversarial per the
+   charter, not just a check that happens to pass against one plugin.
+6. **Full scenario integration** -- boots the real ``delegated_auth.yaml``
+   scenario via ``ScenarioRunner`` and asserts the cascading-revocation
+   outcome (exactly the 4 leaves under the revoked branch fail) and
+   byte-identical determinism across two runs of the same seed.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.delegatable import (
+    AudienceMismatchError,
+    DelegatableAuth,
+    DelegationTtlError,
+    InvalidTokenError,
+    RevokedAncestorError,
+    ScopeEscalationError,
+)
+from nest_plugins_reference.auth.jwt_auth import JwtAuth
+from nest_plugins_reference.validators import (
+    check_audience_confusion_rejected,
+    check_scope_escalation_rejected,
+    check_stale_parent_rejected,
+)
+
+if TYPE_CHECKING:
+    from nest_core.types import AuthContext
+
+# ---------------------------------------------------------------------------
+# 1. Base Auth protocol conformance
+# ---------------------------------------------------------------------------
+
+
+async def test_issue_verify_round_trip() -> None:
+    auth = DelegatableAuth(secret=b"test-secret", clock=1000.0)
+    token = await auth.issue(AgentId("root"), ["read", "write"])
+    ctx = await auth.verify(token)
+    assert ctx.subject == AgentId("root")
+    assert ctx.scopes == ["read", "write"]
+    assert ctx.issued_at == 1000.0
+
+
+async def test_revoke_root_token() -> None:
+    auth = DelegatableAuth(secret=b"test-secret", clock=1000.0)
+    token = await auth.issue(AgentId("root"), ["read"])
+    await auth.revoke(token)
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify(token)
+
+
+async def test_tampered_payload_rejected() -> None:
+    auth = DelegatableAuth(secret=b"test-secret", clock=1000.0)
+    token = await auth.issue(AgentId("root"), ["read"])
+    tampered = Token(str(token).replace('"read"', '"admin"'))
+    with pytest.raises(InvalidTokenError, match="signature"):
+        await auth.verify(tampered)
+
+
+async def test_malformed_token_rejected() -> None:
+    auth = DelegatableAuth(secret=b"test-secret")
+    with pytest.raises(InvalidTokenError):
+        await auth.verify(Token("not-json"))
+
+
+async def test_empty_chain_rejected() -> None:
+    auth = DelegatableAuth(secret=b"test-secret")
+    with pytest.raises(InvalidTokenError):
+        await auth.verify(Token('{"chain": []}'))
+
+
+async def test_cross_instance_signature_mismatch() -> None:
+    auth1 = DelegatableAuth(secret=b"secret1", clock=1000.0)
+    auth2 = DelegatableAuth(secret=b"secret2", clock=1000.0)
+    token = await auth1.issue(AgentId("root"), ["read"])
+    with pytest.raises(InvalidTokenError, match="signature"):
+        await auth2.verify(token)
+
+
+async def test_expired_token_rejected() -> None:
+    auth = DelegatableAuth(secret=b"test-secret", clock=1000.0, default_root_ttl=10.0)
+    token = await auth.issue(AgentId("root"), ["read"])
+    # A second instance sharing the same secret, but with its clock advanced
+    # well past expiry, stands in for "time has passed" without reaching
+    # into the first instance's internals.
+    later = DelegatableAuth(secret=b"test-secret", clock=2000.0, default_root_ttl=10.0)
+    with pytest.raises(InvalidTokenError, match="expired"):
+        await later.verify(token)
+
+
+# ---------------------------------------------------------------------------
+# 2. Successful delegation and multi-level chains
+# ---------------------------------------------------------------------------
+
+
+async def test_delegate_narrows_scopes_and_verifies() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write", "admin"])
+    child = await auth.delegate(root, AgentId("child"), ["read", "write"], ttl=60.0)
+    ctx = await auth.verify(child)
+    assert ctx.subject == AgentId("child")
+    assert ctx.scopes == ["read", "write"]
+
+
+async def test_grandchild_chain_resolves_back_to_root() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write", "admin"])
+    child = await auth.delegate(root, AgentId("child"), ["read", "write"], ttl=120.0)
+    grandchild = await auth.delegate(child, AgentId("grandchild"), ["read"], ttl=60.0)
+    ctx = await auth.verify_presented_by(grandchild, AgentId("grandchild"))
+    assert ctx.subject == AgentId("grandchild")
+    assert ctx.scopes == ["read"]
+
+
+async def test_delegate_does_not_require_the_root_secret() -> None:
+    """A holder of a valid parent token can delegate with zero knowledge of
+    the issuer's secret -- ``delegate`` never reads ``self._secret``."""
+    auth = DelegatableAuth(secret=b"secret-only-the-issuer-knows", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write"])
+    # An independent instance with a *different* (wrong) secret can still
+    # correctly compute a child signature, because it is keyed off the
+    # parent's own trailing signature, not either instance's ``_secret``.
+    delegator = DelegatableAuth(secret=b"delegator-does-not-know-the-real-secret", clock=1000.0)
+    child = await delegator.delegate(root, AgentId("child"), ["read"], ttl=60.0)
+    # The *issuer* (holder of the real secret) still verifies it correctly.
+    ctx = await auth.verify(child)
+    assert ctx.subject == AgentId("child")
+
+
+# ---------------------------------------------------------------------------
+# 3a. Scope escalation
+# ---------------------------------------------------------------------------
+
+
+async def test_scope_escalation_superset_rejected() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write"])
+    with pytest.raises(ScopeEscalationError):
+        await auth.delegate(root, AgentId("child"), ["read", "write", "admin"], ttl=60.0)
+
+
+async def test_scope_escalation_unrelated_scope_rejected() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write"])
+    with pytest.raises(ScopeEscalationError):
+        await auth.delegate(root, AgentId("child"), ["read", "delete"], ttl=60.0)
+
+
+async def test_equal_scopes_rejected_not_a_strict_subset() -> None:
+    """Every hop must shed at least one scope -- equal scopes are not a
+    *strict* subset, per the problem doc's success criteria."""
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write"])
+    with pytest.raises(ScopeEscalationError):
+        await auth.delegate(root, AgentId("child"), ["read", "write"], ttl=60.0)
+
+
+@given(
+    parent_scopes=st.sets(
+        st.sampled_from(["read", "write", "admin", "delete", "audit"]), min_size=2
+    ),
+    extra_scope=st.sampled_from(["deploy", "root", "sudo"]),
+)
+@settings(max_examples=50, deadline=None)
+@pytest.mark.asyncio
+async def test_property_any_scope_outside_parent_is_rejected(
+    parent_scopes: set[str], extra_scope: str
+) -> None:
+    """For any parent scope set, requesting one scope the parent never held
+    is always a ``ScopeEscalationError``, regardless of what else is asked for."""
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), sorted(parent_scopes))
+    requested = [*sorted(parent_scopes)[:-1], extra_scope]
+    with pytest.raises(ScopeEscalationError):
+        await auth.delegate(root, AgentId("child"), requested, ttl=60.0)
+
+
+# ---------------------------------------------------------------------------
+# 3b. TTL violation
+# ---------------------------------------------------------------------------
+
+
+async def test_ttl_exceeding_parent_rejected() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0, default_root_ttl=100.0)
+    root = await auth.issue(AgentId("root"), ["read", "write"])
+    with pytest.raises(DelegationTtlError):
+        await auth.delegate(root, AgentId("child"), ["read"], ttl=1000.0)
+
+
+async def test_non_positive_ttl_rejected() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write"])
+    with pytest.raises(DelegationTtlError):
+        await auth.delegate(root, AgentId("child"), ["read"], ttl=0.0)
+
+
+async def test_ttl_at_exact_parent_boundary_is_allowed() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0, default_root_ttl=100.0)
+    root = await auth.issue(AgentId("root"), ["read", "write"])
+    child = await auth.delegate(root, AgentId("child"), ["read"], ttl=100.0)
+    ctx = await auth.verify(child)
+    assert ctx.expires_at == 1100.0
+
+
+# ---------------------------------------------------------------------------
+# 3c. Audience confusion
+# ---------------------------------------------------------------------------
+
+
+async def test_audience_confusion_rejected() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write"])
+    child = await auth.delegate(root, AgentId("intended"), ["read"], ttl=60.0)
+    with pytest.raises(AudienceMismatchError):
+        await auth.verify_presented_by(child, AgentId("attacker"))
+
+
+async def test_audience_match_succeeds() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write"])
+    child = await auth.delegate(root, AgentId("intended"), ["read"], ttl=60.0)
+    ctx = await auth.verify_presented_by(child, AgentId("intended"))
+    assert ctx.subject == AgentId("intended")
+
+
+async def test_root_token_audience_defaults_to_subject() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read"])
+    ctx = await auth.verify_presented_by(root, AgentId("root"))
+    assert ctx.subject == AgentId("root")
+    with pytest.raises(AudienceMismatchError):
+        await auth.verify_presented_by(root, AgentId("someone-else"))
+
+
+# ---------------------------------------------------------------------------
+# 4. Cascading revocation
+# ---------------------------------------------------------------------------
+
+
+async def test_cascading_revocation_invalidates_child() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write", "admin"])
+    child = await auth.delegate(root, AgentId("child"), ["read", "write"], ttl=120.0)
+
+    await auth.revoke(root)
+
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify(child)
+
+
+async def test_cascading_revocation_invalidates_grandchild_without_touching_it() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write", "admin"])
+    child = await auth.delegate(root, AgentId("child"), ["read", "write"], ttl=120.0)
+    grandchild = await auth.delegate(child, AgentId("grandchild"), ["read"], ttl=60.0)
+    # A sibling delegated straight from root, never touched by the revoke
+    # call below, is how we observe that only one entry was ever written
+    # (a blanket/broad revocation would have caught this one too).
+    sibling = await auth.delegate(root, AgentId("sibling"), ["read"], ttl=60.0)
+
+    # Revoke only the intermediate "child" -- the grandchild's own token
+    # string is never passed to revoke().
+    await auth.revoke(child)
+
+    with pytest.raises(RevokedAncestorError, match="depth 1"):
+        await auth.verify(grandchild)
+    # The root, and the untouched sibling branch, still verify fine.
+    ctx_root = await auth.verify(root)
+    assert ctx_root.subject == AgentId("root")
+    ctx_sibling = await auth.verify(sibling)
+    assert ctx_sibling.subject == AgentId("sibling")
+
+
+async def test_sibling_branch_unaffected_by_revocation() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write", "admin"])
+    branch_a = await auth.delegate(root, AgentId("a"), ["read", "write"], ttl=120.0)
+    branch_b = await auth.delegate(root, AgentId("b"), ["read", "write"], ttl=120.0)
+
+    await auth.revoke(branch_a)
+
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify(branch_a)
+    ctx_b = await auth.verify(branch_b)
+    assert ctx_b.subject == AgentId("b")
+
+
+# ---------------------------------------------------------------------------
+# 5. Adversarial validator differential proof
+#
+# Charter's bar for "adversarial": the same validator function must FAIL
+# against the default jwt plugin and PASS against delegatable.
+# ---------------------------------------------------------------------------
+
+
+async def test_scope_escalation_validator_fails_against_jwt() -> None:
+    jwt = JwtAuth(secret=b"jwt-secret")
+    await jwt.issue(AgentId("root"), ["read"])
+
+    async def attempt_mint() -> Token:
+        # The only "delegation" jwt exposes is re-issuance -- no parent to
+        # compare against, so nothing stops a broader scope set.
+        return await jwt.issue(AgentId("child"), ["read", "admin"])
+
+    report = await check_scope_escalation_rejected(attempt_mint, verify=jwt.verify)
+    assert not report.passed, "jwt has no delegation primitive to catch escalation with"
+
+
+async def test_scope_escalation_validator_passes_against_delegatable() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    parent = await auth.issue(AgentId("root"), ["read"])
+
+    async def attempt_mint() -> Token:
+        return await auth.delegate(parent, AgentId("child"), ["read", "admin"], ttl=60.0)
+
+    report = await check_scope_escalation_rejected(attempt_mint, verify=auth.verify)
+    assert report.passed, report.detail
+
+
+async def test_stale_parent_validator_fails_against_jwt() -> None:
+    jwt = JwtAuth(secret=b"jwt-secret")
+    parent = await jwt.issue(AgentId("root"), ["read", "write"])
+    # jwt has no delegation, so a "child" is just an independently issued token.
+    child = await jwt.issue(AgentId("child"), ["read"])
+
+    report = await check_stale_parent_rejected(
+        child, revoke_parent=lambda: jwt.revoke(parent), verify=jwt.verify
+    )
+    assert not report.passed, "jwt's flat revocation set can't cascade to an unrelated token"
+
+
+async def test_stale_parent_validator_passes_against_delegatable() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    parent = await auth.issue(AgentId("root"), ["read", "write"])
+    child = await auth.delegate(parent, AgentId("child"), ["read"], ttl=60.0)
+
+    report = await check_stale_parent_rejected(
+        child, revoke_parent=lambda: auth.revoke(parent), verify=auth.verify
+    )
+    assert report.passed, report.detail
+
+
+async def test_audience_confusion_validator_fails_against_jwt() -> None:
+    jwt = JwtAuth(secret=b"jwt-secret")
+    token = await jwt.issue(AgentId("intended"), ["read"])
+
+    async def present(presenter: AgentId) -> AuthContext:
+        # jwt.verify ignores who is presenting entirely.
+        del presenter
+        return await jwt.verify(token)
+
+    report = await check_audience_confusion_rejected(present, AgentId("attacker"))
+    assert not report.passed, "jwt has no audience concept to enforce"
+
+
+async def test_audience_confusion_validator_passes_against_delegatable() -> None:
+    auth = DelegatableAuth(secret=b"secret", clock=1000.0)
+    root = await auth.issue(AgentId("root"), ["read", "write"])
+    token = await auth.delegate(root, AgentId("intended"), ["read"], ttl=60.0)
+
+    async def present(presenter: AgentId) -> AuthContext:
+        return await auth.verify_presented_by(token, presenter)
+
+    report = await check_audience_confusion_rejected(present, AgentId("attacker"))
+    assert report.passed, report.detail
+
+
+# ---------------------------------------------------------------------------
+# 6. Full scenario integration
+# ---------------------------------------------------------------------------
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "delegated_auth.yaml"
+
+
+async def _run_delegation_scenario(trace_name: str) -> tuple[dict[str, str], bytes]:
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / trace_name
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        await runner.run()
+        report = runner.resolved_plugins.get("_delegation_report")
+        assert report is not None, "scenario factory should expose _delegation_report"
+        trace_bytes = trace_path.read_bytes() if trace_path.exists() else b""
+        return dict(report), trace_bytes
+
+
+async def test_scenario_cascades_revocation_to_exactly_one_branch() -> None:
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / "delegated_auth.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        await runner.run()
+
+        report = runner.resolved_plugins.get("_delegation_report")
+        revoked_leaf_ids = runner.resolved_plugins.get("_delegation_revoked_leaf_ids")
+        all_leaf_ids = runner.resolved_plugins.get("_delegation_leaf_ids")
+        assert report is not None
+        assert revoked_leaf_ids is not None
+        assert all_leaf_ids is not None
+        assert len(all_leaf_ids) == 12
+        assert len(revoked_leaf_ids) == 4
+        assert len(report) == 12
+
+        for leaf_id in all_leaf_ids:
+            expected = "revoked" if leaf_id in revoked_leaf_ids else "ok"
+            assert report[leaf_id] == expected, (
+                f"{leaf_id}: expected {expected!r}, got {report[leaf_id]!r}"
+            )
+
+
+async def test_scenario_deterministic_under_replay() -> None:
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+
+    report_a, trace_a = await _run_delegation_scenario("delegated_auth_run_a.jsonl")
+    report_b, trace_b = await _run_delegation_scenario("delegated_auth_run_b.jsonl")
+
+    assert report_a == report_b
+    assert len(report_a) == 12
+    assert trace_a == trace_b, "same seed must produce a byte-identical trace"

--- a/scenarios/delegated_auth.yaml
+++ b/scenarios/delegated_auth.yaml
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegated capability-token scenario.
+#
+# coordinator-0 issues a root token (scopes: read/write/admin) and delegates
+# a narrower token (read/write) to each of 3 intermediaries, who each
+# delegate a further-narrowed token (read) to 4 leaves -- 16 agents total in
+# a strict tree (1 coordinator, 3 intermediaries, 12 leaves; single parent
+# per token, no DAG).
+#
+# Midway through the run the coordinator revokes ONE intermediary's token.
+# All 4 leaves under that branch must fail re-verification with
+# RevokedAncestorError while the other 8 leaves keep verifying -- cascading
+# revocation "by construction": no leaf token is ever revoked directly.
+#
+# Deterministic: the scenario factory pins DelegatableAuth's clock to a
+# fixed value (see delegation_tree.py's _instantiate_auth) instead of
+# wall-clock time, so every issued/delegated token's timestamps -- and the
+# whole trace -- are byte-identical run over run for the same seed. Agent
+# scheduling uses only the seeded simulator clock via ctx.schedule.
+name: delegated_auth
+description: "Coordinator -> 3 intermediaries -> 12 leaves capability delegation tree with mid-run cascading revocation of one branch."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 16
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+    - name: intermediary
+      count: 3
+    - name: leaf
+      count: 12
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: delegatable
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: delegation_tree
+  config:
+    revoke_intermediary_index: 1
+    revoke_delay: 50
+    reverify_delay: 100
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/delegated_auth.jsonl


### PR DESCRIPTION
## Motivation

The default auth plugin (`nest_plugins_reference/auth/jwt_auth.py`) is 106 lines of HMAC-signed token issuance. It has no notion of delegation: `JwtAuth._revoked: set[str]` tracks revocation by exact token string, with no parent-child relationship between tokens at all. That makes the auth layer unable to model the most common real-world capability pattern — "agent A holds a long-lived root token, mints a 10-minute sub-token for agent B without going back to the issuer, and revoking A's token invalidates B's at the next verify, automatically." Macaroons (Google, 2014), biscuits (CleverCloud), and SPIFFE delegation all do this; `docs/layers/auth.md` explicitly lists "capability delegation" and "revocation propagation" as wanted. Solves `docs/hackathon/problems/04-auth-capability-delegation.md`.

Anyone building a multi-agent workflow where an orchestrator hands out narrowly-scoped, time-bounded sub-capabilities needs this — e.g. an LLM agent sub-renting tool access to a worker, and being able to withdraw it cleanly without hunting down every descendant token.

## Design

`DelegatableAuth` (`packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py`) borrows the caveat-chaining trick from macaroons (Birgisson et al., 2014): a token is not one HMAC over one flat payload, it's an ordered chain of caveats, where each caveat's signature is keyed off the **previous caveat's own signature**, not the root secret:

```
sig_0 = HMAC(root_secret, caveat_0)   # issue()
sig_1 = HMAC(sig_0,       caveat_1)   # delegate()
sig_2 = HMAC(sig_1,       caveat_2)   # delegate() again
```

Two properties fall out of that for free:

1. **Delegation needs no issuer round-trip.** `delegate()` never reads `self._secret`. It only needs the parent token's own trailing signature (which travels with the token in plain sight) to key the next caveat, plus a local, secret-free check that no ancestor in the chain is in the revocation table. This is the anti-pattern the problem doc calls out explicitly: "don't ship delegation that's actually just re-issuance by the central authority." A forged/tampered parent isn't rejected at delegate time — it's still caught the next time anyone calls `verify()`, when the real root secret replays the whole chain.
2. **Revocation is transitive by construction.** Every token is self-contained — it carries its *entire* ancestor chain, not a pointer to one. `verify()` replays the whole chain from `self._secret` and, at every level, recomputes that ancestor's *exact* original token string and checks its digest against `self._revoked: dict[str, bool]`. That dict only ever gains an entry for a token *directly* passed to `revoke()` — a child's entry is never written. Revoking a parent invalidates every descendant the next time any of them is verified, with zero bookkeeping proportional to subtree size.

On top of the base `Auth` protocol (`issue`/`verify`/`revoke`, unchanged signatures), it adds:
- `delegate(parent_token, audience, scopes_subset, ttl) -> Token` — `scopes_subset` must be a **strict** (proper) subset of the parent's scopes (`ScopeEscalationError` otherwise — every hop must shed at least one capability, not just avoid escalating), and `ttl` must land the child's expiry at or before the parent's own (`DelegationTtlError` otherwise, which also naturally rejects delegating from an already-expired parent).
- `verify_presented_by(token, presenter) -> AuthContext` — the audience-aware sibling of `verify()`. The base `Auth.verify(token)` signature can't check *who* presents a token since it only receives the token; this adds that check (`AudienceMismatchError`) on top without breaking the base contract.

## Adversarial validator

`packages/nest-plugins-reference/nest_plugins_reference/validators/auth_delegation_validators.py` ships three checks, each deliberately **plugin-agnostic** — they take async callables the caller builds however that plugin exposes the relevant operation, and only inspect the outcome:

1. `check_scope_escalation_rejected` — attempt to mint/verify an over-scoped child.
2. `check_stale_parent_rejected` — revoke the parent *after* a child already exists, then re-verify the child.
3. `check_audience_confusion_rejected` — present a token as an agent other than its declared audience.

Wired against `JwtAuth` (whose only "delegation" surface is calling `issue()` again, with no parent to compare against and no audience concept at all) all three **fail**. Wired against `DelegatableAuth`'s real `delegate`/`verify`/`verify_presented_by` surface, all three **pass**. The differential proof is in `test_delegatable_auth.py` (`test_*_validator_fails_against_jwt` / `test_*_validator_passes_against_delegatable`, 6 tests total) — the same validator function, run against both plugins, produces the charter's required opposite verdicts.

## Scenario

`scenarios/delegated_auth.yaml` + `packages/nest-core/nest_core/scenarios_builtin/delegation_tree.py`: a strict tree — 1 coordinator → 3 intermediaries → 12 leaves (4 per intermediary). The coordinator issues a root token, delegates a narrower token to each intermediary, which each delegate a further-narrowed token to their 4 leaves. Mid-run, the coordinator revokes **exactly one** intermediary's token; all 4 leaves under that branch fail re-verification with `RevokedAncestorError` while the other 8 keep verifying — without any leaf token ever being revoked directly. The scenario factory pins the plugin's clock to a fixed value (both `DelegatableAuth` and `JwtAuth` accept `clock=`) instead of wall-clock time, so the trace is byte-identical run over run for the same seed.

## Tradeoffs / out of scope

- **Strict tree, not a DAG.** The problem doc explicitly says a strict tree (single parent per token) is sufficient, and it keeps the "recompute every ancestor's digest by replaying the embedded chain" verification model simple — a DAG would need a different revocation-check strategy (e.g. checking all parent chains a token could route through). Out of scope here, as the problem doc allows.
- **"Strict" subset interpretation.** The problem doc's success criteria say scopes must be a "strict subset" of the parent's; I enforce that literally (proper subset — equal scopes are rejected, not just supersets), on the theory that every hop should shed at least one capability. This is called out in the plugin's docstring in case reviewers read "strict" more loosely.
- **Out of scope per the problem doc:** hardware-backed key attestation (TPM/HSM), OAuth2 server endpoints (pure in-process is fine), token introspection over the network. Not attempted.
- **Shared-instance architecture.** Like `JwtAuth`, a single `DelegatableAuth` instance is meant to be shared by every agent in a scenario (mirrors how the existing `_instantiate_plugins` shared-instance pattern works for `registry`/`trust`/`payments`). `delegate()`'s independence from the root secret is a real cryptographic property (verified by `test_delegate_does_not_require_the_root_secret`, using two instances with different secrets), not just an artifact of instance-sharing.

## Verification snippet

Paste into `uv run python -c "..."` (or a Python shell) from the repo root:

```python
import asyncio
from nest_core.types import AgentId
from nest_plugins_reference.auth.delegatable import DelegatableAuth, RevokedAncestorError

async def main():
    auth = DelegatableAuth(secret=b"town-secret", clock=1000.0)

    # Orchestrator issues itself a root capability.
    root = await auth.issue(AgentId("orchestrator"), ["read", "write", "admin"])

    # Orchestrator delegates a narrower, shorter-lived token to a worker --
    # no call back to any issuer, just the root token it already holds.
    worker_token = await auth.delegate(root, AgentId("worker-1"), ["read", "write"], ttl=300.0)
    ctx = await auth.verify_presented_by(worker_token, AgentId("worker-1"))
    print("worker verified with scopes:", ctx.scopes)

    # Worker sub-delegates an even narrower token to a helper.
    helper_token = await auth.delegate(worker_token, AgentId("helper-1"), ["read"], ttl=60.0)
    ctx2 = await auth.verify_presented_by(helper_token, AgentId("helper-1"))
    print("helper verified with scopes:", ctx2.scopes)

    # Revoking the ROOT invalidates the worker AND the helper transitively --
    # neither token's own digest was ever written to the revocation table.
    await auth.revoke(root)
    for label, token in [("worker", worker_token), ("helper", helper_token)]:
        try:
            await auth.verify(token)
            print(f"{label}: still valid (BUG)")
        except RevokedAncestorError as exc:
            print(f"{label}: cascaded correctly -> {exc}")

asyncio.run(main())
```

Expected output:
```
worker verified with scopes: ['read', 'write']
helper verified with scopes: ['read']
worker: cascaded correctly -> ancestor at depth 0 (subject='orchestrator') has been revoked
helper: cascaded correctly -> ancestor at depth 0 (subject='orchestrator') has been revoked
```

## Testing

`packages/nest-plugins-reference/tests/test_delegatable_auth.py` — 31 tests: base `Auth` protocol conformance (round-trip, tamper/malformed/expired/cross-secret rejection), successful multi-level delegation, the three named attacks (scope escalation — including a Hypothesis property test, TTL violation, audience confusion) each individually, cascading revocation (parent → child, grandparent → grandchild without touching the grandchild, sibling-branch-unaffected), the six-test validator differential proof, and full scenario integration (cascading revocation lands on exactly the revoked branch's 4 leaves; byte-identical trace across two runs of the same seed).

Local CI (`uv sync && uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -v`) is green: 976 passed, 1 skipped (pre-existing, unrelated), 1 deselected (`live` marker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
