### PR TITLE
hackathon/john-kioko-weighted-trust: WeightedTrust plugin

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -26,6 +26,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
+    ("trust", "weighted"): f"{_REF}.trust.weighted:WeightedTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/weighted.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/weighted.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Weighted trust plugin — recency-decayed, volume-weighted reputation.
+
+A richer alternative to ScoreAverageTrust that considers:
+
+  * **Recency** — newer evidence counts more than stale evidence via an
+    exponential decay factor.
+  * **Evidence severity** — ``positive`` adds weight, ``negative`` subtracts
+    moderately, ``byzantine`` (fault/malicious) subtracts heavily.
+  * **Volume confidence** — more data points → higher confidence score,
+    capped at ``max_samples``.
+  * **Reporter weighting** — reporters with a good track record are trusted
+    more than unknown/new reporters.
+
+The result is a score in ``[0, 1]`` that is more responsive to recent
+behaviour and more robust to a few noisy reports than a flat average.
+
+Example::
+
+    trust = WeightedTrust()
+    await trust.report(AgentId("a1"), evidence)
+    score = await trust.score(AgentId("a1"))  # → ReputationScore
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import Any
+
+from nest_core.types import (
+    AgentId,
+    Attestation,
+    Claim,
+    Evidence,
+    ReputationScore,
+    Signature,
+)
+
+# Severity weights for each evidence kind.
+_SEVERITY: dict[str, float] = {
+    "positive": 1.0,
+    "neutral": 0.5,
+    "negative": 0.0,
+    "byzantine": -0.5,   # worst — explicit malice
+}
+
+
+class _Report:
+    """Internal record of a single piece of evidence."""
+
+    __slots__ = ("value", "weight", "ts")
+
+    def __init__(self, value: float, weight: float, ts: float) -> None:
+        self.value = value
+        self.weight = weight
+        self.ts = ts
+
+
+class WeightedTrust:
+    """Recency-decayed, volume-weighted reputation model.
+
+    Parameters
+    ----------
+    identity:
+        Optional identity provider for signing attestations.
+    decay_half_life:
+        Evidence older than this many seconds has half the weight of
+        fresh evidence (exponential decay).  Default 7 days.
+    max_samples:
+        Number of samples at which confidence reaches 1.0.  Default 50.
+    """
+
+    def __init__(
+        self,
+        identity: Any = None,
+        decay_half_life: float = 7 * 24 * 3600,
+        max_samples: int = 50,
+    ) -> None:
+        self._identity = identity
+        self._decay_half_life = decay_half_life
+        self._max_samples = max_samples
+        self._reports: dict[AgentId, list[_Report]] = {}
+        self._reporter_scores: dict[AgentId, float] = {}
+        self._stakes: dict[AgentId, int] = {}
+
+    # ------------------------------------------------------------------ #
+    #  Public API (same interface as ScoreAverageTrust)
+    # ------------------------------------------------------------------ #
+
+    async def score(self, agent: AgentId) -> ReputationScore:
+        """Compute the weighted reputation score for *agent*.
+
+        Returns a ``ReputationScore`` with:
+
+        * ``score`` in ``[0, 1]`` — 0.5 is neutral.
+        * ``confidence`` in ``[0, 1]`` — rises with sample count.
+        * ``sample_count`` — number of evidence items on file.
+        """
+        reports = self._reports.get(agent, [])
+        n = len(reports)
+        if n == 0:
+            return ReputationScore(
+                agent_id=agent, score=0.5, confidence=0.0, sample_count=0,
+            )
+
+        now = time.time()
+        decay_lambda = math.log(2) / self._decay_half_life if self._decay_half_life else 0.0
+
+        weighted_sum = 0.0
+        total_weight = 0.0
+        for r in reports:
+            age = max(0.0, now - r.ts)
+            recency = math.exp(-decay_lambda * age)
+            w = r.weight * recency
+            weighted_sum += r.value * w
+            total_weight += w
+
+        raw = weighted_sum / total_weight if total_weight else 0.5
+        # Clamp to [0, 1]
+        score = max(0.0, min(1.0, raw))
+        confidence = min(1.0, n / self._max_samples)
+
+        return ReputationScore(
+            agent_id=agent,
+            score=score,
+            confidence=confidence,
+            sample_count=n,
+        )
+
+    async def attest(self, agent: AgentId, claim: Claim) -> Attestation:
+        """Create a signed attestation about *agent*."""
+        sig = Signature(signer=AgentId("system"), value=b"attestation", algorithm="none")
+        if self._identity is not None:
+            sig = self._identity.sign(claim.model_dump_json().encode())
+        return Attestation(issuer=AgentId("system"), claim=claim, signature=sig)
+
+    async def report(self, agent: AgentId, evidence: Evidence) -> None:
+        """Record *evidence* about *agent*, updating the weighted score.
+
+        Evidence kinds and their contribution:
+
+        * ``positive`` → value 1.0 (strong good)
+        * ``neutral``  → value 0.5 (neither good nor bad)
+        * ``negative`` → value 0.0 (poor performance)
+        * ``byzantine`` → value -0.5 (active malice — penalised hardest)
+        """
+        ts = evidence.timestamp if evidence.timestamp is not None else time.time()
+        value = _SEVERITY.get(evidence.kind, 0.5)
+
+        # Reporter weight: known-good reporters carry more weight.
+        # New reporters default to 0.7 (slightly above neutral).
+        reporter_score = self._reporter_scores.get(evidence.reporter, 0.7)
+        weight = max(0.1, reporter_score)  # floor so even bad reporters count a little
+
+        self._reports.setdefault(agent, []).append(
+            _Report(value=value, weight=weight, ts=ts),
+        )
+
+        # Update the reporter's own score: if their report aligns with
+        # the subject's average, they become more credible next time.
+        # (Simplified: positive reporters slowly gain credibility.)
+        if evidence.kind == "positive":
+            self._reporter_scores[evidence.reporter] = min(1.0, reporter_score + 0.02)
+        elif evidence.kind in ("negative", "byzantine"):
+            self._reporter_scores[evidence.reporter] = max(0.1, reporter_score - 0.01)
+
+    async def stake(self, agent: AgentId, amount: int) -> None:
+        """Stake reputation on *agent*."""
+        self._stakes[agent] = self._stakes.get(agent, 0) + amount

--- a/packages/nest-plugins-reference/tests/test_weighted_trust.py
+++ b/packages/nest-plugins-reference/tests/test_weighted_trust.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the weighted trust plugin (recency-decayed, volume-weighted)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from nest_core.types import AgentId, Evidence
+
+from nest_plugins_reference.trust.weighted import WeightedTrust
+
+
+class TestWeightedTrust:
+    """Conformance + behavioural tests for WeightedTrust."""
+
+    @pytest.mark.asyncio
+    async def test_default_score_is_neutral(self) -> None:
+        """An agent with no history gets a neutral 0.5 score with zero confidence."""
+        trust = WeightedTrust()
+        score = await trust.score(AgentId("a1"))
+        assert score.score == 0.5
+        assert score.confidence == 0.0
+        assert score.sample_count == 0
+
+    @pytest.mark.asyncio
+    async def test_positive_evidence_raises_score(self) -> None:
+        """Positive evidence should push the score above neutral."""
+        trust = WeightedTrust()
+        ev = Evidence(reporter=AgentId("a2"), subject=AgentId("a1"), kind="positive")
+        await trust.report(AgentId("a1"), ev)
+        await trust.report(AgentId("a1"), ev)
+
+        score = await trust.score(AgentId("a1"))
+        assert score.score > 0.5
+        assert score.sample_count == 2
+        assert score.confidence > 0.0
+
+    @pytest.mark.asyncio
+    async def test_negative_evidence_lowers_score(self) -> None:
+        """Negative evidence should push the score below neutral."""
+        trust = WeightedTrust()
+        neg = Evidence(reporter=AgentId("a2"), subject=AgentId("a1"), kind="negative")
+        await trust.report(AgentId("a1"), neg)
+
+        score = await trust.score(AgentId("a1"))
+        assert score.score < 0.5
+
+    @pytest.mark.asyncio
+    async def test_byzantine_worse_than_negative(self) -> None:
+        """Byzantine (malicious) evidence should produce a lower score than negative."""
+        trust_neg = WeightedTrust()
+        trust_byz = WeightedTrust()
+
+        neg = Evidence(reporter=AgentId("a2"), subject=AgentId("a1"), kind="negative")
+        byz = Evidence(reporter=AgentId("a2"), subject=AgentId("a1"), kind="byzantine")
+
+        # Use a mix of positive + negative vs positive + byzantine so the
+        # difference in severity is visible (single reports both clamp to 0).
+        pos = Evidence(reporter=AgentId("a3"), subject=AgentId("a1"), kind="positive")
+
+        await trust_neg.report(AgentId("a1"), pos)
+        await trust_neg.report(AgentId("a1"), neg)
+
+        await trust_byz.report(AgentId("a1"), pos)
+        await trust_byz.report(AgentId("a1"), byz)
+
+        s_neg = await trust_neg.score(AgentId("a1"))
+        s_byz = await trust_byz.score(AgentId("a1"))
+        assert s_byz.score < s_neg.score
+
+    @pytest.mark.asyncio
+    async def test_mixed_evidence_converges_to_weighted_average(self) -> None:
+        """A mix of positive and negative should land between the two extremes."""
+        trust = WeightedTrust()
+        pos = Evidence(reporter=AgentId("a2"), subject=AgentId("a1"), kind="positive")
+        neg = Evidence(reporter=AgentId("a3"), subject=AgentId("a1"), kind="negative")
+
+        for _ in range(3):
+            await trust.report(AgentId("a1"), pos)
+        for _ in range(1):
+            await trust.report(AgentId("a1"), neg)
+
+        score = await trust.score(AgentId("a1"))
+        # 3 positives (1.0) + 1 negative (0.0) → weighted avg around 0.75
+        assert 0.6 < score.score < 0.9
+        assert score.sample_count == 4
+
+    @pytest.mark.asyncio
+    async def test_confidence_grows_with_volume(self) -> None:
+        """More samples → higher confidence, capped at 1.0."""
+        trust = WeightedTrust(max_samples=10)
+        ev = Evidence(reporter=AgentId("a2"), subject=AgentId("a1"), kind="positive")
+
+        await trust.report(AgentId("a1"), ev)
+        s1 = await trust.score(AgentId("a1"))
+
+        for _ in range(9):
+            await trust.report(AgentId("a1"), ev)
+        s2 = await trust.score(AgentId("a1"))
+
+        assert s2.confidence > s1.confidence
+        assert s2.confidence == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_recency_decay(self) -> None:
+        """Old evidence should weigh less than fresh evidence."""
+        trust = WeightedTrust(decay_half_life=1.0)  # 1 second half-life
+
+        old_ts = time.time() - 100  # 100 seconds ago → heavily decayed
+        fresh_ts = time.time()
+
+        old_neg = Evidence(
+            reporter=AgentId("a2"), subject=AgentId("a1"),
+            kind="negative", timestamp=old_ts,
+        )
+        fresh_pos = Evidence(
+            reporter=AgentId("a2"), subject=AgentId("a1"),
+            kind="positive", timestamp=fresh_ts,
+        )
+
+        await trust.report(AgentId("a1"), old_neg)
+        await trust.report(AgentId("a1"), fresh_pos)
+
+        score = await trust.score(AgentId("a1"))
+        # Fresh positive should dominate → score > 0.5
+        assert score.score > 0.5
+
+    @pytest.mark.asyncio
+    async def test_score_is_clamped_to_unit_interval(self) -> None:
+        """Score must never go below 0 or above 1."""
+        trust = WeightedTrust()
+
+        # Flood with byzantine evidence
+        byz = Evidence(reporter=AgentId("a2"), subject=AgentId("a1"), kind="byzantine")
+        for _ in range(50):
+            await trust.report(AgentId("a1"), byz)
+        s_low = await trust.score(AgentId("a1"))
+        assert s_low.score >= 0.0
+
+        # Flood with positive evidence
+        trust2 = WeightedTrust()
+        pos = Evidence(reporter=AgentId("a2"), subject=AgentId("a1"), kind="positive")
+        for _ in range(50):
+            await trust2.report(AgentId("a1"), pos)
+        s_high = await trust2.score(AgentId("a1"))
+        assert s_high.score <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_stake(self) -> None:
+        """Staking accumulates amounts per agent."""
+        trust = WeightedTrust()
+        await trust.stake(AgentId("a1"), 100)
+        await trust.stake(AgentId("a1"), 50)
+        assert trust._stakes[AgentId("a1")] == 150
+
+    @pytest.mark.asyncio
+    async def test_reporter_credibility_tracking(self) -> None:
+        """Positive reporters slowly gain credibility over time."""
+        trust = WeightedTrust()
+        reporter = AgentId("r1")
+        subject = AgentId("s1")
+        pos = Evidence(reporter=reporter, subject=subject, kind="positive")
+
+        initial_cred = trust._reporter_scores.get(reporter, 0.7)
+        for _ in range(10):
+            await trust.report(subject, pos)
+        final_cred = trust._reporter_scores[reporter]
+        assert final_cred > initial_cred

--- a/scenarios/weighted_trust.yaml
+++ b/scenarios/weighted_trust.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# Weighted trust scenario: test recency-decayed, volume-weighted reputation.
+# Compares the weighted trust model against the flat-average model with
+# honest agents, occasional failures, and byzantine attackers.
+name: weighted_trust
+description: "16 honest, 4 malicious traders. Weighted trust model with recency decay and reporter credibility."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 21
+  brain: state-machine
+  roles:
+    - name: honest
+      count: 16
+    - name: malicious
+      count: 4
+    - name: observer
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: weighted
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: reputation
+  config:
+    rounds: 5
+    malicious_fraction: 0.2
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/weighted_trust.jsonl


### PR DESCRIPTION
## WeightedTrust — recency-decayed, volume-weighted reputation

A new trust plugin that improves on `ScoreAverageTrust` with:

- **Recency decay** — exponential half-life weighting so recent evidence matters more than stale evidence
- **Evidence severity** — `positive` (1.0), `neutral` (0.5), `negative` (0.0), and `byzantine` (-0.5) are weighted differently instead of the flat binary average
- **Volume confidence** — more data points produce higher confidence, capped at 1.0
- **Reporter credibility tracking** — reporters with a good track record are weighted more than unknown reporters

### Same interface as ScoreAverageTrust
Drop-in replacement — same `score()`, `report()`, `attest()`, and `stake()` methods. Selectable as `trust: weighted` in scenario YAML.

### Files added
- `nest_plugins_reference/trust/weighted.py` — the plugin
- `tests/test_weighted_trust.py` — 10 tests (all passing)
- `scenarios/weighted_trust.yaml` — scenario using the weighted trust layer

### Files modified
- `nest_core/plugins.py` — registered `("trust", "weighted")` in the builtin registry

### Test results
```
10 new tests — ALL PASS
37 existing tests — ALL PASS (no regressions)
```

Author: **John Kioko** (@Mutinda-Kioko)