### PR TITLE
[Hackathon] Bind score-average trust evidence to subjects

### DIFF
--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/score_average.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/score_average.py
@@ -58,29 +58,43 @@ class ScoreAverageTrust:
     async def attest(self, agent: AgentId, claim: Claim) -> Attestation:
         """Create an attestation about an agent.
 
+        The requested agent must match the claim subject. When an identity
+        signs the claim, the signature signer is also recorded as the issuer.
+
         Example::
 
             att = await trust.attest(AgentId("a1"), claim)
         """
+        if agent != claim.subject:
+            msg = "attestation agent must match claim subject"
+            raise ValueError(msg)
         sig = Signature(signer=AgentId("system"), value=b"attestation", algorithm="none")
         if self._identity is not None:
             sig = self._identity.sign(claim.model_dump_json().encode())
-        return Attestation(issuer=AgentId("system"), claim=claim, signature=sig)
+        return Attestation(issuer=sig.signer, claim=claim, signature=sig)
 
     async def report(self, agent: AgentId, evidence: Evidence) -> None:
         """Report evidence, updating the agent's score.
 
-        Evidence kind 'positive' adds 1.0, 'negative' adds 0.0, 'byzantine' adds 0.0.
+        The requested agent must match the evidence subject. Evidence kind
+        'positive' adds 1.0; 'negative' and 'byzantine' add 0.0. Other kinds
+        are rejected so they cannot inflate sample count or confidence.
 
         Example::
 
             await trust.report(AgentId("a1"), Evidence(reporter=..., subject=..., kind="negative"))
         """
-        score_val = 0.5
+        if agent != evidence.subject:
+            msg = "reported agent must match evidence subject"
+            raise ValueError(msg)
+        score_val: float
         if evidence.kind == "positive":
             score_val = 1.0
         elif evidence.kind in ("negative", "byzantine"):
             score_val = 0.0
+        else:
+            msg = f"unsupported evidence kind: {evidence.kind}"
+            raise ValueError(msg)
         self._scores.setdefault(agent, []).append(score_val)
 
     async def stake(self, agent: AgentId, amount: int) -> None:

--- a/packages/nest-plugins-reference/tests/test_plugins.py
+++ b/packages/nest-plugins-reference/tests/test_plugins.py
@@ -7,6 +7,7 @@ import pytest
 from nest_core.types import (
     AgentCard,
     AgentId,
+    Claim,
     DatasetMetadata,
     Evidence,
     Message,
@@ -272,6 +273,72 @@ class TestScoreAverageTrust:
 
         score = await trust.score(AgentId("a1"))
         assert score.score == 0.5
+
+    @pytest.mark.asyncio
+    async def test_report_rejects_subject_mismatch_without_mutation(self) -> None:
+        from nest_plugins_reference.trust.score_average import ScoreAverageTrust
+
+        trust = ScoreAverageTrust()
+        evidence = Evidence(
+            reporter=AgentId("attacker"),
+            subject=AgentId("victim"),
+            kind="negative",
+        )
+
+        with pytest.raises(ValueError, match="must match evidence subject"):
+            await trust.report(AgentId("innocent"), evidence)
+
+        score = await trust.score(AgentId("innocent"))
+        assert score.score == 0.5
+        assert score.confidence == 0.0
+        assert score.sample_count == 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_evidence_kind_cannot_inflate_confidence(self) -> None:
+        from nest_plugins_reference.trust.score_average import ScoreAverageTrust
+
+        trust = ScoreAverageTrust()
+        evidence = Evidence(
+            reporter=AgentId("reporter"),
+            subject=AgentId("subject"),
+            kind="unknown",
+        )
+
+        with pytest.raises(ValueError, match="unsupported evidence kind"):
+            await trust.report(AgentId("subject"), evidence)
+
+        score = await trust.score(AgentId("subject"))
+        assert score.confidence == 0.0
+        assert score.sample_count == 0
+
+    @pytest.mark.asyncio
+    async def test_attest_rejects_claim_subject_mismatch(self) -> None:
+        from nest_plugins_reference.trust.score_average import ScoreAverageTrust
+
+        trust = ScoreAverageTrust()
+        claim = Claim(subject=AgentId("victim"), predicate="completed", value="task-1")
+
+        with pytest.raises(ValueError, match="must match claim subject"):
+            await trust.attest(AgentId("innocent"), claim)
+
+    @pytest.mark.asyncio
+    async def test_identity_signed_attestation_binds_issuer_to_signer(self) -> None:
+        from nest_plugins_reference.identity.did_key import DidKeyIdentity
+        from nest_plugins_reference.trust.score_average import ScoreAverageTrust
+
+        identity = DidKeyIdentity(AgentId("issuer"), seed=b"trust-test")
+        trust = ScoreAverageTrust(identity)
+        claim = Claim(subject=AgentId("subject"), predicate="completed", value="task-1")
+
+        attestation = await trust.attest(AgentId("subject"), claim)
+
+        assert attestation.issuer == AgentId("issuer")
+        assert attestation.signature.signer == AgentId("issuer")
+        assert identity.verify(
+            claim.model_dump_json().encode(),
+            attestation.signature,
+            attestation.issuer,
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`ScoreAverageTrust` trusted two caller-controlled references to the subject independently. A malicious caller could report evidence about `victim` while mutating `innocent`, and an attestation could pair an arbitrary `agent` argument with a claim about someone else. Unknown evidence kinds were also recorded as neutral samples, allowing meaningless reports to raise confidence to 1.0. Finally, identity-signed attestations reported `issuer=system` even when the signature named the real signer.

## Change

- Reject reports when `agent != evidence.subject` before state mutation.
- Reject unsupported evidence kinds instead of counting them as neutral samples.
- Reject attestations when `agent != claim.subject`.
- Bind `Attestation.issuer` to `Signature.signer` for both system and identity-backed signatures.
- Document the fail-closed behavior in the public method docstrings.

## Adversarial coverage

Four regression tests prove that:

1. evidence about one subject cannot mutate another subject;
2. unknown kinds cannot inflate sample count or confidence;
3. a mismatched claim cannot be attested; and
4. an identity-backed attestation has a verifiable issuer/signer binding.

## Verification

`make ci-local` passes all five gates:

- `uv sync`
- `ruff check`
- `ruff format --check`
- `pyright` (0 errors)
- `pytest` (984 passed, 1 skipped, 1 deselected)
