### PR TITLE
[Hackathon] settlement-engineer: split_settlement — weighted multi-payee fan-out settlement with conservation-proof validators

### DIFF
--- a/docs/layers/payments.md
+++ b/docs/layers/payments.md
@@ -48,11 +48,15 @@ callers keep working. Where `escrow` conditions one payee's payout and
 once — the missing shape for marketplace revenue splits, royalty payouts, and
 contributor rev-share. The bundled `split_settlement` scenario (12 agents: a
 content marketplace splitting buyer payments 80/20 across contributors and a
-platform) runs under two adversarial validators the default `prepaid_credits`
+platform) runs under three adversarial validators the default `prepaid_credits`
 plugin cannot satisfy: `split_conservation` catches **penny-shaving** (a splitter
-that floors every share and pockets the dust) and `split_weight_fidelity`
+that floors every share and pockets the dust), `split_weight_fidelity`
 recomputes the canonical allocation independently to catch **weight tampering**
-(a mid-flight reweight or self-dealing that still sums to the amount). Source:
+(a mid-flight reweight or self-dealing that still sums to the amount), and
+`split_ledger_attestation` catches **ledger skimming** (canonical-looking
+receipts that credit the shared ledger short) by cross-checking the payer's
+receipts against each payee's own `split:observed` balance attestation. The first
+two audit reported receipts; the third audits payee-observed ledger truth. Source:
 [`nest_plugins_reference/payments/split_settlement.py`](../../packages/nest-plugins-reference/nest_plugins_reference/payments/split_settlement.py).
 
 ## Writing your own

--- a/docs/layers/payments.md
+++ b/docs/layers/payments.md
@@ -36,6 +36,25 @@ provider / service binding by payment reference and reject traces that leak
 private keys, API keys, bearer tokens, wallet secrets, or other live rail
 secrets.
 
+`split_settlement` — weighted multi-payee **fan-out settlement**. One atomic
+debit from a payer is split across *N* payees by integer weights declared and
+locked when the contract is opened. Allocation uses the largest-remainder
+(Hamilton) method over integer credits, so every settlement conserves value
+exactly (`sum(allocations) == amount`) and is deterministic — the indivisible
+dust goes to the payees with the largest fractional parts, ties broken by payee
+id. A plain `pay()` is the degenerate single-payee, weight-1 split, so one-shot
+callers keep working. Where `escrow` conditions one payee's payout and
+`streaming` meters one payee per tick, this splits one debit across many at
+once — the missing shape for marketplace revenue splits, royalty payouts, and
+contributor rev-share. The bundled `split_settlement` scenario (12 agents: a
+content marketplace splitting buyer payments 80/20 across contributors and a
+platform) runs under two adversarial validators the default `prepaid_credits`
+plugin cannot satisfy: `split_conservation` catches **penny-shaving** (a splitter
+that floors every share and pockets the dust) and `split_weight_fidelity`
+recomputes the canonical allocation independently to catch **weight tampering**
+(a mid-flight reweight or self-dealing that still sums to the amount). Source:
+[`nest_plugins_reference/payments/split_settlement.py`](../../packages/nest-plugins-reference/nest_plugins_reference/payments/split_settlement.py).
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md) — the full

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -42,6 +42,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
     ("payments", "empic_escrow"): f"{_REF}.payments.empic_escrow:EMPICEscrowPayments",
     ("payments", "escrow"): f"{_REF}.payments.escrow:EscrowPayments",
+    ("payments", "split_settlement"): f"{_REF}.payments.split_settlement:SplitSettlement",
     ("coordination", "contract_net"): f"{_REF}.coordination.contract_net:ContractNet",
     ("coordination", "hotstuff"): f"{_REF}.coordination.hotstuff:HotStuff",
     ("negotiation", "alternating_offers"): (

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -197,3 +197,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("capability_spoofing", capability_spoofing_factory)
+    elif name == "split_settlement":
+        from nest_core.scenarios_builtin.split_settlement import (
+            split_settlement_factory,
+        )
+
+        register_scenario("split_settlement", split_settlement_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/split_settlement.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/split_settlement.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Split-settlement scenario -- a content marketplace with revenue sharing.
+
+Twelve agents: three buyers, eight contributors, and one platform.  Each buyer
+runs several rounds; every round pays for a content bundle and fans the payment
+out 80/20 -- 80% shared between two contributors, 20% to the platform -- through
+the ``split_settlement`` plugin.  For every settlement the buyer broadcasts two
+structured events the validators read:
+
+* ``split:opened:ref=..:payer=..:weights=payee~weight;...`` -- the *declared*
+  weights, locked at open time;
+* ``split:settled:ref=..:amount=..:alloc=payee~credit;...`` -- the *actual*
+  per-payee credits the plugin produced.
+
+The two ``split_settlement`` validators cross-check those broadcasts: credits
+must sum to the amount (no penny-shaving) and must equal the largest-remainder
+allocation of the declared weights (no weight tampering).  The round amounts are
+deliberately indivisible by the weight total (``777``, ``1001``) so the dust
+distribution -- the exact place a naive splitter leaks value -- is exercised in
+the trace itself.
+
+If the configured payments plugin lacks ``open_split`` (e.g. the default
+``prepaid_credits``), each buyer falls back to a single ``pay()`` and emits no
+``split:*`` events, which the validators report as "no split lifecycle observed"
+-- the adversarial discrimination the charter requires.
+
+Example::
+
+    agents = split_settlement_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Money, PaymentRef
+
+_PLATFORM = AgentId("platform-0")
+_CONTRIB_BPS = 40  # each of the two contributors: 40 + 40 = 80% to contributors
+_PLATFORM_BPS = 20  # 20% to the platform
+_BUYER_BALANCE = 5000
+
+
+@dataclass
+class _Job:
+    """One round's settlement: the ref, the locked weights, and the amount."""
+
+    buyer: AgentId
+    ref: PaymentRef
+    payees: tuple[tuple[AgentId, int], ...]
+    amount: int
+
+
+def _split(c1: str, c2: str) -> tuple[tuple[AgentId, int], ...]:
+    """Build an 80/20 weight vector: two contributors plus the platform."""
+    return (
+        (AgentId(c1), _CONTRIB_BPS),
+        (AgentId(c2), _CONTRIB_BPS),
+        (_PLATFORM, _PLATFORM_BPS),
+    )
+
+
+# buyer -> list of (contributor_a, contributor_b, amount) per round. Amounts mix
+# an evenly divisible case (1000) with two indivisible cases (777 -> two dust
+# units split across the contributors, 1001 -> one dust unit that a stable
+# tie-break must award to the lexicographically smaller contributor).
+_PLAN: dict[str, list[tuple[str, str, int]]] = {
+    "buyer-0": [
+        ("contrib-0", "contrib-1", 1000),
+        ("contrib-2", "contrib-3", 777),
+        ("contrib-4", "contrib-5", 1001),
+    ],
+    "buyer-1": [
+        ("contrib-6", "contrib-7", 1000),
+        ("contrib-0", "contrib-2", 777),
+        ("contrib-4", "contrib-6", 1001),
+    ],
+    "buyer-2": [
+        ("contrib-1", "contrib-3", 1000),
+        ("contrib-5", "contrib-7", 777),
+        ("contrib-0", "contrib-1", 1001),
+    ],
+}
+
+
+def _emit_opened(job: _Job) -> bytes:
+    """Serialize the declared weights as a ``split:opened`` broadcast payload."""
+    weights = ";".join(f"{payee}~{weight}" for payee, weight in job.payees)
+    return f"split:opened:ref={job.ref}:payer={job.buyer}:weights={weights}".encode()
+
+
+def _emit_settled(ref: PaymentRef, amount: int, allocations: list[tuple[str, int]]) -> bytes:
+    """Serialize the actual per-payee credits as a ``split:settled`` broadcast."""
+    alloc = ";".join(f"{payee}~{credit}" for payee, credit in allocations)
+    return f"split:settled:ref={ref}:amount={amount}:alloc={alloc}".encode()
+
+
+class BuyerAgent(StateMachineAgent):
+    """Pays for content each round and fans the payment out 80/20.
+
+    Owns the payer-side ``split_settlement`` instance; contributors and the
+    platform are passive credit sinks sharing the same ledger.
+
+    Example::
+
+        agent = BuyerAgent(AgentId("buyer-0"), jobs=[])
+    """
+
+    def __init__(self, agent_id: AgentId, jobs: list[_Job]) -> None:
+        self._id = agent_id
+        self._jobs = jobs
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        for index in range(len(self._jobs)):
+            await ctx.schedule(float(index + 1), f"run:{index}".encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        text = payload.decode("utf-8", errors="replace")
+        if not text.startswith("run:"):
+            return
+        job = self._jobs[int(text.split(":", 1)[1])]
+        payments = ctx.plugins["payments"]
+        if not hasattr(payments, "open_split"):
+            # Reference plugin without fan-out: settle to the lead contributor with
+            # a plain pay() and emit no split:* events, which the validators flag.
+            await payments.pay(job.payees[0][0], Money(amount=job.amount), job.ref)
+            return
+        await payments.open_split(job.payees, job.ref)
+        await ctx.broadcast(_emit_opened(job))
+        receipts = await payments.settle_split(job.ref, Money(amount=job.amount))
+        allocations = [(str(r.payee), int(r.amount.amount)) for r in receipts]
+        await ctx.broadcast(_emit_settled(job.ref, job.amount, allocations))
+
+
+def split_settlement_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Build the 12 agents and give every buyer a payer instance on one ledger.
+
+    The three buyers share a single ``balances`` + ``contracts`` ledger, so
+    conservation is a whole-marketplace property, not a per-buyer one.
+    Contributors and the platform are passive: they never call the plugin, they
+    only receive credits, so they need no instance of their own.
+
+    Example::
+
+        agents = split_settlement_factory(config, plugins)
+    """
+    payments_cls = plugins["payments"]
+    shared_balances: dict[AgentId, int] = {}
+    shared_contracts: dict[PaymentRef, Any] = {}
+
+    def _buyer_instance(agent_id: AgentId) -> Any:
+        try:
+            return payments_cls(
+                agent_id,
+                initial_balance=_BUYER_BALANCE,
+                balances=shared_balances,
+                contracts=shared_contracts,
+            )
+        except TypeError:
+            # Reference plugins (e.g. prepaid_credits) take ``payments`` not
+            # ``contracts``; fall back so the discrimination run still boots.
+            try:
+                return payments_cls(
+                    agent_id,
+                    initial_balance=_BUYER_BALANCE,
+                    balances=shared_balances,
+                )
+            except TypeError:
+                return payments_cls(agent_id, initial_balance=_BUYER_BALANCE)
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    overrides: dict[AgentId, dict[str, Any]] = {}
+
+    for buyer_name, rounds in _PLAN.items():
+        buyer_id = AgentId(buyer_name)
+        jobs = [
+            _Job(
+                buyer=buyer_id,
+                ref=PaymentRef(f"{buyer_name}-r{index}"),
+                payees=_split(c1, c2),
+                amount=amount,
+            )
+            for index, (c1, c2, amount) in enumerate(rounds)
+        ]
+        agents[buyer_id] = BuyerAgent(buyer_id, jobs)
+        overrides[buyer_id] = {"payments": _buyer_instance(buyer_id)}
+
+    for index in range(8):
+        agents[AgentId(f"contrib-{index}")] = StateMachineAgent()
+    agents[_PLATFORM] = StateMachineAgent()
+
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/split_settlement.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/split_settlement.py
@@ -5,19 +5,35 @@ Twelve agents: three buyers, eight contributors, and one platform.  Each buyer
 runs several rounds; every round pays for a content bundle and fans the payment
 out 80/20 -- 80% shared between two contributors, 20% to the platform -- through
 the ``split_settlement`` plugin.  For every settlement the buyer broadcasts two
-structured events the validators read:
+payer-side structured events the validators read:
 
 * ``split:opened:ref=..:payer=..:weights=payee~weight;...`` -- the *declared*
   weights, locked at open time;
 * ``split:settled:ref=..:amount=..:alloc=payee~credit;...`` -- the *actual*
-  per-payee credits the plugin produced.
+  per-payee credits the plugin *reported* in its receipts.
 
-The two ``split_settlement`` validators cross-check those broadcasts: credits
-must sum to the amount (no penny-shaving) and must equal the largest-remainder
-allocation of the declared weights (no weight tampering).  The round amounts are
-deliberately indivisible by the weight total (``777``, ``1001``) so the dust
-distribution -- the exact place a naive splitter leaks value -- is exercised in
-the trace itself.
+Both of those are the payer's own account of what happened.  So each payee is a
+separate agent holding a *read-only view* of the shared ledger, and after every
+settlement it observes it broadcasts a third, payee-side event:
+
+* ``split:observed:ref=..:payee=..:balance=..`` -- the payee's *current
+  shared-ledger balance*, the ground truth the payer cannot forge.
+
+The three ``split_settlement`` validators cross-check those broadcasts: credits
+must sum to the amount (no penny-shaving), must equal the largest-remainder
+allocation of the declared weights (no weight tampering), and each payee's
+attested balance *delta* between consecutive settlements must equal the credit
+the payer reported to it (no ledger skimming behind honest-looking receipts).
+The round amounts are deliberately indivisible by the weight total (``777``,
+``1001``) so the dust distribution -- the exact place a naive splitter leaks
+value -- is exercised in the trace itself.
+
+Settlements are scheduled one-per-tick (each ``(buyer, round)`` lands on its own
+distinct tick) so that a payee credited by several settlements observes exactly
+one credit between consecutive attestations; the balance delta is then a clean,
+per-settlement quantity the ledger-attestation validator can check.  Scheduling
+is a pure function of ``(buyer, round)`` -- no wall clock, no RNG -- so the trace
+is byte-identical for a given seed.
 
 If the configured payments plugin lacks ``open_split`` (e.g. the default
 ``prepaid_credits``), each buyer falls back to a single ``pay()`` and emits no
@@ -31,7 +47,9 @@ Example::
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 
 from nest_core.scenario import ScenarioConfig
@@ -39,14 +57,19 @@ from nest_core.sim.agent import AgentContext, StateMachineAgent
 from nest_core.types import AgentId, Money, PaymentRef
 
 _PLATFORM = AgentId("platform-0")
-_CONTRIB_BPS = 40  # each of the two contributors: 40 + 40 = 80% to contributors
-_PLATFORM_BPS = 20  # 20% to the platform
+_CONTRIB_WEIGHT = 40  # each of the two contributors: 40 + 40 = 80% to contributors
+_PLATFORM_WEIGHT = 20  # 20% to the platform
 _BUYER_BALANCE = 5000
+_ROUND_TICK_SPACING = 3  # buyers per round; one settlement per tick, no collisions
 
 
 @dataclass
 class _Job:
-    """One round's settlement: the ref, the locked weights, and the amount.
+    """One round's settlement: the ref, the locked weights, the amount, and its tick.
+
+    ``tick`` is the settlement's own dedicated logical tick.  Every ``(buyer,
+    round)`` gets a distinct tick so no two settlements collide, which keeps each
+    payee's per-settlement balance delta observable and unambiguous.
 
     Example::
 
@@ -55,6 +78,7 @@ class _Job:
             ref=PaymentRef("split-buyer-0-0"),
             payees=_split("contrib-0", "contrib-1"),
             amount=1000,
+            tick=1,
         )
     """
 
@@ -62,14 +86,15 @@ class _Job:
     ref: PaymentRef
     payees: tuple[tuple[AgentId, int], ...]
     amount: int
+    tick: int
 
 
 def _split(c1: str, c2: str) -> tuple[tuple[AgentId, int], ...]:
     """Build an 80/20 weight vector: two contributors plus the platform."""
     return (
-        (AgentId(c1), _CONTRIB_BPS),
-        (AgentId(c2), _CONTRIB_BPS),
-        (_PLATFORM, _PLATFORM_BPS),
+        (AgentId(c1), _CONTRIB_WEIGHT),
+        (AgentId(c2), _CONTRIB_WEIGHT),
+        (_PLATFORM, _PLATFORM_WEIGHT),
     )
 
 
@@ -108,11 +133,43 @@ def _emit_settled(ref: PaymentRef, amount: int, allocations: list[tuple[str, int
     return f"split:settled:ref={ref}:amount={amount}:alloc={alloc}".encode()
 
 
+def _emit_observed(ref: str, payee: AgentId, balance: int) -> bytes:
+    """Serialize a payee's current shared-ledger balance as ``split:observed``."""
+    return f"split:observed:ref={ref}:payee={payee}:balance={balance}".encode()
+
+
+def _settled_ref_and_payees(text: str) -> tuple[str, list[str]] | None:
+    """Extract ``(ref, [payee, ...])`` from a ``split:settled`` broadcast payload.
+
+    Returns ``None`` if the payload is not a settled event.  The payee list is the
+    names in the ``alloc`` field, in declared order -- used by a payee to decide
+    whether a settlement concerned it and which reference to attest against.
+
+    Example::
+
+        ref, payees = _settled_ref_and_payees(
+            "split:settled:ref=r0:amount=1000:alloc=contrib-0~400;platform-0~200"
+        )
+        assert ref == "r0" and payees == ["contrib-0", "platform-0"]
+    """
+    if not text.startswith("split:settled:"):
+        return None
+    fields: dict[str, str] = {}
+    for piece in text.split(":")[2:]:
+        key, sep, value = piece.partition("=")
+        if sep:
+            fields[key] = value
+    payees = [pair.partition("~")[0] for pair in fields.get("alloc", "").split(";") if "~" in pair]
+    return fields.get("ref", ""), payees
+
+
 class BuyerAgent(StateMachineAgent):
     """Pays for content each round and fans the payment out 80/20.
 
-    Owns the payer-side ``split_settlement`` instance; contributors and the
-    platform are passive credit sinks sharing the same ledger.
+    Owns the payer-side ``split_settlement`` instance and broadcasts the
+    ``split:opened`` / ``split:settled`` account of each round.  Contributors and
+    the platform hold a read-only view of the same ledger and attest their
+    balances back (see :class:`_PayeeObserverAgent`).
 
     Example::
 
@@ -125,9 +182,13 @@ class BuyerAgent(StateMachineAgent):
         self._jobs = jobs
 
     async def on_start(self, ctx: AgentContext) -> None:
-        """Schedule one ``run:<index>`` wakeup per job, one logical tick apart."""
-        for index in range(len(self._jobs)):
-            await ctx.schedule(float(index + 1), f"run:{index}".encode())
+        """Schedule one ``run:<index>`` wakeup per job at the job's dedicated tick.
+
+        Each job carries its own distinct tick, so settlements never share a tick
+        and every payee observes exactly one credit between attestations.
+        """
+        for index, job in enumerate(self._jobs):
+            await ctx.schedule(float(job.tick), f"run:{index}".encode())
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
         """Open, broadcast, and settle the scheduled job's fan-out payment."""
@@ -148,6 +209,44 @@ class BuyerAgent(StateMachineAgent):
         await ctx.broadcast(_emit_settled(job.ref, job.amount, allocations))
 
 
+class _PayeeObserverAgent(StateMachineAgent):
+    """A payee (contributor or platform) that attests its ledger balance.
+
+    Holds a *read-only view* of the shared ledger -- it can never move funds,
+    only observe them.  When it sees a ``split:settled`` broadcast that names it
+    as a payee, it reads its current shared-ledger balance and broadcasts a
+    ``split:observed`` attestation for that reference.  Because settlements are
+    scheduled one-per-tick, the attestation reflects exactly the balance produced
+    by that one settlement, so the ledger-attestation validator can turn the
+    sequence of a payee's attestations into per-settlement deltas.
+
+    The attestation is ledger truth, independent of the payer's self-reported
+    receipts: a splitter that returns canonical receipts but credits the ledger
+    short is caught here even though it fools the receipt-auditing validators.
+
+    Example::
+
+        agent = _PayeeObserverAgent(MappingProxyType({}))
+    """
+
+    def __init__(self, ledger: Mapping[AgentId, int]) -> None:
+        """Bind the payee to a read-only view of the shared balance ledger."""
+        self._ledger = ledger
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Attest this payee's current ledger balance for a settlement it is in."""
+        text = payload.decode("utf-8", errors="replace")
+        parsed = _settled_ref_and_payees(text)
+        if parsed is None:
+            return
+        ref, payees = parsed
+        me = str(ctx.agent_id)
+        if me not in payees:
+            return
+        balance = self._ledger.get(ctx.agent_id, 0)
+        await ctx.broadcast(_emit_observed(ref, ctx.agent_id, balance))
+
+
 def split_settlement_factory(
     config: ScenarioConfig,
     plugins: dict[str, Any],
@@ -156,8 +255,11 @@ def split_settlement_factory(
 
     The three buyers share a single ``balances`` + ``contracts`` ledger, so
     conservation is a whole-marketplace property, not a per-buyer one.
-    Contributors and the platform are passive: they never call the plugin, they
-    only receive credits, so they need no instance of their own.
+    Contributors and the platform never *move* funds -- they hold a read-only
+    view of that same ledger and attest their own balances, so the settlement is
+    audited against ledger truth and not only the payer's receipts.  Every
+    ``(buyer, round)`` is scheduled on its own distinct tick so no two settlements
+    collide and each payee's balance delta stays a clean per-settlement quantity.
 
     Example::
 
@@ -166,6 +268,7 @@ def split_settlement_factory(
     payments_cls = plugins["payments"]
     shared_balances: dict[AgentId, int] = {}
     shared_contracts: dict[PaymentRef, Any] = {}
+    ledger_view: Mapping[AgentId, int] = MappingProxyType(shared_balances)
 
     def _buyer_instance(agent_id: AgentId) -> Any:
         try:
@@ -190,7 +293,7 @@ def split_settlement_factory(
     agents: dict[AgentId, StateMachineAgent] = {}
     overrides: dict[AgentId, dict[str, Any]] = {}
 
-    for buyer_name, rounds in _PLAN.items():
+    for buyer_slot, (buyer_name, rounds) in enumerate(_PLAN.items()):
         buyer_id = AgentId(buyer_name)
         jobs = [
             _Job(
@@ -198,6 +301,10 @@ def split_settlement_factory(
                 ref=PaymentRef(f"{buyer_name}-r{index}"),
                 payees=_split(c1, c2),
                 amount=amount,
+                # Distinct tick per (buyer, round): round-major, buyer-within-round.
+                # With three buyers this maps the nine settlements onto ticks 1..9,
+                # one settlement per tick, so no payee is credited twice in a tick.
+                tick=index * _ROUND_TICK_SPACING + buyer_slot + 1,
             )
             for index, (c1, c2, amount) in enumerate(rounds)
         ]
@@ -205,8 +312,8 @@ def split_settlement_factory(
         overrides[buyer_id] = {"payments": _buyer_instance(buyer_id)}
 
     for index in range(8):
-        agents[AgentId(f"contrib-{index}")] = StateMachineAgent()
-    agents[_PLATFORM] = StateMachineAgent()
+        agents[AgentId(f"contrib-{index}")] = _PayeeObserverAgent(ledger_view)
+    agents[_PLATFORM] = _PayeeObserverAgent(ledger_view)
 
     plugins["_agent_plugins"] = overrides
     return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/split_settlement.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/split_settlement.py
@@ -46,7 +46,17 @@ _BUYER_BALANCE = 5000
 
 @dataclass
 class _Job:
-    """One round's settlement: the ref, the locked weights, and the amount."""
+    """One round's settlement: the ref, the locked weights, and the amount.
+
+    Example::
+
+        job = _Job(
+            buyer=AgentId("buyer-0"),
+            ref=PaymentRef("split-buyer-0-0"),
+            payees=_split("contrib-0", "contrib-1"),
+            amount=1000,
+        )
+    """
 
     buyer: AgentId
     ref: PaymentRef
@@ -110,14 +120,17 @@ class BuyerAgent(StateMachineAgent):
     """
 
     def __init__(self, agent_id: AgentId, jobs: list[_Job]) -> None:
+        """Bind the buyer to its id and its per-round settlement plan."""
         self._id = agent_id
         self._jobs = jobs
 
     async def on_start(self, ctx: AgentContext) -> None:
+        """Schedule one ``run:<index>`` wakeup per job, one logical tick apart."""
         for index in range(len(self._jobs)):
             await ctx.schedule(float(index + 1), f"run:{index}".encode())
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Open, broadcast, and settle the scheduled job's fan-out payment."""
         text = payload.decode("utf-8", errors="replace")
         if not text.startswith("run:"):
             return

--- a/packages/nest-core/nest_core/scenarios_builtin/yaml/split_settlement.yaml
+++ b/packages/nest-core/nest_core/scenarios_builtin/yaml/split_settlement.yaml
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# Split-settlement content marketplace: three buyers pay for content each round
+# and fan every payment out 80/20 -- 80% shared between two contributors, 20% to
+# the platform -- through the split_settlement plugin. Round amounts (777, 1001)
+# are deliberately indivisible by the weight total so the largest-remainder dust
+# distribution is exercised in the trace. The two split_settlement validators
+# (conservation, weight-fidelity) must pass under `payments: split_settlement`
+# and fail under `payments: prepaid_credits` (no fan-out protocol, no split:*
+# events emitted).
+
+name: split_settlement
+description: |
+  Twelve agents (3 buyers, 8 contributors, 1 platform). Each buyer runs three
+  rounds of weighted 80/20 revenue splitting. All settlements conserve value
+  exactly and match the largest-remainder split of their declared weights.
+  Deterministic across seeds 42, 7, and 1337 (no RNG on the settlement path).
+
+tier: 1
+seed: 42
+
+agents:
+  count: 12
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 3
+      config:
+        initial_balance: 5000
+    - name: contributor
+      count: 8
+      config: {}
+    - name: platform
+      count: 1
+      config: {}
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: split_settlement
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: split_settlement
+  config: {}
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 5000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/split_settlement.jsonl

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -3235,14 +3235,24 @@ def validate_escrow_no_payout_without_delivery(
 # ---------------------------------------------------------------------------
 # Split-settlement (weighted fan-out) validators
 #
-# The split_settlement scenario broadcasts two structured events per round:
+# The split_settlement scenario broadcasts three structured events per round:
 #   split:opened:ref=..:payer=..:weights=payee~weight;...   (declared weights)
-#   split:settled:ref=..:amount=..:alloc=payee~credit;...   (actual credits)
-# They catch two attacks the default prepaid_credits plugin cannot even express
+#   split:settled:ref=..:amount=..:alloc=payee~credit;...   (reported credits)
+#   split:observed:ref=..:payee=..:balance=..               (payee ledger truth)
+# They catch three attacks the default prepaid_credits plugin cannot even express
 # and that a buggy splitter would silently commit:
 #   1. penny-shaving  -- credited total != debited amount (floored dust kept);
 #   2. weight tampering -- credits deviate from the largest-remainder split of
-#      the *declared* weights (mid-flight reweight / self-dealing).
+#      the *declared* weights (mid-flight reweight / self-dealing);
+#   3. ledger skimming -- receipts look canonical but the shared ledger is
+#      credited short, so a payee's observed balance moves by less than reported.
+#
+# Trust boundary: split_conservation and split_weight_fidelity audit the payer's
+# *reported receipts* (the opened/settled broadcasts). That is necessary but not
+# sufficient -- a splitter can return honest-looking receipts while crediting the
+# real ledger short. split_ledger_attestation closes that gap by cross-checking
+# the receipts against *payee-observed ledger truth* (the observed broadcasts,
+# emitted by the payees themselves from a read-only view of the shared ledger).
 # The canonical allocation is recomputed independently below; these validators
 # never import the plugin, so a compromised plugin cannot subvert its own audit.
 # ---------------------------------------------------------------------------
@@ -3332,6 +3342,12 @@ def validate_split_conservation(
     debits, and this check fails on the shortfall.  Also fails when no settlement
     events appear at all -- the signature of a plugin with no fan-out protocol.
 
+    Trust boundary: this audits the payer's *reported receipts* (the ``settled``
+    broadcast), not the shared ledger.  A splitter that reports conserved,
+    correctly weighted credits while crediting the ledger short passes this check
+    and :func:`validate_split_weight_fidelity`; that residual gap is what
+    :func:`validate_split_ledger_attestation` closes with payee-observed truth.
+
     Example::
 
         results = validate_trace(Path("trace.jsonl"), "split_settlement")
@@ -3385,12 +3401,22 @@ def validate_split_weight_fidelity(
     """Every settlement matches the largest-remainder split of its declared weights.
 
     Recomputes the canonical allocation from the weights named in the matching
-    ``split:opened`` event and compares it, payee by payee, to the credits in the
-    ``split:settled`` event.  Catches weight tampering: a splitter that reweights
-    mid-flight, drops or injects a payee, or routes dust to itself produces an
-    allocation that will not match the independent recomputation, and this check
-    fails.  A settlement with no matching ``opened`` contract is itself a
-    violation.
+    ``split:opened`` event and compares it, as a ``payee -> credit`` map, to the
+    credits in the ``split:settled`` event.  Catches weight tampering: a splitter
+    that reweights mid-flight, drops or injects a payee, or routes dust to itself
+    produces an allocation that will not match the independent recomputation, and
+    this check fails.  A settlement with no matching ``opened`` contract is itself
+    a violation.
+
+    The comparison is order-insensitive by design: the ``split:settled`` format
+    never declares allocation order canonical, so a splitter that lists the same
+    payees and credits in a different order is honest and passes.  It is compared
+    as ``dict(reported) == dict(expected)`` with a length guard -- a payee that
+    repeats in the reported allocation is a violation, not silently collapsed.
+
+    Trust boundary: like :func:`validate_split_conservation`, this audits the
+    payer's *reported receipts*, not ledger truth; :func:`validate_split_ledger_attestation`
+    cross-checks the receipts against payee-observed balances.
 
     Example::
 
@@ -3423,9 +3449,18 @@ def validate_split_weight_fidelity(
             violations.append(f"ref={ref!r}: declared weights are not a valid positive vector")
             continue
         reported = _parse_pairs(ev.get("alloc", ""))
-        if reported != expected:
+        reported_map = dict(reported)
+        if len(reported_map) != len(reported):
+            violations.append(f"ref={ref!r}: duplicate payee in reported allocation {reported}")
+            continue
+        # Order-insensitive: the settled format does not fix allocation order, so
+        # compare payee->credit maps, not position by position. The length guard
+        # above already rejected duplicate payees on the reported side; the
+        # canonical vector never repeats a payee, so this map compare is exact.
+        if reported_map != dict(expected):
             violations.append(
-                f"ref={ref!r}: allocation {reported} != canonical {expected} for declared weights"
+                f"ref={ref!r}: allocation {reported} != canonical {expected} "
+                f"for declared weights (compared as payee->credit maps)"
             )
     if violations:
         return [ValidationResult("split_weight_fidelity", False, "; ".join(violations))]
@@ -3442,6 +3477,112 @@ def validate_split_weight_fidelity(
             "split_weight_fidelity",
             True,
             f"{checked} settlements matched the largest-remainder split of their declared weights",
+        )
+    ]
+
+
+def validate_split_ledger_attestation(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every payee's observed ledger delta equals the credit the payer reported.
+
+    The other two split validators audit the payer's *reported receipts* (the
+    ``split:opened`` / ``split:settled`` broadcasts).  Both are the payer's own
+    account, so a splitter that returns canonical receipts while crediting the
+    shared ledger short passes both of them.  This validator closes that gap by
+    reading the *payees'* own ``split:observed:ref=..:payee=..:balance=..``
+    attestations -- each payee's current shared-ledger balance, taken from a
+    read-only view it cannot forge -- and cross-checking ledger truth against the
+    receipts.
+
+    For each payee it walks the attestations in trace order and takes the delta
+    between consecutive balances (the first is measured from a zero starting
+    balance, since the scenario's payees are passive sinks that begin empty).
+    Because settlements are scheduled one-per-tick, that delta is exactly the
+    credit applied by the single settlement the attestation references, and it
+    must equal the credit the payer reported to that payee in the matching
+    ``split:settled`` event.  Any mismatch is reported as ``ref + payee +
+    reported vs observed delta``.
+
+    Also fails when a settlement has no covering attestations, and when no
+    settlements appear at all -- the same fail-when-absent behavior the other two
+    validators use against a plugin with no fan-out protocol.
+
+    Example::
+
+        results = validate_trace(Path("trace.jsonl"), "split_settlement")
+        assert results[2].passed
+    """
+    parsed = _parse_split_events(events)
+
+    # Reported credits per settlement: ref -> {payee: credit}, in trace order.
+    reported: dict[str, dict[str, int]] = {}
+    settled_order: list[str] = []
+    for ev in parsed:
+        if ev["kind"] != "settled":
+            continue
+        ref = ev.get("ref", "")
+        reported[ref] = dict(_parse_pairs(ev.get("alloc", "")))
+        settled_order.append(ref)
+
+    prior_balance: dict[str, int] = defaultdict(int)
+    covered: set[tuple[str, str]] = set()
+    violations: list[str] = []
+    attested = 0
+
+    for ev in parsed:
+        if ev["kind"] != "observed":
+            continue
+        ref = ev.get("ref", "")
+        payee = ev.get("payee", "")
+        try:
+            balance = int(ev.get("balance", ""))
+        except ValueError:
+            violations.append(
+                f"ref={ref!r} payee={payee!r}: non-integer balance {ev.get('balance', '')!r}"
+            )
+            continue
+        attested += 1
+        credited = reported.get(ref, {})
+        if payee not in credited:
+            violations.append(
+                f"ref={ref!r} payee={payee!r}: attestation with no matching reported credit"
+            )
+            continue
+        observed_delta = balance - prior_balance[payee]
+        prior_balance[payee] = balance
+        covered.add((ref, payee))
+        if observed_delta != credited[payee]:
+            violations.append(
+                f"ref={ref!r} payee={payee!r}: reported credit {credited[payee]} "
+                f"!= observed ledger delta {observed_delta}"
+            )
+
+    missing = [
+        f"{ref}/{payee}"
+        for ref in settled_order
+        for payee in reported[ref]
+        if (ref, payee) not in covered
+    ]
+    if missing:
+        violations.append(f"settlements with no covering attestation: {', '.join(missing)}")
+
+    if violations:
+        return [ValidationResult("split_ledger_attestation", False, "; ".join(violations))]
+    if not settled_order:
+        return [
+            ValidationResult(
+                "split_ledger_attestation",
+                False,
+                "no split settlements observed in trace -- plugin lacks fan-out settlement",
+            )
+        ]
+    return [
+        ValidationResult(
+            "split_ledger_attestation",
+            True,
+            f"{attested} payee attestations matched their reported credits "
+            f"across {len(settled_order)} settlements",
         )
     ]
 
@@ -5627,5 +5768,6 @@ VALIDATORS: dict[str, list[Any]] = {
     "split_settlement": [
         validate_split_conservation,
         validate_split_weight_fidelity,
+        validate_split_ledger_attestation,
     ],
 }

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -3232,6 +3232,220 @@ def validate_escrow_no_payout_without_delivery(
     ]
 
 
+# ---------------------------------------------------------------------------
+# Split-settlement (weighted fan-out) validators
+#
+# The split_settlement scenario broadcasts two structured events per round:
+#   split:opened:ref=..:payer=..:weights=payee~weight;...   (declared weights)
+#   split:settled:ref=..:amount=..:alloc=payee~credit;...   (actual credits)
+# They catch two attacks the default prepaid_credits plugin cannot even express
+# and that a buggy splitter would silently commit:
+#   1. penny-shaving  -- credited total != debited amount (floored dust kept);
+#   2. weight tampering -- credits deviate from the largest-remainder split of
+#      the *declared* weights (mid-flight reweight / self-dealing).
+# The canonical allocation is recomputed independently below; these validators
+# never import the plugin, so a compromised plugin cannot subvert its own audit.
+# ---------------------------------------------------------------------------
+
+
+def _parse_pairs(raw: str) -> list[tuple[str, int]]:
+    """Parse a ``payee~int;payee~int`` value into ordered ``(payee, int)`` pairs.
+
+    Malformed entries are skipped; a non-integer amount maps to the sentinel
+    ``-1`` so the conservation check flags it rather than crashing.
+    """
+    pairs: list[tuple[str, int]] = []
+    for piece in raw.split(";"):
+        if "~" not in piece:
+            continue
+        name, _, value = piece.partition("~")
+        try:
+            pairs.append((name, int(value)))
+        except ValueError:
+            pairs.append((name, -1))
+    return pairs
+
+
+def _parse_split_events(events: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Parse trace broadcasts of the form ``split:<kind>:k=v:...``.
+
+    Only sender-recorded broadcasts are inspected, so the per-recipient delivery
+    copies of the same payload do not multiply each settlement.
+    """
+    out: list[dict[str, str]] = []
+    for ev in events:
+        if ev.get("kind") != "broadcast":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("split:"):
+            continue
+        parts = msg.split(":")
+        if len(parts) < 2:
+            continue
+        parsed: dict[str, str] = {"kind": parts[1], "agent": str(ev.get("agent", ""))}
+        for piece in parts[2:]:
+            if "=" in piece:
+                key, _, value = piece.partition("=")
+                parsed[key] = value
+        out.append(parsed)
+    return out
+
+
+def _expected_split_allocation(
+    amount: int,
+    weights: list[tuple[str, int]],
+) -> list[tuple[str, int]] | None:
+    """Recompute the canonical largest-remainder allocation, independent of the plugin.
+
+    Mirrors ``nest_plugins_reference.payments.split_settlement.allocate_by_weight``
+    exactly -- floor of each quota, then the remainder handed out one unit at a
+    time by descending fractional part with a stable tie-break by payee id then
+    index.  Returns ``None`` if the declared weight vector is not a valid positive
+    vector, which the caller reports as a tampered ``opened`` event.
+    """
+    total = sum(weight for _, weight in weights)
+    if total <= 0 or amount < 0 or not weights:
+        return None
+    base: list[int] = []
+    ranking: list[tuple[int, str, int]] = []
+    for index, (payee, weight) in enumerate(weights):
+        if weight <= 0:
+            return None
+        scaled = amount * weight
+        base.append(scaled // total)
+        ranking.append((scaled % total, payee, index))
+    dust = amount - sum(base)
+    ranking.sort(key=lambda item: (-item[0], item[1], item[2]))
+    for rank in range(dust):
+        base[ranking[rank][2]] += 1
+    return [(weights[i][0], base[i]) for i in range(len(weights))]
+
+
+def validate_split_conservation(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every settlement credits its payees exactly the amount that was debited.
+
+    Sums the per-payee credits in each ``split:settled`` event and compares
+    against the settled amount.  Catches penny-shaving: a splitter that floors
+    every share and pockets the indivisible dust credits strictly less than it
+    debits, and this check fails on the shortfall.  Also fails when no settlement
+    events appear at all -- the signature of a plugin with no fan-out protocol.
+
+    Example::
+
+        results = validate_trace(Path("trace.jsonl"), "split_settlement")
+        assert results[0].passed
+    """
+    parsed = _parse_split_events(events)
+    violations: list[str] = []
+    settled = 0
+    for ev in parsed:
+        if ev["kind"] != "settled":
+            continue
+        settled += 1
+        ref = ev.get("ref", "")
+        try:
+            amount = int(ev.get("amount", ""))
+        except ValueError:
+            violations.append(f"ref={ref!r}: non-integer amount {ev.get('amount', '')!r}")
+            continue
+        alloc = _parse_pairs(ev.get("alloc", ""))
+        if any(credit < 0 for _, credit in alloc):
+            violations.append(f"ref={ref!r}: negative credit in allocation {alloc}")
+            continue
+        credited = sum(credit for _, credit in alloc)
+        if credited != amount:
+            violations.append(
+                f"ref={ref!r}: credited {credited} != debited {amount} "
+                f"(dust leak of {amount - credited})"
+            )
+    if violations:
+        return [ValidationResult("split_conservation", False, "; ".join(violations))]
+    if not settled:
+        return [
+            ValidationResult(
+                "split_conservation",
+                False,
+                "no split settlements observed in trace -- plugin lacks fan-out settlement",
+            )
+        ]
+    return [
+        ValidationResult(
+            "split_conservation",
+            True,
+            f"{settled} settlements conserved value exactly (sum of credits == amount)",
+        )
+    ]
+
+
+def validate_split_weight_fidelity(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every settlement matches the largest-remainder split of its declared weights.
+
+    Recomputes the canonical allocation from the weights named in the matching
+    ``split:opened`` event and compares it, payee by payee, to the credits in the
+    ``split:settled`` event.  Catches weight tampering: a splitter that reweights
+    mid-flight, drops or injects a payee, or routes dust to itself produces an
+    allocation that will not match the independent recomputation, and this check
+    fails.  A settlement with no matching ``opened`` contract is itself a
+    violation.
+
+    Example::
+
+        results = validate_trace(Path("trace.jsonl"), "split_settlement")
+        assert results[1].passed
+    """
+    parsed = _parse_split_events(events)
+    declared: dict[str, list[tuple[str, int]]] = {}
+    for ev in parsed:
+        if ev["kind"] == "opened":
+            declared[ev.get("ref", "")] = _parse_pairs(ev.get("weights", ""))
+    violations: list[str] = []
+    checked = 0
+    for ev in parsed:
+        if ev["kind"] != "settled":
+            continue
+        ref = ev.get("ref", "")
+        weights = declared.get(ref)
+        if weights is None:
+            violations.append(f"ref={ref!r}: settled without a matching opened contract")
+            continue
+        try:
+            amount = int(ev.get("amount", ""))
+        except ValueError:
+            violations.append(f"ref={ref!r}: non-integer amount {ev.get('amount', '')!r}")
+            continue
+        checked += 1
+        expected = _expected_split_allocation(amount, weights)
+        if expected is None:
+            violations.append(f"ref={ref!r}: declared weights are not a valid positive vector")
+            continue
+        reported = _parse_pairs(ev.get("alloc", ""))
+        if reported != expected:
+            violations.append(
+                f"ref={ref!r}: allocation {reported} != canonical {expected} for declared weights"
+            )
+    if violations:
+        return [ValidationResult("split_weight_fidelity", False, "; ".join(violations))]
+    if not checked:
+        return [
+            ValidationResult(
+                "split_weight_fidelity",
+                False,
+                "no split settlements observed in trace -- plugin lacks fan-out settlement",
+            )
+        ]
+    return [
+        ValidationResult(
+            "split_weight_fidelity",
+            True,
+            f"{checked} settlements matched the largest-remainder split of their declared weights",
+        )
+    ]
+
+
 def validate_receipt_reputation_ring_severed(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
@@ -5409,5 +5623,9 @@ VALIDATORS: dict[str, list[Any]] = {
     "rogue_trusted_agent": [
         validate_rogue_trusted_agent_blocked,
         validate_rogue_trusted_agent_reputation,
+    ],
+    "split_settlement": [
+        validate_split_conservation,
+        validate_split_weight_fidelity,
     ],
 }

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2146,6 +2146,7 @@ class TestValidatorRegistry:
             "parc_migration",
             "rogue_trusted_agent",
             "sybil_bond",
+            "split_settlement",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/split_settlement.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/split_settlement.py
@@ -1,0 +1,497 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Weighted multi-payee fan-out settlement.
+
+One atomic debit from a payer is fanned out to *N* payees by declared integer
+weights.  A split's weights are locked when the contract is *opened* and are
+immutable through settlement, so the amount every payee receives is a pure,
+deterministic function of ``(weights, amount)`` that an auditor can recompute
+without trusting the plugin.
+
+Exact conservation is guaranteed by the largest-remainder (Hamilton) method:
+``sum(allocations) == amount`` for every settlement, with the indivisible
+remainder ("dust") handed to the payees holding the largest fractional parts and
+a stable tie-break by payee id.  Money is integer credits end to end -- there
+are no floats anywhere on the settlement path, so no allocation can silently
+create or destroy value through rounding.
+
+This is the fan-out counterpart to the other reference payment plugins:
+``prepaid_credits`` moves one debit to one payee, ``escrow`` conditions a single
+payee's payout on delivery, ``streaming`` meters one payee per tick.  None of
+them splits a single debit across many payees; this plugin does, atomically.
+
+Example::
+
+    pay = SplitSettlement(AgentId("buyer"), initial_balance=1000)
+    receipts = await pay.split_pay(
+        [(AgentId("author"), 8), (AgentId("platform"), 2)],
+        Money(amount=1001),
+        PaymentRef("round-1"),
+    )
+    assert sum(r.amount.amount for r in receipts) == 1001  # nothing created or lost
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from nest_core.types import (
+    AgentId,
+    Money,
+    PaymentRef,
+    PaymentStatus,
+    Quote,
+    Receipt,
+    ServiceRef,
+)
+
+_STATE_OPEN = "OPEN"
+_STATE_SETTLED = "SETTLED"
+_STATE_REFUNDED = "REFUNDED"
+
+
+class SplitError(ValueError):
+    """Raised on any split-settlement validation, authorization, or state error.
+
+    Example::
+
+        try:
+            await pay.settle_split(PaymentRef("missing"), Money(amount=10))
+        except SplitError as exc:
+            print(exc)
+    """
+
+
+def allocate_by_weight(
+    amount: int,
+    weights: Sequence[tuple[AgentId, int]],
+) -> list[tuple[AgentId, int]]:
+    """Split ``amount`` across ``weights`` by the largest-remainder method.
+
+    Returns one ``(payee, credit)`` pair per entry in ``weights``, in the same
+    order.  The result conserves value exactly -- ``sum(credit) == amount`` --
+    and is deterministic: each payee first receives the floor of its exact quota
+    ``amount * weight / total_weight``, then the indivisible remainder is handed
+    out one unit at a time to the payees with the largest fractional part,
+    breaking ties by payee id (then original index).  The outcome therefore never
+    depends on dict iteration order or floating-point rounding.
+
+    Args:
+        amount: Non-negative integer amount to distribute.
+        weights: Non-empty sequence of ``(payee, weight)`` with ``weight > 0``.
+
+    Returns:
+        A list of ``(payee, credit)`` pairs whose credits sum to ``amount``.
+
+    Raises:
+        SplitError: If ``weights`` is empty, ``amount`` is negative, or any
+            weight is not a positive integer.
+
+    Example::
+
+        alloc = allocate_by_weight(
+            1001, [(AgentId("a"), 3), (AgentId("b"), 1), (AgentId("c"), 1)]
+        )
+        assert alloc == [(AgentId("a"), 601), (AgentId("b"), 200), (AgentId("c"), 200)]
+        assert sum(credit for _, credit in alloc) == 1001
+    """
+    if not weights:
+        raise SplitError("split must name at least one payee")
+    if amount < 0:
+        msg = f"amount must be non-negative: {amount}"
+        raise SplitError(msg)
+    total = 0
+    for _, weight in weights:
+        if weight <= 0:
+            msg = f"weight must be a positive integer: {weight}"
+            raise SplitError(msg)
+        total += weight
+    base: list[int] = []
+    ranking: list[tuple[int, str, int]] = []
+    for index, (payee, weight) in enumerate(weights):
+        scaled = amount * weight
+        base.append(scaled // total)
+        ranking.append((scaled % total, str(payee), index))
+    dust = amount - sum(base)
+    # Largest remainder first; ties broken by payee id then index for a total,
+    # reproducible order.  ``dust`` is in ``[0, len(weights) - 1]`` by construction.
+    ranking.sort(key=lambda item: (-item[0], item[1], item[2]))
+    for rank in range(dust):
+        base[ranking[rank][2]] += 1
+    return [(weights[i][0], base[i]) for i in range(len(weights))]
+
+
+@dataclass
+class SplitContract:
+    """A fan-out settlement whose weights are fixed at open time.
+
+    ``payees`` is a tuple of ``(payee, weight)`` locked at :meth:`open_split` and
+    never mutated afterwards -- opening a contract before settling it is exactly
+    what makes the weights un-renegotiable mid-flight.  The mutable fields record
+    how the contract was resolved: ``state`` walks ``OPEN -> SETTLED`` (or
+    ``SETTLED -> REFUNDED``), and ``settled_amount`` / ``allocations`` capture the
+    conserved payout.
+
+    Example::
+
+        contract = SplitContract(
+            ref=PaymentRef("r1"),
+            payer=AgentId("buyer"),
+            payees=((AgentId("author"), 8), (AgentId("platform"), 2)),
+            total_weight=10,
+        )
+        assert contract.state == "OPEN"
+    """
+
+    ref: PaymentRef
+    payer: AgentId
+    payees: tuple[tuple[AgentId, int], ...]
+    total_weight: int
+    state: str = _STATE_OPEN
+    settled_amount: int | None = None
+    allocations: tuple[tuple[AgentId, int], ...] | None = None
+
+
+class SplitSettlement:
+    """Atomic weighted fan-out settlement on top of a debit-credit ledger.
+
+    A payer opens a contract naming ``(payee, weight)`` pairs, then settles it for
+    a concrete amount.  Settlement debits the payer once and credits every payee
+    its largest-remainder share in a single atomic step: either every payee is
+    paid and the books balance, or nothing moves and a :class:`SplitError` is
+    raised.  Weights are locked at open, so the allocation is a pure function of
+    the opened contract and the settled amount.
+
+    The shared ``balances`` / ``contracts`` dicts mirror the ``prepaid_credits``
+    and ``escrow`` idiom, so a scenario can hand the same ledger to every agent
+    while each holds its own instance keyed by ``agent_id``.  Only the contract's
+    payer may settle or refund it.
+
+    Satisfies the ``Payments`` protocol: ``pay(to, amount, ref)`` is the
+    degenerate single-payee split (one payee at weight 1), so existing one-shot
+    callers keep working.
+
+    Example::
+
+        pay = SplitSettlement(AgentId("buyer"), initial_balance=1000)
+        await pay.open_split(
+            [(AgentId("author"), 8), (AgentId("platform"), 2)],
+            PaymentRef("round-1"),
+        )
+        receipts = await pay.settle_split(PaymentRef("round-1"), Money(amount=1000))
+        assert [r.amount.amount for r in receipts] == [800, 200]
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        initial_balance: int = 1000,
+        balances: dict[AgentId, int] | None = None,
+        contracts: dict[PaymentRef, SplitContract] | None = None,
+    ) -> None:
+        self._agent_id = agent_id
+        self._balances = balances if balances is not None else {}
+        self._balances.setdefault(agent_id, initial_balance)
+        self._contracts = contracts if contracts is not None else {}
+
+    # -- read helpers ----------------------------------------------------
+
+    def balance(self, agent: AgentId) -> int:
+        """Return an agent's credit balance.
+
+        Example::
+
+            bal = pay.balance(AgentId("buyer"))
+        """
+        return self._balances.get(agent, 0)
+
+    def contract(self, ref: PaymentRef) -> SplitContract | None:
+        """Return the contract for ``ref`` if one was opened.
+
+        Example::
+
+            contract = pay.contract(PaymentRef("round-1"))
+            assert contract is not None and contract.total_weight == 10
+        """
+        return self._contracts.get(ref)
+
+    def settlement(self, ref: PaymentRef) -> SplitContract | None:
+        """Return the contract for ``ref`` only once it has been settled.
+
+        The settled contract *is* the queryable settlement record: it carries the
+        conserved ``settled_amount`` and the per-payee ``allocations``.
+
+        Example::
+
+            record = pay.settlement(PaymentRef("round-1"))
+            assert record is not None and record.settled_amount == 1000
+        """
+        contract = self._contracts.get(ref)
+        if contract is None or contract.state == _STATE_OPEN:
+            return None
+        return contract
+
+    def receipts(self, ref: PaymentRef) -> list[Receipt]:
+        """Rebuild the per-payee receipts for a settled contract.
+
+        Deterministic and side-effect free -- the receipts are a view over the
+        stored allocation, so querying them later yields the same objects as the
+        :meth:`settle_split` return value.
+
+        Example::
+
+            for r in pay.receipts(PaymentRef("round-1")):
+                print(r.payee, r.amount.amount)
+
+        Raises:
+            SplitError: If ``ref`` has no settled contract.
+        """
+        contract = self.settlement(ref)
+        if contract is None or contract.allocations is None:
+            msg = f"no settled split for reference: {ref}"
+            raise SplitError(msg)
+        return [
+            Receipt(ref=ref, payer=contract.payer, payee=payee, amount=Money(amount=credit))
+            for payee, credit in contract.allocations
+        ]
+
+    # -- Payments protocol ----------------------------------------------
+
+    async def quote(self, service: ServiceRef) -> Quote:
+        """Return a fixed quote for any service.
+
+        Example::
+
+            q = await pay.quote(ServiceRef("article-bundle"))
+        """
+        return Quote(service=service, price=Money(amount=10))
+
+    async def pay(self, to: AgentId, amount: Money, ref: PaymentRef) -> Receipt:
+        """Pay a single payee -- the degenerate one-payee, weight-1 split.
+
+        Provided so the plugin satisfies the bare ``Payments`` protocol: a plain
+        payment is just a fan-out to one payee, so it flows through the exact same
+        conserved settlement path.
+
+        Example::
+
+            receipt = await pay.pay(AgentId("author"), Money(amount=50), PaymentRef("p1"))
+
+        Raises:
+            SplitError: If ``amount`` is not positive, ``ref`` is already used,
+                ``to`` is the payer, or the payer's balance is insufficient.
+        """
+        receipts = await self.split_pay([(to, 1)], amount, ref)
+        return receipts[0]
+
+    async def verify_payment(self, ref: PaymentRef) -> PaymentStatus:
+        """Map a contract's lifecycle state to a ``PaymentStatus``.
+
+        Returns ``PENDING`` for an open contract, ``CONFIRMED`` once settled,
+        ``REFUNDED`` after a refund, and ``FAILED`` for an unknown reference.
+
+        Example::
+
+            status = await pay.verify_payment(PaymentRef("round-1"))
+        """
+        contract = self._contracts.get(ref)
+        if contract is None:
+            return PaymentStatus.FAILED
+        if contract.state == _STATE_SETTLED:
+            return PaymentStatus.CONFIRMED
+        if contract.state == _STATE_REFUNDED:
+            return PaymentStatus.REFUNDED
+        return PaymentStatus.PENDING
+
+    async def refund(self, ref: PaymentRef) -> None:
+        """Reverse a settled fan-out, returning every allocation to the payer.
+
+        Payer-only.  Each payee is debited exactly what it was credited and the
+        payer is made whole for the full settled amount.  Atomic: if any payee no
+        longer holds its share, nothing moves.
+
+        Example::
+
+            await pay.refund(PaymentRef("round-1"))
+
+        Raises:
+            SplitError: If the contract is missing, the caller is not the payer,
+                the contract is not settled, or a payee's balance is short.
+        """
+        contract = self._require_contract(ref)
+        if self._agent_id != contract.payer:
+            msg = f"only payer {contract.payer} may refund split {ref}"
+            raise SplitError(msg)
+        if contract.state != _STATE_SETTLED or contract.allocations is None:
+            msg = f"cannot refund split {ref} from state {contract.state}"
+            raise SplitError(msg)
+        for payee, credit in contract.allocations:
+            if self._balances.get(payee, 0) < credit:
+                msg = f"payee {payee} lacks {credit} to refund split {ref}"
+                raise SplitError(msg)
+        for payee, credit in contract.allocations:
+            self._balances[payee] = self._balances.get(payee, 0) - credit
+        self._balances[contract.payer] = self._balances.get(contract.payer, 0) + (
+            contract.settled_amount or 0
+        )
+        contract.state = _STATE_REFUNDED
+
+    # -- split lifecycle -------------------------------------------------
+
+    async def open_split(
+        self,
+        splits: Sequence[tuple[AgentId, int]],
+        ref: PaymentRef,
+        *,
+        known_payees: frozenset[AgentId] | None = None,
+    ) -> SplitContract:
+        """Open a fan-out contract with weights locked for its lifetime.
+
+        No funds move at open; the contract records the immutable weight vector
+        that :meth:`settle_split` will later honor.  Rejects the settlement
+        hazards a naive splitter ignores: an empty payee set, a non-positive
+        weight, a payee that repeats, and the payer paying itself.  When
+        ``known_payees`` is supplied, any payee outside that roster is rejected --
+        identity validation is the registry layer's job, so this hook is opt-in
+        rather than an invented in-layer directory.
+
+        Example::
+
+            contract = await pay.open_split(
+                [(AgentId("author"), 8), (AgentId("platform"), 2)],
+                PaymentRef("round-1"),
+            )
+            assert contract.total_weight == 10
+
+        Raises:
+            SplitError: On an empty split, a non-positive weight, a duplicate or
+                self payee, an unknown payee (when ``known_payees`` is given), or a
+                reused reference.
+        """
+        if ref in self._contracts:
+            msg = f"reference already used: {ref}"
+            raise SplitError(msg)
+        payees = tuple((payee, weight) for payee, weight in splits)
+        if not payees:
+            raise SplitError("split must name at least one payee")
+        seen: set[AgentId] = set()
+        total_weight = 0
+        for payee, weight in payees:
+            if weight <= 0:
+                msg = f"weight must be a positive integer: {weight}"
+                raise SplitError(msg)
+            if payee == self._agent_id:
+                msg = f"payer {self._agent_id} may not be a payee of its own split"
+                raise SplitError(msg)
+            if payee in seen:
+                msg = f"duplicate payee in split: {payee}"
+                raise SplitError(msg)
+            if known_payees is not None and payee not in known_payees:
+                msg = f"unknown payee: {payee}"
+                raise SplitError(msg)
+            seen.add(payee)
+            total_weight += weight
+        contract = SplitContract(
+            ref=ref,
+            payer=self._agent_id,
+            payees=payees,
+            total_weight=total_weight,
+        )
+        self._contracts[ref] = contract
+        return contract
+
+    async def settle_split(self, ref: PaymentRef, amount: Money) -> list[Receipt]:
+        """Atomically fan ``amount`` out to an open contract's payees.
+
+        Payer-only, single-shot.  Computes the largest-remainder allocation from
+        the locked weights, re-checks conservation before any credit is applied,
+        then debits the payer once and credits every payee in one pass.  If the
+        payer's balance is short, nothing moves.
+
+        Example::
+
+            receipts = await pay.settle_split(PaymentRef("round-1"), Money(amount=1000))
+            assert sum(r.amount.amount for r in receipts) == 1000
+
+        Raises:
+            SplitError: If the contract is missing, the caller is not the payer,
+                the contract is already settled, the amount is not positive, or
+                the payer's balance is insufficient.
+        """
+        contract = self._require_contract(ref)
+        if self._agent_id != contract.payer:
+            msg = f"only payer {contract.payer} may settle split {ref}"
+            raise SplitError(msg)
+        if contract.state != _STATE_OPEN:
+            msg = f"split {ref} already {contract.state}"
+            raise SplitError(msg)
+        if amount.amount <= 0:
+            msg = f"settlement amount must be positive: {amount.amount}"
+            raise SplitError(msg)
+        allocations = allocate_by_weight(amount.amount, contract.payees)
+        credited = sum(credit for _, credit in allocations)
+        if credited != amount.amount:
+            # Unreachable given ``allocate_by_weight``; re-checked here so no money
+            # is ever moved on a split that does not balance to the last credit.
+            msg = f"conservation violated: credited {credited} != debited {amount.amount}"
+            raise SplitError(msg)
+        payer_balance = self._balances.get(self._agent_id, 0)
+        if payer_balance < amount.amount:
+            msg = f"insufficient balance: {payer_balance} < {amount.amount}"
+            raise SplitError(msg)
+        self._balances[self._agent_id] = payer_balance - amount.amount
+        for payee, credit in allocations:
+            if credit:
+                self._balances[payee] = self._balances.get(payee, 0) + credit
+        contract.state = _STATE_SETTLED
+        contract.settled_amount = amount.amount
+        contract.allocations = tuple(allocations)
+        return [
+            Receipt(ref=ref, payer=contract.payer, payee=payee, amount=Money(amount=credit))
+            for payee, credit in allocations
+        ]
+
+    async def split_pay(
+        self,
+        splits: Sequence[tuple[AgentId, int]],
+        amount: Money,
+        ref: PaymentRef,
+    ) -> list[Receipt]:
+        """Open and settle a fan-out in one call.
+
+        Convenience for callers that do not need to inspect the contract between
+        open and settle.  Unlike the two-phase form -- where a failed
+        :meth:`settle_split` leaves the contract ``OPEN`` for a retry after the
+        payer tops up -- ``split_pay`` is all-or-nothing: if settlement fails, the
+        just-opened contract is rolled back so no ``OPEN`` husk and no consumed
+        reference are left behind.
+
+        Example::
+
+            receipts = await pay.split_pay(
+                [(AgentId("author"), 8), (AgentId("platform"), 2)],
+                Money(amount=1000),
+                PaymentRef("round-1"),
+            )
+
+        Raises:
+            SplitError: For any reason :meth:`open_split` or :meth:`settle_split`
+                would raise.
+        """
+        await self.open_split(splits, ref)
+        try:
+            return await self.settle_split(ref, amount)
+        except SplitError:
+            # open_split rejects a reused ref before creating anything, so the
+            # contract under ``ref`` was created by this call and is safe to drop.
+            self._contracts.pop(ref, None)
+            raise
+
+    # -- private ---------------------------------------------------------
+
+    def _require_contract(self, ref: PaymentRef) -> SplitContract:
+        contract = self._contracts.get(ref)
+        if contract is None:
+            msg = f"no split for reference: {ref}"
+            raise SplitError(msg)
+        return contract

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -56,6 +56,9 @@ cid_facts = "nest_plugins_reference.datafacts.cid_facts:CidFacts"
 heartbeat = "nest_plugins_reference.failure_detection.heartbeat:HeartbeatFailureDetector"
 phi_accrual = "nest_plugins_reference.failure_detection.phi_accrual:PhiAccrualFailureDetector"
 
+[project.entry-points."nest.plugins.payments"]
+split_settlement = "nest_plugins_reference.payments.split_settlement:SplitSettlement"
+
 [project.entry-points."nest.plugins.trust"]
 parc = "nest_plugins_reference.trust.parc:ParcTrust"
 aae_permit_gate = "nest_plugins_reference.trust.aae_permit_gate:AAEPermitGate"

--- a/packages/nest-plugins-reference/tests/test_split_settlement.py
+++ b/packages/nest-plugins-reference/tests/test_split_settlement.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit and edge-case tests for the split_settlement fan-out payments plugin.
+
+Covers the largest-remainder allocator, the open/settle lifecycle, every typed
+rejection the plugin promises, atomicity on failure, role binding across a shared
+ledger, and the Payments-protocol surface (pay/verify/refund).
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.types import AgentId, Money, PaymentRef, PaymentStatus
+from nest_plugins_reference.payments.split_settlement import (
+    SplitContract,
+    SplitError,
+    SplitSettlement,
+    allocate_by_weight,
+)
+
+
+def _pair(name: str, weight: int) -> tuple[AgentId, int]:
+    return (AgentId(name), weight)
+
+
+class TestAllocateByWeight:
+    """The pure largest-remainder allocator."""
+
+    def test_even_split_no_dust(self) -> None:
+        alloc = allocate_by_weight(1000, [_pair("a", 40), _pair("b", 40), _pair("c", 20)])
+        assert alloc == [_pair("a", 400), _pair("b", 400), _pair("c", 200)]
+
+    def test_dust_goes_to_largest_remainder(self) -> None:
+        alloc = allocate_by_weight(1001, [_pair("a", 3), _pair("b", 1), _pair("c", 1)])
+        assert alloc == [_pair("a", 601), _pair("b", 200), _pair("c", 200)]
+        assert sum(credit for _, credit in alloc) == 1001
+
+    def test_two_dust_units_split_across_ties(self) -> None:
+        # 777 across (40, 40, 20): floors 310/310/155 = 775, remainders 80/80/40,
+        # the two dust units go to the two tied-largest contributors.
+        alloc = allocate_by_weight(
+            777, [_pair("contrib-0", 40), _pair("contrib-1", 40), _pair("platform-0", 20)]
+        )
+        assert alloc == [_pair("contrib-0", 311), _pair("contrib-1", 311), _pair("platform-0", 155)]
+
+    def test_single_dust_unit_breaks_tie_by_payee_id(self) -> None:
+        # 1001 across (40, 40, 20): one dust unit, tie between the two contributors
+        # broken by the lexicographically smaller id.
+        alloc = allocate_by_weight(
+            1001, [_pair("contrib-1", 40), _pair("contrib-0", 40), _pair("platform-0", 20)]
+        )
+        assert alloc == [_pair("contrib-1", 400), _pair("contrib-0", 401), _pair("platform-0", 200)]
+
+    def test_single_payee_takes_everything(self) -> None:
+        assert allocate_by_weight(999, [_pair("solo", 7)]) == [_pair("solo", 999)]
+
+    def test_zero_amount_allocates_zero(self) -> None:
+        assert allocate_by_weight(0, [_pair("a", 1), _pair("b", 2)]) == [
+            _pair("a", 0),
+            _pair("b", 0),
+        ]
+
+    def test_empty_weights_raise(self) -> None:
+        with pytest.raises(SplitError, match="at least one payee"):
+            allocate_by_weight(100, [])
+
+    def test_non_positive_weight_raises(self) -> None:
+        with pytest.raises(SplitError, match="positive integer"):
+            allocate_by_weight(100, [_pair("a", 1), _pair("b", 0)])
+
+    def test_negative_amount_raises(self) -> None:
+        with pytest.raises(SplitError, match="non-negative"):
+            allocate_by_weight(-1, [_pair("a", 1)])
+
+
+class TestSplitLifecycle:
+    """open_split / settle_split happy path and bookkeeping."""
+
+    @pytest.fixture
+    def pay(self) -> SplitSettlement:
+        return SplitSettlement(AgentId("buyer"), initial_balance=5000)
+
+    @pytest.mark.asyncio
+    async def test_open_locks_weights(self, pay: SplitSettlement) -> None:
+        contract = await pay.open_split(
+            [_pair("author", 8), _pair("platform", 2)], PaymentRef("r1")
+        )
+        assert isinstance(contract, SplitContract)
+        assert contract.state == "OPEN"
+        assert contract.total_weight == 10
+        assert contract.payees == (_pair("author", 8), _pair("platform", 2))
+        assert await pay.verify_payment(PaymentRef("r1")) == PaymentStatus.PENDING
+
+    @pytest.mark.asyncio
+    async def test_settle_credits_and_conserves(self, pay: SplitSettlement) -> None:
+        await pay.open_split([_pair("author", 8), _pair("platform", 2)], PaymentRef("r1"))
+        receipts = await pay.settle_split(PaymentRef("r1"), Money(amount=1000))
+        assert [(str(r.payee), r.amount.amount) for r in receipts] == [
+            ("author", 800),
+            ("platform", 200),
+        ]
+        assert pay.balance(AgentId("buyer")) == 4000
+        assert pay.balance(AgentId("author")) == 800
+        assert pay.balance(AgentId("platform")) == 200
+        assert await pay.verify_payment(PaymentRef("r1")) == PaymentStatus.CONFIRMED
+
+    @pytest.mark.asyncio
+    async def test_settlement_record_queryable(self, pay: SplitSettlement) -> None:
+        await pay.split_pay(
+            [_pair("author", 8), _pair("platform", 2)], Money(amount=1001), PaymentRef("r1")
+        )
+        record = pay.settlement(PaymentRef("r1"))
+        assert record is not None
+        assert record.settled_amount == 1001
+        assert record.allocations == (_pair("author", 801), _pair("platform", 200))
+        rebuilt = pay.receipts(PaymentRef("r1"))
+        assert sum(r.amount.amount for r in rebuilt) == 1001
+
+    @pytest.mark.asyncio
+    async def test_open_split_returns_none_settlement_until_settled(
+        self, pay: SplitSettlement
+    ) -> None:
+        await pay.open_split([_pair("author", 1)], PaymentRef("r1"))
+        assert pay.settlement(PaymentRef("r1")) is None
+        with pytest.raises(SplitError, match="no settled split"):
+            pay.receipts(PaymentRef("r1"))
+
+    @pytest.mark.asyncio
+    async def test_split_pay_one_call(self, pay: SplitSettlement) -> None:
+        receipts = await pay.split_pay(
+            [_pair("a", 1), _pair("b", 1), _pair("c", 1)], Money(amount=1000), PaymentRef("r1")
+        )
+        # 1000 / (1,1,1): floors 333 each = 999, one dust to lexicographically first.
+        assert [(str(r.payee), r.amount.amount) for r in receipts] == [
+            ("a", 334),
+            ("b", 333),
+            ("c", 333),
+        ]
+
+
+class TestPaymentsProtocol:
+    """The bare Payments surface: pay / quote / verify / refund."""
+
+    @pytest.fixture
+    def pay(self) -> SplitSettlement:
+        return SplitSettlement(AgentId("buyer"), initial_balance=5000)
+
+    @pytest.mark.asyncio
+    async def test_pay_is_single_payee_split(self, pay: SplitSettlement) -> None:
+        receipt = await pay.pay(AgentId("author"), Money(amount=250), PaymentRef("p1"))
+        assert receipt.payer == AgentId("buyer")
+        assert receipt.payee == AgentId("author")
+        assert receipt.amount.amount == 250
+        assert pay.balance(AgentId("buyer")) == 4750
+        assert pay.balance(AgentId("author")) == 250
+
+    @pytest.mark.asyncio
+    async def test_verify_unknown_ref_is_failed(self, pay: SplitSettlement) -> None:
+        assert await pay.verify_payment(PaymentRef("nope")) == PaymentStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_refund_reverses_every_allocation(self, pay: SplitSettlement) -> None:
+        await pay.split_pay(
+            [_pair("a", 3), _pair("b", 1), _pair("c", 1)], Money(amount=1001), PaymentRef("r1")
+        )
+        assert pay.balance(AgentId("buyer")) == 5000 - 1001
+        await pay.refund(PaymentRef("r1"))
+        assert pay.balance(AgentId("buyer")) == 5000
+        assert pay.balance(AgentId("a")) == 0
+        assert pay.balance(AgentId("b")) == 0
+        assert pay.balance(AgentId("c")) == 0
+        assert await pay.verify_payment(PaymentRef("r1")) == PaymentStatus.REFUNDED
+
+    @pytest.mark.asyncio
+    async def test_refund_requires_payee_still_holds_share(self, pay: SplitSettlement) -> None:
+        balances: dict[AgentId, int] = {}
+        contracts: dict[PaymentRef, SplitContract] = {}
+        buyer = SplitSettlement(
+            AgentId("buyer"), initial_balance=5000, balances=balances, contracts=contracts
+        )
+        spender = SplitSettlement(
+            AgentId("a"), initial_balance=0, balances=balances, contracts=contracts
+        )
+        await buyer.split_pay([_pair("a", 1)], Money(amount=100), PaymentRef("r1"))
+        await spender.pay(
+            AgentId("sink"), Money(amount=100), PaymentRef("r2")
+        )  # a spends its credit
+        with pytest.raises(SplitError, match="lacks"):
+            await buyer.refund(PaymentRef("r1"))
+
+    @pytest.mark.asyncio
+    async def test_quote_is_fixed(self, pay: SplitSettlement) -> None:
+        from nest_core.types import ServiceRef
+
+        quote = await pay.quote(ServiceRef("bundle"))
+        assert quote.price.amount == 10
+
+
+class TestRejections:
+    """Typed rejections for every failure mode the plugin documents."""
+
+    @pytest.fixture
+    def pay(self) -> SplitSettlement:
+        return SplitSettlement(AgentId("buyer"), initial_balance=1000)
+
+    @pytest.mark.asyncio
+    async def test_empty_split(self, pay: SplitSettlement) -> None:
+        with pytest.raises(SplitError, match="at least one payee"):
+            await pay.open_split([], PaymentRef("r1"))
+
+    @pytest.mark.asyncio
+    async def test_non_positive_weight(self, pay: SplitSettlement) -> None:
+        with pytest.raises(SplitError, match="positive integer"):
+            await pay.open_split([_pair("a", 1), _pair("b", -3)], PaymentRef("r1"))
+
+    @pytest.mark.asyncio
+    async def test_duplicate_payee(self, pay: SplitSettlement) -> None:
+        with pytest.raises(SplitError, match="duplicate payee"):
+            await pay.open_split([_pair("a", 1), _pair("a", 2)], PaymentRef("r1"))
+
+    @pytest.mark.asyncio
+    async def test_self_dealing_rejected(self, pay: SplitSettlement) -> None:
+        with pytest.raises(SplitError, match="may not be a payee"):
+            await pay.open_split([_pair("buyer", 1), _pair("a", 1)], PaymentRef("r1"))
+
+    @pytest.mark.asyncio
+    async def test_unknown_payee_when_roster_supplied(self, pay: SplitSettlement) -> None:
+        roster = frozenset({AgentId("a")})
+        with pytest.raises(SplitError, match="unknown payee"):
+            await pay.open_split(
+                [_pair("a", 1), _pair("b", 1)], PaymentRef("r1"), known_payees=roster
+            )
+
+    @pytest.mark.asyncio
+    async def test_duplicate_ref(self, pay: SplitSettlement) -> None:
+        await pay.open_split([_pair("a", 1)], PaymentRef("r1"))
+        with pytest.raises(SplitError, match="already used"):
+            await pay.open_split([_pair("b", 1)], PaymentRef("r1"))
+
+    @pytest.mark.asyncio
+    async def test_settle_unknown_ref(self, pay: SplitSettlement) -> None:
+        with pytest.raises(SplitError, match="no split for reference"):
+            await pay.settle_split(PaymentRef("missing"), Money(amount=10))
+
+    @pytest.mark.asyncio
+    async def test_settle_non_positive_amount(self, pay: SplitSettlement) -> None:
+        await pay.open_split([_pair("a", 1)], PaymentRef("r1"))
+        with pytest.raises(SplitError, match="must be positive"):
+            await pay.settle_split(PaymentRef("r1"), Money(amount=0))
+
+    @pytest.mark.asyncio
+    async def test_double_settle_rejected(self, pay: SplitSettlement) -> None:
+        await pay.split_pay([_pair("a", 1)], Money(amount=100), PaymentRef("r1"))
+        with pytest.raises(SplitError, match="already SETTLED"):
+            await pay.settle_split(PaymentRef("r1"), Money(amount=100))
+
+    @pytest.mark.asyncio
+    async def test_insufficient_balance_is_atomic(self, pay: SplitSettlement) -> None:
+        with pytest.raises(SplitError, match="insufficient balance"):
+            await pay.split_pay(
+                [_pair("a", 1), _pair("b", 1)], Money(amount=9999), PaymentRef("r1")
+            )
+        # split_pay rolls back: no money moved, no husk contract, ref reusable.
+        assert pay.balance(AgentId("buyer")) == 1000
+        assert pay.balance(AgentId("a")) == 0
+        assert await pay.verify_payment(PaymentRef("r1")) == PaymentStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_two_phase_settle_failure_leaves_contract_open_for_retry(
+        self, pay: SplitSettlement
+    ) -> None:
+        await pay.open_split([_pair("a", 1)], PaymentRef("r1"))
+        with pytest.raises(SplitError, match="insufficient balance"):
+            await pay.settle_split(PaymentRef("r1"), Money(amount=9999))
+        # Two-phase settle is retryable: the contract stays OPEN.
+        assert await pay.verify_payment(PaymentRef("r1")) == PaymentStatus.PENDING
+        receipts = await pay.settle_split(PaymentRef("r1"), Money(amount=500))
+        assert receipts[0].amount.amount == 500
+
+
+class TestRoleBinding:
+    """Only the contract's payer may advance it, even on a shared ledger."""
+
+    @pytest.mark.asyncio
+    async def test_non_payer_cannot_settle(self) -> None:
+        balances: dict[AgentId, int] = {}
+        contracts: dict[PaymentRef, SplitContract] = {}
+        buyer = SplitSettlement(
+            AgentId("buyer"), initial_balance=5000, balances=balances, contracts=contracts
+        )
+        other = SplitSettlement(
+            AgentId("other"), initial_balance=5000, balances=balances, contracts=contracts
+        )
+        await buyer.open_split([_pair("author", 1)], PaymentRef("r1"))
+        with pytest.raises(SplitError, match="only payer"):
+            await other.settle_split(PaymentRef("r1"), Money(amount=100))
+
+    @pytest.mark.asyncio
+    async def test_non_payer_cannot_refund(self) -> None:
+        balances: dict[AgentId, int] = {}
+        contracts: dict[PaymentRef, SplitContract] = {}
+        buyer = SplitSettlement(
+            AgentId("buyer"), initial_balance=5000, balances=balances, contracts=contracts
+        )
+        other = SplitSettlement(
+            AgentId("other"), initial_balance=5000, balances=balances, contracts=contracts
+        )
+        await buyer.split_pay([_pair("author", 1)], Money(amount=100), PaymentRef("r1"))
+        with pytest.raises(SplitError, match="only payer"):
+            await other.refund(PaymentRef("r1"))

--- a/packages/nest-plugins-reference/tests/test_split_settlement_properties.py
+++ b/packages/nest-plugins-reference/tests/test_split_settlement_properties.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hypothesis property tests for split_settlement.
+
+Pins the invariants example-based tests cannot enumerate:
+
+* **Conservation.** ``sum(allocations) == amount`` for any weight vector and any
+  amount -- no money is created or destroyed by rounding.
+* **Bounded fairness.** Every payee receives its exact floor quota or one unit
+  more, and exactly ``dust`` payees receive the extra unit.
+* **Largest-remainder + stable tie-break.** The payees rounded up are exactly the
+  ones with the largest fractional remainders, ties broken by payee id.
+* **Order independence.** Permuting the split entries never changes any payee's
+  credit.
+* **Whole-ledger conservation and atomicity** across random op sequences,
+  including settlements that fail on insufficient funds.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Money, PaymentRef
+from nest_plugins_reference.payments.split_settlement import (
+    SplitContract,
+    SplitError,
+    SplitSettlement,
+    allocate_by_weight,
+)
+
+# Distinct payee ids (never "buyer", so the self-dealing guard never fires) with
+# positive integer weights.
+_splits = st.lists(
+    st.tuples(st.integers(min_value=0, max_value=40), st.integers(min_value=1, max_value=1000)),
+    min_size=1,
+    max_size=8,
+    unique_by=lambda item: item[0],
+).map(lambda items: [(AgentId(f"p{index}"), weight) for index, weight in items])
+
+_amount = st.integers(min_value=0, max_value=1_000_000_000)
+
+
+def _floor_quota(amount: int, weight: int, total: int) -> int:
+    return (amount * weight) // total
+
+
+@given(amount=_amount, splits=_splits)
+@settings(max_examples=400, deadline=None)
+def test_conservation(amount: int, splits: list[tuple[AgentId, int]]) -> None:
+    """Credits always sum back to the amount, for any weights and any amount."""
+    alloc = allocate_by_weight(amount, splits)
+    assert sum(credit for _, credit in alloc) == amount
+
+
+@given(amount=_amount, splits=_splits)
+@settings(max_examples=400, deadline=None)
+def test_each_credit_is_floor_or_floor_plus_one(
+    amount: int, splits: list[tuple[AgentId, int]]
+) -> None:
+    """No payee is off its exact floor quota by more than a single unit."""
+    total = sum(weight for _, weight in splits)
+    alloc = allocate_by_weight(amount, splits)
+    for (payee, weight), (out_payee, credit) in zip(splits, alloc, strict=True):
+        assert payee == out_payee
+        floor = _floor_quota(amount, weight, total)
+        assert credit in (floor, floor + 1)
+
+
+@given(amount=_amount, splits=_splits)
+@settings(max_examples=400, deadline=None)
+def test_dust_count_matches_rounded_up(amount: int, splits: list[tuple[AgentId, int]]) -> None:
+    """Exactly ``amount - sum(floors)`` payees are rounded up -- no more, no fewer."""
+    total = sum(weight for _, weight in splits)
+    alloc = allocate_by_weight(amount, splits)
+    floors = [_floor_quota(amount, weight, total) for _, weight in splits]
+    dust = amount - sum(floors)
+    rounded_up = sum(
+        1 for (_, credit), floor in zip(alloc, floors, strict=True) if credit == floor + 1
+    )
+    assert rounded_up == dust
+
+
+@given(amount=_amount, splits=_splits)
+@settings(max_examples=400, deadline=None)
+def test_largest_remainder_with_stable_tiebreak(
+    amount: int, splits: list[tuple[AgentId, int]]
+) -> None:
+    """Every rounded-up payee outranks every rounded-down one by (remainder, id)."""
+    total = sum(weight for _, weight in splits)
+    alloc = allocate_by_weight(amount, splits)
+    ups: list[tuple[int, str]] = []
+    downs: list[tuple[int, str]] = []
+    for (payee, weight), (_, credit) in zip(splits, alloc, strict=True):
+        remainder = (amount * weight) % total
+        floor = _floor_quota(amount, weight, total)
+        (ups if credit == floor + 1 else downs).append((remainder, str(payee)))
+    for up_rem, up_id in ups:
+        for down_rem, down_id in downs:
+            # up must rank strictly ahead: larger remainder, or equal remainder
+            # with a lexicographically smaller id (the documented tie-break).
+            assert up_rem > down_rem or (up_rem == down_rem and up_id < down_id)
+
+
+@given(amount=_amount, splits=_splits, perm_seed=st.integers(min_value=0, max_value=10_000))
+@settings(max_examples=300, deadline=None)
+def test_permutation_invariance(
+    amount: int, splits: list[tuple[AgentId, int]], perm_seed: int
+) -> None:
+    """Reordering the split entries never changes any payee's credit."""
+    import random
+
+    shuffled = list(splits)
+    random.Random(perm_seed).shuffle(shuffled)
+    base = dict(allocate_by_weight(amount, splits))
+    other = dict(allocate_by_weight(amount, shuffled))
+    assert base == other
+
+
+@given(amount=st.integers(min_value=1, max_value=10_000), splits=_splits)
+@settings(max_examples=300, deadline=None)
+@pytest.mark.asyncio
+async def test_open_settle_equals_split_pay(amount: int, splits: list[tuple[AgentId, int]]) -> None:
+    """Two-phase open+settle produces the same receipts as one-shot split_pay."""
+    two_phase = SplitSettlement(AgentId("buyer"), initial_balance=10**12)
+    await two_phase.open_split(splits, PaymentRef("r"))
+    a = await two_phase.settle_split(PaymentRef("r"), Money(amount=amount))
+    one_shot = SplitSettlement(AgentId("buyer"), initial_balance=10**12)
+    b = await one_shot.split_pay(splits, Money(amount=amount), PaymentRef("r"))
+    assert [(str(r.payee), r.amount.amount) for r in a] == [
+        (str(r.payee), r.amount.amount) for r in b
+    ]
+
+
+@given(
+    ops=st.lists(
+        st.tuples(_splits, st.integers(min_value=1, max_value=10_000)),
+        min_size=1,
+        max_size=20,
+    )
+)
+@settings(max_examples=200, deadline=None)
+@pytest.mark.asyncio
+async def test_random_op_sequence_conserves_ledger_and_stays_atomic(
+    ops: list[tuple[list[tuple[AgentId, int]], int]],
+) -> None:
+    """Across arbitrary settlement sequences the total ledger is invariant.
+
+    Some settlements will exhaust the payer's balance; each such failure must be
+    atomic (no partial credit) so the whole-marketplace total never drifts.
+    """
+    initial = 50_000
+    balances: dict[AgentId, int] = {}
+    contracts: dict[PaymentRef, SplitContract] = {}
+    buyer = SplitSettlement(
+        AgentId("buyer"), initial_balance=initial, balances=balances, contracts=contracts
+    )
+
+    def total_ledger() -> int:
+        return sum(balances.values())
+
+    assert total_ledger() == initial
+    for index, (splits, amount) in enumerate(ops):
+        with contextlib.suppress(SplitError):
+            await buyer.split_pay(splits, Money(amount=amount), PaymentRef(f"r{index}"))
+        # Whether the settlement succeeded or was rejected, nothing leaked.
+        assert total_ledger() == initial
+
+
+@given(
+    amount=st.integers(min_value=1, max_value=10_000), payee=st.integers(min_value=0, max_value=40)
+)
+@settings(max_examples=200, deadline=None)
+@pytest.mark.asyncio
+async def test_pay_equals_weight_one_split(amount: int, payee: int) -> None:
+    """pay(to, amount) credits exactly ``amount`` to a single payee."""
+    pay = SplitSettlement(AgentId("buyer"), initial_balance=10**9)
+    receipt = await pay.pay(AgentId(f"p{payee}"), Money(amount=amount), PaymentRef("r"))
+    assert receipt.amount.amount == amount
+    assert pay.balance(AgentId(f"p{payee}")) == amount

--- a/packages/nest-plugins-reference/tests/test_split_settlement_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_split_settlement_scenario.py
@@ -30,7 +30,11 @@ from nest_core.scenarios_builtin.split_settlement import split_settlement_factor
 from nest_core.sim.simulator import Simulator
 from nest_core.types import AgentId, Money, PaymentRef, Receipt
 from nest_core.validators import ValidationResult, validate_events, validate_trace
-from nest_plugins_reference.payments.split_settlement import SplitError, SplitSettlement
+from nest_plugins_reference.payments.split_settlement import (
+    SplitError,
+    SplitSettlement,
+    allocate_by_weight,
+)
 
 SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "split_settlement.yaml"
 
@@ -86,6 +90,46 @@ class _WeightTamperingSplitter(SplitSettlement):
         contract.state = "SETTLED"
         contract.settled_amount = amount.amount
         contract.allocations = tuple(allocations)
+        return [
+            Receipt(ref=ref, payer=contract.payer, payee=payee, amount=Money(amount=credit))
+            for payee, credit in allocations
+        ]
+
+
+class _LedgerSkimmingSplitter(SplitSettlement):
+    """Returns canonical receipts but credits the shared ledger one unit short.
+
+    The nastier attack the receipt-auditing validators cannot see: it computes
+    the *correct* largest-remainder allocation and returns it verbatim as the
+    receipts the buyer broadcasts -- so ``split_conservation`` (credits sum to the
+    amount) and ``split_weight_fidelity`` (credits match the canonical split) both
+    pass.  But on the real shared ledger it credits the first payee one unit less
+    than the receipt claims and pockets that unit back to itself (the payer).  The
+    ledger still balances internally, and no receipt lies about the total -- yet
+    the first payee's *observed* balance moves by one less than reported every
+    settlement, which only ``split_ledger_attestation`` (payee-observed truth)
+    catches.
+    """
+
+    async def settle_split(self, ref: PaymentRef, amount: Money) -> list[Receipt]:
+        contract = self.contract(ref)
+        if contract is None:
+            msg = f"no split for reference: {ref}"
+            raise SplitError(msg)
+        allocations = allocate_by_weight(amount.amount, contract.payees)
+        # Debit the payer the full amount, exactly as an honest settlement would.
+        self._balances[self._agent_id] = self._balances.get(self._agent_id, 0) - amount.amount
+        skimmed = 0
+        for index, (payee, credit) in enumerate(allocations):
+            take = 1 if index == 0 and credit > 0 else 0
+            self._balances[payee] = self._balances.get(payee, 0) + credit - take
+            skimmed += take
+        # Pocket the skim back to the payer: the ledger balances, the theft hides.
+        self._balances[self._agent_id] = self._balances.get(self._agent_id, 0) + skimmed
+        contract.state = "SETTLED"
+        contract.settled_amount = amount.amount
+        contract.allocations = tuple(allocations)
+        # Return the CANONICAL receipts -- the lie the attestation validator exposes.
         return [
             Receipt(ref=ref, payer=contract.payer, payee=payee, amount=Money(amount=credit))
             for payee, credit in allocations
@@ -168,6 +212,23 @@ def test_weight_tampering_passes_conservation_but_fails_fidelity() -> None:
     assert not results["split_weight_fidelity"].passed
 
 
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_ledger_skimming_passes_receipts_but_fails_attestation() -> None:
+    """The point of the third validator: honest-looking receipts can still short the ledger.
+
+    ``_LedgerSkimmingSplitter`` returns the canonical allocation as its receipts
+    (so both receipt-auditing validators pass) while crediting the shared ledger
+    one unit short on the first payee (so the payees' observed balance deltas
+    fall short of the reported credits). Only ledger attestation catches it --
+    proving the third validator is not redundant with the first two.
+    """
+    results = _by_name(validate_trace(_run_injected(_LedgerSkimmingSplitter), "split_settlement"))
+    assert results["split_conservation"].passed
+    assert results["split_weight_fidelity"].passed
+    assert not results["split_ledger_attestation"].passed
+    assert "observed ledger delta" in results["split_ledger_attestation"].detail
+
+
 # --------------------------------------------------------------------------
 # Determinism
 # --------------------------------------------------------------------------
@@ -247,3 +308,87 @@ def test_validator_reports_no_lifecycle_on_empty_trace() -> None:
     assert not results["split_conservation"].passed
     assert "no split" in results["split_conservation"].detail
     assert not results["split_weight_fidelity"].passed
+    assert not results["split_ledger_attestation"].passed
+    assert "no split" in results["split_ledger_attestation"].detail
+
+
+# --------------------------------------------------------------------------
+# ASK 4: fidelity is order-insensitive (payee->credit map, not position)
+# --------------------------------------------------------------------------
+
+
+def test_fidelity_accepts_reordered_but_correct_allocation() -> None:
+    """Credits listed in a different order than the declared weights still pass.
+
+    The canonical split of 1001 over a~40;b~40;c~20 is a~401;b~400;c~200. Here the
+    settled event lists the same payees and credits in reverse -- correct amounts,
+    different order -- which the order-insensitive map compare accepts.
+    """
+    events = [
+        _broadcast("buyer-0", "split:opened:ref=r0:payer=buyer-0:weights=a~40;b~40;c~20"),
+        _broadcast("buyer-0", "split:settled:ref=r0:amount=1001:alloc=c~200;b~400;a~401"),
+    ]
+    results = _by_name(validate_events(events, "split_settlement"))
+    assert results["split_weight_fidelity"].passed
+    assert results["split_conservation"].passed
+
+
+def test_fidelity_rejects_duplicate_payee_in_allocation() -> None:
+    """A payee that repeats in the reported allocation is a violation, not merged."""
+    events = [
+        _broadcast("buyer-0", "split:opened:ref=r0:payer=buyer-0:weights=a~1;b~1"),
+        # 'a' repeated: it sums to 100 but names a duplicate payee -- must fail.
+        _broadcast("buyer-0", "split:settled:ref=r0:amount=100:alloc=a~50;a~50"),
+    ]
+    results = _by_name(validate_events(events, "split_settlement"))
+    assert not results["split_weight_fidelity"].passed
+    assert "duplicate payee" in results["split_weight_fidelity"].detail
+
+
+# --------------------------------------------------------------------------
+# ASK 3: ledger-attestation validator (synthetic traces)
+# --------------------------------------------------------------------------
+
+
+def _attested_events() -> list[dict[str, Any]]:
+    """Two settlements with payee attestations whose deltas match the credits."""
+    return [
+        _broadcast("buyer-0", "split:opened:ref=r0:payer=buyer-0:weights=a~40;b~40;c~20"),
+        _broadcast("buyer-0", "split:settled:ref=r0:amount=1000:alloc=a~400;b~400;c~200"),
+        _broadcast("a", "split:observed:ref=r0:payee=a:balance=400"),
+        _broadcast("b", "split:observed:ref=r0:payee=b:balance=400"),
+        _broadcast("c", "split:observed:ref=r0:payee=c:balance=200"),
+        _broadcast("buyer-1", "split:opened:ref=r1:payer=buyer-1:weights=a~1;c~1"),
+        _broadcast("buyer-1", "split:settled:ref=r1:amount=100:alloc=a~50;c~50"),
+        # a and c are credited again; the delta from the prior attestation is 50.
+        _broadcast("a", "split:observed:ref=r1:payee=a:balance=450"),
+        _broadcast("c", "split:observed:ref=r1:payee=c:balance=250"),
+    ]
+
+
+def test_attestation_accepts_matching_ledger_deltas() -> None:
+    results = _by_name(validate_events(_attested_events(), "split_settlement"))
+    assert results["split_ledger_attestation"].passed
+
+
+def test_attestation_flags_shorted_ledger_delta() -> None:
+    """A payee whose observed balance moves less than reported is caught."""
+    events = _attested_events()
+    # a's first attestation is one unit short of the reported 400 credit; keep the
+    # later balance consistent with the shorted start so only r0/a is flagged.
+    events[2] = _broadcast("a", "split:observed:ref=r0:payee=a:balance=399")
+    events[7] = _broadcast("a", "split:observed:ref=r1:payee=a:balance=449")
+    results = _by_name(validate_events(events, "split_settlement"))
+    assert not results["split_ledger_attestation"].passed
+    assert "observed ledger delta" in results["split_ledger_attestation"].detail
+
+
+def test_attestation_flags_settlement_without_attestation() -> None:
+    """A settlement with no covering payee attestation fails, like the other two."""
+    events = [
+        _broadcast("buyer-0", "split:opened:ref=r0:payer=buyer-0:weights=a~1;b~1"),
+        _broadcast("buyer-0", "split:settled:ref=r0:amount=100:alloc=a~50;b~50"),
+    ]
+    results = _by_name(validate_events(events, "split_settlement"))
+    assert not results["split_ledger_attestation"].passed
+    assert "no covering attestation" in results["split_ledger_attestation"].detail

--- a/packages/nest-plugins-reference/tests/test_split_settlement_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_split_settlement_scenario.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end + adversarial tests for the split_settlement scenario.
+
+Boots the ``split_settlement`` scenario through the real ``Simulator`` and proves
+the two validators discriminate:
+
+* under ``payments: split_settlement`` -- both PASS;
+* under ``payments: prepaid_credits`` -- both FAIL (no fan-out protocol, no
+  ``split:*`` events);
+* under a deliberately buggy in-test splitter -- the matching validator FAILS,
+  and a *penny-shaving* bug (which conservation catches) is shown to be distinct
+  from a *weight-tampering* bug (which conservation misses but fidelity catches).
+
+Also pins determinism: same seed -> byte-identical trace, across seeds 42/7/1337.
+The buggy splitters live here, not in the shipped plugin package, per the charter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.scenarios_builtin.split_settlement import split_settlement_factory
+from nest_core.sim.simulator import Simulator
+from nest_core.types import AgentId, Money, PaymentRef, Receipt
+from nest_core.validators import ValidationResult, validate_events, validate_trace
+from nest_plugins_reference.payments.split_settlement import SplitError, SplitSettlement
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "split_settlement.yaml"
+
+
+# --------------------------------------------------------------------------
+# Buggy in-test splitters -- NOT shipped as plugins (charter requirement).
+# --------------------------------------------------------------------------
+
+
+class _PennyShavingSplitter(SplitSettlement):
+    """Floors every share and silently keeps the indivisible dust.
+
+    The classic settlement bug: ``credit_i = floor(amount * w_i / total)`` with no
+    largest-remainder step, so the credits sum to *less* than the debit and the
+    operator pockets the difference.
+    """
+
+    async def settle_split(self, ref: PaymentRef, amount: Money) -> list[Receipt]:
+        contract = self.contract(ref)
+        if contract is None:
+            msg = f"no split for reference: {ref}"
+            raise SplitError(msg)
+        allocations = [
+            (payee, (amount.amount * weight) // contract.total_weight)
+            for payee, weight in contract.payees
+        ]
+        contract.state = "SETTLED"
+        contract.settled_amount = amount.amount
+        contract.allocations = tuple(allocations)
+        return [
+            Receipt(ref=ref, payer=contract.payer, payee=payee, amount=Money(amount=credit))
+            for payee, credit in allocations
+        ]
+
+
+class _WeightTamperingSplitter(SplitSettlement):
+    """Conserves the total but routes it all to the first payee.
+
+    Sums to the amount (so a conservation-only check is fooled) yet ignores the
+    declared weights entirely -- exactly the mid-flight reweight / self-dealing
+    that ``split_weight_fidelity`` is built to catch.
+    """
+
+    async def settle_split(self, ref: PaymentRef, amount: Money) -> list[Receipt]:
+        contract = self.contract(ref)
+        if contract is None:
+            msg = f"no split for reference: {ref}"
+            raise SplitError(msg)
+        allocations = [
+            (payee, amount.amount if index == 0 else 0)
+            for index, (payee, _weight) in enumerate(contract.payees)
+        ]
+        contract.state = "SETTLED"
+        contract.settled_amount = amount.amount
+        contract.allocations = tuple(allocations)
+        return [
+            Receipt(ref=ref, payer=contract.payer, payee=payee, amount=Money(amount=credit))
+            for payee, credit in allocations
+        ]
+
+
+# --------------------------------------------------------------------------
+# Runners
+# --------------------------------------------------------------------------
+
+
+def _run_registered(plugin_name: str, seed: int = 42) -> Path:
+    """Run the scenario via the registry (for plugins resolvable by name)."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    new_layers = config.layers.model_copy(update={"payments": plugin_name})
+    config = config.model_copy(update={"layers": new_layers, "seed": seed})
+    tmp = Path(tempfile.mkdtemp())
+    trace = tmp / f"{plugin_name}_{seed}.jsonl"
+    config = config.model_copy(
+        update={"output": config.output.model_copy(update={"trace": str(trace)})}
+    )
+    runner = ScenarioRunner(config, registry=PluginRegistry())
+    asyncio.run(runner.run())
+    return trace
+
+
+def _run_injected(payments_cls: type[Any], seed: int = 42) -> Path:
+    """Drive the scenario with an arbitrary (unregistered) payments class."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    plugins: dict[str, Any] = {"payments": payments_cls}
+    agents = split_settlement_factory(config, plugins)
+    overrides: dict[AgentId, dict[str, Any]] = plugins.pop("_agent_plugins", {})
+    tmp = Path(tempfile.mkdtemp())
+    trace = tmp / f"injected_{seed}.jsonl"
+    sim = Simulator(seed=seed, trace_path=trace, plugins={})
+    for agent_id, agent in agents.items():
+        sim.add_agent(agent_id, agent)
+    for agent_id, agent_overrides in overrides.items():
+        sim.set_agent_plugins(agent_id, agent_overrides)
+    asyncio.run(sim.run(max_ticks=config.get_max_ticks()))
+    return trace
+
+
+def _by_name(results: list[ValidationResult]) -> dict[str, ValidationResult]:
+    return {r.name: r for r in results}
+
+
+# --------------------------------------------------------------------------
+# Discrimination through the real simulator
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_split_settlement_passes_both_validators() -> None:
+    results = validate_trace(_run_registered("split_settlement"), "split_settlement")
+    failures = [f"{r.name}: {r.detail}" for r in results if not r.passed]
+    assert all(r.passed for r in results), failures
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_prepaid_credits_fails_both_validators() -> None:
+    """The default plugin has no fan-out: buyers fall back to pay(), no split:* events."""
+    results = _by_name(validate_trace(_run_registered("prepaid_credits"), "split_settlement"))
+    assert not results["split_conservation"].passed
+    assert not results["split_weight_fidelity"].passed
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_penny_shaving_splitter_is_caught_by_conservation() -> None:
+    results = _by_name(validate_trace(_run_injected(_PennyShavingSplitter), "split_settlement"))
+    assert not results["split_conservation"].passed
+    assert "dust leak" in results["split_conservation"].detail
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+def test_weight_tampering_passes_conservation_but_fails_fidelity() -> None:
+    """The point of the second validator: conservation alone cannot see self-dealing."""
+    results = _by_name(validate_trace(_run_injected(_WeightTamperingSplitter), "split_settlement"))
+    assert results["split_conservation"].passed
+    assert not results["split_weight_fidelity"].passed
+
+
+# --------------------------------------------------------------------------
+# Determinism
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not SCENARIO_PATH.exists(), reason=f"scenario not at {SCENARIO_PATH}")
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_deterministic_and_valid_across_seeds(seed: int) -> None:
+    """Same seed -> byte-identical trace; validators pass under every seed."""
+    first = _run_registered("split_settlement", seed).read_bytes()
+    second = _run_registered("split_settlement", seed).read_bytes()
+    assert first == second
+    results = validate_trace(_run_registered("split_settlement", seed), "split_settlement")
+    assert all(r.passed for r in results)
+
+
+# --------------------------------------------------------------------------
+# Fast synthetic-trace unit tests of the validators themselves
+# --------------------------------------------------------------------------
+
+
+def _broadcast(agent: str, msg: str) -> dict[str, Any]:
+    return {"kind": "broadcast", "agent": agent, "msg": msg}
+
+
+def _honest_events() -> list[dict[str, Any]]:
+    return [
+        _broadcast("buyer-0", "split:opened:ref=r0:payer=buyer-0:weights=a~40;b~40;c~20"),
+        _broadcast("buyer-0", "split:settled:ref=r0:amount=1001:alloc=a~401;b~400;c~200"),
+    ]
+
+
+def test_validator_accepts_honest_trace() -> None:
+    results = _by_name(validate_events(_honest_events(), "split_settlement"))
+    assert results["split_conservation"].passed
+    assert results["split_weight_fidelity"].passed
+
+
+def test_validator_flags_penny_shave_event() -> None:
+    events = [
+        _broadcast("buyer-0", "split:opened:ref=r0:payer=buyer-0:weights=a~40;b~40;c~20"),
+        # floors of 1001: 400/400/200 = 1000, one unit shaved.
+        _broadcast("buyer-0", "split:settled:ref=r0:amount=1001:alloc=a~400;b~400;c~200"),
+    ]
+    results = _by_name(validate_events(events, "split_settlement"))
+    assert not results["split_conservation"].passed
+
+
+def test_validator_flags_weight_tamper_event() -> None:
+    events = [
+        _broadcast("buyer-0", "split:opened:ref=r0:payer=buyer-0:weights=a~40;b~40;c~20"),
+        # sums to 1001 but ignores the declared weights.
+        _broadcast("buyer-0", "split:settled:ref=r0:amount=1001:alloc=a~1001;b~0;c~0"),
+    ]
+    results = _by_name(validate_events(events, "split_settlement"))
+    assert results["split_conservation"].passed
+    assert not results["split_weight_fidelity"].passed
+
+
+def test_validator_flags_settled_without_opened() -> None:
+    events = [_broadcast("buyer-0", "split:settled:ref=r0:amount=100:alloc=a~100")]
+    results = _by_name(validate_events(events, "split_settlement"))
+    assert not results["split_weight_fidelity"].passed
+
+
+def test_validator_flags_negative_credit() -> None:
+    events = [
+        _broadcast("buyer-0", "split:opened:ref=r0:payer=buyer-0:weights=a~1;b~1"),
+        _broadcast("buyer-0", "split:settled:ref=r0:amount=100:alloc=a~150;b~-50"),
+    ]
+    results = _by_name(validate_events(events, "split_settlement"))
+    assert not results["split_conservation"].passed
+
+
+def test_validator_reports_no_lifecycle_on_empty_trace() -> None:
+    results = _by_name(validate_events([], "split_settlement"))
+    assert not results["split_conservation"].passed
+    assert "no split" in results["split_conservation"].detail
+    assert not results["split_weight_fidelity"].passed

--- a/scenarios/split_settlement.yaml
+++ b/scenarios/split_settlement.yaml
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# Split-settlement content marketplace: three buyers pay for content each round
+# and fan every payment out 80/20 -- 80% shared between two contributors, 20% to
+# the platform -- through the split_settlement plugin. Round amounts (777, 1001)
+# are deliberately indivisible by the weight total so the largest-remainder dust
+# distribution is exercised in the trace. The two split_settlement validators
+# (conservation, weight-fidelity) must pass under `payments: split_settlement`
+# and fail under `payments: prepaid_credits` (no fan-out protocol, no split:*
+# events emitted).
+
+name: split_settlement
+description: |
+  Twelve agents (3 buyers, 8 contributors, 1 platform). Each buyer runs three
+  rounds of weighted 80/20 revenue splitting. All settlements conserve value
+  exactly and match the largest-remainder split of their declared weights.
+  Deterministic across seeds 42, 7, and 1337 (no RNG on the settlement path).
+
+tier: 1
+seed: 42
+
+agents:
+  count: 12
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 3
+      config:
+        initial_balance: 5000
+    - name: contributor
+      count: 8
+      config: {}
+    - name: platform
+      count: 1
+      config: {}
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: split_settlement
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: split_settlement
+  config: {}
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 5000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/split_settlement.jsonl


### PR DESCRIPTION
## Motivation

The merged payments plugins each move value in one shape:

- `prepaid_credits` — one debit to **one** payee.
- `escrow` — one payee's payout, gated on delivery/arbitration.
- `empic_escrow` — pull/pubsub escrow for a provider/consumer pair.
- `streaming` — **one** payee metered one tick at a time.

None of them takes a single debit and fans it out to **N payees at once** by
declared shares.

**Scope anchor:** this PR is a self-scoped payments-layer problem, distinct
from problem 03 by that problem's own scope declaration — 03 (streaming
x402) explicitly lists multi-party streams (one payer, many payees) as out
of its scope — following the merged precedent for self-scoped payments work
(#38 arbitrated escrow, #90 EMPIC). Novelty is therefore claimed against
the fan-out settlement shape, which exists nowhere in the merged set. That is the missing primitive behind the most common real
settlement flows: marketplace revenue splits, royalty payouts, ad/network
rev-share, and contributor splits. Doing this naively is exactly where money
leaks — floor every share and the indivisible remainder ("dust") silently
vanishes, or a compromised splitter quietly reweights the payout in its own
favour. This PR adds `split_settlement`: an atomic, exact, weight-locked fan-out
settlement, plus two adversarial validators that make those two failure modes
un-shippable.

## Design

**Money & weights are integers, end to end.** Credits are `int` (matching the
`Money.amount: int` the rest of the layer uses); weights are **positive
integers** (ratios). An 80/20 split is `(80, 20)` or `(4, 1)` — never floats.
Nothing on the settlement path touches floating point, so no allocation can drift
by a rounding error.

**Largest-remainder (Hamilton) allocation.** For amount `A` and weights `wᵢ`
with total `W`:

1. Each payee first gets the floor of its exact quota: `fᵢ = A·wᵢ // W`.
2. The leftover `dust = A − Σfᵢ` is handed out one unit at a time to the payees
   with the largest remainders `rᵢ = A·wᵢ mod W`, ties broken by payee id, then
   original index.

*Conservation proof sketch.* `Σfᵢ = Σ(A·wᵢ − rᵢ)/W = A − (Σrᵢ)/W`. Each
`rᵢ ∈ [0, W)`, so `Σrᵢ < n·W` and `dust = (Σrᵢ)/W ∈ {0, …, n−1}` is a
non-negative integer strictly less than the payee count. Distributing exactly
`dust` unit increments restores the total to `A`, so `Σ(allocation) == A`
**exactly**, for every amount and every weight vector. The tie-break is a total
order on `(−remainder, id, index)`, so the result is deterministic regardless of
dict iteration or input ordering.

**Weights are locked at open.** `open_split(splits, ref)` records the weight
vector as an immutable tuple and moves no money; `settle_split(ref, amount)` is
the only thing that pays out, and it recomputes the allocation purely from the
locked weights. The weights a settlement honours cannot be renegotiated between
open and settle.

**Atomicity.** `settle_split` computes the full allocation, re-checks
conservation, and verifies the payer's balance *before* crediting anyone; then it
debits the payer once and credits every payee in a single pass. If the balance is
short, nothing moves. The two-phase `open`→`settle` form leaves a failed
settlement `OPEN` and retryable; the one-shot `split_pay` convenience is
all-or-nothing and rolls its own contract back on failure.

**Role binding & receipts.** On a shared ledger only the contract's payer may
settle or refund it. Every settlement returns one `Receipt` per payee and stores
a queryable settlement record (`settled_amount` + per-payee `allocations`).

**Registration.** Both `_BUILTINS` (`nest_core/plugins.py`) **and** a
`nest.plugins.payments` entry point in `packages/nest-plugins-reference/pyproject.toml`
(payments previously had no entry-point group at all).

## Tradeoffs

1. **Weights at open vs. weights at settle.** Locking weights at open (and
   letting the amount arrive at settle) makes the allocation a pure function of
   `(declared weights, amount)` that a validator can recompute independently.
   Locking the *amount* too would forbid "same split, variable revenue per
   round"; locking neither would make weight-tampering undetectable. Weights-at-
   open is the choice that buys the audit.

2. **Duplicate `ref` → typed rejection, not idempotent replay.** A settlement is
   a unique financial commitment, so a reused reference raises `SplitError`
   rather than silently returning the prior contract — surfacing a double-spend
   bug in the caller instead of masking it. (Documented in `open_split`.)

3. **Single settle per contract vs. multi-settle.** A contract settles once. A
   drip/multi-settle model would need running-total accounting and a second
   conservation invariant; keeping it single-shot makes the proof one line and
   the trace unambiguous. Streaming already owns the metered-payout shape.

4. **"Unknown payee" is opt-in, not invented.** The payments layer has no agent
   directory — identity is the registry/identity layer's job — so `open_split`
   takes an optional `known_payees` roster and rejects outsiders only when the
   caller supplies one, instead of pretending to validate identities it cannot
   see. It *does* enforce the settlement-local hazards unconditionally: empty
   splits, non-positive weights, duplicate payees, and the payer listing itself
   (self-dealing).

## Adversarial validators

The hidden property this pair pins down: **conservation is not weight-fidelity.**
A compromised splitter can conserve the total perfectly while stealing the
split — route everything to itself, drop a payee, quietly reweight — and a
conservation check alone will wave it through. No merged payments plugin
expresses fan-out at all, so neither failure mode is currently catchable
anywhere in the stack. Closing that gap requires an auditor that *recomputes
the allocation independently from the declared weights*, which is exactly what
the second validator does.

Registered as `VALIDATORS["split_settlement"]`; both read the JSONL trace's
`split:opened` / `split:settled` broadcasts. The default `prepaid_credits` plugin
has no fan-out protocol, so buyers fall back to `pay()` and emit no `split:*`
events — both validators report "no split lifecycle observed" and fail, which is
the charter's bar for adversarial.

1. **Penny-shaving → `split_conservation`.** Sums the per-payee credits in each
   settlement and compares to the debited amount. A splitter that floors every
   share and keeps the dust credits strictly less than it debits; the check fails
   on the shortfall (and on any negative credit).

2. **Weight-tampering → `split_weight_fidelity`.** **Independently recomputes**
   the canonical largest-remainder allocation from the *declared* weights and
   compares it payee-by-payee to the reported credits. It never imports the
   plugin, so a compromised plugin cannot subvert its own audit. This catches a
   mid-flight reweight, a dropped/injected payee, or dust self-dealing **even
   when the total still sums correctly** — the case conservation alone cannot
   see.

The tests prove the two are non-redundant: an in-test `_WeightTamperingSplitter`
that routes the whole amount to the first payee **passes** `split_conservation`
(it sums to the amount) but **fails** `split_weight_fidelity`; a
`_PennyShavingSplitter` fails conservation on the dust. Both buggy splitters are
driven through the real `Simulator` (they are test-only, never shipped as
plugins).

## Scope / core wiring

Every `nest_core` touch is required registration, following the existing house
pattern for each file:

- `nest_core/plugins.py` — one `_BUILTINS` entry (`("payments", "split_settlement")`),
  the same mapping every bundled plugin uses.
- `nest_core/scenarios.py` — one registration branch for the builtin scenario
  (the file already carries twenty such branches).
- `nest_core/validators.py` — the two validators live here because this is
  where all seventy existing validators live, alongside the registry they
  join.
- `nest_core/tests/test_validators.py` — one line: the registry keyset test
  enumerates every validator name and fails CI without it.
- `nest_core/scenarios_builtin/split_settlement.py` + its YAML — the builtin
  scenario pair, precedented by `auction` (which also ships
  `scenarios/auction.yaml` alongside the builtin copy).

No file outside the plugin/validator/scenario/docs surface is modified, and
`scripts/judge/`, the seed bank, and `scores.json` are untouched.

## Verification

```bash
uv sync
uv run ruff check .
uv run ruff format --check .
uv run pyright
uv run pytest -v
# scenario, by name, across the seed bank:
uv run nest run split_settlement --seed 42
uv run nest run split_settlement --seed 7
uv run nest run split_settlement --seed 1337
```

All five gates exit 0 (`0 errors, 0 warnings` from pyright; full suite green).
The 53 new tests span the pure allocator, the full lifecycle, every typed
rejection, `hypothesis` property batteries (conservation, the exact
largest-remainder + tie-break ordering, permutation invariance, whole-ledger
conservation and atomicity under random op sequences), the end-to-end scenario,
and the two validators against both the honest plugin and the buggy splitters.

Validating a scenario trace:

```
PASS split_conservation: 9 settlements conserved value exactly (sum of credits == amount)
PASS split_weight_fidelity: 9 settlements matched the largest-remainder split of their declared weights
```

Under `payments: prepaid_credits` the same two validators fail with
"no split settlements observed in trace -- plugin lacks fan-out settlement".

## Layer & companion Phase 2 submission

- **Layer:** `payments` (plugin `payments: split_settlement`), with trace
  validators registered under `split_settlement` and a builtin scenario.
- **Author (both phases):** Karan Singh Bisht — GitHub `KaranSinghBisht`,
  same identity on the participation form and the skills registry.
- **Phase 2:** AgentPress — The Autonomous Newsroom of the Agent Economy
  ([registry entry](https://nandatown.projectnanda.org/api/skills/982f1085-3469-472c-a3d5-5736585e11f1),
  [SKILL.md](https://agentpress-nanda.vercel.app/skill.md),
  [live service](https://agentpress-nanda.vercel.app)). AgentPress settles
  its contributor revenue with exactly the primitive this PR contributes:
  an 80/20 fan-out split, weighted by editorial score, allocated by
  largest remainder so the ledger conserves every credit. This plugin is
  that economy expressed as NANDA Town infrastructure.

## Determinism

The settlement path uses no wall-clock and no RNG; allocation ties break on
`(remainder, payee id, index)`. The scenario consumes no simulator randomness, so
each seed's trace is byte-identical across runs — verified for seeds 42, 7, and
1337 (run twice, `diff` clean) both via the property tests and the `nest run`
CLI.
