### PR TITLE
[Hackathon] auth-engineer: delegatable capability tokens with cascading revocation

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -26,6 +26,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
+    ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -145,3 +145,7 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("rogue_trusted_agent", rogue_trusted_agent_factory)
+    elif name == "delegated_auth":
+        from nest_core.scenarios_builtin.delegated_auth import delegated_auth_factory
+
+        register_scenario("delegated_auth", delegated_auth_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
@@ -1,0 +1,405 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegated-capability scenario: a coordinator builds a delegation tree and
+stages the three attacks the ``delegatable`` auth plugin is built to defeat.
+
+Topology: one ``coordinator`` roots a delegation tree over three
+``intermediary`` agents, each of which sub-delegates to four ``leaf`` agents
+(twelve leaves total), plus one ``auditor`` sink that records the structured
+trace lines the validators parse.
+
+The coordinator resolves its auth plugin from ``ctx.plugins["auth"]`` and drives
+the whole tree through it — *capability-gated* on ``hasattr(auth, "delegate")``:
+
+* Under ``auth: delegatable`` the coordinator delegates real macaroon-style
+  sub-tokens (scopes narrow at each hop) and every staged attack is rejected by
+  the plugin, so each ``attack:*`` line records ``blocked``.
+* Under ``auth: jwt`` (the default) there is no ``delegate``; the coordinator
+  falls back to independent ``issue`` calls, which is the honest picture of
+  what JWT can express. Each attack then succeeds — an agent mints itself
+  broader scopes (no delegation constraint), a revoked parent leaves its
+  separately-issued child usable, and a token has no audience to bind — so each
+  ``attack:*`` line records ``accepted`` and the validators fail.
+
+That contrast is the point: the same scenario **passes** under ``delegatable``
+and **fails** under ``jwt``, with no change to the driver.
+
+Every security decision runs locally against the shared plugin at tick 0, so the
+trace is byte-deterministic under any seed regardless of message drop; the
+``grant:``/``ack:`` chatter between agents exists only to exercise the transport.
+
+Trace line protocol (message bodies, ``:``-delimited; scope lists are
+``,``-joined):
+
+* ``deleg:<parent>:<child>:ok`` — a successful delegation (or issue) hop.
+* ``verify:<agent>:ok`` — an honest leaf token verified for its own audience.
+* ``revoke:<agent>`` — the coordinator revoked an agent's token.
+* ``attack:escalation:<agent>:<blocked|accepted>`` — agent tried to gain a
+  scope broader than it was delegated.
+* ``attack:audience:<agent>:<blocked|accepted>`` — agent presented a token
+  bound to a different audience.
+* ``attack:revoke:<agent>:<blocked|accepted>`` — agent used a token whose
+  ancestor was revoked.
+
+Example::
+
+    agents = delegated_auth_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Token
+
+_ROOT_SCOPES = ["tool:exec", "tool:read", "tool:write"]
+
+
+async def _grant(
+    auth: Any,
+    *,
+    delegation_aware: bool,
+    parent: Token,
+    audience: AgentId,
+    scopes: list[str],
+    ttl: float,
+) -> Token:
+    """Delegate a narrower sub-token, or (JWT fallback) issue an independent one.
+
+    Example::
+
+        tok = await _grant(auth, delegation_aware=True, parent=root,
+                           audience=AgentId("i0"), scopes=["tool:read"], ttl=100.0)
+    """
+    if delegation_aware:
+        return await auth.delegate(parent, audience, scopes, ttl)
+    return await auth.issue(audience, scopes)
+
+
+async def _attempt_escalation(
+    auth: Any, *, delegation_aware: bool, held: Token, agent: AgentId, broader: list[str]
+) -> str:
+    """Try to obtain ``broader`` scopes than ``held`` grants; return the outcome.
+
+    Example::
+
+        outcome = await _attempt_escalation(auth, delegation_aware=True,
+            held=leaf_tok, agent=AgentId("leaf-0"), broader=_ROOT_SCOPES)
+    """
+    try:
+        if delegation_aware:
+            token = await auth.delegate(held, agent, broader, 50.0)
+        else:
+            token = await auth.issue(agent, broader)
+        ctx = await auth.verify(token)
+        return "accepted" if set(broader).issubset(set(ctx.scopes)) else "blocked"
+    except ValueError:
+        return "blocked"
+
+
+async def _attempt_audience(
+    auth: Any, *, delegation_aware: bool, token: Token, intruder: AgentId
+) -> str:
+    """Present ``token`` (bound to someone else) as ``intruder``; return outcome.
+
+    Example::
+
+        outcome = await _attempt_audience(auth, delegation_aware=True,
+            token=worker_tok, intruder=AgentId("leaf-9"))
+    """
+    try:
+        if delegation_aware:
+            await auth.verify(token, presenter=intruder)
+        else:
+            await auth.verify(token)  # JWT has no audience binding to check
+        return "accepted"
+    except ValueError:
+        return "blocked"
+
+
+async def _attempt_use_after_revoke(
+    auth: Any, *, delegation_aware: bool, token: Token, presenter: AgentId
+) -> str:
+    """Use ``token`` after an ancestor was revoked; return the outcome.
+
+    Example::
+
+        outcome = await _attempt_use_after_revoke(auth, delegation_aware=True,
+            token=leaf_tok, presenter=AgentId("leaf-8"))
+    """
+    try:
+        if delegation_aware:
+            await auth.verify(token, presenter=presenter)
+        else:
+            await auth.verify(token)
+        return "accepted"
+    except ValueError:
+        return "blocked"
+
+
+class CoordinatorAgent(StateMachineAgent):
+    """Roots the delegation tree and stages all three attacks against the plugin.
+
+    All delegation and attack logic runs in :meth:`on_start` at tick 0 against
+    the shared auth instance in ``ctx.plugins["auth"]``, so the emitted trace is
+    deterministic. Subtree 0 stages scope-escalation attacks, subtree 1 stages
+    audience-confusion attacks, and subtree 2 stages use-after-revoke attacks.
+
+    Example::
+
+        coord = CoordinatorAgent(AgentId("coordinator"), AgentId("auditor-0"),
+            {AgentId("i0"): [AgentId("leaf-0")]})
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        auditor: AgentId,
+        tree: dict[AgentId, list[AgentId]],
+    ) -> None:
+        self._id = agent_id
+        self._auditor = auditor
+        self._tree = tree
+
+    async def _emit(self, ctx: AgentContext, line: str) -> None:
+        await ctx.send(self._auditor, line.encode())
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Build the delegation tree and stage the attack suite.
+
+        Example::
+
+            await coord.on_start(ctx)
+        """
+        auth = ctx.plugins.get("auth")
+        if auth is None:  # pragma: no cover - scenario always configures auth
+            return
+        delegation_aware = hasattr(auth, "delegate")
+        if hasattr(auth, "set_clock"):
+            auth.set_clock(ctx.time)
+
+        root = await auth.issue(self._id, _ROOT_SCOPES)
+
+        # -- Build the tree: each intermediary drops one scope; each leaf holds one.
+        interm_tokens: dict[AgentId, Token] = {}
+        interm_scopes: dict[AgentId, list[str]] = {}
+        leaf_tokens: dict[AgentId, Token] = {}
+
+        subtrees = list(self._tree.items())
+        for idx, (interm, leaves) in enumerate(subtrees):
+            dropped = _ROOT_SCOPES[idx % len(_ROOT_SCOPES)]
+            iscopes = [s for s in _ROOT_SCOPES if s != dropped] or [_ROOT_SCOPES[0]]
+            itok = await _grant(
+                auth,
+                delegation_aware=delegation_aware,
+                parent=root,
+                audience=interm,
+                scopes=iscopes,
+                ttl=500.0,
+            )
+            interm_tokens[interm] = itok
+            interm_scopes[interm] = iscopes
+            await self._emit(ctx, f"deleg:{self._id}:{interm}:ok")
+            await ctx.send(interm, f"grant:{','.join(iscopes)}".encode())
+
+            for lidx, leaf in enumerate(leaves):
+                lscope = [iscopes[lidx % len(iscopes)]]
+                ltok = await _grant(
+                    auth,
+                    delegation_aware=delegation_aware,
+                    parent=itok,
+                    audience=leaf,
+                    scopes=lscope,
+                    ttl=100.0,
+                )
+                leaf_tokens[leaf] = ltok
+                await self._emit(ctx, f"deleg:{interm}:{leaf}:ok")
+                if (
+                    await _attempt_use_after_revoke(
+                        auth, delegation_aware=delegation_aware, token=ltok, presenter=leaf
+                    )
+                    == "accepted"
+                ):
+                    await self._emit(ctx, f"verify:{leaf}:ok")
+
+        # -- Attack subtree 0: scope escalation (leaves try to widen to root scopes).
+        _, esc_leaves = subtrees[0]
+        for leaf in esc_leaves:
+            outcome = await _attempt_escalation(
+                auth,
+                delegation_aware=delegation_aware,
+                held=leaf_tokens[leaf],
+                agent=leaf,
+                broader=_ROOT_SCOPES,
+            )
+            await self._emit(ctx, f"attack:escalation:{leaf}:{outcome}")
+
+        # -- Attack subtree 1: audience confusion (a subtree-0 leaf poses as each holder).
+        _, aud_leaves = subtrees[1]
+        intruder = esc_leaves[0]
+        for leaf in aud_leaves:
+            outcome = await _attempt_audience(
+                auth,
+                delegation_aware=delegation_aware,
+                token=leaf_tokens[leaf],
+                intruder=intruder,
+            )
+            await self._emit(ctx, f"attack:audience:{intruder}:{outcome}")
+
+        # -- Attack subtree 2: use-after-revoke (revoke the intermediary, use leaves).
+        rev_interm, rev_leaves = subtrees[2]
+        await auth.revoke(interm_tokens[rev_interm])
+        await self._emit(ctx, f"revoke:{rev_interm}")
+        for leaf in rev_leaves:
+            outcome = await _attempt_use_after_revoke(
+                auth,
+                delegation_aware=delegation_aware,
+                token=leaf_tokens[leaf],
+                presenter=leaf,
+            )
+            await self._emit(ctx, f"attack:revoke:{leaf}:{outcome}")
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Coordinator ignores replies; all logic ran in ``on_start``.
+
+        Example::
+
+            await coord.on_message(ctx, AgentId("i0"), b"ack:")
+        """
+        return
+
+
+class TreeAgent(StateMachineAgent):
+    """Intermediary or leaf: acks grants so the transport carries real traffic.
+
+    Holds no security logic — the coordinator drives every delegation and attack
+    against the shared plugin. This agent exists to give the scenario its tree
+    shape and to make message-drop/partition injection observable in the trace.
+
+    Example::
+
+        node = TreeAgent(AgentId("i0"), AgentId("coordinator"))
+    """
+
+    def __init__(self, agent_id: AgentId, coordinator: AgentId) -> None:
+        self._id = agent_id
+        self._coordinator = coordinator
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """No-op; tree agents are driven by the coordinator's grants.
+
+        Example::
+
+            await node.on_start(ctx)
+        """
+        return
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Acknowledge a grant back to its sender.
+
+        Example::
+
+            await node.on_message(ctx, AgentId("coordinator"), b"grant:tool:read")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if msg.startswith("grant:"):
+            await ctx.send(sender, f"ack:{self._id}".encode())
+
+
+class AuditorAgent(StateMachineAgent):
+    """Sink for the coordinator's structured lines; the trace is the audit log.
+
+    Example::
+
+        auditor = AuditorAgent(AgentId("auditor-0"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """No-op; the auditor only receives.
+
+        Example::
+
+            await auditor.on_start(ctx)
+        """
+        return
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Record-only; validators read the emitted lines from the trace.
+
+        Example::
+
+            await auditor.on_message(ctx, AgentId("coordinator"), b"deleg:a:b:ok")
+        """
+        return
+
+
+def _provision_auth(plugins: dict[str, Any], coordinator: AgentId) -> None:
+    """Instantiate one shared auth plugin and hand it to the coordinator.
+
+    Mirrors the identity-rotation scenario's per-agent provisioning: resolve the
+    configured auth class, build a single clock-pinned instance (so its
+    revocation set and MAC secret are shared), and stash it under
+    ``plugins["_agent_plugins"]`` for the runner to apply. No-op when the auth
+    plugin is already an instance or is absent.
+
+    Example::
+
+        _provision_auth(plugins, AgentId("coordinator"))
+    """
+    auth_cls = plugins.get("auth")
+    if auth_cls is None or not isinstance(auth_cls, type):
+        return
+    auth = auth_cls(clock=0.0)
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+    agent_plugins.setdefault(coordinator, {})["auth"] = auth
+    plugins.pop("auth", None)
+
+
+def delegated_auth_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create a coordinator, 3 intermediaries, 12 leaves, and an auditor.
+
+    The tree shape is fixed (3 subtrees of 4 leaves) so the delegation depth and
+    attack coverage are identical across seeds; only the transport chatter is
+    seed-sensitive. Swapping ``auth: jwt`` for ``auth: delegatable`` in the YAML
+    genuinely changes behaviour — the same driver stages the same attacks and
+    the validators tell the two plugins apart.
+
+    Example::
+
+        agents = delegated_auth_factory(config, plugins)
+    """
+    task_config = config.task.config
+    intermediary_count = int(task_config.get("intermediaries", 3))
+    leaves_per = int(task_config.get("leaves_per_intermediary", 4))
+
+    coordinator_id = AgentId("coordinator")
+    auditor_id = AgentId("auditor-0")
+
+    tree: dict[AgentId, list[AgentId]] = {}
+    leaf_index = 0
+    for i in range(intermediary_count):
+        interm = AgentId(f"intermediary-{i}")
+        leaves: list[AgentId] = []
+        for _ in range(leaves_per):
+            leaves.append(AgentId(f"leaf-{leaf_index}"))
+            leaf_index += 1
+        tree[interm] = leaves
+
+    _provision_auth(plugins, coordinator_id)
+
+    agents: dict[AgentId, StateMachineAgent] = {
+        coordinator_id: CoordinatorAgent(coordinator_id, auditor_id, tree),
+        auditor_id: AuditorAgent(auditor_id),
+    }
+    for interm, leaves in tree.items():
+        agents[interm] = TreeAgent(interm, coordinator_id)
+        for leaf in leaves:
+            agents[leaf] = TreeAgent(leaf, coordinator_id)
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -4600,11 +4600,139 @@ def validate_parc_stale_key_rejected(events: list[dict[str, Any]]) -> list[Valid
 
 
 # ---------------------------------------------------------------------------
+# Delegated-auth (capability-token) validators
+# ---------------------------------------------------------------------------
+
+
+def _auth_attack_outcomes(events: list[dict[str, Any]], attack: str) -> list[tuple[str, str]]:
+    """Collect ``(agent, outcome)`` for ``attack:<attack>:<agent>:<outcome>`` lines.
+
+    The delegated-auth scenario emits one such line per attack it stages,
+    recording the *actual* verdict the configured auth plugin returned. A
+    delegation-aware plugin blocks the attack (``blocked``); a plugin without
+    delegation semantics (e.g. ``jwt``) lets it through (``accepted``).
+
+    Example::
+
+        outcomes = _auth_attack_outcomes(events, "escalation")
+    """
+    prefix = f"attack:{attack}:"
+    outcomes: list[tuple[str, str]] = []
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith(prefix):
+            continue
+        parts = msg.split(":")
+        if len(parts) >= 4:
+            outcomes.append((parts[2], parts[3]))
+    return outcomes
+
+
+def _validate_auth_attack(
+    events: list[dict[str, Any]],
+    *,
+    name: str,
+    attack: str,
+) -> list[ValidationResult]:
+    """Fail if any staged ``attack`` was accepted, or if none were staged.
+
+    Requiring at least one staged attack means a plugin cannot pass by simply
+    never exercising the defence: under ``jwt`` the scenario stages the attacks
+    and records ``accepted``; under ``delegatable`` it records ``blocked``.
+
+    Example::
+
+        results = _validate_auth_attack(events, name="auth_no_scope_escalation",
+                                        attack="escalation")
+    """
+    outcomes = _auth_attack_outcomes(events, attack)
+    if not outcomes:
+        return [
+            ValidationResult(
+                name,
+                False,
+                f"no {attack} attack was staged in the trace (defence unexercised)",
+            )
+        ]
+    accepted = [agent for agent, outcome in outcomes if outcome != "blocked"]
+    if accepted:
+        return [
+            ValidationResult(
+                name,
+                False,
+                f"{len(accepted)} {attack} attack(s) accepted: {', '.join(sorted(accepted))}",
+            )
+        ]
+    return [
+        ValidationResult(
+            name,
+            True,
+            f"all {len(outcomes)} {attack} attack(s) blocked",
+        )
+    ]
+
+
+def validate_auth_no_scope_escalation(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Attack 1: a delegated token must never gain scopes its parent lacks.
+
+    Fails if any staged scope-escalation attack was accepted. ``jwt`` lets an
+    agent mint itself a broader token (accepted); ``delegatable`` rejects the
+    widened caveat at ``delegate``/``verify`` (blocked).
+
+    Example::
+
+        results = validate_auth_no_scope_escalation(events)
+    """
+    return _validate_auth_attack(events, name="auth_no_scope_escalation", attack="escalation")
+
+
+def validate_auth_cascading_revocation(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Attack 2: revoking a parent must invalidate every descendant token.
+
+    Fails if any staged use-after-revoke attack was accepted. ``jwt`` revokes by
+    exact token string, so a separately-held child survives (accepted);
+    ``delegatable`` checks every ancestor ``tid`` on verify (blocked).
+
+    Example::
+
+        results = validate_auth_cascading_revocation(events)
+    """
+    return _validate_auth_attack(events, name="auth_cascading_revocation", attack="revoke")
+
+
+def validate_auth_audience_binding(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Attack 3: a token must only be usable by its declared audience.
+
+    Fails if any staged audience-confusion attack was accepted. ``jwt`` has no
+    audience concept, so any holder passes (accepted); ``delegatable`` binds the
+    leaf ``aud`` and rejects a mismatched presenter (blocked).
+
+    Example::
+
+        results = validate_auth_audience_binding(events)
+    """
+    return _validate_auth_attack(events, name="auth_audience_binding", attack="audience")
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
 
 VALIDATORS: dict[str, list[Any]] = {
+    "delegated_auth": [
+        validate_auth_no_scope_escalation,
+        validate_auth_cascading_revocation,
+        validate_auth_audience_binding,
+    ],
     "comms_versioning": [
         validate_comms_reject_unknown_major,
         validate_comms_no_silent_drop,

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -13,6 +13,9 @@ from nest_core.validators import (
     validate_auction_all_notified,
     validate_auction_single_winner,
     validate_auction_winner_highest,
+    validate_auth_audience_binding,
+    validate_auth_cascading_revocation,
+    validate_auth_no_scope_escalation,
     validate_consensus_agreement,
     validate_consensus_no_conflict,
     validate_consensus_validity,
@@ -1974,6 +1977,44 @@ class TestRogueTrustedAgentValidators:
         assert not validate_rogue_trusted_agent_reputation([])[0].passed
 
 
+class TestDelegatedAuthValidators:
+    """The delegated-auth validators fail when any staged attack is accepted."""
+
+    @staticmethod
+    def _attack(kind: str, agent: str, outcome: str) -> dict[str, object]:
+        return {"kind": "send", "msg": f"attack:{kind}:{agent}:{outcome}"}
+
+    def test_escalation_all_blocked_passes(self) -> None:
+        events = [self._attack("escalation", f"leaf-{i}", "blocked") for i in range(4)]
+        result = validate_auth_no_scope_escalation(events)[0]
+        assert result.passed
+        assert "4 escalation attack(s) blocked" in result.detail
+
+    def test_escalation_any_accepted_fails(self) -> None:
+        events = [
+            self._attack("escalation", "leaf-0", "blocked"),
+            self._attack("escalation", "leaf-1", "accepted"),
+        ]
+        result = validate_auth_no_scope_escalation(events)[0]
+        assert not result.passed
+        assert "leaf-1" in result.detail
+
+    def test_revocation_accepted_fails(self) -> None:
+        events = [self._attack("revoke", "leaf-8", "accepted")]
+        result = validate_auth_cascading_revocation(events)[0]
+        assert not result.passed
+
+    def test_audience_all_blocked_passes(self) -> None:
+        events = [self._attack("audience", "intruder", "blocked") for _ in range(3)]
+        assert validate_auth_audience_binding(events)[0].passed
+
+    def test_unexercised_defence_fails(self) -> None:
+        # No staged attack of the relevant kind -> cannot pass by omission.
+        assert not validate_auth_no_scope_escalation([])[0].passed
+        assert not validate_auth_cascading_revocation([])[0].passed
+        assert not validate_auth_audience_binding([])[0].passed
+
+
 class TestValidatorRegistry:
     def test_all_scenario_types_registered(self) -> None:
         expected = {
@@ -1997,6 +2038,7 @@ class TestValidatorRegistry:
             "failure_detection",
             "parc_migration",
             "rogue_trusted_agent",
+            "delegated_auth",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
@@ -1,0 +1,432 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegatable capability tokens with cascading revocation (macaroon-style).
+
+The default :class:`~nest_plugins_reference.auth.jwt_auth.JwtAuth` plugin can
+*issue* and *revoke* a token, but it has no notion of one agent minting a
+narrower sub-token for another agent, and its revocation set is keyed by the
+exact token string — revoking a parent does nothing to its children.
+
+``DelegatableAuth`` closes that gap with the macaroon construction (Birgisson
+et al., 2014). A token carries an ordered *chain* of caveats (root → leaf).
+Each link is bound to the previous one with an HMAC keyed by the **parent's
+signature**, so:
+
+* Delegation needs no issuer round-trip: any holder of a valid parent token can
+  mint a child by appending a caveat and re-chaining the MAC. The root secret
+  never leaves the issuer.
+* Restriction is enforced at *verification*, not mint time. A holder can append
+  any caveat (they know the parent signature, which is the child's MAC key), so
+  ``verify`` re-checks that every child only **narrows** its parent: scopes must
+  be a subset and expiry must not extend. A widened caveat is cryptographically
+  well-formed but rejected on verify — this is what defeats scope escalation.
+* Revocation cascades by construction: every link carries a ``tid`` and every
+  ``tid`` in the chain is checked against the revocation set on verify. Revoke a
+  parent's ``tid`` and every descendant fails at the next verify, with no
+  per-child bookkeeping.
+
+Determinism (Tier 1): token ids are derived by SHA-256 over the caveat's own
+fields — no RNG, no wall clock. Timestamps come from an injected logical clock
+(:meth:`set_clock`); ``time.time()`` is only the fallback for out-of-simulation
+use, exactly as ``JwtAuth`` does it.
+
+All raised errors subclass :class:`ValueError`, so existing callers that catch
+``ValueError`` around ``verify`` keep working unchanged.
+
+Example::
+
+    auth = DelegatableAuth(secret=b"root-secret", clock=0.0)
+    root = await auth.issue(AgentId("orchestrator"), ["tool:read", "tool:write"])
+    child = await auth.delegate(
+        root, audience=AgentId("worker"), scopes_subset=["tool:read"], ttl=600.0
+    )
+    ctx = await auth.verify(child, presenter=AgentId("worker"))
+    assert ctx.scopes == ["tool:read"]
+    await auth.revoke(root)          # revoke the parent...
+    # ...and the child no longer verifies:
+    # await auth.verify(child)  ->  RevokedAncestorError
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, cast
+
+from nest_core.types import AgentId, AuthContext, Token
+
+
+class DelegationError(ValueError):
+    """Base class for all delegation/verification failures.
+
+    Subclasses :class:`ValueError` so callers that already guard ``verify`` with
+    ``except ValueError`` continue to catch every delegation failure.
+
+    Example::
+
+        try:
+            await auth.verify(bad_token)
+        except DelegationError as exc:
+            print("rejected:", exc)
+    """
+
+
+class InvalidTokenError(DelegationError):
+    """The token is malformed or its MAC chain does not recompute.
+
+    Example::
+
+        # A token whose bytes were tampered with raises InvalidTokenError.
+    """
+
+
+class ScopeEscalationError(DelegationError):
+    """A caveat requests scopes broader than the parent grants.
+
+    Raised at ``delegate`` time (honest minting) and again at ``verify`` time
+    (a forged wide caveat that recomputes its MAC correctly).
+
+    Example::
+
+        # delegate(root[read], scopes_subset=["write"]) -> ScopeEscalationError
+    """
+
+
+class RevokedAncestorError(DelegationError):
+    """Some token in the chain (this token or an ancestor) has been revoked.
+
+    Example::
+
+        await auth.revoke(parent)
+        # await auth.verify(child) -> RevokedAncestorError
+    """
+
+
+class AudienceMismatchError(DelegationError):
+    """The presenting agent is not the token's declared audience.
+
+    Example::
+
+        # child is bound to AgentId("worker"); presented by AgentId("intruder")
+        # await auth.verify(child, presenter=AgentId("intruder"))
+        #   -> AudienceMismatchError
+    """
+
+
+class ExpiredTokenError(DelegationError):
+    """The token's leaf caveat has expired relative to the current clock.
+
+    Example::
+
+        # auth.set_clock(token_exp + 1); await auth.verify(token)
+        #   -> ExpiredTokenError
+    """
+
+
+def _canonical(caveat: dict[str, Any]) -> bytes:
+    """Return the canonical JSON encoding of a caveat for MAC input.
+
+    Keys are sorted and separators are tight so the encoding is byte-stable
+    across runs and Python versions.
+
+    Example::
+
+        raw = _canonical({"tid": "abc", "scopes": ["read"]})
+    """
+    return json.dumps(caveat, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _derive_tid(
+    parent_tid: str | None,
+    subject: str,
+    scopes: list[str],
+    issued_at: float,
+    expires_at: float,
+    audience: str | None,
+) -> str:
+    """Derive a deterministic token id from a caveat's own fields.
+
+    No RNG and no wall clock: the same caveat always yields the same id, so
+    traces replay byte-for-byte. ``issued_at`` (a logical tick) plus the parent
+    id disambiguate otherwise-identical delegations.
+
+    Example::
+
+        tid = _derive_tid(None, "orchestrator", ["read"], 0.0, 3600.0, "orchestrator")
+    """
+    material = "|".join(
+        [
+            str(parent_tid),
+            subject,
+            ",".join(sorted(scopes)),
+            repr(issued_at),
+            repr(expires_at),
+            str(audience),
+        ]
+    )
+    return hashlib.sha256(material.encode()).hexdigest()[:16]
+
+
+class DelegatableAuth:
+    """Macaroon-style delegatable capability tokens with cascading revocation.
+
+    Satisfies the ``Auth`` protocol (``issue`` / ``verify`` / ``revoke``) and
+    adds :meth:`delegate`. A single instance is shared by every agent in a
+    scenario: it holds the root ``secret`` used to anchor the MAC chain and the
+    revocation set consulted on every ``verify``.
+
+    Example::
+
+        auth = DelegatableAuth(secret=b"secret", clock=0.0)
+        root = await auth.issue(AgentId("a1"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("a2"), ["read"], ttl=60.0)
+        assert (await auth.verify(child)).scopes == ["read"]
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId | None = None,
+        secret: bytes = b"nest-delegatable-secret",
+        clock: float | None = None,
+        default_ttl: float = 3600.0,
+        revoked: set[str] | None = None,
+    ) -> None:
+        self._agent_id = agent_id
+        self._secret = secret
+        self._clock = clock
+        self._default_ttl = default_ttl
+        self._revoked: set[str] = revoked if revoked is not None else set()
+
+    # -- clock -------------------------------------------------------------
+
+    def set_clock(self, tick: float) -> None:
+        """Pin the logical clock so issuance/expiry are deterministic.
+
+        The scenario driver calls this with ``ctx.time`` before every auth
+        operation, exactly as the identity-rotation scenario pins its identity
+        plugin's clock. Without it the plugin falls back to ``time.time()``.
+
+        Example::
+
+            auth.set_clock(12.0)
+        """
+        self._clock = tick
+
+    def _now(self) -> float:
+        if self._clock is not None:
+            return self._clock
+        return time.time()
+
+    # -- MAC chain ---------------------------------------------------------
+
+    def _chain_sig(self, chain: list[dict[str, Any]]) -> str:
+        """Compute the macaroon MAC over the whole caveat chain.
+
+        The root caveat is keyed by ``secret``; every subsequent caveat is keyed
+        by the running MAC, so the final signature binds the entire chain and
+        the parent signature is the child's signing key.
+
+        Example::
+
+            sig = auth._chain_sig([root_caveat, child_caveat])
+        """
+        key = self._secret
+        for caveat in chain:
+            key = hmac.new(key, _canonical(caveat), hashlib.sha256).digest()
+        return key.hex()
+
+    def _encode(self, chain: list[dict[str, Any]]) -> Token:
+        """Serialize a chain + its MAC into an inspectable token string.
+
+        Example::
+
+            token = auth._encode([root_caveat])
+        """
+        body = json.dumps({"chain": chain}, sort_keys=True, separators=(",", ":"))
+        return Token(f"{body}|sig:{self._chain_sig(chain)}")
+
+    def _decode(self, token: Token) -> tuple[list[dict[str, Any]], str]:
+        """Parse a token into its caveat chain and transmitted MAC.
+
+        Raises:
+            InvalidTokenError: if the envelope is malformed.
+
+        Example::
+
+            chain, sig = auth._decode(token)
+        """
+        raw = str(token)
+        head, _, sig = raw.rpartition("|sig:")
+        if not sig or not head:
+            msg = "Malformed delegatable token: missing MAC"
+            raise InvalidTokenError(msg)
+        try:
+            data = json.loads(head)
+            raw_chain = data["chain"]
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            msg = f"Malformed delegatable token body: {exc}"
+            raise InvalidTokenError(msg) from exc
+        if not isinstance(raw_chain, list) or not raw_chain:
+            msg = "Malformed delegatable token: empty caveat chain"
+            raise InvalidTokenError(msg)
+        return cast("list[dict[str, Any]]", raw_chain), sig
+
+    # -- Auth protocol -----------------------------------------------------
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Issue a root capability token bound to ``subject``.
+
+        Example::
+
+            root = await auth.issue(AgentId("orchestrator"), ["tool:read"])
+        """
+        now = self._now()
+        expires_at = now + self._default_ttl
+        sorted_scopes = sorted(scopes)
+        caveat = {
+            "tid": _derive_tid(None, str(subject), sorted_scopes, now, expires_at, str(subject)),
+            "parent_tid": None,
+            "sub": str(subject),
+            "aud": str(subject),
+            "scopes": sorted_scopes,
+            "iat": now,
+            "exp": expires_at,
+        }
+        return self._encode([caveat])
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token:
+        """Mint a narrower child token for ``audience`` off ``parent_token``.
+
+        The child's scopes must be a subset of the parent's, and its expiry is
+        clamped to at most the parent's. Requires no issuer round-trip; the
+        parent's signature keys the new caveat.
+
+        Args:
+            parent_token: A structurally valid token held by the delegator.
+            audience: The agent the child token is bound to.
+            scopes_subset: Scopes to grant; must be ``⊆`` the parent's scopes.
+            ttl: Requested lifetime; the effective expiry is
+                ``min(now + ttl, parent.exp)``.
+
+        Raises:
+            InvalidTokenError: parent MAC does not recompute.
+            ScopeEscalationError: ``scopes_subset`` exceeds the parent's scopes.
+
+        Example::
+
+            child = await auth.delegate(
+                root, AgentId("worker"), ["tool:read"], ttl=600.0
+            )
+        """
+        chain, sig = self._decode(parent_token)
+        if not hmac.compare_digest(sig, self._chain_sig(chain)):
+            msg = "Parent token signature does not verify"
+            raise InvalidTokenError(msg)
+
+        parent = chain[-1]
+        parent_scopes = set(parent["scopes"])
+        requested = set(scopes_subset)
+        if not requested.issubset(parent_scopes):
+            extra = sorted(requested - parent_scopes)
+            msg = f"Scope escalation: {extra} not held by parent {sorted(parent_scopes)}"
+            raise ScopeEscalationError(msg)
+
+        now = self._now()
+        expires_at = min(now + ttl, float(parent["exp"]))
+        sorted_scopes = sorted(requested)
+        caveat = {
+            "tid": _derive_tid(
+                parent["tid"], str(audience), sorted_scopes, now, expires_at, str(audience)
+            ),
+            "parent_tid": parent["tid"],
+            "sub": str(audience),
+            "aud": str(audience),
+            "scopes": sorted_scopes,
+            "iat": now,
+            "exp": expires_at,
+        }
+        return self._encode([*chain, caveat])
+
+    async def verify(self, token: Token, presenter: AgentId | None = None) -> AuthContext:
+        """Verify a token and return the leaf caveat's auth context.
+
+        Enforces, in order: MAC-chain integrity, per-link revocation (any
+        revoked ``tid`` in the chain fails), monotonic narrowing (each child's
+        scopes ``⊆`` parent's and ``exp`` not extended, ``parent_tid`` linked),
+        leaf expiry, and — when ``presenter`` is supplied — audience binding.
+
+        The ``presenter`` parameter is optional, so this method still satisfies
+        the ``Auth`` protocol; omitting it skips only the audience check.
+
+        Raises:
+            InvalidTokenError: malformed token or bad MAC / broken chain link.
+            RevokedAncestorError: this token or an ancestor was revoked.
+            ScopeEscalationError: a child widens its parent's scopes.
+            ExpiredTokenError: the leaf caveat has expired.
+            AudienceMismatchError: ``presenter`` is not the leaf's audience.
+
+        Example::
+
+            ctx = await auth.verify(child, presenter=AgentId("worker"))
+            assert ctx.subject == AgentId("worker")
+        """
+        chain, sig = self._decode(token)
+        if not hmac.compare_digest(sig, self._chain_sig(chain)):
+            msg = "Token signature does not verify"
+            raise InvalidTokenError(msg)
+
+        for i, caveat in enumerate(chain):
+            if caveat["tid"] in self._revoked:
+                who = "token" if i == len(chain) - 1 else "ancestor"
+                msg = f"Revoked {who} in chain: tid={caveat['tid']}"
+                raise RevokedAncestorError(msg)
+            if i == 0:
+                continue
+            parent = chain[i - 1]
+            if caveat.get("parent_tid") != parent["tid"]:
+                msg = "Broken delegation chain: parent_tid mismatch"
+                raise InvalidTokenError(msg)
+            if not set(caveat["scopes"]).issubset(set(parent["scopes"])):
+                extra = sorted(set(caveat["scopes"]) - set(parent["scopes"]))
+                msg = f"Scope escalation in chain: {extra} not held by parent"
+                raise ScopeEscalationError(msg)
+            if float(caveat["exp"]) > float(parent["exp"]):
+                msg = "Child token outlives its parent"
+                raise ExpiredTokenError(msg)
+
+        leaf = chain[-1]
+        if float(leaf["exp"]) < self._now():
+            msg = f"Token expired at {leaf['exp']} (now {self._now()})"
+            raise ExpiredTokenError(msg)
+
+        if presenter is not None and leaf["aud"] is not None and str(presenter) != leaf["aud"]:
+            msg = f"Audience mismatch: token bound to {leaf['aud']}, presented by {presenter}"
+            raise AudienceMismatchError(msg)
+
+        return AuthContext(
+            subject=AgentId(leaf["sub"]),
+            scopes=list(leaf["scopes"]),
+            issued_at=leaf["iat"],
+            expires_at=leaf["exp"],
+        )
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke ``token`` by its leaf id; all descendants fail transitively.
+
+        Because every descendant carries this token's ``tid`` in its chain,
+        revoking here invalidates the whole subtree at the next ``verify`` — no
+        per-child revocation entries are needed.
+
+        Example::
+
+            await auth.revoke(parent)   # every child of parent now fails verify
+        """
+        chain, _ = self._decode(token)
+        self._revoked.add(chain[-1]["tid"])

--- a/packages/nest-plugins-reference/tests/test_delegatable_auth.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable_auth.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportPrivateUsage=false
+"""Example-based tests for the ``delegatable`` auth plugin.
+
+Covers the ``Auth`` protocol surface, the ``delegate`` extension, and the three
+attacks the delegated-auth problem calls out: scope escalation (honest and
+MAC-forged), cascading revocation, and audience confusion — plus tampering,
+TTL clamping, and expiry.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.layers.auth import Auth
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.delegatable import (
+    AudienceMismatchError,
+    DelegatableAuth,
+    ExpiredTokenError,
+    InvalidTokenError,
+    RevokedAncestorError,
+    ScopeEscalationError,
+)
+
+
+@pytest.fixture
+def auth() -> DelegatableAuth:
+    """A fresh plugin pinned to logical tick 0."""
+    return DelegatableAuth(secret=b"root-secret", clock=0.0, default_ttl=1000.0)
+
+
+class TestProtocolConformance:
+    """The plugin must be a structural ``Auth`` and keep its base behaviour."""
+
+    def test_is_auth_instance(self, auth: DelegatableAuth) -> None:
+        """It satisfies the runtime-checkable ``Auth`` protocol."""
+        assert isinstance(auth, Auth)
+
+    async def test_issue_verify_roundtrip(self, auth: DelegatableAuth) -> None:
+        """A freshly issued root token verifies with its scopes and subject."""
+        root = await auth.issue(AgentId("orch"), ["tool:write", "tool:read"])
+        ctx = await auth.verify(root)
+        assert ctx.subject == AgentId("orch")
+        assert ctx.scopes == ["tool:read", "tool:write"]  # sorted, canonical
+
+    async def test_issue_is_inspectable(self, auth: DelegatableAuth) -> None:
+        """The token is human-inspectable JSON (grep-able in a trace)."""
+        root = await auth.issue(AgentId("orch"), ["read"])
+        assert '"chain"' in str(root)
+        assert "|sig:" in str(root)
+
+
+class TestDelegation:
+    """``delegate`` mints strictly-narrowing child tokens without the issuer."""
+
+    async def test_child_narrows_scopes(self, auth: DelegatableAuth) -> None:
+        """A child restricted to a subset verifies with exactly that subset."""
+        root = await auth.issue(AgentId("orch"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=100.0)
+        ctx = await auth.verify(child, presenter=AgentId("worker"))
+        assert ctx.subject == AgentId("worker")
+        assert ctx.scopes == ["read"]
+
+    async def test_multi_hop_chain(self, auth: DelegatableAuth) -> None:
+        """Delegation composes: grandchild off a child still verifies."""
+        root = await auth.issue(AgentId("orch"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("mid"), ["read", "write"], ttl=500.0)
+        grand = await auth.delegate(child, AgentId("leaf"), ["read"], ttl=100.0)
+        assert (await auth.verify(grand, presenter=AgentId("leaf"))).scopes == ["read"]
+
+    async def test_ttl_clamped_to_parent(self, auth: DelegatableAuth) -> None:
+        """A child TTL request beyond the parent's expiry is clamped down."""
+        auth_short = DelegatableAuth(secret=b"s", clock=0.0, default_ttl=100.0)
+        root = await auth_short.issue(AgentId("orch"), ["read"])
+        child = await auth_short.delegate(root, AgentId("worker"), ["read"], ttl=9999.0)
+        assert (await auth_short.verify(child)).expires_at == 100.0
+
+
+class TestScopeEscalation:
+    """Attack 1: a child must never hold scopes the parent lacks."""
+
+    async def test_escalation_rejected_at_delegate(self, auth: DelegatableAuth) -> None:
+        """Honest minting of a wider child raises immediately."""
+        root = await auth.issue(AgentId("orch"), ["read"])
+        with pytest.raises(ScopeEscalationError):
+            await auth.delegate(root, AgentId("worker"), ["read", "write"], ttl=10.0)
+
+    async def test_forged_wide_caveat_rejected_at_verify(self, auth: DelegatableAuth) -> None:
+        """A MAC-valid but widened caveat is rejected on verify.
+
+        The holder knows the parent signature (the child's MAC key), so it can
+        forge a caveat with a valid chain MAC. Restriction is enforced at verify
+        time — this is the macaroon property that actually stops escalation.
+        """
+        root = await auth.issue(AgentId("orch"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=100.0)
+        chain, _ = auth._decode(child)
+        forged = {
+            "tid": "forged0000000000",
+            "parent_tid": chain[-1]["tid"],
+            "sub": "evil",
+            "aud": "evil",
+            "scopes": ["read", "write"],  # parent (child) only holds read
+            "iat": 0.0,
+            "exp": 50.0,
+        }
+        forged_token = auth._encode([*chain, forged])  # recomputes a valid MAC
+        with pytest.raises(ScopeEscalationError):
+            await auth.verify(forged_token)
+
+
+class TestCascadingRevocation:
+    """Attack 2: revoking any ancestor invalidates the whole subtree."""
+
+    async def test_revoke_parent_kills_descendants(self, auth: DelegatableAuth) -> None:
+        """Revoking the root fails root, child, and grandchild at verify."""
+        root = await auth.issue(AgentId("orch"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("mid"), ["read"], ttl=500.0)
+        grand = await auth.delegate(child, AgentId("leaf"), ["read"], ttl=100.0)
+
+        await auth.revoke(root)
+
+        for token in (root, child, grand):
+            with pytest.raises(RevokedAncestorError):
+                await auth.verify(token)
+
+    async def test_revoke_middle_spares_ancestor(self, auth: DelegatableAuth) -> None:
+        """Revoking a middle node fails it and its child but not its parent."""
+        root = await auth.issue(AgentId("orch"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("mid"), ["read"], ttl=500.0)
+        grand = await auth.delegate(child, AgentId("leaf"), ["read"], ttl=100.0)
+
+        await auth.revoke(child)
+
+        assert (await auth.verify(root)).subject == AgentId("orch")  # parent survives
+        for token in (child, grand):
+            with pytest.raises(RevokedAncestorError):
+                await auth.verify(token)
+
+
+class TestAudienceBinding:
+    """Attack 3: a token is usable only by its declared audience."""
+
+    async def test_wrong_presenter_rejected(self, auth: DelegatableAuth) -> None:
+        """A child bound to `worker` fails when presented by an intruder."""
+        root = await auth.issue(AgentId("orch"), ["read"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=100.0)
+        with pytest.raises(AudienceMismatchError):
+            await auth.verify(child, presenter=AgentId("intruder"))
+
+    async def test_right_presenter_accepted(self, auth: DelegatableAuth) -> None:
+        """The declared audience verifies fine."""
+        root = await auth.issue(AgentId("orch"), ["read"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=100.0)
+        assert (await auth.verify(child, presenter=AgentId("worker"))).subject == AgentId("worker")
+
+    async def test_presenter_optional(self, auth: DelegatableAuth) -> None:
+        """Omitting `presenter` keeps protocol compatibility (skips aud check)."""
+        root = await auth.issue(AgentId("orch"), ["read"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=100.0)
+        assert (await auth.verify(child)).subject == AgentId("worker")
+
+
+class TestIntegrityAndExpiry:
+    """MAC tampering and expiry are rejected with typed errors."""
+
+    async def test_tampered_token_rejected(self, auth: DelegatableAuth) -> None:
+        """Flipping any byte breaks the chain MAC."""
+        root = await auth.issue(AgentId("orch"), ["read"])
+        with pytest.raises(InvalidTokenError):
+            await auth.verify(Token(str(root) + "x"))
+
+    async def test_malformed_token_rejected(self, auth: DelegatableAuth) -> None:
+        """A token without the MAC envelope is rejected."""
+        with pytest.raises(InvalidTokenError):
+            await auth.verify(Token("garbage"))
+
+    async def test_expired_leaf_rejected(self, auth: DelegatableAuth) -> None:
+        """A token past its expiry fails once the clock advances."""
+        short = DelegatableAuth(secret=b"s", clock=0.0, default_ttl=10.0)
+        root = await short.issue(AgentId("orch"), ["read"])
+        short.set_clock(11.0)
+        with pytest.raises(ExpiredTokenError):
+            await short.verify(root)
+
+
+class TestDeterminism:
+    """Same inputs -> byte-identical tokens (Tier 1 requirement)."""
+
+    async def test_issue_is_deterministic(self) -> None:
+        """Two plugins with the same secret/clock issue identical tokens."""
+        a = DelegatableAuth(secret=b"k", clock=5.0)
+        b = DelegatableAuth(secret=b"k", clock=5.0)
+        ta = await a.issue(AgentId("x"), ["read"])
+        tb = await b.issue(AgentId("x"), ["read"])
+        assert str(ta) == str(tb)
+
+    async def test_delegate_is_deterministic(self) -> None:
+        """Identical delegation chains produce identical child tokens."""
+        a = DelegatableAuth(secret=b"k", clock=0.0)
+        b = DelegatableAuth(secret=b"k", clock=0.0)
+        ra = await a.issue(AgentId("x"), ["read", "write"])
+        rb = await b.issue(AgentId("x"), ["read", "write"])
+        ca = await a.delegate(ra, AgentId("y"), ["read"], ttl=10.0)
+        cb = await b.delegate(rb, AgentId("y"), ["read"], ttl=10.0)
+        assert str(ca) == str(cb)

--- a/packages/nest-plugins-reference/tests/test_delegatable_auth_properties.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable_auth_properties.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportPrivateUsage=false
+"""Hypothesis property-based tests for the ``delegatable`` auth plugin.
+
+Each invariant is checked over generated scope sets, delegation depths, TTLs,
+and revocation points so the macaroon guarantees hold for *all* inputs, not
+just the hand-picked cases in ``test_delegatable_auth.py``:
+
+1. Scope monotonicity: a verified leaf's scopes are always a subset of the root's.
+2. Forged widening is always rejected at verify, at any depth.
+3. Cascading revocation: revoking link ``k`` fails every token at depth ``>= k``
+   and spares every token at depth ``< k``.
+4. Determinism: identical delegation chains yield byte-identical tokens.
+5. TTL never extends: each child's expiry is ``<=`` its parent's.
+
+Delegation only ever narrows, so the strategies build a descending chain of
+scope subsets and non-increasing TTLs and assert the plugin honours them.
+
+Example::
+
+    pytest packages/nest-plugins-reference/tests/test_delegatable_auth_properties.py
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.delegatable import (
+    DelegatableAuth,
+    RevokedAncestorError,
+    ScopeEscalationError,
+)
+
+_ALL_SCOPES = ["read", "write", "exec", "admin", "list"]
+
+# A descending chain of scope subsets: each element is a subset of the prior.
+_scope_chains = st.lists(
+    st.sets(st.sampled_from(_ALL_SCOPES), min_size=1), min_size=1, max_size=4
+).map(lambda subsets: [set(_ALL_SCOPES)] + subsets)
+
+
+def _descending(scopes: list[set[str]]) -> list[list[str]]:
+    """Coerce a list of scope sets into a strictly-narrowing chain (root first)."""
+    chain: list[list[str]] = [sorted(scopes[0])]
+    current = set(scopes[0])
+    for nxt in scopes[1:]:
+        current = current & nxt  # intersection is always a subset
+        chain.append(sorted(current))
+    return chain
+
+
+async def _build_chain(auth: DelegatableAuth, scope_levels: list[list[str]]) -> list[Token]:
+    """Issue a root and delegate down through ``scope_levels`` (root first)."""
+    tokens = [await auth.issue(AgentId("agent-0"), scope_levels[0])]
+    for depth, scopes in enumerate(scope_levels[1:], start=1):
+        tokens.append(
+            await auth.delegate(tokens[-1], AgentId(f"agent-{depth}"), scopes, ttl=1000.0 - depth)
+        )
+    return tokens
+
+
+@settings(max_examples=100, deadline=None)
+@given(scope_levels=_scope_chains)
+async def test_leaf_scopes_subset_of_root(scope_levels: list[set[str]]) -> None:
+    """Property 1: every verified leaf's scopes ⊆ the root's scopes."""
+    levels = _descending(scope_levels)
+    auth = DelegatableAuth(secret=b"k", clock=0.0)
+    tokens = await _build_chain(auth, levels)
+    leaf_ctx = await auth.verify(tokens[-1])
+    root_scopes = set(levels[0])
+    assert set(leaf_ctx.scopes).issubset(root_scopes)
+
+
+@settings(max_examples=100, deadline=None)
+@given(scope_levels=_scope_chains)
+async def test_ttl_never_extends(scope_levels: list[set[str]]) -> None:
+    """Property 5: each child's expiry never exceeds its parent's."""
+    levels = _descending(scope_levels)
+    auth = DelegatableAuth(secret=b"k", clock=0.0)
+    tokens = await _build_chain(auth, levels)
+    exps = [(await auth.verify(t)).expires_at for t in tokens]
+    for parent_exp, child_exp in zip(exps, exps[1:], strict=False):
+        assert child_exp is not None and parent_exp is not None
+        assert child_exp <= parent_exp
+
+
+@settings(max_examples=100, deadline=None)
+@given(scope_levels=_scope_chains, extra=st.sampled_from(_ALL_SCOPES))
+async def test_forged_widening_rejected(scope_levels: list[set[str]], extra: str) -> None:
+    """Property 2: a MAC-valid caveat that adds a scope the parent lacks fails."""
+    levels = _descending(scope_levels)
+    auth = DelegatableAuth(secret=b"k", clock=0.0)
+    tokens = await _build_chain(auth, levels)
+    parent = tokens[-1]
+    parent_scopes = set(levels[-1])
+    if extra in parent_scopes:
+        return  # not a widening; nothing to prove
+    chain, _ = auth._decode(parent)
+    forged = {
+        "tid": "forged0000000000",
+        "parent_tid": chain[-1]["tid"],
+        "sub": "evil",
+        "aud": "evil",
+        "scopes": sorted(parent_scopes | {extra}),
+        "iat": 0.0,
+        "exp": 10.0,
+    }
+    forged_token = auth._encode([*chain, forged])  # recomputes a valid MAC
+    try:
+        await auth.verify(forged_token)
+        raise AssertionError("forged widening was accepted")
+    except ScopeEscalationError:
+        pass
+
+
+@settings(max_examples=100, deadline=None)
+@given(scope_levels=_scope_chains, revoke_at=st.integers(min_value=0, max_value=4))
+async def test_cascading_revocation(scope_levels: list[set[str]], revoke_at: int) -> None:
+    """Property 3: revoking depth k fails depths >= k, spares depths < k."""
+    levels = _descending(scope_levels)
+    auth = DelegatableAuth(secret=b"k", clock=0.0)
+    tokens = await _build_chain(auth, levels)
+    k = min(revoke_at, len(tokens) - 1)
+
+    await auth.revoke(tokens[k])
+
+    for depth, token in enumerate(tokens):
+        if depth < k:
+            assert (await auth.verify(token)).subject == AgentId(f"agent-{depth}")
+        else:
+            try:
+                await auth.verify(token)
+                raise AssertionError(f"depth {depth} verified after revoking {k}")
+            except RevokedAncestorError:
+                pass
+
+
+@settings(max_examples=50, deadline=None)
+@given(scope_levels=_scope_chains)
+async def test_determinism(scope_levels: list[set[str]]) -> None:
+    """Property 4: identical chains produce byte-identical tokens."""
+    levels = _descending(scope_levels)
+    a = DelegatableAuth(secret=b"k", clock=0.0)
+    b = DelegatableAuth(secret=b"k", clock=0.0)
+    ta = await _build_chain(a, levels)
+    tb = await _build_chain(b, levels)
+    assert [str(t) for t in ta] == [str(t) for t in tb]

--- a/scenarios/delegated_auth.yaml
+++ b/scenarios/delegated_auth.yaml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegated-capability scenario: a coordinator roots a delegation tree over 3
+# intermediaries and 12 leaves, then stages scope-escalation, audience-confusion,
+# and use-after-revoke attacks against the configured auth plugin.
+#
+# Under `auth: delegatable` all three attacks are blocked and the validators
+# pass. Flip `auth` to `jwt` (the default) and the same attacks succeed, so the
+# validators fail — the honest demonstration that JWT cannot express delegated,
+# transitively-revocable capabilities.
+name: delegated_auth
+description: "Coordinator delegates to 3 intermediaries and 12 leaves; stages scope-escalation, audience, and cascading-revocation attacks."
+
+tier: 1
+seed: 42
+
+agents:
+  # 1 coordinator + 3 intermediaries + 12 leaves + 1 auditor = 17.
+  count: 17
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+    - name: intermediary
+      count: 3
+    - name: leaf
+      count: 12
+    - name: auditor
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: delegatable
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: delegated_auth
+  config:
+    intermediaries: 3
+    leaves_per_intermediary: 4
+
+failures:
+  message_drop: 0.05
+
+duration: "ticks: 10000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/delegated_auth.jsonl


### PR DESCRIPTION
# Delegatable capability tokens with cascading revocation (auth layer)

Solves hackathon problem **04 — Delegatable capability tokens with cascading revocation**.
Persona: an auth engineer who cares about least-privilege delegation and clean revocation.

## Motivation

The default `jwt` auth plugin (`jwt_auth.py`) can only *issue* and *revoke* whole
tokens, and its revocation set is keyed by the exact token string. It cannot
express the most common multi-agent auth pattern: an orchestrator holds a
long-lived root capability, mints a **narrower, time-bounded** sub-capability
for a worker agent *without* asking the issuer, and can pull the whole subtree
back by revoking one ancestor. Today, revoking a parent does nothing to a child
that was handed out separately — the child sails through `verify`.

This is exactly what you need to model an LLM agent sub-renting a tool to
another agent and cleanly withdrawing it. It was one of the ten open problems
and the only one with no plugin on `main`.

## Design

A macaroon (Birgisson et al., 2014). A token carries an ordered **chain of
caveats** (root → leaf). Each link is MAC'd with an HMAC **keyed by its parent's
signature**, so:

- **Delegation needs no issuer round-trip.** Any holder of a valid parent can
  append a caveat and re-chain the MAC (`delegate(parent, audience, scopes_subset, ttl)`).
  The root secret never leaves the issuer.
- **Restriction is enforced at verify, not at mint.** A holder knows the parent
  signature (the child's MAC key), so it *can* forge a MAC-valid caveat with wider
  scopes. `verify` therefore re-checks that every child only **narrows** its
  parent — scopes ⊆ parent, expiry ≤ parent, `parent_tid` linked. A widened
  caveat is cryptographically well-formed but rejected. **This is what actually
  stops scope escalation** (see the `test_forged_wide_caveat_rejected_at_verify`
  test — the honest `delegate`-time check alone is not enough).
- **Revocation cascades by construction.** Every caveat carries a `tid`; `verify`
  checks every `tid` in the chain against the revocation set. Revoke a parent's
  `tid` and every descendant fails at the next `verify` — no per-child bookkeeping.
- **Audience binding.** The leaf caveat is bound to an `aud`; `verify(token, presenter=...)`
  rejects a mismatched presenter. `presenter` is optional, so the plugin still
  satisfies the `Auth` protocol exactly (`isinstance(plugin, Auth)` is `True`).

### Tradeoffs (explicit)

- **Chain grows with depth.** Each hop adds one caveat + re-MAC; verify is O(depth).
  For agent delegation trees (depth ≤ a handful) this is negligible; I did not add
  QC aggregation.
- **Third-party caveats / discharge macaroons are out of scope.** Only first-party
  caveats (scope, expiry, audience) are implemented — enough for the problem.
- **Revocation is a growing set of `tid`s.** Bounded by tokens issued; no GC. Fine
  for a simulation; a real deployment would TTL the revocation entries.
- **Errors subclass `ValueError`** so existing callers that already guard `verify`
  with `except ValueError` keep working unchanged.

## Determinism (Tier 1)

Token ids are `sha256` over the caveat's own fields — no RNG, no wall clock.
Timestamps come from an injected logical clock (`set_clock`), exactly as `JwtAuth`
uses its `clock`. Same inputs → byte-identical tokens; the scenario trace is
**byte-identical under seeds 42, 7, 1337**.

## Adversarial validators (FAIL on `jwt`, PASS on `delegatable`)

Under the `delegated_auth` scenario, three validators stage the three attacks the
problem names and read the outcome the *configured* plugin actually returned:

| Validator                     | Attack                                    | `jwt`                   | `delegatable`          |
| ----------------------------- | ----------------------------------------- | ------------------------- | ------------------------ |
| `auth_no_scope_escalation`  | agent obtains a scope it wasn't delegated | accepted →**FAIL** | blocked →**PASS** |
| `auth_cascading_revocation` | child used after an ancestor is revoked   | accepted →**FAIL** | blocked →**PASS** |
| `auth_audience_binding`     | token presented by the wrong agent        | accepted →**FAIL** | blocked →**PASS** |

The scenario driver (`coordinator` + 3 `intermediary` + 12 `leaf` + `auditor`) is
capability-gated on `hasattr(auth, "delegate")`: under `jwt` it honestly falls
back to independent `issue` calls, which is what JWT can actually express — and
that is precisely why the attacks succeed there.

## Verify it yourself

```bash
uv sync

# Plugin + property tests
uv run pytest packages/nest-plugins-reference/tests/test_delegatable_auth.py \
              packages/nest-plugins-reference/tests/test_delegatable_auth_properties.py -q

# Run the scenario and check the validators PASS under delegatable
uv run nest run scenarios/delegated_auth.yaml -o ./traces/delegated_auth.jsonl
uv run python -c "
from pathlib import Path
from nest_core.validators import validate_trace
for r in validate_trace(Path('traces/delegated_auth.jsonl'), 'delegated_auth'):
    print(('PASS' if r.passed else 'FAIL'), r.name, '-', r.detail)
"

# Flip auth -> jwt and watch all three validators FAIL
sed 's/auth: delegatable/auth: jwt/' scenarios/delegated_auth.yaml > /tmp/da_jwt.yaml
uv run nest run /tmp/da_jwt.yaml -o ./traces/da_jwt.jsonl
uv run python -c "
from pathlib import Path
from nest_core.validators import validate_trace
for r in validate_trace(Path('traces/da_jwt.jsonl'), 'delegated_auth'):
    print(('PASS' if r.passed else 'FAIL'), r.name, '-', r.detail)
"
```

## CI

`uv sync`, `ruff check .`, `ruff format --check .`, `pyright`, `pytest -v` all pass
(**976 passed, 1 skipped**). No new runtime dependencies.

## Files

- `packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py` — the plugin
- `packages/nest-core/nest_core/plugins.py` — register `("auth", "delegatable")`
- `packages/nest-core/nest_core/validators.py` — three validators + `delegated_auth` registry entry
- `packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py` — scenario driver
- `packages/nest-core/nest_core/scenarios.py` — register the scenario factory
- `scenarios/delegated_auth.yaml` — the scenario
- `packages/nest-plugins-reference/tests/test_delegatable_auth{,_properties}.py` — tests
- `packages/nest-core/tests/test_validators.py` — validator unit tests + registry update