### PR TITLE
feat: add structured receipt field to Evidence type

### DIFF
--- a/packages/nest-core/nest_core/scenarios_builtin/parc_migration.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/parc_migration.py
@@ -225,7 +225,7 @@ class DomainAAuditor(StateMachineAgent):
                     reporter=self._id,
                     subject=self._id,
                     kind="positive",
-                    detail=json.dumps(receipt),
+                    receipt=receipt,
                 ),
             )
         # The plugin maps AgentId -> receipt did via the same sha256 seed
@@ -308,7 +308,7 @@ class CorruptAuditor(StateMachineAgent):
                     reporter=self._id,
                     subject=self._id,
                     kind="positive",
-                    detail=json.dumps(receipt),
+                    detail=json.dumps(receipt),  # Keep one detail caller as fallback test
                 ),
             )
         vc = await trust.build_credential(

--- a/packages/nest-core/nest_core/scenarios_builtin/receipt_reputation.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/receipt_reputation.py
@@ -220,20 +220,36 @@ class AuditorAgent(StateMachineAgent):
         """Report one receipt to the trust plugin under its issuer.
 
         The ``Evidence`` carries ``kind="positive"`` (so ``score_average``
-        rewards it) and ``detail`` = the JSON receipt (so ``agent_receipts``
-        gates it). ``subject`` is the issuer — the agent the receipt is *about*.
+        rewards it) and ``receipt`` = the structured receipt (so ``agent_receipts``
+        uses the new field). Falls back to ``detail`` for legacy compatibility.
+        ``subject`` is the issuer — the agent the receipt is *about*.
         """
         if self._trust is None:  # pragma: no cover - on_start always runs first
             return
-        await self._trust.report(
-            issuer,
-            Evidence(
-                reporter=self._id,
-                subject=issuer,
-                kind="positive",
-                detail=receipt_json,
-            ),
-        )
+
+        # Parse JSON to use structured receipt field
+        try:
+            receipt_dict = json.loads(receipt_json)
+            await self._trust.report(
+                issuer,
+                Evidence(
+                    reporter=self._id,
+                    subject=issuer,
+                    kind="positive",
+                    receipt=receipt_dict,
+                ),
+            )
+        except (json.JSONDecodeError, TypeError):
+            # Fallback to detail field for malformed JSON
+            await self._trust.report(
+                issuer,
+                Evidence(
+                    reporter=self._id,
+                    subject=issuer,
+                    kind="positive",
+                    detail=receipt_json,
+                ),
+            )
 
     async def _finalize(self, ctx: AgentContext) -> None:
         """Score every agent and emit one ``score:`` trace line per agent."""

--- a/packages/nest-core/nest_core/types.py
+++ b/packages/nest-core/nest_core/types.py
@@ -299,7 +299,7 @@ class Attestation(BaseModel):
 class Evidence(BaseModel):
     """Evidence of misbehavior for trust reporting.
 
-    The ``receipt`` field (added in v0.2.0) carries structured evidence such as
+    The ``receipt`` field carries structured evidence such as
     cross-signed receipts or cryptographic proofs. When present, trust plugins
     prefer it over parsing ``detail`` as JSON. The ``detail`` field remains for
     backward compatibility and plain-text evidence.

--- a/packages/nest-core/nest_core/types.py
+++ b/packages/nest-core/nest_core/types.py
@@ -299,11 +299,24 @@ class Attestation(BaseModel):
 class Evidence(BaseModel):
     """Evidence of misbehavior for trust reporting.
 
+    The ``receipt`` field (added in v0.2.0) carries structured evidence such as
+    cross-signed receipts or cryptographic proofs. When present, trust plugins
+    prefer it over parsing ``detail`` as JSON. The ``detail`` field remains for
+    backward compatibility and plain-text evidence.
+
     Example::
 
+        # Plain text evidence (legacy)
         ev = Evidence(
             reporter=AgentId("a1"), subject=AgentId("a2"),
             kind="byzantine", detail="sent garbage",
+        )
+
+        # Structured receipt evidence (preferred)
+        ev = Evidence(
+            reporter=AgentId("a1"), subject=AgentId("a2"),
+            kind="positive",
+            receipt={"action": "delivered", "signature": "0xabc..."},
         )
     """
 
@@ -311,6 +324,7 @@ class Evidence(BaseModel):
     subject: AgentId
     kind: str
     detail: str = ""
+    receipt: dict[str, Any] | None = None
     timestamp: float | None = None
 
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py
@@ -613,7 +613,9 @@ class AgentReceiptsTrust:
     async def report(self, agent: AgentId, evidence: Evidence) -> None:
         """Report evidence — a cross-signed receipt, or a stock heuristic.
 
-        ``evidence.detail`` is tried as JSON. If it decodes to a dict that passes
+        ``evidence.receipt`` (if present) is used as structured evidence.
+        Otherwise, ``evidence.detail`` is tried as JSON for backward
+        compatibility. If it decodes to a dict that passes
         :func:`_verify_receipt`, it enters the global ledger. A decoded dict that
         fails verification is logged (never silently dropped) and falls through
         to the heuristic. A plain-string ``detail`` (stock scenarios) uses the
@@ -621,9 +623,32 @@ class AgentReceiptsTrust:
 
         Example::
 
-            await trust.report(AgentId("a1"), Evidence(reporter=r, subject=s,
-                kind="positive", detail=json.dumps(receipt)))
+            # Preferred: structured receipt field
+            await trust.report(AgentId("a1"), Evidence(
+                reporter=r, subject=s, kind="positive",
+                receipt={"action": "delivered", "signature": "0xabc..."}
+            ))
+
+            # Legacy: JSON in detail field (still supported)
+            await trust.report(AgentId("a1"), Evidence(
+                reporter=r, subject=s, kind="positive",
+                detail=json.dumps(receipt)
+            ))
         """
+        # Prefer structured receipt field
+        if evidence.receipt is not None:
+            if _verify_receipt(evidence.receipt):
+                self._ledger.append(evidence.receipt)
+                return
+            logger.warning(
+                "report: receipt field present but failed verification "
+                "for agent=%s; using heuristic fallback",
+                agent,
+            )
+            self._record_fallback(agent, evidence)
+            return
+
+        # Fallback: try parsing detail as JSON (backward compatibility)
         try:
             parsed: object = json.loads(evidence.detail)
         except (json.JSONDecodeError, TypeError):

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py
@@ -35,9 +35,10 @@ This is **self-contained**: it depends only on the standard library and
 Receipts are plain ``dict`` documents; canonicalization is sorted-key JSON; an
 agent's identity is the lowercase hex of its raw 32-byte Ed25519 public key.
 
-NEST's ``Evidence`` has no receipt field, so a cross-signed receipt rides as
-JSON in ``evidence.detail``. Stock scenarios (e.g. the marketplace) pass a
-plain-string ``detail``; those fall back to the reference score-average
+NEST's ``Evidence`` supports a structured ``receipt`` field for cross-signed receipts,
+with fallback to parsing JSON from ``evidence.detail`` for backward compatibility.
+Structured receipts are preferred when available; stock scenarios (e.g. the marketplace)
+that pass plain-string ``detail`` fall back to the reference score-average
 heuristic so this plugin still works as a drop-in ``trust:`` replacement.
 
 Registered under ``("trust", "agent_receipts")`` in ``nest_core.plugins``.
@@ -45,6 +46,14 @@ Registered under ``("trust", "agent_receipts")`` in ``nest_core.plugins``.
 Example::
 
     trust = AgentReceiptsTrust()
+
+    # Preferred: structured receipt field
+    await trust.report(
+        AgentId("a1"),
+        Evidence(reporter=r, subject=s, kind="positive", receipt=receipt_dict),
+    )
+
+    # Legacy: JSON in detail field (still supported)
     await trust.report(
         AgentId("a1"),
         Evidence(reporter=r, subject=s, kind="positive", detail=json.dumps(receipt)),

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/agent_receipts.py
@@ -640,6 +640,11 @@ class AgentReceiptsTrust:
             if _verify_receipt(evidence.receipt):
                 self._ledger.append(evidence.receipt)
                 return
+            # Receipt present but failed verification. Use heuristic fallback
+            # rather than trying detail field — if caller provided receipt,
+            # falling back to detail would be a security downgrade (accept
+            # potentially malicious unverified data when verified data was
+            # explicitly provided but invalid).
             logger.warning(
                 "report: receipt field present but failed verification "
                 "for agent=%s; using heuristic fallback",

--- a/packages/nest-plugins-reference/tests/test_plugins.py
+++ b/packages/nest-plugins-reference/tests/test_plugins.py
@@ -520,3 +520,172 @@ class TestDataFactsV1:
         df = DataFactsV1()
         with pytest.raises(KeyError):
             await df.fetch(DataFactsUrl("df://missing"))
+
+
+# ---------------------------------------------------------------------------
+# Trust: agent_receipts (structured receipt field tests)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentReceiptsStructuredReceipt:
+    """Tests for Evidence.receipt field in agent_receipts plugin.
+
+    These tests verify the new structured receipt field works alongside
+    the legacy detail-as-JSON path. Tests use the heuristic fallback
+    (invalid receipts) to verify the code paths, not cryptographic validity.
+    """
+
+    @pytest.mark.asyncio
+    async def test_structured_receipt_field_present_invalid_fallback(self) -> None:
+        """Invalid receipt in structured field falls back to heuristic."""
+        from nest_plugins_reference.trust.agent_receipts import AgentReceiptsTrust
+
+        trust = AgentReceiptsTrust()
+        agent = AgentId("agent-1")
+
+        # Invalid receipt (will fail verification, use heuristic)
+        # This tests that the structured field is being READ
+        invalid_receipt = {
+            "receipt_id": "r1",
+            # Missing required issuer_did, action, signature
+        }
+
+        evidence = Evidence(
+            reporter=AgentId("reporter"),
+            subject=agent,
+            kind="positive",
+            receipt=invalid_receipt,
+        )
+
+        await trust.report(agent, evidence)
+
+        # Should fall back to heuristic (kind="positive" -> score 1.0)
+        score_obj = await trust.score(agent)
+        assert score_obj.score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_structured_receipt_preferred_over_detail(self) -> None:
+        """When both receipt and detail present, receipt field is checked first."""
+        import json
+
+        from nest_plugins_reference.trust.agent_receipts import AgentReceiptsTrust
+
+        trust = AgentReceiptsTrust()
+        agent = AgentId("agent-2")
+
+        # Both fields present - receipt should be tried first
+        # (both invalid, will use heuristic, but logs show which was tried)
+        receipt_field = {"receipt_id": "structured"}
+        detail_json = {"receipt_id": "detail"}
+
+        evidence = Evidence(
+            reporter=AgentId("reporter"),
+            subject=agent,
+            kind="positive",
+            receipt=receipt_field,
+            detail=json.dumps(detail_json),
+        )
+
+        await trust.report(agent, evidence)
+
+        # Should use heuristic from kind="positive"
+        score_obj = await trust.score(agent)
+        assert score_obj.score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_none_receipt_uses_detail_path(self) -> None:
+        """When receipt is None, falls back to detail field."""
+        import json
+
+        from nest_plugins_reference.trust.agent_receipts import AgentReceiptsTrust
+
+        trust = AgentReceiptsTrust()
+        agent = AgentId("agent-3")
+
+        # Invalid receipt in detail (will use heuristic)
+        receipt = {"receipt_id": "r3"}
+
+        evidence = Evidence(
+            reporter=AgentId("reporter"),
+            subject=agent,
+            kind="positive",
+            receipt=None,  # Explicitly None
+            detail=json.dumps(receipt),
+        )
+
+        await trust.report(agent, evidence)
+
+        # Should use detail path, then fall back to heuristic
+        score_obj = await trust.score(agent)
+        assert score_obj.score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_plain_text_detail_still_works(self) -> None:
+        """Plain text in detail field (no receipt) still uses heuristic."""
+        from nest_plugins_reference.trust.agent_receipts import AgentReceiptsTrust
+
+        trust = AgentReceiptsTrust()
+        agent = AgentId("agent-4")
+
+        # Plain text evidence (no receipt, no JSON in detail)
+        evidence = Evidence(
+            reporter=AgentId("reporter"),
+            subject=agent,
+            kind="negative",
+            detail="agent misbehaved",
+            receipt=None,
+        )
+
+        await trust.report(agent, evidence)
+
+        # Should use heuristic (kind="negative" -> score 0.0)
+        score_obj = await trust.score(agent)
+        assert score_obj.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_empty_detail_and_receipt_uses_heuristic(self) -> None:
+        """When both receipt and detail are empty, uses kind-based heuristic."""
+        from nest_plugins_reference.trust.agent_receipts import AgentReceiptsTrust
+
+        trust = AgentReceiptsTrust()
+        agent = AgentId("agent-5")
+
+        evidence = Evidence(
+            reporter=AgentId("reporter"),
+            subject=agent,
+            kind="positive",
+            detail="",
+            receipt=None,
+        )
+
+        await trust.report(agent, evidence)
+
+        # Should use heuristic (kind="positive" -> score 1.0)
+        score_obj = await trust.score(agent)
+        assert score_obj.score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_receipt_field_backward_compatible(self) -> None:
+        """Evidence without receipt field (old code) still works."""
+        from nest_plugins_reference.trust.agent_receipts import AgentReceiptsTrust
+
+        trust = AgentReceiptsTrust()
+        agent = AgentId("agent-6")
+
+        # Create Evidence the old way (no receipt kwarg)
+        # This ensures backward compatibility
+        evidence = Evidence(
+            reporter=AgentId("reporter"),
+            subject=agent,
+            kind="byzantine",
+            detail="malicious behavior",
+        )
+
+        # receipt field defaults to None (backward compatible)
+        assert evidence.receipt is None
+
+        await trust.report(agent, evidence)
+
+        # Should use heuristic (kind="byzantine" -> score 0.0)
+        score_obj = await trust.score(agent)
+        assert score_obj.score == 0.0

--- a/packages/nest-plugins-reference/tests/test_plugins.py
+++ b/packages/nest-plugins-reference/tests/test_plugins.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from nest_core.types import (
     AgentCard,
@@ -531,20 +533,149 @@ class TestAgentReceiptsStructuredReceipt:
     """Tests for Evidence.receipt field in agent_receipts plugin.
 
     These tests verify the new structured receipt field works alongside
-    the legacy detail-as-JSON path. Tests use the heuristic fallback
-    (invalid receipts) to verify the code paths, not cryptographic validity.
+    the legacy detail-as-JSON path. Uses valid receipts with proper signatures
+    to test the actual receipt processing code path.
     """
 
+    def _seed(self, name: str) -> bytes:
+        """Deterministic 32-byte Ed25519 seed for an agent."""
+        import hashlib
+
+        return hashlib.sha256(name.encode()).digest()[:32]
+
+    def _did(self, name: str) -> str:
+        """The receipt identity (hex pubkey) for an agent."""
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+        from nest_plugins_reference.trust.agent_receipts import did_for_pubkey
+
+        sk = Ed25519PrivateKey.from_private_bytes(self._seed(name))
+        return did_for_pubkey(sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw))
+
+    def _receipt(
+        self, issuer: str, cp: str, *, rid: str, category: str = "purchase"
+    ) -> dict[str, Any]:
+        """Build a signed receipt."""
+        from nest_plugins_reference.trust.agent_receipts import sign_receipt
+
+        r: dict[str, Any] = {
+            "receipt_id": rid,
+            "issuer_did": self._did(issuer),
+            "action": {"category": category, "counterparty_did": self._did(cp)},
+        }
+        return sign_receipt(r, issuer_seed=self._seed(issuer))
+
+    def _corroborated(
+        self, issuer: str, cp: str, *, rid: str, category: str = "purchase"
+    ) -> dict[str, Any]:
+        """Build a corroborated (cosigned) receipt."""
+        from nest_plugins_reference.trust.agent_receipts import cosign_receipt
+
+        return cosign_receipt(
+            self._receipt(issuer, cp, rid=rid, category=category),
+            counterparty_seed=self._seed(cp),
+        )
+
     @pytest.mark.asyncio
-    async def test_structured_receipt_field_present_invalid_fallback(self) -> None:
-        """Invalid receipt in structured field falls back to heuristic."""
+    async def test_structured_receipt_field_with_valid_receipt(self) -> None:
+        """Valid receipt in structured field is processed properly."""
         from nest_plugins_reference.trust.agent_receipts import AgentReceiptsTrust
 
         trust = AgentReceiptsTrust()
         agent = AgentId("agent-1")
 
+        # Create a valid, corroborated receipt using the helper functions
+        valid_receipt = self._corroborated("agent-1", "agent-2", rid="r1", category="purchase")
+
+        evidence = Evidence(
+            reporter=AgentId("reporter"),
+            subject=agent,
+            kind="positive",
+            receipt=valid_receipt,
+        )
+
+        await trust.report(agent, evidence)
+
+        # Should process the valid receipt (not use heuristic)
+        score_obj = await trust.score(agent)
+        assert score_obj.score > 0.0  # Non-zero score from receipt processing
+        assert score_obj.sample_count == 1
+        assert score_obj.confidence > 0.0
+
+    @pytest.mark.asyncio
+    async def test_structured_receipt_preferred_over_detail(self) -> None:
+        """When both receipt and detail present, valid receipt field takes precedence."""
+        import json
+
+        from nest_plugins_reference.trust.agent_receipts import AgentReceiptsTrust
+
+        trust = AgentReceiptsTrust()
+        agent = AgentId("agent-2")
+
+        # Valid receipt in receipt field, invalid detail - receipt should be used
+        valid_receipt = self._corroborated("agent-2", "agent-3", rid="r2", category="purchase")
+        invalid_detail_json = {"receipt_id": "invalid-detail"}
+
+        evidence = Evidence(
+            reporter=AgentId("reporter"),
+            subject=agent,
+            kind="positive",
+            receipt=valid_receipt,
+            detail=json.dumps(invalid_detail_json),
+        )
+
+        await trust.report(agent, evidence)
+
+        # Should use valid receipt (not invalid detail)
+        score_obj = await trust.score(agent)
+        assert score_obj.score > 0.0  # From valid receipt processing
+        assert score_obj.sample_count == 1
+        assert score_obj.confidence > 0.0
+
+    @pytest.mark.asyncio
+    async def test_receipt_ordering_with_discriminating_test(self) -> None:
+        """Receipt field wins over detail when both present (discriminating test)."""
+        import json
+
+        from nest_plugins_reference.trust.agent_receipts import AgentReceiptsTrust
+
+        trust = AgentReceiptsTrust()
+        agent = AgentId("agent-order")
+
+        # Valid receipt in receipt field
+        valid_receipt = self._corroborated(
+            "agent-order", "agent-other", rid="rvalid", category="purchase"
+        )
+
+        # Invalid detail (will fallback to heuristic if used)
+        invalid_detail = {"receipt_id": "invalid", "missing": "fields"}
+
+        evidence = Evidence(
+            reporter=AgentId("reporter"),
+            subject=agent,
+            kind="negative",  # Negative kind for heuristic fallback
+            receipt=valid_receipt,  # Valid receipt
+            detail=json.dumps(invalid_detail),  # Invalid detail
+        )
+
+        await trust.report(agent, evidence)
+
+        # If receipt field was used: score > 0 from valid receipt processing
+        # If detail was used: score = 0 from negative heuristic fallback
+        score_obj = await trust.score(agent)
+        assert score_obj.score > 0.0  # Proves receipt field was used, not detail
+        assert score_obj.sample_count == 1
+        assert score_obj.confidence > 0.0
+
+    @pytest.mark.asyncio
+    async def test_structured_receipt_field_invalid_fallback(self) -> None:
+        """Invalid receipt in structured field falls back to heuristic."""
+        from nest_plugins_reference.trust.agent_receipts import AgentReceiptsTrust
+
+        trust = AgentReceiptsTrust()
+        agent = AgentId("agent-fallback")
+
         # Invalid receipt (will fail verification, use heuristic)
-        # This tests that the structured field is being READ
         invalid_receipt = {
             "receipt_id": "r1",
             # Missing required issuer_did, action, signature
@@ -564,37 +695,8 @@ class TestAgentReceiptsStructuredReceipt:
         assert score_obj.score == 1.0
 
     @pytest.mark.asyncio
-    async def test_structured_receipt_preferred_over_detail(self) -> None:
-        """When both receipt and detail present, receipt field is checked first."""
-        import json
-
-        from nest_plugins_reference.trust.agent_receipts import AgentReceiptsTrust
-
-        trust = AgentReceiptsTrust()
-        agent = AgentId("agent-2")
-
-        # Both fields present - receipt should be tried first
-        # (both invalid, will use heuristic, but logs show which was tried)
-        receipt_field = {"receipt_id": "structured"}
-        detail_json = {"receipt_id": "detail"}
-
-        evidence = Evidence(
-            reporter=AgentId("reporter"),
-            subject=agent,
-            kind="positive",
-            receipt=receipt_field,
-            detail=json.dumps(detail_json),
-        )
-
-        await trust.report(agent, evidence)
-
-        # Should use heuristic from kind="positive"
-        score_obj = await trust.score(agent)
-        assert score_obj.score == 1.0
-
-    @pytest.mark.asyncio
     async def test_none_receipt_uses_detail_path(self) -> None:
-        """When receipt is None, falls back to detail field."""
+        """When receipt is None, falls back to detail field with valid receipt."""
         import json
 
         from nest_plugins_reference.trust.agent_receipts import AgentReceiptsTrust
@@ -602,22 +704,24 @@ class TestAgentReceiptsStructuredReceipt:
         trust = AgentReceiptsTrust()
         agent = AgentId("agent-3")
 
-        # Invalid receipt in detail (will use heuristic)
-        receipt = {"receipt_id": "r3"}
+        # Valid receipt in detail JSON (legacy path)
+        valid_receipt = self._corroborated("agent-3", "agent-4", rid="r3", category="purchase")
 
         evidence = Evidence(
             reporter=AgentId("reporter"),
             subject=agent,
             kind="positive",
             receipt=None,  # Explicitly None
-            detail=json.dumps(receipt),
+            detail=json.dumps(valid_receipt),
         )
 
         await trust.report(agent, evidence)
 
-        # Should use detail path, then fall back to heuristic
+        # Should use detail path successfully
         score_obj = await trust.score(agent)
-        assert score_obj.score == 1.0
+        assert score_obj.score > 0.0  # From valid receipt processing
+        assert score_obj.sample_count == 1
+        assert score_obj.confidence > 0.0
 
     @pytest.mark.asyncio
     async def test_plain_text_detail_still_works(self) -> None:


### PR DESCRIPTION
 feat: add structured receipt field to Evidence type

Fixes #64

Problem: Evidence type had no structured payload field for receipts.
Trust plugins (agent_receipts, parc) were forced to smuggle receipts
as JSON strings in the 'detail' field, requiring every consumer to
try-parse and handle decode failures.

Solution: Add optional 'receipt: dict[str, Any] | None' field to Evidence.
- Backward compatible: defaults to None, existing code unchanged
- agent_receipts now prefers receipt field over detail JSON parsing
- Falls back to detail field for legacy Evidence objects
- Plain text detail still works (heuristic path)

Changes:
- nest_core/types.py: Added receipt field with documentation
- agent_receipts.py: Updated report() to check receipt field first
- test_plugins.py: Added 8 tests covering all code paths:
  * Structured receipt field with valid receipts (new path)
  * Receipt preferred over detail when both present
  * Discriminating test proving field ordering
  * None receipt falls back to detail
  * Plain text detail still works
  * Empty fields use heuristic
  * Backward compatibility verified

---

## Submission Statement

**This is my primary NandaHack Phase 1 submission.**

PR #129 (Reputation Validator Fix) is a supplementary bug fix for issue #98 that I'm contributing alongside this main submission.

---

## Reviewer Feedback Addressed

All 4 points from the initial review have been addressed:

1. ✅ **Valid receipt tests**: Added 8 comprehensive tests using `_receipt()` and `_corroborated()` helpers. Tests verify actual receipt processing (score > 0) vs heuristic fallback.

2. ✅ **Scenarios updated**: 
   - `parc_migration.py` line 228: uses `receipt=receipt`
   - `parc_migration.py` line 311: kept `detail=json.dumps(receipt)` as fallback test
   - `receipt_reputation.py`: uses `receipt=receipt_dict`

3. ✅ **Documentation fixed**:
   - Updated `agent_receipts.py` module docstring (removed "has no receipt field")
   - Removed v0.2.0 version claim from Evidence docstring
   - Added examples for both structured and legacy usage

4. ✅ **CI verified**: All checks pass

---
 ## CI Output

``` 
make ci-local

All checks passed!
===== 1158 passed, 1 skipped, 1 deselected, 1 warning in 97.94s (0:01:37) =====
ci-local: all 5 checks passed. Safe to push.
```