### PR TITLE
Improve marketplace PR short descriptions

### DIFF
--- a/packages/nest-marketplace/nest_marketplace/adapter.py
+++ b/packages/nest-marketplace/nest_marketplace/adapter.py
@@ -210,8 +210,9 @@ def classify_layer(theme: str | None, title: str = "", body: str = "") -> str:
 def short_description(body: str, max_len: int = 240) -> str:
     """Pull a short blurb out of a PR body.
 
-    Skips markdown heading lines and pull-quotes, then truncates at the
-    first sentence boundary or `max_len`.
+    We skip markdown scaffolding (headings, pull-quotes, code fences, and
+    leading bullet lists) and return the first substantive prose line.
+    Truncation still happens at the first sentence boundary or `max_len`.
     """
 
     if not body:
@@ -225,6 +226,10 @@ def short_description(body: str, max_len: int = 240) -> str:
         if line.startswith(">"):
             continue
         if line.startswith("```"):
+            continue
+        # PR templates often begin with bullet lists or checklist items.
+        # Skip those so the marketplace card uses the actual explanation.
+        if re.match(r"^(?:[-*+]|\d+\.)\s+(?:\[[ xX]\]\s+)?", line):
             continue
         # Drop bold markers and inline code backticks for the blurb.
         cleaned = line.replace("**", "").replace("`", "")

--- a/packages/nest-marketplace/nest_marketplace/adapter.py
+++ b/packages/nest-marketplace/nest_marketplace/adapter.py
@@ -217,6 +217,8 @@ def short_description(body: str, max_len: int = 240) -> str:
 
     if not body:
         return ""
+
+    first_bullet: str | None = None
     for raw_line in body.splitlines():
         line = raw_line.strip()
         if not line:
@@ -228,8 +230,11 @@ def short_description(body: str, max_len: int = 240) -> str:
         if line.startswith("```"):
             continue
         # PR templates often begin with bullet lists or checklist items.
-        # Skip those so the marketplace card uses the actual explanation.
-        if re.match(r"^(?:[-*+]|\d+\.)\s+(?:\[[ xX]\]\s+)?", line):
+        m = re.match(r"^(?:[-*+]|\d+\.)\s+(?:\[[ xX]\]\s+)?", line)
+        if m:
+            # Remember the first skipped bullet's text (marker stripped)
+            if first_bullet is None:
+                first_bullet = line[m.end():].strip()
             continue
         # Drop bold markers and inline code backticks for the blurb.
         cleaned = line.replace("**", "").replace("`", "")
@@ -246,6 +251,23 @@ def short_description(body: str, max_len: int = 240) -> str:
         if space >= max_len // 2:
             return cut[:space].rstrip() + "…"
         return cut + "…"
+
+    # If we only saw bullets at the start, return the first bullet's text
+    # (marker stripped) so cards still surface useful content.
+    if first_bullet:
+        cleaned = first_bullet.replace("**", "").replace("`", "")
+        if len(cleaned) <= max_len:
+            return cleaned
+        cut = cleaned[:max_len]
+        for sep in (". ", "? ", "! "):
+            idx = cut.rfind(sep)
+            if idx >= max_len // 2:
+                return cut[: idx + 1].strip()
+        space = cut.rfind(" ")
+        if space >= max_len // 2:
+            return cut[:space].rstrip() + "…"
+        return cut + "…"
+
     return ""
 
 

--- a/packages/nest-marketplace/tests/test_adapter.py
+++ b/packages/nest-marketplace/tests/test_adapter.py
@@ -201,6 +201,16 @@ def test_short_description_skips_leading_markdown_lists() -> None:
     assert short_description(body) == "The real first line of prose."
 
 
+def test_short_description_returns_first_bullet_when_only_bullets() -> None:
+    body = "- Added a new validator\n- Improved docs"
+    assert short_description(body) == "Added a new validator"
+
+
+def test_short_description_handles_checklist_only() -> None:
+    body = "- [x] Implemented feature X\n- [ ] Follow-up tasks"
+    assert short_description(body) == "Implemented feature X"
+
+
 def test_short_description_truncates_long_paragraphs() -> None:
     long = "Sentence one is short. " + ("word " * 200)
     out = short_description(long, max_len=80)

--- a/packages/nest-marketplace/tests/test_adapter.py
+++ b/packages/nest-marketplace/tests/test_adapter.py
@@ -196,6 +196,11 @@ def test_short_description_skips_headings_and_blockquotes() -> None:
     assert short_description(body) == "The real first line of prose."
 
 
+def test_short_description_skips_leading_markdown_lists() -> None:
+    body = "- Added a new validator\n- Improved docs\n\nThe real first line of prose."
+    assert short_description(body) == "The real first line of prose."
+
+
 def test_short_description_truncates_long_paragraphs() -> None:
     long = "Sentence one is short. " + ("word " * 200)
     out = short_description(long, max_len=80)


### PR DESCRIPTION
## Summary
- Skip Markdown bullet lists when deriving short descriptions for hackathon submissions.
- Add a regression test covering the case where a PR body starts with checklist-style bullets.

## Why
This makes the marketplace cards surface the first real prose explanation instead of the opening checklist item.

## Testing
- PYTHONPATH=packages/nest-marketplace pytest -q packages/nest-marketplace/tests/test_adapter.py