### PR TITLE
[Hackathon] ckeda-security: delegatable capability tokens with cascading revocation

### DIFF
--- a/docs/layers/auth.md
+++ b/docs/layers/auth.md
@@ -21,6 +21,27 @@ shape (header.payload.sig), no claim validation beyond the signature.
 
 Source: [`nest_plugins_reference/auth/jwt_auth.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/jwt_auth.py).
 
+## Hardened plugin: `delegatable`
+
+Macaroon-style HMAC-chained capability tokens. Any token holder mints
+attenuated child tokens **offline** via
+`delegate(parent_token, audience, scopes_subset, ttl)`; each child's
+signature is keyed by its parent's signature, so revoking any segment
+invalidates every descendant at the next `verify` — cascading revocation
+by construction, no per-child revocation lists. `verify` re-checks the
+full chain (signature, per-segment revocation and expiry, monotonic scope
+and expiry attenuation); `verify_presented(token, presenter)` additionally
+binds presentation to the token's audience.
+
+Adversarial validators (`check_no_scope_escalation`,
+`check_no_stale_ancestor_use`, `check_audience_binding`) fail against the
+`jwt` plugin and pass against `delegatable`; the `delegated_auth` scenario
+exercises all three attacks deterministically.
+
+Source: [`nest_plugins_reference/auth/delegatable.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py).
+Validators: [`nest_plugins_reference/validators/delegation_validators.py`](../../packages/nest-plugins-reference/nest_plugins_reference/validators/delegation_validators.py).
+Scenario: [`scenarios/delegated_auth.yaml`](../../scenarios/delegated_auth.yaml).
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -26,6 +26,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
+    ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -105,6 +105,10 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.empic_payments import empic_payments_factory
 
         register_scenario("empic_payments", empic_payments_factory)
+    elif name == "delegated_auth":
+        from nest_core.scenarios_builtin.delegated_auth import delegated_auth_factory
+
+        register_scenario("delegated_auth", delegated_auth_factory)
     elif name == "multi_attribute_market":
         from nest_core.scenarios_builtin.multi_attribute_market import (
             multi_attribute_market_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegated-auth scenario: a capability tree under adversarial use.
+
+A coordinator self-issues a root capability and delegates attenuated
+tokens to three intermediaries; each intermediary sub-delegates to four
+leaf agents, which then present their tokens back to the coordinator to
+access a resource.  Three adversarial behaviours are baked in:
+
+1. one intermediary requests a *broader* scope for its first leaf
+   (scope escalation);
+2. the coordinator revokes one intermediary's grant mid-run, after
+   which that subtree keeps presenting (stale ancestor);
+3. one leaf shares its token with a sibling, which presents it
+   (audience confusion).
+
+Every delegate / revoke / verify emits a ``delegation_audit`` event so
+the validators in
+``nest_plugins_reference.validators.delegation_validators`` can replay
+the trace.  Under ``auth: delegatable`` all three attacks are refused;
+under ``auth: jwt`` they succeed and the validators fail.
+
+Example::
+
+    agents = delegated_auth_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Awaitable
+from typing import Any, cast
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Token
+
+ROOT_SCOPES: list[str] = ["read", "write", "pay"]
+MID_SCOPES: list[str] = ["read", "write"]
+LEAF_SCOPES: list[str] = ["read"]
+ESCALATED_SCOPES: list[str] = ["read", "admin"]
+
+
+def _json(data: dict[str, Any]) -> bytes:
+    return json.dumps(data, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _load(payload: bytes) -> dict[str, Any]:
+    try:
+        data: object = json.loads(payload.decode("utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return cast("dict[str, Any]", data) if isinstance(data, dict) else {}
+
+
+def _tid(token: Token) -> str:
+    """Correlation id for a token, uniform across auth plugins.
+
+    Example::
+
+        tid = _tid(token)
+    """
+    return hashlib.sha256(str(token).encode()).hexdigest()[:16]
+
+
+async def _audit(ctx: AgentContext, data: dict[str, Any]) -> None:
+    event = {"type": "delegation_audit", "tick": int(ctx.time), **data}
+    await ctx.send(ctx.agent_id, _json(event))
+
+
+def _pin_clock(auth: Any, now: float) -> None:
+    set_clock = getattr(auth, "set_clock", None)
+    if callable(set_clock):
+        set_clock(now)
+
+
+async def _delegate(
+    auth: Any,
+    parent_token: Token,
+    audience: AgentId,
+    scopes: list[str],
+    ttl: float,
+) -> Token | None:
+    """Delegate via the plugin if it can, else fall back to re-issuance.
+
+    The fallback is deliberately the vulnerable pattern the default
+    ``jwt`` plugin forces: a "child" is a brand-new root with whatever
+    scopes were requested and no link to its parent.
+
+    Example::
+
+        child = await _delegate(auth, root, AgentId("leaf-0"), ["read"], 300.0)
+    """
+    delegate = getattr(auth, "delegate", None)
+    if callable(delegate):
+        try:
+            pending = cast("Awaitable[Token]", delegate(parent_token, audience, scopes, ttl))
+            return await pending
+        except ValueError:
+            return None
+    return cast("Token", await auth.issue(audience, scopes))
+
+
+async def _verify(auth: Any, token: Token, presenter: AgentId) -> bool:
+    """Verify a presented token, audience-bound when the plugin can.
+
+    Example::
+
+        ok = await _verify(auth, token, AgentId("leaf-0"))
+    """
+    verify_presented = getattr(auth, "verify_presented", None)
+    try:
+        if callable(verify_presented):
+            await cast("Awaitable[object]", verify_presented(token, presenter))
+        else:
+            await auth.verify(token)
+    except ValueError:
+        return False
+    return True
+
+
+class CoordinatorAgent(StateMachineAgent):
+    """Root of the delegation tree; grants, revokes, and gates access.
+
+    Example::
+
+        agent = CoordinatorAgent(AgentId("coordinator-0"), auth=auth,
+                                 intermediaries=[AgentId("intermediary-0")],
+                                 revoke_tick=20, revoke_target=0)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        auth: Any,
+        intermediaries: list[AgentId],
+        revoke_tick: int,
+        revoke_target: int,
+    ) -> None:
+        self._id = agent_id
+        self._auth = auth
+        self._intermediaries = intermediaries
+        self._revoke_tick = revoke_tick
+        self._revoke_target = revoke_target
+        self._grants: dict[AgentId, Token] = {}
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        await ctx.schedule(1.0, _json({"type": "bootstrap"}))
+        await ctx.schedule(float(self._revoke_tick), _json({"type": "revoke"}))
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        data = _load(payload)
+        kind = data.get("type")
+        _pin_clock(self._auth, ctx.time)
+        if kind == "bootstrap" and sender == ctx.agent_id:
+            root = cast("Token", await self._auth.issue(ctx.agent_id, ROOT_SCOPES))
+            for mid in self._intermediaries:
+                token = await _delegate(self._auth, root, mid, MID_SCOPES, ttl=600.0)
+                granted = token is not None
+                await _audit(
+                    ctx,
+                    {
+                        "op": "delegate",
+                        "delegator": str(ctx.agent_id),
+                        "audience": str(mid),
+                        "parent_scopes": ROOT_SCOPES,
+                        "child_scopes": MID_SCOPES,
+                        "granted": granted,
+                    },
+                )
+                if token is None:
+                    continue
+                self._grants[mid] = token
+                lineage = [_tid(root), _tid(token)]
+                grant = {"type": "grant", "token": str(token), "lineage": lineage}
+                await ctx.send(mid, _json(grant))
+        elif kind == "revoke" and sender == ctx.agent_id:
+            target = self._intermediaries[self._revoke_target]
+            token = self._grants.get(target)
+            if token is None:
+                return
+            await self._auth.revoke(token)
+            await _audit(ctx, {"op": "revoke", "tid": _tid(token), "target": str(target)})
+        elif kind == "access_request":
+            token = Token(str(data.get("token", "")))
+            lineage = [str(t) for t in cast("list[Any]", data.get("lineage", []))]
+            audience = str(data.get("audience", ""))
+            verified = await _verify(self._auth, token, sender)
+            await _audit(
+                ctx,
+                {
+                    "op": "verify",
+                    "presenter": str(sender),
+                    "audience": audience,
+                    "chain_tids": [*lineage, _tid(token)],
+                    "verified": verified,
+                },
+            )
+
+
+class IntermediaryAgent(StateMachineAgent):
+    """Sub-delegates its grant to a block of leaf agents.
+
+    Example::
+
+        agent = IntermediaryAgent(AgentId("intermediary-0"), auth=auth,
+                                  leaves=[AgentId("leaf-0")], escalate=False)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        auth: Any,
+        leaves: list[AgentId],
+        escalate: bool,
+    ) -> None:
+        self._id = agent_id
+        self._auth = auth
+        self._leaves = leaves
+        self._escalate = escalate
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        data = _load(payload)
+        if data.get("type") != "grant":
+            return
+        _pin_clock(self._auth, ctx.time)
+        parent = Token(str(data.get("token", "")))
+        lineage = [str(t) for t in cast("list[Any]", data.get("lineage", []))]
+        for index, leaf in enumerate(self._leaves):
+            scopes = ESCALATED_SCOPES if self._escalate and index == 0 else LEAF_SCOPES
+            token = await _delegate(self._auth, parent, leaf, scopes, ttl=300.0)
+            granted = token is not None
+            await _audit(
+                ctx,
+                {
+                    "op": "delegate",
+                    "delegator": str(ctx.agent_id),
+                    "audience": str(leaf),
+                    "parent_scopes": MID_SCOPES,
+                    "child_scopes": scopes,
+                    "granted": granted,
+                },
+            )
+            if token is None:
+                continue
+            await ctx.send(
+                leaf,
+                _json(
+                    {
+                        "type": "grant",
+                        "token": str(token),
+                        "lineage": [*lineage, _tid(token)],
+                    }
+                ),
+            )
+
+
+class LeafAgent(StateMachineAgent):
+    """Presents its token to the coordinator; may leak it to a sibling.
+
+    Example::
+
+        agent = LeafAgent(AgentId("leaf-0"), coordinator=AgentId("coordinator-0"),
+                          share_with=None, presents=4, interval=10)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        coordinator: AgentId,
+        share_with: AgentId | None,
+        presents: int,
+        interval: int,
+    ) -> None:
+        self._id = agent_id
+        self._coordinator = coordinator
+        self._share_with = share_with
+        self._presents = presents
+        self._interval = interval
+        self._token: str | None = None
+        self._lineage: list[str] = []
+        self._audience: str = str(agent_id)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        data = _load(payload)
+        kind = data.get("type")
+        if kind == "grant" or kind == "share":
+            self._token = str(data.get("token", ""))
+            self._lineage = [str(t) for t in cast("list[Any]", data.get("lineage", []))]
+            if kind == "share":
+                self._audience = str(data.get("audience", ""))
+            if kind == "grant" and self._share_with is not None:
+                await ctx.send(
+                    self._share_with,
+                    _json(
+                        {
+                            "type": "share",
+                            "token": self._token,
+                            "lineage": self._lineage,
+                            "audience": str(ctx.agent_id),
+                        }
+                    ),
+                )
+            for step in range(self._presents):
+                await ctx.schedule(2.0 + step * self._interval, _json({"type": "present"}))
+        elif kind == "present" and sender == ctx.agent_id and self._token is not None:
+            await ctx.send(
+                self._coordinator,
+                _json(
+                    {
+                        "type": "access_request",
+                        "token": self._token,
+                        "lineage": self._lineage,
+                        "audience": self._audience,
+                    }
+                ),
+            )
+
+
+def delegated_auth_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create the coordinator, intermediaries, and leaf agents.
+
+    Example::
+
+        agents = delegated_auth_factory(config, plugins)
+    """
+    task_config = config.task.config
+    mid_count = 3
+    leaf_count = 12
+    for role in config.agents.roles:
+        if role.name == "intermediary":
+            mid_count = role.count
+        elif role.name == "leaf":
+            leaf_count = role.count
+    revoke_tick = int(cast("int", task_config.get("revoke_tick", 20)))
+    presents = int(cast("int", task_config.get("presents", 4)))
+    interval = int(cast("int", task_config.get("present_interval", 10)))
+
+    auth_cls = cast("Any", plugins.get("auth"))
+    auth: Any = auth_cls(secret=b"delegated-auth-scenario", clock=0.0)
+
+    coordinator_id = AgentId("coordinator-0")
+    intermediary_ids = [AgentId(f"intermediary-{i}") for i in range(mid_count)]
+    leaf_ids = [AgentId(f"leaf-{i}") for i in range(leaf_count)]
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    agents[coordinator_id] = CoordinatorAgent(
+        coordinator_id,
+        auth=auth,
+        intermediaries=intermediary_ids,
+        revoke_tick=revoke_tick,
+        revoke_target=min(1, mid_count - 1),
+    )
+    per_block = max(1, leaf_count // max(1, mid_count))
+    for index, mid in enumerate(intermediary_ids):
+        block = leaf_ids[index * per_block : (index + 1) * per_block]
+        agents[mid] = IntermediaryAgent(
+            mid,
+            auth=auth,
+            leaves=block,
+            escalate=index == min(2, mid_count - 1),
+        )
+    for index, leaf in enumerate(leaf_ids):
+        share_with = leaf_ids[1] if index == 0 and leaf_count > 1 else None
+        agents[leaf] = LeafAgent(
+            leaf,
+            coordinator=coordinator_id,
+            share_with=share_with,
+            presents=presents,
+            interval=interval,
+        )
+    return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
@@ -19,6 +19,11 @@ the validators in
 the trace.  Under ``auth: delegatable`` all three attacks are refused;
 under ``auth: jwt`` they succeed and the validators fail.
 
+The scenario is deliberately **seed-invariant**: agents draw nothing
+from ``ctx.rng``, so the trace is byte-identical across seeds.  The
+adversarial behaviours are structural (fixed roles, fixed ticks), not
+sampled — determinism here is a property under test, not an accident.
+
 Example::
 
     agents = delegated_auth_factory(config, plugins)

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegatable capability tokens with cascading revocation (macaroon-style).
+
+A holder of a token can mint a narrower child token for another agent
+*without* contacting the issuer, by HMAC-chaining the child segment to the
+parent signature (Birgisson et al., 2014).  Revoking any segment invalidates
+every descendant at the next ``verify`` — no per-child revocation lists.
+
+Attenuation invariants enforced at mint *and* re-checked at verify:
+
+- child ``scopes`` must be a strict-or-equal subset of the parent's;
+- child ``exp`` must not exceed the parent's;
+- a child is bound to a single ``audience`` and only that agent may
+  present it (checked via :meth:`DelegatableAuth.verify_presented`).
+
+Example::
+
+    auth = DelegatableAuth(secret=b"secret", clock=0.0)
+    root = await auth.issue(AgentId("coordinator"), ["read", "write"])
+    child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=60.0)
+    ctx = await auth.verify_presented(child, AgentId("worker"))
+    await auth.revoke(root)          # cascades:
+    await auth.verify(child)         # raises RevokedAncestorError
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any, cast
+
+from nest_core.types import AgentId, AuthContext, Token
+
+_DEFAULT_TTL: float = 3600.0
+
+
+class DelegationError(ValueError):
+    """Base class for delegation failures.
+
+    Subclasses ``ValueError`` so callers written against the reference
+    ``jwt`` plugin (which raises bare ``ValueError``) keep working.
+
+    Example::
+
+        try:
+            await auth.verify(token)
+        except DelegationError as err:
+            print(f"rejected: {err}")
+    """
+
+
+class ScopeEscalationError(DelegationError):
+    """A child requested scopes its parent does not hold.
+
+    Example::
+
+        raise ScopeEscalationError("scope 'admin' not held by parent")
+    """
+
+
+class RevokedAncestorError(DelegationError):
+    """A token in the ancestry chain has been revoked.
+
+    Example::
+
+        raise RevokedAncestorError("ancestor tid=ab12 revoked")
+    """
+
+
+class ExpiredAncestorError(DelegationError):
+    """A token in the ancestry chain has expired.
+
+    Example::
+
+        raise ExpiredAncestorError("ancestor tid=ab12 expired")
+    """
+
+
+class AudienceMismatchError(DelegationError):
+    """A token was presented by an agent other than its audience.
+
+    Example::
+
+        raise AudienceMismatchError("presented by a2, bound to a1")
+    """
+
+
+def _canonical(segment: dict[str, Any]) -> bytes:
+    """Serialize a segment deterministically for signing.
+
+    Example::
+
+        digest_input = _canonical({"tid": "ab", "aud": "a1"})
+    """
+    return json.dumps(segment, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _segment_tid(
+    audience: str,
+    scopes: list[str],
+    issued_at: float,
+    expires_at: float,
+    parent_tid: str | None,
+) -> str:
+    """Derive a deterministic segment id from segment content.
+
+    Example::
+
+        tid = _segment_tid("a1", ["read"], 0.0, 60.0, None)
+    """
+    preimage = json.dumps(
+        {
+            "aud": audience,
+            "scopes": sorted(scopes),
+            "iat": issued_at,
+            "exp": expires_at,
+            "parent": parent_tid,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(preimage).hexdigest()[:16]
+
+
+class DelegatableAuth:
+    """Macaroon-style delegatable auth with cascading revocation.
+
+    Satisfies the base ``Auth`` protocol (``issue`` / ``verify`` /
+    ``revoke``) and adds ``delegate`` and ``verify_presented``.
+
+    Example::
+
+        auth = DelegatableAuth(secret=b"secret", clock=0.0)
+        root = await auth.issue(AgentId("a1"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("a2"), ["read"], ttl=60.0)
+    """
+
+    def __init__(self, secret: bytes = b"nest-default-secret", clock: float | None = None) -> None:
+        self._secret = secret
+        self._clock = clock
+        self._revoked: set[str] = set()
+
+    def set_clock(self, now: float) -> None:
+        """Pin the plugin's logical clock (deterministic scenarios).
+
+        Example::
+
+            auth.set_clock(ctx.time)
+        """
+        self._clock = now
+
+    def _now(self) -> float:
+        if self._clock is not None:
+            return self._clock
+        import time
+
+        return time.time()
+
+    def _chain_signature(self, chain: list[dict[str, Any]]) -> str:
+        key = self._secret
+        for segment in chain:
+            key = hmac.new(key, _canonical(segment), hashlib.sha256).digest()
+        return key.hex()
+
+    def _encode(self, chain: list[dict[str, Any]]) -> Token:
+        envelope = {"chain": chain, "sig": self._chain_signature(chain)}
+        return Token(json.dumps(envelope, sort_keys=True, separators=(",", ":")))
+
+    def _decode(self, token: Token) -> list[dict[str, Any]]:
+        try:
+            data: object = json.loads(str(token))
+        except json.JSONDecodeError as err:
+            msg = "Invalid token format"
+            raise DelegationError(msg) from err
+        if not isinstance(data, dict):
+            msg = "Invalid token format"
+            raise DelegationError(msg)
+        envelope = cast("dict[str, Any]", data)
+        chain_obj: object = envelope.get("chain")
+        sig_obj: object = envelope.get("sig")
+        if not isinstance(chain_obj, list) or not chain_obj or not isinstance(sig_obj, str):
+            msg = "Invalid token format"
+            raise DelegationError(msg)
+        chain = cast("list[dict[str, Any]]", chain_obj)
+        expected = self._chain_signature(chain)
+        if not hmac.compare_digest(sig_obj, expected):
+            msg = "Invalid token signature"
+            raise DelegationError(msg)
+        return chain
+
+    def _check_chain(self, chain: list[dict[str, Any]], now: float) -> None:
+        parent_scopes: set[str] | None = None
+        parent_exp: float | None = None
+        for segment in chain:
+            tid = str(segment.get("tid", ""))
+            scopes = {str(s) for s in cast("list[Any]", segment.get("scopes", []))}
+            exp = float(cast("float", segment.get("exp", 0.0)))
+            if tid in self._revoked:
+                msg = f"ancestor tid={tid} revoked"
+                raise RevokedAncestorError(msg)
+            if exp < now:
+                msg = f"ancestor tid={tid} expired"
+                raise ExpiredAncestorError(msg)
+            if parent_scopes is not None and not scopes.issubset(parent_scopes):
+                escalated = sorted(scopes - parent_scopes)
+                msg = f"scopes {escalated} not held by parent"
+                raise ScopeEscalationError(msg)
+            if parent_exp is not None and exp > parent_exp:
+                msg = f"child exp {exp} exceeds parent exp {parent_exp}"
+                raise ExpiredAncestorError(msg)
+            parent_scopes = scopes
+            parent_exp = exp
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Issue a root token for a subject with given scopes.
+
+        Example::
+
+            root = await auth.issue(AgentId("a1"), ["read", "write"])
+        """
+        now = self._now()
+        exp = now + _DEFAULT_TTL
+        segment: dict[str, Any] = {
+            "tid": _segment_tid(str(subject), scopes, now, exp, None),
+            "aud": str(subject),
+            "scopes": sorted(scopes),
+            "iat": now,
+            "exp": exp,
+            "parent": None,
+        }
+        return self._encode([segment])
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token:
+        """Mint a child token from a parent, without contacting the issuer.
+
+        The child's scopes must be a subset of the parent's, and its
+        expiry is clamped to the parent's.  Raises
+        :class:`ScopeEscalationError` on a broader request and any
+        chain error (revoked / expired ancestor) eagerly.
+
+        Example::
+
+            child = await auth.delegate(root, AgentId("a2"), ["read"], ttl=60.0)
+        """
+        now = self._now()
+        chain = self._decode(parent_token)
+        self._check_chain(chain, now)
+        parent = chain[-1]
+        parent_scopes = {str(s) for s in cast("list[Any]", parent.get("scopes", []))}
+        requested = {str(s) for s in scopes_subset}
+        if not requested.issubset(parent_scopes):
+            escalated = sorted(requested - parent_scopes)
+            msg = f"scopes {escalated} not held by parent"
+            raise ScopeEscalationError(msg)
+        parent_exp = float(cast("float", parent.get("exp", now)))
+        exp = min(now + ttl, parent_exp)
+        parent_tid = str(parent.get("tid", ""))
+        segment: dict[str, Any] = {
+            "tid": _segment_tid(str(audience), sorted(requested), now, exp, parent_tid),
+            "aud": str(audience),
+            "scopes": sorted(requested),
+            "iat": now,
+            "exp": exp,
+            "parent": parent_tid,
+        }
+        return self._encode([*chain, segment])
+
+    async def verify(self, token: Token) -> AuthContext:
+        """Verify a token, walking the full ancestry chain.
+
+        Checks signature, per-segment revocation (cascading), expiry of
+        every ancestor, and monotonic scope / expiry attenuation.
+
+        Example::
+
+            ctx = await auth.verify(child)
+        """
+        now = self._now()
+        chain = self._decode(token)
+        self._check_chain(chain, now)
+        leaf = chain[-1]
+        return AuthContext(
+            subject=AgentId(str(leaf.get("aud", ""))),
+            scopes=[str(s) for s in cast("list[Any]", leaf.get("scopes", []))],
+            issued_at=float(cast("float", leaf.get("iat", now))),
+            expires_at=float(cast("float", leaf.get("exp", now))),
+        )
+
+    async def verify_presented(self, token: Token, presenter: AgentId) -> AuthContext:
+        """Verify a token *and* that the presenter is its bound audience.
+
+        Example::
+
+            ctx = await auth.verify_presented(child, AgentId("a2"))
+        """
+        ctx = await self.verify(token)
+        if ctx.subject != presenter:
+            msg = f"presented by {presenter}, bound to {ctx.subject}"
+            raise AudienceMismatchError(msg)
+        return ctx
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke a token; every descendant fails verify from now on.
+
+        Example::
+
+            await auth.revoke(root)
+        """
+        chain = self._decode(token)
+        leaf = chain[-1]
+        self._revoked.add(str(leaf.get("tid", "")))

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -16,6 +16,12 @@ Example::
 
 from __future__ import annotations
 
+from nest_plugins_reference.validators.delegation_validators import (
+    check_audience_binding,
+    check_no_scope_escalation,
+    check_no_stale_ancestor_use,
+    extract_delegation_audits,
+)
 from nest_plugins_reference.validators.gossip_validators import (
     ConvergenceFailureError,
     PartitionLeakError,
@@ -42,6 +48,7 @@ __all__ = [
     "ConvergenceFailureError",
     "PartitionLeakError",
     "ValidatorReport",
+    "check_audience_binding",
     "check_converged",
     "check_denial_receipt_auditable",
     "check_eavesdropper_blocked",
@@ -49,9 +56,12 @@ __all__ = [
     "check_gate_tamper_rejected",
     "check_low_trust_blocked",
     "check_no_partition_view_leak",
+    "check_no_scope_escalation",
+    "check_no_stale_ancestor_use",
     "check_partial_redaction_enforced",
     "check_replay_rejected",
     "check_stale_revocation_blocked",
     "corrupt_proof",
+    "extract_delegation_audits",
     "forge_tier_upgrade",
 ]

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/delegation_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/delegation_validators.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for the delegatable capability-token plugin.
+
+Three attacks the default ``jwt`` auth plugin silently allows, because it
+has no parent/child relationship between tokens (``JwtAuth._revoked`` is a
+flat set of exact token strings):
+
+1. **Scope escalation.**  A "delegated" token under ``jwt`` is simply a
+   fresh issuance, so a child can be minted with scopes its delegator
+   never held.  ``check_no_scope_escalation`` asserts every *granted*
+   delegation's scopes are a subset of the delegator's scopes.
+2. **Stale parent.**  Revoking or expiring a parent token leaves
+   ``jwt`` children fully valid — there is no chain to walk.
+   ``check_no_stale_ancestor_use`` asserts no successful verification
+   happens at or after the tick where any ancestor was revoked.
+3. **Audience confusion.**  ``jwt`` binds a token to a subject but never
+   checks who *presents* it.  ``check_audience_binding`` asserts every
+   successful presentation was made by the token's bound audience.
+
+All three are pure functions over ``delegation_audit`` events emitted by
+the ``delegated_auth`` scenario, so they compose with unit tests
+(hand-built events), integration tests, and trace replays.
+
+By construction: against the **delegatable** plugin every adversarial
+action in the scenario is refused, the audits record ``granted=False`` /
+``verified=False``, and all three checks pass; against the **jwt**
+plugin the same actions succeed, the audits record successes, and the
+checks fail — the charter's bar for "adversarial".
+
+Example::
+
+    events = [json.loads(line) for line in trace.open()]
+    audits = extract_delegation_audits(events)
+    assert check_no_scope_escalation(audits).passed
+    assert check_no_stale_ancestor_use(audits).passed
+    assert check_audience_binding(audits).passed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+AuditEvent = dict[str, Any]
+"""One ``delegation_audit`` payload as emitted by the scenario agents."""
+
+
+@dataclass
+class ValidatorReport:
+    """Pass/fail report with a short human-readable explanation.
+
+    Example::
+
+        report = check_audience_binding(audits)
+        assert report.passed, report.detail
+    """
+
+    passed: bool
+    detail: str
+    evidence: list[AuditEvent] = field(default_factory=list[AuditEvent])
+
+
+def _payload(event: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract a ``delegation_audit`` payload from a raw trace event.
+
+    Example::
+
+        audit = _payload({"msg": '{"type": "delegation_audit", ...}'})
+    """
+    import json
+
+    msg: object = event.get("msg")
+    if isinstance(msg, dict):
+        data = cast("dict[str, Any]", msg)
+    elif isinstance(msg, str):
+        try:
+            loaded: object = json.loads(msg)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(loaded, dict):
+            return None
+        data = cast("dict[str, Any]", loaded)
+    else:
+        return None
+    if data.get("type") != "delegation_audit":
+        return None
+    return data
+
+
+def extract_delegation_audits(events: list[dict[str, Any]]) -> list[AuditEvent]:
+    """Pull all ``delegation_audit`` payloads out of raw trace events.
+
+    Example::
+
+        audits = extract_delegation_audits(events)
+    """
+    audits: list[AuditEvent] = []
+    for event in events:
+        data = _payload(event)
+        if data is not None:
+            audits.append(data)
+    return audits
+
+
+def check_no_scope_escalation(audits: list[AuditEvent]) -> ValidatorReport:
+    """Assert no granted delegation exceeds the delegator's scopes.
+
+    Example::
+
+        assert check_no_scope_escalation(audits).passed
+    """
+    violations: list[AuditEvent] = []
+    for audit in audits:
+        if audit.get("op") != "delegate" or not audit.get("granted"):
+            continue
+        parent = {str(s) for s in cast("list[Any]", audit.get("parent_scopes", []))}
+        child = {str(s) for s in cast("list[Any]", audit.get("child_scopes", []))}
+        if not child.issubset(parent):
+            violations.append(audit)
+    if violations:
+        detail = f"{len(violations)} delegation(s) granted scopes beyond the parent"
+        return ValidatorReport(passed=False, detail=detail, evidence=violations)
+    return ValidatorReport(passed=True, detail="all granted delegations attenuate scopes")
+
+
+def check_no_stale_ancestor_use(audits: list[AuditEvent]) -> ValidatorReport:
+    """Assert no token verifies at/after the tick an ancestor was revoked.
+
+    Example::
+
+        assert check_no_stale_ancestor_use(audits).passed
+    """
+    revoked_at: dict[str, int] = {}
+    for audit in audits:
+        if audit.get("op") == "revoke":
+            revoked_at[str(audit.get("tid", ""))] = int(cast("int", audit.get("tick", 0)))
+    violations: list[AuditEvent] = []
+    for audit in audits:
+        if audit.get("op") != "verify" or not audit.get("verified"):
+            continue
+        tick = int(cast("int", audit.get("tick", 0)))
+        chain = [str(t) for t in cast("list[Any]", audit.get("chain_tids", []))]
+        for tid in chain:
+            if tid in revoked_at and tick >= revoked_at[tid]:
+                violations.append(audit)
+                break
+    if violations:
+        detail = f"{len(violations)} verification(s) succeeded under a revoked ancestor"
+        return ValidatorReport(passed=False, detail=detail, evidence=violations)
+    return ValidatorReport(passed=True, detail="no token outlived a revoked ancestor")
+
+
+def check_audience_binding(audits: list[AuditEvent]) -> ValidatorReport:
+    """Assert every successful presentation came from the bound audience.
+
+    Example::
+
+        assert check_audience_binding(audits).passed
+    """
+    violations: list[AuditEvent] = []
+    for audit in audits:
+        if audit.get("op") != "verify" or not audit.get("verified"):
+            continue
+        presenter = str(audit.get("presenter", ""))
+        audience = str(audit.get("audience", ""))
+        if presenter and audience and presenter != audience:
+            violations.append(audit)
+    if violations:
+        detail = f"{len(violations)} presentation(s) accepted from a non-audience agent"
+        return ValidatorReport(passed=False, detail=detail, evidence=violations)
+    return ValidatorReport(passed=True, detail="all presentations came from the bound audience")

--- a/packages/nest-plugins-reference/tests/test_delegatable_auth.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable_auth.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the delegatable capability-token auth plugin.
+
+Covers issuance, offline delegation, scope attenuation, TTL clamping,
+cascading revocation across deep chains, audience binding, the three
+adversarial patterns from the problem brief (scope escalation, stale
+parent, audience confusion), and base ``Auth`` protocol compatibility.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.layers.auth import Auth
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.delegatable import (
+    AudienceMismatchError,
+    DelegatableAuth,
+    DelegationError,
+    ExpiredAncestorError,
+    RevokedAncestorError,
+    ScopeEscalationError,
+)
+from nest_plugins_reference.auth.jwt_auth import JwtAuth
+
+ROOT = AgentId("coordinator")
+MID = AgentId("intermediary")
+LEAF = AgentId("leaf")
+
+
+def _auth(clock: float = 0.0) -> DelegatableAuth:
+    return DelegatableAuth(secret=b"test-secret", clock=clock)
+
+
+@pytest.mark.asyncio
+async def test_satisfies_auth_protocol() -> None:
+    auth = _auth()
+    assert isinstance(auth, Auth)
+
+
+@pytest.mark.asyncio
+async def test_issue_and_verify_root() -> None:
+    auth = _auth()
+    root = await auth.issue(ROOT, ["read", "write"])
+    ctx = await auth.verify(root)
+    assert ctx.subject == ROOT
+    assert sorted(ctx.scopes) == ["read", "write"]
+
+
+@pytest.mark.asyncio
+async def test_delegate_offline_and_verify_child() -> None:
+    auth = _auth()
+    root = await auth.issue(ROOT, ["read", "write"])
+    child = await auth.delegate(root, MID, ["read"], ttl=60.0)
+    ctx = await auth.verify(child)
+    assert ctx.subject == MID
+    assert ctx.scopes == ["read"]
+
+
+@pytest.mark.asyncio
+async def test_scope_escalation_raises_at_mint() -> None:
+    auth = _auth()
+    root = await auth.issue(ROOT, ["read"])
+    with pytest.raises(ScopeEscalationError):
+        await auth.delegate(root, MID, ["read", "admin"], ttl=60.0)
+
+
+@pytest.mark.asyncio
+async def test_grandchild_cannot_exceed_grandparent() -> None:
+    auth = _auth()
+    root = await auth.issue(ROOT, ["read", "write"])
+    child = await auth.delegate(root, MID, ["read"], ttl=60.0)
+    with pytest.raises(ScopeEscalationError):
+        await auth.delegate(child, LEAF, ["write"], ttl=30.0)
+
+
+@pytest.mark.asyncio
+async def test_child_ttl_clamped_to_parent() -> None:
+    auth = _auth()
+    root = await auth.issue(ROOT, ["read"])
+    root_exp = (await auth.verify(root)).expires_at
+    child = await auth.delegate(root, MID, ["read"], ttl=10_000_000.0)
+    child_exp = (await auth.verify(child)).expires_at
+    assert root_exp is not None and child_exp is not None
+    assert child_exp <= root_exp
+
+
+@pytest.mark.asyncio
+async def test_cascading_revocation_root_kills_grandchild() -> None:
+    auth = _auth()
+    root = await auth.issue(ROOT, ["read", "write"])
+    child = await auth.delegate(root, MID, ["read"], ttl=60.0)
+    grandchild = await auth.delegate(child, LEAF, ["read"], ttl=30.0)
+    await auth.revoke(root)
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify(grandchild)
+
+
+@pytest.mark.asyncio
+async def test_revoking_middle_spares_sibling_branch() -> None:
+    auth = _auth()
+    root = await auth.issue(ROOT, ["read", "write"])
+    mid_a = await auth.delegate(root, AgentId("mid-a"), ["read"], ttl=60.0)
+    mid_b = await auth.delegate(root, AgentId("mid-b"), ["write"], ttl=60.0)
+    leaf_a = await auth.delegate(mid_a, LEAF, ["read"], ttl=30.0)
+    await auth.revoke(mid_a)
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify(leaf_a)
+    ctx = await auth.verify(mid_b)
+    assert ctx.scopes == ["write"]
+
+
+@pytest.mark.asyncio
+async def test_stale_parent_expired_ancestor_fails() -> None:
+    auth = _auth(clock=0.0)
+    root = await auth.issue(ROOT, ["read"])
+    child = await auth.delegate(root, MID, ["read"], ttl=60.0)
+    auth.set_clock(10_000_000.0)
+    with pytest.raises(ExpiredAncestorError):
+        await auth.verify(child)
+
+
+@pytest.mark.asyncio
+async def test_revoked_parent_cannot_mint_children() -> None:
+    auth = _auth()
+    root = await auth.issue(ROOT, ["read"])
+    await auth.revoke(root)
+    with pytest.raises(RevokedAncestorError):
+        await auth.delegate(root, MID, ["read"], ttl=60.0)
+
+
+@pytest.mark.asyncio
+async def test_audience_confusion_rejected() -> None:
+    auth = _auth()
+    root = await auth.issue(ROOT, ["read"])
+    child = await auth.delegate(root, MID, ["read"], ttl=60.0)
+    with pytest.raises(AudienceMismatchError):
+        await auth.verify_presented(child, LEAF)
+    ctx = await auth.verify_presented(child, MID)
+    assert ctx.subject == MID
+
+
+@pytest.mark.asyncio
+async def test_tampered_chain_rejected() -> None:
+    auth = _auth()
+    root = await auth.issue(ROOT, ["read"])
+    forged = Token(str(root).replace('"read"', '"admin"'))
+    with pytest.raises(DelegationError):
+        await auth.verify(forged)
+
+
+@pytest.mark.asyncio
+async def test_garbage_token_rejected() -> None:
+    auth = _auth()
+    for garbage in ("", "not-json", '{"chain": [], "sig": "00"}'):
+        with pytest.raises(DelegationError):
+            await auth.verify(Token(garbage))
+
+
+@pytest.mark.asyncio
+async def test_delegation_errors_are_value_errors() -> None:
+    auth = _auth()
+    root = await auth.issue(ROOT, ["read"])
+    await auth.revoke(root)
+    with pytest.raises(ValueError, match="revoked"):
+        await auth.verify(root)
+
+
+@pytest.mark.asyncio
+async def test_default_jwt_plugin_is_vulnerable_baseline() -> None:
+    """Document the gap this plugin closes: jwt has no chain semantics.
+
+    Under ``JwtAuth`` a "delegated" token is just a fresh issuance, so
+    revoking the parent leaves the child fully valid — the stale-parent
+    attack the adversarial validator must catch.
+    """
+    jwt = JwtAuth(secret=b"test-secret")
+    parent = await jwt.issue(ROOT, ["read"])
+    child = await jwt.issue(MID, ["read", "admin"])  # escalation unnoticed
+    await jwt.revoke(parent)
+    ctx = await jwt.verify(child)  # still verifies: no cascade
+    assert "admin" in ctx.scopes

--- a/packages/nest-plugins-reference/tests/test_delegatable_auth_properties.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable_auth_properties.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Property tests for the delegatable auth plugin.
+
+Two invariants under random delegation chains: (1) *monotone
+attenuation* — a verified leaf never holds a scope its root lacked and
+never outlives any ancestor; (2) *cascading revocation* — revoking a
+random ancestor always invalidates every descendant minted under it.
+Token bytes are also deterministic for a fixed clock and secret.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.delegatable import (
+    DelegatableAuth,
+    RevokedAncestorError,
+)
+
+_SCOPES = st.sets(st.sampled_from(["read", "write", "pay", "admin"]), min_size=1)
+
+
+def _run(coro: Coroutine[Any, Any, None]) -> None:
+    asyncio.run(coro)
+
+
+async def _build_chain(
+    auth: DelegatableAuth,
+    root_scopes: set[str],
+    subset_picks: list[int],
+) -> tuple[list[Token], list[set[str]]]:
+    tokens: list[Token] = [await auth.issue(AgentId("agent-0"), sorted(root_scopes))]
+    scope_sets: list[set[str]] = [set(root_scopes)]
+    for depth, pick in enumerate(subset_picks, start=1):
+        parent_scopes = sorted(scope_sets[-1])
+        keep = max(1, pick % (len(parent_scopes) + 1))
+        child_scopes = set(parent_scopes[:keep])
+        token = await auth.delegate(
+            tokens[-1],
+            AgentId(f"agent-{depth}"),
+            sorted(child_scopes),
+            ttl=100.0,
+        )
+        tokens.append(token)
+        scope_sets.append(child_scopes)
+    return tokens, scope_sets
+
+
+@settings(max_examples=50, deadline=None)
+@given(root_scopes=_SCOPES, picks=st.lists(st.integers(min_value=1), min_size=1, max_size=6))
+def test_leaf_scopes_never_exceed_root(root_scopes: set[str], picks: list[int]) -> None:
+    async def scenario() -> None:
+        auth = DelegatableAuth(secret=b"prop", clock=0.0)
+        tokens, _ = await _build_chain(auth, root_scopes, picks)
+        ctx = await auth.verify(tokens[-1])
+        assert set(ctx.scopes).issubset(root_scopes)
+        root_ctx = await auth.verify(tokens[0])
+        assert root_ctx.expires_at is not None and ctx.expires_at is not None
+        assert ctx.expires_at <= root_ctx.expires_at
+
+    _run(scenario())
+
+
+@settings(max_examples=50, deadline=None)
+@given(
+    root_scopes=_SCOPES,
+    picks=st.lists(st.integers(min_value=1), min_size=1, max_size=6),
+    revoke_at=st.integers(min_value=0),
+)
+def test_revoking_any_ancestor_invalidates_leaf(
+    root_scopes: set[str],
+    picks: list[int],
+    revoke_at: int,
+) -> None:
+    async def scenario() -> None:
+        auth = DelegatableAuth(secret=b"prop", clock=0.0)
+        tokens, _ = await _build_chain(auth, root_scopes, picks)
+        target = revoke_at % (len(tokens) - 1)  # any strict ancestor of the leaf
+        await auth.revoke(tokens[target])
+        try:
+            await auth.verify(tokens[-1])
+        except RevokedAncestorError:
+            return
+        raise AssertionError("leaf verified despite revoked ancestor")
+
+    _run(scenario())
+
+
+@settings(max_examples=25, deadline=None)
+@given(root_scopes=_SCOPES)
+def test_token_bytes_deterministic(root_scopes: set[str]) -> None:
+    async def scenario() -> None:
+        first = DelegatableAuth(secret=b"prop", clock=42.0)
+        second = DelegatableAuth(secret=b"prop", clock=42.0)
+        token_a = await first.issue(AgentId("a1"), sorted(root_scopes))
+        token_b = await second.issue(AgentId("a1"), sorted(root_scopes))
+        assert str(token_a) == str(token_b)
+
+    _run(scenario())

--- a/packages/nest-plugins-reference/tests/test_delegation_validators.py
+++ b/packages/nest-plugins-reference/tests/test_delegation_validators.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the delegation adversarial validators.
+
+Synthetic audit streams model the two plugins' behaviour: the
+``jwt``-shaped stream (attacks succeed) must FAIL all three checks and
+the ``delegatable``-shaped stream (attacks refused) must PASS them —
+the charter's bar for an adversarial validator.  An end-to-end test
+also drives the real scenario agents under both auth plugins.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+from nest_plugins_reference.validators.delegation_validators import (
+    AuditEvent,
+    check_audience_binding,
+    check_no_scope_escalation,
+    check_no_stale_ancestor_use,
+    extract_delegation_audits,
+)
+
+
+def _jwt_shaped_audits() -> list[AuditEvent]:
+    """Audits as they come out of the scenario under ``auth: jwt``."""
+    return [
+        {
+            "type": "delegation_audit",
+            "tick": 3,
+            "op": "delegate",
+            "delegator": "intermediary-2",
+            "audience": "leaf-8",
+            "parent_scopes": ["read", "write"],
+            "child_scopes": ["read", "admin"],
+            "granted": True,
+        },
+        {
+            "type": "delegation_audit",
+            "tick": 20,
+            "op": "revoke",
+            "tid": "aa11",
+            "target": "intermediary-1",
+        },
+        {
+            "type": "delegation_audit",
+            "tick": 25,
+            "op": "verify",
+            "presenter": "leaf-4",
+            "audience": "leaf-4",
+            "chain_tids": ["root0", "aa11", "bb22"],
+            "verified": True,
+        },
+        {
+            "type": "delegation_audit",
+            "tick": 5,
+            "op": "verify",
+            "presenter": "leaf-1",
+            "audience": "leaf-0",
+            "chain_tids": ["root0", "cc33", "dd44"],
+            "verified": True,
+        },
+    ]
+
+
+def _delegatable_shaped_audits() -> list[AuditEvent]:
+    """Audits as they come out of the scenario under ``auth: delegatable``."""
+    return [
+        {
+            "type": "delegation_audit",
+            "tick": 3,
+            "op": "delegate",
+            "delegator": "intermediary-2",
+            "audience": "leaf-8",
+            "parent_scopes": ["read", "write"],
+            "child_scopes": ["read", "admin"],
+            "granted": False,
+        },
+        {
+            "type": "delegation_audit",
+            "tick": 20,
+            "op": "revoke",
+            "tid": "aa11",
+            "target": "intermediary-1",
+        },
+        {
+            "type": "delegation_audit",
+            "tick": 25,
+            "op": "verify",
+            "presenter": "leaf-4",
+            "audience": "leaf-4",
+            "chain_tids": ["root0", "aa11", "bb22"],
+            "verified": False,
+        },
+        {
+            "type": "delegation_audit",
+            "tick": 15,
+            "op": "verify",
+            "presenter": "leaf-4",
+            "audience": "leaf-4",
+            "chain_tids": ["root0", "aa11", "bb22"],
+            "verified": True,
+        },
+        {
+            "type": "delegation_audit",
+            "tick": 5,
+            "op": "verify",
+            "presenter": "leaf-1",
+            "audience": "leaf-0",
+            "chain_tids": ["root0", "cc33", "dd44"],
+            "verified": False,
+        },
+    ]
+
+
+def test_validators_fail_against_jwt_shaped_trace() -> None:
+    audits = _jwt_shaped_audits()
+    assert not check_no_scope_escalation(audits).passed
+    assert not check_no_stale_ancestor_use(audits).passed
+    assert not check_audience_binding(audits).passed
+
+
+def test_validators_pass_against_delegatable_shaped_trace() -> None:
+    audits = _delegatable_shaped_audits()
+    assert check_no_scope_escalation(audits).passed
+    assert check_no_stale_ancestor_use(audits).passed
+    assert check_audience_binding(audits).passed
+
+
+def test_verify_before_revocation_is_legitimate() -> None:
+    audits = _delegatable_shaped_audits()
+    report = check_no_stale_ancestor_use(audits)
+    assert report.passed, "pre-revocation verification must not be flagged"
+
+
+def test_extract_from_raw_trace_events() -> None:
+    raw: list[dict[str, Any]] = [
+        {"msg": json.dumps(_jwt_shaped_audits()[0])},
+        {"msg": "not json"},
+        {"msg": json.dumps({"type": "other"})},
+        {"no_msg": True},
+    ]
+    audits = extract_delegation_audits(raw)
+    assert len(audits) == 1
+    assert audits[0]["op"] == "delegate"
+
+
+def test_end_to_end_scenario_agents_under_both_plugins() -> None:
+    """Drive the real scenario agents in-process under both auth plugins.
+
+    A minimal in-memory harness delivers messages and scheduled
+    callbacks in deterministic tick order, collects the audit stream,
+    and asserts the validator verdicts flip between plugins.
+    """
+    import asyncio
+    import heapq
+    import itertools
+
+    from nest_core.scenario import RoleConfig, ScenarioConfig, TaskConfig
+    from nest_core.scenarios_builtin.delegated_auth import delegated_auth_factory
+    from nest_core.types import AgentId
+    from nest_plugins_reference.auth.delegatable import DelegatableAuth
+    from nest_plugins_reference.auth.jwt_auth import JwtAuth
+
+    class _Ctx:
+        def __init__(self, agent_id: AgentId, harness: _Harness) -> None:
+            self._agent_id = agent_id
+            self._harness = harness
+
+        @property
+        def agent_id(self) -> AgentId:
+            return self._agent_id
+
+        @property
+        def time(self) -> float:
+            return self._harness.now
+
+        @property
+        def plugins(self) -> dict[str, Any]:
+            return {}
+
+        async def send(self, to: AgentId, payload: bytes) -> None:
+            self._harness.push(self._harness.now, self._agent_id, to, payload)
+
+        async def broadcast(self, payload: bytes) -> None:  # pragma: no cover
+            for aid in self._harness.agents:
+                await self.send(aid, payload)
+
+        async def schedule(self, delay: float, payload: bytes) -> None:
+            self._harness.push(self._harness.now + delay, self._agent_id, self._agent_id, payload)
+
+    class _Harness:
+        def __init__(self, agents: dict[AgentId, Any]) -> None:
+            self.agents = agents
+            self.now: float = 0.0
+            self._seq = itertools.count()
+            self._queue: list[tuple[float, int, AgentId, AgentId, bytes]] = []
+
+        def push(self, at: float, sender: AgentId, to: AgentId, payload: bytes) -> None:
+            heapq.heappush(self._queue, (at, next(self._seq), sender, to, payload))
+
+        def run(self, until: float) -> list[AuditEvent]:
+            async def _run() -> list[AuditEvent]:
+                audits: list[AuditEvent] = []
+                for aid, agent in self.agents.items():
+                    await agent.on_start(_Ctx(aid, self))
+                while self._queue and self._queue[0][0] <= until:
+                    at, _, sender, to, payload = heapq.heappop(self._queue)
+                    self.now = at
+                    loaded: object = json.loads(payload.decode())
+                    if isinstance(loaded, dict):
+                        data = cast("AuditEvent", loaded)
+                        if data.get("type") == "delegation_audit":
+                            audits.append(data)
+                            continue
+                    agent = self.agents.get(to)
+                    if agent is not None:
+                        await agent.on_message(_Ctx(to, self), sender, payload)
+                return audits
+
+            return asyncio.run(_run())
+
+    def _run_scenario(auth_cls: type) -> list[AuditEvent]:
+        config = ScenarioConfig(
+            name="delegated_auth",
+            task=TaskConfig(
+                type="delegated_auth",
+                config={"revoke_tick": 20, "presents": 4, "present_interval": 10},
+            ),
+        )
+        config.agents.roles = [
+            RoleConfig(name="coordinator", count=1),
+            RoleConfig(name="intermediary", count=3),
+            RoleConfig(name="leaf", count=12),
+        ]
+        agents = delegated_auth_factory(config, {"auth": auth_cls})
+        return _Harness(dict(agents)).run(until=100.0)
+
+    jwt_audits = _run_scenario(JwtAuth)
+    assert not check_no_scope_escalation(jwt_audits).passed
+    assert not check_no_stale_ancestor_use(jwt_audits).passed
+    assert not check_audience_binding(jwt_audits).passed
+
+    good_audits = _run_scenario(DelegatableAuth)
+    assert check_no_scope_escalation(good_audits).passed
+    assert check_no_stale_ancestor_use(good_audits).passed
+    assert check_audience_binding(good_audits).passed

--- a/scenarios/delegated_auth.yaml
+++ b/scenarios/delegated_auth.yaml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegated auth scenario: a three-level capability tree under attack.
+# One intermediary attempts scope escalation, the coordinator revokes an
+# intermediary's grant mid-run, and one leaf presents a sibling's token.
+# Under auth: delegatable all three validators pass; under auth: jwt all
+# three fail (see nest_plugins_reference.validators.delegation_validators).
+
+name: delegated_auth
+description: |
+  A coordinator delegates attenuated capabilities to 3 intermediaries,
+  which sub-delegate to 12 leaves. Adversarial behaviours: scope
+  escalation at delegation, presentation after ancestor revocation, and
+  audience confusion via a shared token.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 16
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+    - name: intermediary
+      count: 3
+    - name: leaf
+      count: 12
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: delegatable
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: delegated_auth
+  config:
+    revoke_tick: 20
+    presents: 4
+    present_interval: 10
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 100"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/delegated_auth.jsonl


### PR DESCRIPTION
**Branch**: `hackathon/ckeda-delegatable-auth` · **Problem 04**

## What this adds

**Plugin** — `("auth", "delegatable")`, macaroon-style HMAC-chained tokens
(`nest_plugins_reference/auth/delegatable.py`). Any token holder mints
attenuated children *offline* via `delegate(parent_token, audience,
scopes_subset, ttl)`; each child's signature is keyed by its parent's
signature, so revoking any segment's tid invalidates every descendant by
construction — no per-child revocation lists. `verify` walks the full
chain: signature, per-segment revocation, per-segment expiry, monotonic
scope attenuation, monotonic expiry. `verify_presented(token, presenter)`
additionally binds presentation to the token's audience. Typed exceptions
(`ScopeEscalationError`, `RevokedAncestorError`, `ExpiredAncestorError`,
`AudienceMismatchError`) all subclass `ValueError` for drop-in
compatibility with callers written against the `jwt` plugin. Satisfies
the base `Auth` protocol (`isinstance` check included in tests).

**Adversarial validator** —
`nest_plugins_reference/validators/delegation_validators.py`, three pure
functions over `delegation_audit` trace events, catching the brief's
three attacks: scope escalation on granted delegations, verification
under a revoked ancestor, and presentation by a non-audience agent. As
required: all three FAIL against `auth: jwt` and PASS against
`auth: delegatable` — demonstrated both with synthetic audit streams and
an end-to-end in-process run of the real scenario agents under both
plugins (`test_delegation_validators.py`).

**Scenario** — `delegated_auth` (`scenarios/delegated_auth.yaml` +
`scenarios_builtin/delegated_auth.py`): 1 coordinator, 3 intermediaries,
12 leaves in a delegation tree, per the brief. Adversarial behaviours are
baked in deterministically: intermediary-2 attempts a scope-escalated
grant, the coordinator revokes intermediary-1's grant at tick 20 while
that subtree keeps presenting, and leaf-0 shares its token with leaf-1
which presents it. Under `auth: jwt` the scenario's delegation fallback
is deliberately the vulnerable pattern (re-issuance with no chain), so
the same YAML flips all three validators.

## Design decisions

- **Strict tree, not DAG** — single parent per segment, per the brief's
  pointer. Sufficient for cascading revocation and much simpler to audit.
- **Child TTL clamped, not rejected** — `delegate` clamps child expiry to
  the parent's rather than raising, so "give me up to an hour" composes;
  monotonicity is still re-checked at verify.
- **Deterministic everywhere** — injectable logical clock
  (`clock=` / `set_clock`), content-derived segment tids (sha256 of the
  segment preimage, no uuid/wall-clock), sorted-key canonical JSON for
  signing.
- **HMAC chaining, not claims** — per the anti-pattern list, there is no
  `delegated_from` claim; the parent's *signature* is the child's key, so
  transitive revocation is cryptographic, not bookkeeping.

## Tests

23 new tests: 14 unit (three attacks, deep-chain cascade, sibling-branch
isolation after mid-tree revocation, tamper/garbage rejection, protocol
conformance, and a documented jwt-vulnerability baseline), 3 Hypothesis
property tests (leaf scopes never exceed root and leaf never outlives
root under random chains; revoking a random ancestor always invalidates
the leaf; token bytes deterministic for fixed clock+secret), 6 validator
tests including the end-to-end both-plugins run.

## Definition of Done

All five CI