### PR TITLE
[Hackathon] capability-systems-engineer: delegatable capability tokens with cascading revocation

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -26,6 +26,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
+    ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -145,3 +145,7 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("rogue_trusted_agent", rogue_trusted_agent_factory)
+    elif name == "delegated_auth":
+        from nest_core.scenarios_builtin.delegated_auth import delegated_auth_factory
+
+        register_scenario("delegated_auth", delegated_auth_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegated-auth scenario — a coordinator, 3 intermediaries, 12 leaf agents.
+
+Topology (matches the problem brief's required shape exactly):
+
+* ``coordinator-0`` mints a root capability token and delegates a narrowed
+  copy to each of 3 intermediaries.
+* Each ``intermediary-<i>`` (0..2) further narrows its scopes and delegates
+  to its 4 leaves, ``leaf-<i>-<j>`` (j 0..3) — 12 leaves total.
+* Every leaf verifies its own grant with :meth:`~DelegatableAuth.verify_with_audience`
+  and reports the outcome back to the coordinator.
+* One leaf (``task.config.byzantine_leaf_index``, default the last leaf)
+  is byzantine: it holds a perfectly valid token but reports it under a
+  *different* agent's identity — the audience-confusion attack — and its
+  report is expected to come back rejected.
+
+All three plugin-required attacks (scope escalation, stale-parent use,
+audience confusion) are proven adversarially in
+``nest_plugins_reference.validators.delegation_validators`` and
+``tests/test_delegation_validators.py`` (fails against ``jwt``, passes
+against ``delegatable``); this scenario's job is the *topology* the problem
+brief asks for, plus one live demonstration of the audience check firing
+inside the simulator itself.
+
+``ctx.plugins["auth"]`` is a **class**, not an instance (see how
+``identity_rotation.py`` has to provision identities itself for the same
+reason). A delegation chain is only verifiable by whoever holds the *same*
+root secret, so every agent here needs a reference to *one* shared
+authority instance, not sixteen independently-keyed ones — this factory
+builds that single instance and installs it as a per-agent override for
+every agent via ``plugins["_agent_plugins"]``, mirroring
+``_provision_identities``'s pattern exactly.
+
+Example::
+
+    from nest_core.runner import ScenarioRunner
+    runner = ScenarioRunner(ScenarioConfig.from_yaml("scenarios/delegated_auth.yaml"))
+    await runner.run()
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Token
+
+if TYPE_CHECKING:
+    from nest_core.types import AuthContext
+
+INTERMEDIARY_COUNT = 3
+LEAVES_PER_INTERMEDIARY = 4
+ROOT_SCOPES: list[str] = ["read", "write", "deploy", "admin"]
+INTERMEDIARY_SCOPES: list[str] = ["read", "write", "deploy"]
+LEAF_SCOPES: list[str] = ["read"]
+GRANT_PREFIX = b"grant:"
+REPORT_PREFIX = b"report:"
+DEFAULT_TTL = 3000.0
+
+
+def _sync_clock(ctx: AgentContext) -> Any:
+    """Return the shared auth plugin, synced to the simulator's logical clock.
+
+    Mirrors the ``hasattr(ident, "set_clock")`` convention from
+    ``identity_rotation.py`` so tokens are minted/verified against the
+    deterministic simulation clock, never wall-clock time.
+
+    Example::
+
+        auth = _sync_clock(ctx)
+        token = await auth.issue(ctx.agent_id, ["read"])
+    """
+    auth = ctx.plugins.get("auth")
+    if auth is not None and hasattr(auth, "set_clock"):
+        auth.set_clock(ctx.time)
+    return auth
+
+
+class CoordinatorAgent(StateMachineAgent):
+    """Mints the root token, delegates to every intermediary, tallies reports.
+
+    Example::
+
+        agent = CoordinatorAgent(AgentId("coordinator-0"), intermediary_ids=[...])
+    """
+
+    def __init__(self, agent_id: AgentId, intermediary_ids: list[AgentId]) -> None:
+        self._id = agent_id
+        self._intermediary_ids = intermediary_ids
+        self._reports_received = 0
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Issue the root token and delegate one child per intermediary.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        auth = _sync_clock(ctx)
+        root = await auth.issue(self._id, ROOT_SCOPES)
+        for intermediary_id in self._intermediary_ids:
+            child = await auth.delegate(root, intermediary_id, INTERMEDIARY_SCOPES, ttl=DEFAULT_TTL)
+            await ctx.send(intermediary_id, GRANT_PREFIX + str(child).encode("utf-8"))
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Tally leaf verification reports (observability only; no branching logic).
+
+        Example::
+
+            await agent.on_message(ctx, leaf_id, b"report:leaf-0-0:ok:['read']")
+        """
+        if payload.startswith(REPORT_PREFIX):
+            self._reports_received += 1
+
+
+class IntermediaryAgent(StateMachineAgent):
+    """Receives a delegated grant, narrows it further, delegates to its leaves.
+
+    Example::
+
+        agent = IntermediaryAgent(AgentId("intermediary-0"), leaf_ids=[...])
+    """
+
+    def __init__(self, agent_id: AgentId, leaf_ids: list[AgentId]) -> None:
+        self._id = agent_id
+        self._leaf_ids = leaf_ids
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Delegate a leaf-scoped child token to each leaf on receiving a grant.
+
+        Example::
+
+            await agent.on_message(ctx, coordinator_id, b"grant:<token-json>")
+        """
+        if not payload.startswith(GRANT_PREFIX):
+            return
+        auth = _sync_clock(ctx)
+        parent = Token(payload[len(GRANT_PREFIX) :].decode("utf-8"))
+        for leaf_id in self._leaf_ids:
+            child = await auth.delegate(parent, leaf_id, LEAF_SCOPES, ttl=DEFAULT_TTL / 2)
+            await ctx.send(leaf_id, GRANT_PREFIX + str(child).encode("utf-8"))
+
+
+class LeafAgent(StateMachineAgent):
+    """Verifies its own grant and reports the outcome to the coordinator.
+
+    A byzantine leaf (``impersonate_as`` set) presents its *genuine* token
+    under a different agent's identity — the audience-confusion attack — and
+    is expected to be rejected by :meth:`~DelegatableAuth.verify_with_audience`.
+
+    Example::
+
+        agent = LeafAgent(AgentId("leaf-0-0"), coordinator_id=AgentId("coordinator-0"))
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        coordinator_id: AgentId,
+        impersonate_as: AgentId | None = None,
+    ) -> None:
+        self._id = agent_id
+        self._coordinator_id = coordinator_id
+        self._impersonate_as = impersonate_as
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Verify the received grant (honestly, or under a spoofed identity) and report.
+
+        Example::
+
+            await agent.on_message(ctx, intermediary_id, b"grant:<token-json>")
+        """
+        if not payload.startswith(GRANT_PREFIX):
+            return
+        auth = _sync_clock(ctx)
+        token = Token(payload[len(GRANT_PREFIX) :].decode("utf-8"))
+        presented_as = self._impersonate_as or self._id
+        try:
+            ctx_result: AuthContext = await auth.verify_with_audience(token, presented_as)
+        except ValueError as exc:
+            report = f"{self._id}:rejected:{exc}"
+        else:
+            report = f"{self._id}:ok:{sorted(ctx_result.scopes)}"
+        await ctx.send(self._coordinator_id, REPORT_PREFIX + report.encode("utf-8"))
+
+
+def _provision_shared_auth(plugins: dict[str, Any], agent_ids: list[AgentId]) -> None:
+    """Install one shared ``DelegatableAuth`` instance as every agent's auth override.
+
+    Mirrors ``identity_rotation.py``'s ``_provision_identities``: resolve the
+    class at ``plugins["auth"]``, build exactly one instance (a delegation
+    chain is only verifiable against the secret that minted its root), and
+    stash it under ``plugins["_agent_plugins"][agent_id]["auth"]`` for every
+    agent so the runner's per-agent merge picks it up in place of the class.
+    No-op when no auth plugin is configured, or when it isn't a class (e.g.
+    already an instance from a different override path).
+
+    Example::
+
+        _provision_shared_auth(plugins, [coordinator_id, *intermediary_ids])
+    """
+    auth_cls = plugins.get("auth")
+    if auth_cls is None or not isinstance(auth_cls, type):
+        return
+    shared_auth = auth_cls()
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+    for agent_id in agent_ids:
+        agent_plugins.setdefault(agent_id, {})["auth"] = shared_auth
+    plugins.pop("auth", None)
+
+
+def delegated_auth_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Build the coordinator + 3 intermediaries + 12 leaves delegation tree.
+
+    ``task.config.byzantine_leaf_index`` (default: the last leaf, index 11)
+    selects which leaf attempts the audience-confusion attack against the
+    coordinator's own identity.
+
+    Example::
+
+        agents = delegated_auth_factory(config, plugins)
+        assert len(agents) == 1 + INTERMEDIARY_COUNT + INTERMEDIARY_COUNT * LEAVES_PER_INTERMEDIARY
+    """
+    task_config = config.task.config
+    byzantine_leaf_index = int(
+        task_config.get("byzantine_leaf_index", INTERMEDIARY_COUNT * LEAVES_PER_INTERMEDIARY - 1)
+    )
+
+    coordinator_id = AgentId("coordinator-0")
+    intermediary_ids = [AgentId(f"intermediary-{i}") for i in range(INTERMEDIARY_COUNT)]
+
+    agents: dict[AgentId, StateMachineAgent] = {
+        coordinator_id: CoordinatorAgent(coordinator_id, intermediary_ids=intermediary_ids)
+    }
+
+    all_ids = [coordinator_id, *intermediary_ids]
+    leaf_counter = 0
+    for i, intermediary_id in enumerate(intermediary_ids):
+        leaf_ids = [AgentId(f"leaf-{i}-{j}") for j in range(LEAVES_PER_INTERMEDIARY)]
+        agents[intermediary_id] = IntermediaryAgent(intermediary_id, leaf_ids=leaf_ids)
+        for leaf_id in leaf_ids:
+            impersonate_as = coordinator_id if leaf_counter == byzantine_leaf_index else None
+            agents[leaf_id] = LeafAgent(
+                leaf_id, coordinator_id=coordinator_id, impersonate_as=impersonate_as
+            )
+            all_ids.append(leaf_id)
+            leaf_counter += 1
+
+    _provision_shared_auth(plugins, all_ids)
+    return agents

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable.py
@@ -1,0 +1,367 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegatable capability tokens with cascading revocation.
+
+The default :class:`~nest_plugins_reference.auth.jwt_auth.JwtAuth` tracks
+revocation in ``_revoked: set[str]`` keyed by the *exact token string*, with no
+parent-child relationship at all. That makes it impossible to model the most
+common real-world capability pattern: agent A holds a long-lived root token,
+mints a narrow, short-lived sub-token for agent B without contacting the
+issuer, and revoking A's token must invalidate every token B (or anyone B
+further delegated to) derived from it, at the next verify.
+
+This plugin builds a macaroon-style **chained MAC**: a token is a JSON list of
+*hops*, one per delegation step from the root. Each hop's HMAC key is the
+*previous* hop's MAC (the root hop's key is the plugin's secret), so:
+
+* a party without the root secret cannot forge *any* hop, because every hop's
+  MAC recursively depends on a value only the true issuer could have produced;
+* **scope narrows monotonically** — :meth:`DelegatableAuth.delegate` refuses to
+  mint a child whose scopes are not a strict subset of its parent's (and
+  :meth:`~DelegatableAuth.verify` re-checks this structurally, so a tampered
+  or malformed hop chain is rejected even if some future code path skipped the
+  mint-time check);
+* **cascading revocation is O(1) to issue and O(depth) to check**: revoking a
+  token adds *one* MAC to :attr:`DelegatableAuth._revoked`; verifying any
+  descendant walks its own embedded hop chain and fails the moment it finds a
+  revoked MAC — no per-descendant bookkeeping is needed at revoke time.
+
+Audience binding — "child token presented by an agent other than its declared
+audience" — is not expressible through the base :class:`~nest_core.layers.auth.Auth`
+protocol (``verify(token) -> AuthContext`` has no caller identity), so this
+plugin exposes :meth:`~DelegatableAuth.verify_with_audience` as new API on top
+of the protocol, exactly as the problem brief calls for with
+:meth:`~DelegatableAuth.delegate`.
+
+Example::
+
+    auth = DelegatableAuth(secret=b"root-secret")
+    root = await auth.issue(AgentId("orchestrator"), ["read", "write", "deploy"])
+    child = await auth.delegate(root, AgentId("worker-1"), ["read"], ttl=60.0)
+    ctx = await auth.verify(child)
+    assert ctx.subject == AgentId("worker-1")
+    assert ctx.scopes == ["read"]
+
+    await auth.revoke(root)
+    await auth.verify(child)  # raises RevokedAncestorError
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, cast
+
+from nest_core.types import AgentId, AuthContext, Token
+
+
+class ScopeEscalationError(ValueError):
+    """Raised when a delegated token would hold a scope its parent lacks.
+
+    Example::
+
+        try:
+            await auth.delegate(parent, AgentId("worker-1"), ["admin"], ttl=60.0)
+        except ScopeEscalationError as exc:
+            assert "admin" in exc.requested_scopes
+    """
+
+    def __init__(self, requested_scopes: list[str], parent_scopes: list[str]) -> None:
+        self.requested_scopes = requested_scopes
+        self.parent_scopes = parent_scopes
+        extra = sorted(set(requested_scopes) - set(parent_scopes))
+        super().__init__(f"requested scopes {extra} exceed parent scopes {sorted(parent_scopes)}")
+
+
+class RevokedAncestorError(ValueError):
+    """Raised when a token's chain contains a revoked ancestor (or itself).
+
+    Example::
+
+        try:
+            await auth.verify(child_of_revoked_parent)
+        except RevokedAncestorError as exc:
+            assert exc.revoked_mac
+    """
+
+    def __init__(self, revoked_mac: str, depth: int) -> None:
+        self.revoked_mac = revoked_mac
+        self.depth = depth
+        super().__init__(f"chain hop {depth} (mac {revoked_mac[:12]}...) has been revoked")
+
+
+class AudienceMismatchError(ValueError):
+    """Raised when a token is presented by an agent other than its holder.
+
+    Example::
+
+        try:
+            await auth.verify_with_audience(child, AgentId("attacker"))
+        except AudienceMismatchError as exc:
+            assert exc.presented_by == AgentId("attacker")
+    """
+
+    def __init__(self, presented_by: AgentId, declared_holder: AgentId) -> None:
+        self.presented_by = presented_by
+        self.declared_holder = declared_holder
+        super().__init__(f"token held by {declared_holder!r} presented by {presented_by!r}")
+
+
+class TokenChainMalformedError(ValueError):
+    """Raised when a token's structure or MAC chain cannot be trusted.
+
+    Covers empty hop lists, non-monotonic scopes/TTLs baked into the chain,
+    and MAC mismatches (forged or corrupted tokens) in one place so callers
+    verifying untrusted input only need one exception type to guard against
+    "this token is not authentic," distinct from :class:`RevokedAncestorError`
+    ("this token *was* authentic but its authority was withdrawn").
+
+    Example::
+
+        try:
+            await auth.verify(Token("not-json"))
+        except TokenChainMalformedError:
+            pass
+    """
+
+
+def _canonical(hop: dict[str, Any]) -> bytes:
+    """Return the deterministic byte encoding of one hop, used as the HMAC message.
+
+    Example::
+
+        mac = hmac.new(key, _canonical(hop), hashlib.sha256).digest()
+    """
+    return json.dumps(hop, sort_keys=True).encode("utf-8")
+
+
+def _hop(holder: AgentId, scopes: list[str], issued_at: float, expires_at: float) -> dict[str, Any]:
+    """Build one delegation hop's plain-data payload.
+
+    Example::
+
+        hop = _hop(AgentId("worker-1"), ["read"], issued_at=0.0, expires_at=60.0)
+    """
+    return {
+        "holder": str(holder),
+        "scopes": sorted(scopes),
+        "issued_at": issued_at,
+        "expires_at": expires_at,
+    }
+
+
+class DelegatableAuth:
+    """Macaroon-style capability tokens: strict-subset delegation, cascading revocation.
+
+    Drop-in replacement for ``jwt`` that adds :meth:`delegate` on top of the
+    base :class:`~nest_core.layers.auth.Auth` protocol. Revocation state is
+    held in-process for the plugin's lifetime (mirrors ``JwtAuth._revoked``).
+
+    Example::
+
+        auth = DelegatableAuth(secret=b"root-secret")
+        root = await auth.issue(AgentId("orchestrator"), ["read", "write"])
+    """
+
+    def __init__(
+        self,
+        secret: bytes = b"nest-default-delegation-secret",
+        clock: float | None = None,
+    ) -> None:
+        self._secret = secret
+        self._clock = clock
+        self._revoked: set[str] = set()
+
+    def _now(self) -> float:
+        if self._clock is not None:
+            return self._clock
+        return time.time()
+
+    def set_clock(self, clock: float) -> None:
+        """Advance the plugin's deterministic simulation clock.
+
+        Mirrors the ``set_clock`` convention used by other rotating/timed
+        reference plugins (see ``ed25519_rotating``) so scenario drivers can
+        move time forward without reaching into private state.
+
+        Example::
+
+            auth.set_clock(3700.0)
+        """
+        self._clock = clock
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Issue a root capability token for a subject with given scopes.
+
+        Satisfies the base :class:`~nest_core.layers.auth.Auth` protocol: a
+        root token is a one-hop chain keyed directly by :attr:`_secret`.
+
+        Example::
+
+            token = await auth.issue(AgentId("orchestrator"), ["read", "write"])
+        """
+        now = self._now()
+        hop = _hop(subject, scopes, issued_at=now, expires_at=now + 3600)
+        mac = hmac.new(self._secret, _canonical(hop), hashlib.sha256).hexdigest()
+        return Token(json.dumps({"hops": [hop], "mac": mac}, sort_keys=True))
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token:
+        """Mint a child token narrowing ``parent_token``'s authority to ``audience``.
+
+        ``scopes_subset`` must be a strict subset of the parent's current
+        scopes (else :class:`ScopeEscalationError`) and ``ttl`` must not push
+        the child's expiry past the parent's (else :class:`ValueError`). The
+        parent is verified first, so delegating from an already-revoked or
+        expired parent fails immediately rather than minting a child that
+        would only fail later.
+
+        Example::
+
+            child = await auth.delegate(root, AgentId("worker-1"), ["read"], ttl=60.0)
+        """
+        parent_ctx = await self.verify(parent_token)
+        if not set(scopes_subset) <= set(parent_ctx.scopes):
+            raise ScopeEscalationError(scopes_subset, parent_ctx.scopes)
+
+        now = self._now()
+        expires_at = now + ttl
+        if parent_ctx.expires_at is not None and expires_at > parent_ctx.expires_at:
+            msg = (
+                f"child ttl would expire at {expires_at}, "
+                f"after parent expiry {parent_ctx.expires_at}"
+            )
+            raise ValueError(msg)
+
+        parsed = _parse(parent_token)
+        parent_mac_bytes = bytes.fromhex(parsed["mac"])
+        hop = _hop(audience, scopes_subset, issued_at=now, expires_at=expires_at)
+        mac = hmac.new(parent_mac_bytes, _canonical(hop), hashlib.sha256).hexdigest()
+        hops = [*parsed["hops"], hop]
+        return Token(json.dumps({"hops": hops, "mac": mac}, sort_keys=True))
+
+    async def verify(self, token: Token) -> AuthContext:
+        """Verify a token's full MAC chain, monotonicity, expiry, and revocation.
+
+        Recomputes every hop's MAC from :attr:`_secret` forward — a token
+        cannot verify unless every hop was genuinely produced by this plugin
+        (directly or via a chain of :meth:`delegate` calls rooted in it).
+        Also re-checks that scopes only narrow and expiry only tightens hop
+        to hop, so a structurally tampered chain fails even if some MAC
+        collided (defense in depth, not the primary authenticity check).
+
+        Example::
+
+            ctx = await auth.verify(child)
+            assert ctx.subject == AgentId("worker-1")
+        """
+        parsed = _parse(token)
+        hops = parsed["hops"]
+        claimed_mac = parsed["mac"]
+
+        key = self._secret
+        computed_macs: list[str] = []
+        for depth, hop in enumerate(hops):
+            mac_bytes = hmac.new(key, _canonical(hop), hashlib.sha256).digest()
+            mac_hex = mac_bytes.hex()
+            computed_macs.append(mac_hex)
+            if depth > 0:
+                prev = hops[depth - 1]
+                if not set(hop["scopes"]) <= set(prev["scopes"]):
+                    msg = (
+                        f"hop {depth} scopes {hop['scopes']} exceed "
+                        f"hop {depth - 1} scopes {prev['scopes']}"
+                    )
+                    raise TokenChainMalformedError(msg)
+                if hop["expires_at"] > prev["expires_at"]:
+                    msg = (
+                        f"hop {depth} expires_at {hop['expires_at']} exceeds "
+                        f"hop {depth - 1} expires_at {prev['expires_at']}"
+                    )
+                    raise TokenChainMalformedError(msg)
+            key = mac_bytes
+
+        if not hmac.compare_digest(computed_macs[-1], claimed_mac):
+            msg = "token MAC does not match its claimed hop chain"
+            raise TokenChainMalformedError(msg)
+
+        for depth, mac_hex in enumerate(computed_macs):
+            if mac_hex in self._revoked:
+                raise RevokedAncestorError(mac_hex, depth)
+
+        last = hops[-1]
+        expires_at = cast("float", last["expires_at"])
+        if expires_at < self._now():
+            msg = f"token expired at {expires_at}"
+            raise ValueError(msg)
+
+        return AuthContext(
+            subject=AgentId(last["holder"]),
+            scopes=list(last["scopes"]),
+            issued_at=last["issued_at"],
+            expires_at=expires_at,
+        )
+
+    async def verify_with_audience(self, token: Token, presented_by: AgentId) -> AuthContext:
+        """Verify a token and additionally require it be presented by its own holder.
+
+        New API beyond the base :class:`~nest_core.layers.auth.Auth` protocol
+        (``verify`` alone has no caller identity to check against). Catches
+        the "audience confusion" attack: an agent that intercepts or is
+        forwarded a token that was never delegated to it.
+
+        Example::
+
+            ctx = await auth.verify_with_audience(child, AgentId("worker-1"))
+        """
+        ctx = await self.verify(token)
+        if ctx.subject != presented_by:
+            raise AudienceMismatchError(presented_by, ctx.subject)
+        return ctx
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke a token, cascading to every token delegated from it.
+
+        Adds only the *revoked token's own* MAC to :attr:`_revoked` — O(1).
+        Every descendant's chain embeds this MAC at the matching depth, so
+        :meth:`verify` on any descendant fails without any per-descendant
+        state being touched here.
+
+        Example::
+
+            await auth.revoke(root)
+            await auth.verify(child)  # raises RevokedAncestorError
+        """
+        parsed = _parse(token)
+        self._revoked.add(parsed["mac"])
+
+
+def _parse(token: Token) -> dict[str, Any]:
+    """Parse and structurally validate a token's JSON envelope.
+
+    Example::
+
+        parsed = _parse(token)
+        assert parsed["hops"] and parsed["mac"]
+    """
+    try:
+        loaded = json.loads(str(token))
+    except json.JSONDecodeError as exc:
+        raise TokenChainMalformedError(f"token is not valid JSON: {exc}") from exc
+    if (
+        not isinstance(loaded, dict)
+        or "hops" not in loaded
+        or "mac" not in loaded
+        or not isinstance(loaded["hops"], list)
+        or not loaded["hops"]
+    ):
+        raise TokenChainMalformedError(
+            "token must be a JSON object with a non-empty 'hops' list and a 'mac' field"
+        )
+    return cast("dict[str, Any]", loaded)

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -16,6 +16,11 @@ Example::
 
 from __future__ import annotations
 
+from nest_plugins_reference.validators.delegation_validators import (
+    check_audience_enforced,
+    check_no_scope_escalation,
+    check_no_stale_parent_use,
+)
 from nest_plugins_reference.validators.gossip_validators import (
     ConvergenceFailureError,
     PartitionLeakError,
@@ -42,6 +47,7 @@ __all__ = [
     "ConvergenceFailureError",
     "PartitionLeakError",
     "ValidatorReport",
+    "check_audience_enforced",
     "check_converged",
     "check_denial_receipt_auditable",
     "check_eavesdropper_blocked",
@@ -49,6 +55,8 @@ __all__ = [
     "check_gate_tamper_rejected",
     "check_low_trust_blocked",
     "check_no_partition_view_leak",
+    "check_no_scope_escalation",
+    "check_no_stale_parent_use",
     "check_partial_redaction_enforced",
     "check_replay_rejected",
     "check_stale_revocation_blocked",

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/delegation_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/delegation_validators.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for the delegatable capability-token auth plugin.
+
+Three attacks the default ``jwt`` plugin (no delegation concept at all)
+trivially permits, because it has nothing to check against:
+
+1. **Scope escalation.** A "child" token claims broader scopes than any
+   token it was supposedly derived from. ``check_no_scope_escalation``
+   compares the delegator's own scopes against what it handed out.
+2. **Stale parent.** A token derived from an already-revoked or expired
+   parent still verifies. ``check_no_stale_parent_use`` re-verifies every
+   delegated token *after* its declared parent's revocation/expiry point
+   and asserts it fails.
+3. **Audience confusion.** A token minted for one agent is accepted when
+   presented by a different agent. ``check_audience_enforced`` presents
+   each token to a non-holder and asserts it is rejected.
+
+Against ``jwt``, all three trivially pass the *attack* (i.e. the checks
+below report ``passed=False``) because ``jwt`` has no ``delegate``, no
+chain, and no audience concept — any token verifies for anyone, forever,
+until its flat expiry. Against ``delegatable``, all three attacks are
+caught by construction (the checks report ``passed=True``), which is the
+charter's bar for "adversarial": the reference plugin cannot satisfy it.
+
+Example::
+
+    report = await check_no_stale_parent_use(auth, root, [child, grandchild])
+    assert report.passed, report.detail
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, cast
+
+from nest_plugins_reference.validators.gossip_validators import ValidatorReport
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from nest_core.types import AgentId, Token
+
+
+class _DelegatingAuth(Protocol):
+    """The base :class:`~nest_core.layers.auth.Auth` surface every plugin has.
+
+    Deliberately does *not* require ``delegate``/``verify_with_audience`` —
+    those are new API the base ``jwt`` plugin lacks entirely, and lacking
+    them is precisely the vulnerability these validators demonstrate.
+    Checks that need them fetch and call them dynamically via
+    :func:`_extension_method`, so a plugin without them fails honestly at
+    the call site instead of being rejected by the type checker before the
+    adversarial comparison can even run.
+
+    Example::
+
+        async def run(auth: _DelegatingAuth) -> None:
+            token = await auth.issue(AgentId("a1"), ["read"])
+    """
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Issue a token for a subject with given scopes.
+
+        Example::
+
+            token = await auth.issue(AgentId("a1"), ["read"])
+        """
+        ...
+
+    async def verify(self, token: Token) -> object:
+        """Verify a token and return its auth context.
+
+        Example::
+
+            ctx = await auth.verify(token)
+        """
+        ...
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke a previously issued token.
+
+        Example::
+
+            await auth.revoke(token)
+        """
+        ...
+
+
+def _extension_method(auth: _DelegatingAuth, name: str) -> Callable[..., Awaitable[object]]:
+    """Look up an optional method (``delegate``, ``verify_with_audience``) by name.
+
+    Raises :class:`AttributeError` if ``auth`` doesn't have it — callers
+    catch that as the honest "this plugin cannot even attempt the defense"
+    outcome, rather than the type checker silently assuming every plugin
+    implements the full extended surface.
+
+    Example::
+
+        delegate = _extension_method(auth, "delegate")
+        child = await delegate(parent, audience, scopes, ttl=60.0)
+    """
+    method = getattr(auth, name, None)
+    if method is None or not callable(method):
+        msg = f"{type(auth).__name__!r} has no {name}()"
+        raise AttributeError(msg)
+    return cast("Callable[..., Awaitable[object]]", method)
+
+
+async def check_no_scope_escalation(
+    auth: _DelegatingAuth,
+    delegator: AgentId,
+    delegator_scopes: list[str],
+    audience: AgentId,
+    requested_scopes: list[str],
+) -> ValidatorReport:
+    """Assert that delegating a broader scope set than the delegator holds is rejected.
+
+    Issues a token for ``delegator`` with ``delegator_scopes``, then attempts
+    to delegate ``requested_scopes`` to ``audience``. ``passed=True`` iff the
+    plugin refuses the delegation whenever ``requested_scopes`` is not a
+    subset of ``delegator_scopes`` — including trivially passing when the
+    request *is* a valid subset (nothing to reject).
+
+    Example::
+
+        report = await check_no_scope_escalation(
+            auth, AgentId("a1"), ["read"], AgentId("a2"), ["read", "admin"]
+        )
+        assert report.passed
+    """
+    is_escalation = not set(requested_scopes) <= set(delegator_scopes)
+    parent = await auth.issue(delegator, delegator_scopes)
+    try:
+        delegate = _extension_method(auth, "delegate")
+        await delegate(parent, audience, requested_scopes, ttl=60.0)
+    except AttributeError:
+        return ValidatorReport(
+            passed=False,
+            detail="plugin has no delegate() — cannot express, let alone enforce, a scope subset",
+        )
+    except ValueError as exc:
+        if is_escalation:
+            return ValidatorReport(passed=True, detail=f"escalation correctly rejected: {exc}")
+        return ValidatorReport(
+            passed=False,
+            detail=f"valid subset delegation was wrongly rejected: {exc}",
+            evidence={"delegator_scopes": delegator_scopes, "requested": requested_scopes},
+        )
+    if is_escalation:
+        return ValidatorReport(
+            passed=False,
+            detail="escalated delegation was accepted without error",
+            evidence={"delegator_scopes": delegator_scopes, "requested": requested_scopes},
+        )
+    return ValidatorReport(passed=True, detail="valid subset delegation correctly accepted")
+
+
+async def check_no_stale_parent_use(
+    auth: _DelegatingAuth,
+    root: Token,
+    descendants: list[Token],
+) -> ValidatorReport:
+    """Assert every descendant of a revoked token fails to verify afterward.
+
+    Revokes ``root`` and then calls ``verify`` on each token in
+    ``descendants`` (expected to have been delegated, directly or
+    transitively, from ``root`` *before* the revocation). ``passed=True``
+    iff every descendant now raises on verify; any descendant that still
+    verifies is the stale-parent bug this check exists to catch.
+
+    Example::
+
+        report = await check_no_stale_parent_use(auth, root, [child, grandchild])
+        assert report.passed
+    """
+    await auth.revoke(root)
+    still_valid: list[int] = []
+    for i, token in enumerate(descendants):
+        try:
+            await auth.verify(token)
+        except ValueError:
+            continue
+        still_valid.append(i)
+    if still_valid:
+        return ValidatorReport(
+            passed=False,
+            detail=f"{len(still_valid)} of {len(descendants)} descendants still verify"
+            " after parent revocation",
+            evidence={"stale_indices": still_valid},
+        )
+    return ValidatorReport(
+        passed=True, detail=f"all {len(descendants)} descendants correctly rejected"
+    )
+
+
+async def check_audience_enforced(
+    auth: _DelegatingAuth,
+    token: Token,
+    declared_holder: AgentId,
+    impersonator: AgentId,
+) -> ValidatorReport:
+    """Assert a token presented by a non-holder agent is rejected.
+
+    Calls ``verify_with_audience(token, impersonator)`` where ``impersonator
+    != declared_holder`` and asserts it raises. Plugins with no audience
+    concept (e.g. the default ``jwt``, which has no such method at all) are
+    reported as failing this check via ``AttributeError`` capture, which is
+    the honest "cannot even attempt audience enforcement" outcome.
+
+    Example::
+
+        report = await check_audience_enforced(auth, child, AgentId("a2"), AgentId("attacker"))
+        assert report.passed
+    """
+    try:
+        verify_with_audience = _extension_method(auth, "verify_with_audience")
+        await verify_with_audience(token, impersonator)
+    except AttributeError:
+        return ValidatorReport(
+            passed=False,
+            detail="plugin has no verify_with_audience — audience is not enforced at all",
+        )
+    except ValueError as exc:
+        return ValidatorReport(passed=True, detail=f"impersonation correctly rejected: {exc}")
+    return ValidatorReport(
+        passed=False,
+        detail=f"token for {declared_holder!r} was accepted from impersonator {impersonator!r}",
+    )

--- a/packages/nest-plugins-reference/tests/test_delegatable.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the delegatable capability-token auth plugin.
+
+Persona note (capability-systems engineer): the invariants under test are the
+ones a delegation chain lives or dies on -- scopes only narrow, TTLs only
+tighten, a token cannot verify without a genuine chain rooted in the issuer's
+secret, and revoking one hop kills every descendant without touching them.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.layers.auth import Auth
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.delegatable import (
+    AudienceMismatchError,
+    DelegatableAuth,
+    RevokedAncestorError,
+    ScopeEscalationError,
+    TokenChainMalformedError,
+)
+
+_ORCHESTRATOR = AgentId("orchestrator")
+_WORKER = AgentId("worker-1")
+_SUB_WORKER = AgentId("worker-1-1")
+_ATTACKER = AgentId("attacker")
+
+
+def _auth(clock: float = 0.0) -> DelegatableAuth:
+    return DelegatableAuth(secret=b"test-secret", clock=clock)
+
+
+# ---------------------------------------------------------------------------
+# Delegation and scope narrowing
+# ---------------------------------------------------------------------------
+
+
+class TestDelegation:
+    async def test_child_scope_strict_subset_of_parent_verifies(self) -> None:
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read", "write", "deploy"])
+        child = await auth.delegate(root, _WORKER, ["read", "write"], ttl=60.0)
+        ctx = await auth.verify(child)
+        assert ctx.subject == _WORKER
+        assert ctx.scopes == ["read", "write"]
+
+    async def test_child_scope_equal_to_parent_verifies(self) -> None:
+        """Boundary: the subset relation is non-strict on scope *content*."""
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        child = await auth.delegate(root, _WORKER, ["read"], ttl=60.0)
+        ctx = await auth.verify(child)
+        assert ctx.scopes == ["read"]
+
+    async def test_child_scope_superset_of_parent_raises_scope_escalation(self) -> None:
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        with pytest.raises(ScopeEscalationError) as exc:
+            await auth.delegate(root, _WORKER, ["read", "admin"], ttl=60.0)
+        assert "admin" in exc.value.requested_scopes
+
+    async def test_child_scope_disjoint_from_parent_raises_scope_escalation(self) -> None:
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        with pytest.raises(ScopeEscalationError):
+            await auth.delegate(root, _WORKER, ["write"], ttl=60.0)
+
+    async def test_multi_level_delegation_narrows_further(self) -> None:
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read", "write"])
+        child = await auth.delegate(root, _WORKER, ["read", "write"], ttl=100.0)
+        grandchild = await auth.delegate(child, _SUB_WORKER, ["read"], ttl=50.0)
+        ctx = await auth.verify(grandchild)
+        assert ctx.subject == _SUB_WORKER
+        assert ctx.scopes == ["read"]
+
+    async def test_empty_scopes_subset_is_a_valid_boundary(self) -> None:
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        child = await auth.delegate(root, _WORKER, [], ttl=60.0)
+        ctx = await auth.verify(child)
+        assert ctx.scopes == []
+
+
+class TestTtlBounds:
+    async def test_child_ttl_within_parent_window_verifies(self) -> None:
+        auth = _auth(clock=0.0)
+        root = await auth.issue(_ORCHESTRATOR, ["read"])  # expires at 3600
+        child = await auth.delegate(root, _WORKER, ["read"], ttl=60.0)
+        ctx = await auth.verify(child)
+        assert ctx.expires_at == 60.0
+
+    async def test_child_ttl_exceeding_parent_expiry_raises(self) -> None:
+        auth = _auth(clock=0.0)
+        root = await auth.issue(_ORCHESTRATOR, ["read"])  # expires at 3600
+        with pytest.raises(ValueError, match="ttl"):
+            await auth.delegate(root, _WORKER, ["read"], ttl=99999.0)
+
+
+# ---------------------------------------------------------------------------
+# Cascading revocation
+# ---------------------------------------------------------------------------
+
+
+class TestCascadingRevocation:
+    async def test_verify_succeeds_before_any_revocation(self) -> None:
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        child = await auth.delegate(root, _WORKER, ["read"], ttl=60.0)
+        await auth.verify(child)  # does not raise
+
+    async def test_revoking_parent_invalidates_child(self) -> None:
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        child = await auth.delegate(root, _WORKER, ["read"], ttl=60.0)
+        await auth.revoke(root)
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify(child)
+
+    async def test_revoking_grandparent_invalidates_grandchild(self) -> None:
+        """Cascade must propagate more than one level."""
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        child = await auth.delegate(root, _WORKER, ["read"], ttl=100.0)
+        grandchild = await auth.delegate(child, _SUB_WORKER, ["read"], ttl=50.0)
+        await auth.revoke(root)
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify(grandchild)
+
+    async def test_revoking_child_does_not_invalidate_sibling(self) -> None:
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        child_a = await auth.delegate(root, _WORKER, ["read"], ttl=60.0)
+        child_b = await auth.delegate(root, _SUB_WORKER, ["read"], ttl=60.0)
+        await auth.revoke(child_a)
+        await auth.verify(child_b)  # does not raise
+
+    async def test_delegating_from_revoked_parent_raises_immediately(self) -> None:
+        """Stale-parent attack: minting from a dead parent must fail at mint time."""
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        await auth.revoke(root)
+        with pytest.raises(RevokedAncestorError):
+            await auth.delegate(root, _WORKER, ["read"], ttl=60.0)
+
+    async def test_delegating_from_expired_parent_raises(self) -> None:
+        auth = _auth(clock=0.0)
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        auth.set_clock(999999.0)  # advance past root's 3600s default expiry
+        with pytest.raises(ValueError, match="expired"):
+            await auth.delegate(root, _WORKER, ["read"], ttl=60.0)
+
+
+# ---------------------------------------------------------------------------
+# Audience binding
+# ---------------------------------------------------------------------------
+
+
+class TestAudienceBinding:
+    async def test_verify_with_audience_by_correct_holder_succeeds(self) -> None:
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        child = await auth.delegate(root, _WORKER, ["read"], ttl=60.0)
+        ctx = await auth.verify_with_audience(child, _WORKER)
+        assert ctx.subject == _WORKER
+
+    async def test_verify_with_audience_by_wrong_agent_raises(self) -> None:
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        child = await auth.delegate(root, _WORKER, ["read"], ttl=60.0)
+        with pytest.raises(AudienceMismatchError) as exc:
+            await auth.verify_with_audience(child, _ATTACKER)
+        assert exc.value.presented_by == _ATTACKER
+        assert exc.value.declared_holder == _WORKER
+
+
+# ---------------------------------------------------------------------------
+# Chain authenticity / tamper resistance
+# ---------------------------------------------------------------------------
+
+
+class TestChainAuthenticity:
+    async def test_forged_token_with_fabricated_chain_fails_mac_check(self) -> None:
+        """An attacker without the secret cannot mint a valid-looking root."""
+        auth = _auth()
+        forged = Token(
+            json.dumps(
+                {
+                    "hops": [
+                        {
+                            "holder": "attacker",
+                            "scopes": ["admin"],
+                            "issued_at": 0.0,
+                            "expires_at": 3600.0,
+                        }
+                    ],
+                    "mac": "0" * 64,
+                }
+            )
+        )
+        with pytest.raises(TokenChainMalformedError):
+            await auth.verify(forged)
+
+    async def test_tampering_with_hop_payload_breaks_mac(self) -> None:
+        auth = _auth()
+        root = await auth.issue(_ORCHESTRATOR, ["read"])
+        child = await auth.delegate(root, _WORKER, ["read"], ttl=60.0)
+        parsed = json.loads(str(child))
+        parsed["hops"][-1]["scopes"] = ["read", "admin"]  # tamper after minting
+        tampered = Token(json.dumps(parsed))
+        with pytest.raises(TokenChainMalformedError):
+            await auth.verify(tampered)
+
+    async def test_malformed_json_raises_chain_malformed(self) -> None:
+        auth = _auth()
+        with pytest.raises(TokenChainMalformedError):
+            await auth.verify(Token("not-json"))
+
+    async def test_empty_hops_list_raises_chain_malformed(self) -> None:
+        auth = _auth()
+        with pytest.raises(TokenChainMalformedError):
+            await auth.verify(Token(json.dumps({"hops": [], "mac": "abc"})))
+
+    async def test_different_secret_cannot_verify_each_others_tokens(self) -> None:
+        """Two independently-keyed authorities cannot forge for one another."""
+        auth_a = DelegatableAuth(secret=b"secret-a", clock=0.0)
+        auth_b = DelegatableAuth(secret=b"secret-b", clock=0.0)
+        token = await auth_a.issue(_ORCHESTRATOR, ["read"])
+        with pytest.raises(TokenChainMalformedError):
+            await auth_b.verify(token)
+
+
+# ---------------------------------------------------------------------------
+# API fit
+# ---------------------------------------------------------------------------
+
+
+class TestApiFit:
+    async def test_satisfies_auth_protocol(self) -> None:
+        assert isinstance(_auth(), Auth)
+
+    def test_resolvable_from_registry(self) -> None:
+        cls = PluginRegistry().resolve("auth", "delegatable")
+        assert cls is DelegatableAuth
+
+    async def test_issue_matches_base_auth_contract(self) -> None:
+        """issue/verify/revoke alone (no delegation) still behave like a normal Auth plugin."""
+        auth = _auth()
+        token = await auth.issue(_ORCHESTRATOR, ["read", "write"])
+        ctx = await auth.verify(token)
+        assert ctx.subject == _ORCHESTRATOR
+        assert ctx.scopes == ["read", "write"]
+        await auth.revoke(token)
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify(token)
+
+
+# ---------------------------------------------------------------------------
+# Property-based: chain depth and scope narrowing hold across arbitrary chains
+# ---------------------------------------------------------------------------
+
+
+_SCOPE_UNIVERSE = ["read", "write", "deploy", "admin", "billing"]
+
+
+@st.composite
+def _narrowing_chain(draw: st.DrawFn) -> list[list[str]]:
+    """Draw a chain of scope-sets, each a subset of the previous."""
+    depth = draw(st.integers(min_value=1, max_value=5))
+    current = set(draw(st.lists(st.sampled_from(_SCOPE_UNIVERSE), min_size=1, unique=True)))
+    chain = [sorted(current)]
+    for _ in range(depth - 1):
+        if not current:
+            break
+        current = set(draw(st.lists(st.sampled_from(sorted(current)), unique=True)))
+        chain.append(sorted(current))
+    return chain
+
+
+class TestChainProperties:
+    @settings(max_examples=100, deadline=None)
+    @given(chain=_narrowing_chain())
+    async def test_any_valid_narrowing_chain_verifies_end_to_end(
+        self, chain: list[list[str]]
+    ) -> None:
+        auth = _auth(clock=0.0)
+        token = await auth.issue(_ORCHESTRATOR, chain[0])
+        holder = _ORCHESTRATOR
+        for i, scopes in enumerate(chain[1:], start=1):
+            holder = AgentId(f"agent-{i}")
+            token = await auth.delegate(token, holder, scopes, ttl=3600.0 - i)
+        ctx = await auth.verify(token)
+        assert ctx.scopes == chain[-1]
+        assert ctx.subject == holder
+
+    @settings(max_examples=50, deadline=None)
+    @given(chain=_narrowing_chain())
+    async def test_revoking_root_kills_every_depth_of_any_chain(
+        self, chain: list[list[str]]
+    ) -> None:
+        auth = _auth(clock=0.0)
+        root = await auth.issue(_ORCHESTRATOR, chain[0])
+        token = root
+        for i, scopes in enumerate(chain[1:], start=1):
+            token = await auth.delegate(token, AgentId(f"agent-{i}"), scopes, ttl=3600.0 - i)
+        await auth.revoke(root)
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify(token)

--- a/packages/nest-plugins-reference/tests/test_delegation_validators.py
+++ b/packages/nest-plugins-reference/tests/test_delegation_validators.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validator + adversarial-discrimination tests for delegatable capability tokens.
+
+Two layers of coverage:
+
+1. **Validator unit tests** — direct calls against ``delegatable`` exercising
+   the accept / reject path of each of the three required checks.
+2. **Adversarial discrimination** — the same three attacks run against the
+   default ``jwt`` plugin MUST be reported as unmitigated (``passed=False``,
+   or the honest "plugin cannot even attempt this" case for methods `jwt`
+   doesn't have at all), and against ``delegatable`` MUST be caught
+   (``passed=True``). This is the charter's bar: "an adversarial validator
+   that catches a class of attacks the default reference plugin would fail."
+
+``jwt`` has no ``delegate``/``verify_with_audience`` methods, so it cannot
+even attempt scope-subset enforcement or audience binding — calling those
+paths against it produces the "plugin has no delegate()" / "no
+verify_with_audience()" failure reports directly. For stale-parent use,
+``jwt`` *does* have ``issue``/``verify``/``revoke``, so the comparison is
+apples-to-apples: two independently issued jwt tokens have no parent-child
+relationship at all, so revoking one predictably never affects the other —
+which is exactly the bug class this validator exists to catch.
+"""
+
+from __future__ import annotations
+
+from nest_core.types import AgentId
+from nest_plugins_reference.auth.delegatable import DelegatableAuth
+from nest_plugins_reference.auth.jwt_auth import JwtAuth
+from nest_plugins_reference.validators import (
+    check_audience_enforced,
+    check_no_scope_escalation,
+    check_no_stale_parent_use,
+)
+
+_DELEGATOR = AgentId("orchestrator")
+_AUDIENCE = AgentId("worker-1")
+_ATTACKER = AgentId("attacker")
+
+
+def _delegatable() -> DelegatableAuth:
+    return DelegatableAuth(secret=b"validator-test-secret", clock=0.0)
+
+
+def _jwt() -> JwtAuth:
+    return JwtAuth(secret=b"validator-test-secret", clock=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests (against delegatable, the plugin they ship next to)
+# ---------------------------------------------------------------------------
+
+
+class TestScopeEscalationValidator:
+    async def test_reports_passed_when_escalation_is_rejected(self) -> None:
+        report = await check_no_scope_escalation(
+            _delegatable(), _DELEGATOR, ["read"], _AUDIENCE, ["read", "admin"]
+        )
+        assert report.passed, report.detail
+
+    async def test_reports_passed_for_a_genuinely_valid_subset(self) -> None:
+        report = await check_no_scope_escalation(
+            _delegatable(), _DELEGATOR, ["read", "write"], _AUDIENCE, ["read"]
+        )
+        assert report.passed, report.detail
+
+
+class TestStaleParentValidator:
+    async def test_reports_passed_when_descendants_die_with_parent(self) -> None:
+        auth = _delegatable()
+        root = await auth.issue(_DELEGATOR, ["read"])
+        child = await auth.delegate(root, _AUDIENCE, ["read"], ttl=60.0)
+        grandchild = await auth.delegate(child, AgentId("worker-1-1"), ["read"], ttl=30.0)
+        report = await check_no_stale_parent_use(auth, root, [child, grandchild])
+        assert report.passed, report.detail
+
+
+class TestAudienceValidator:
+    async def test_reports_passed_when_impersonation_is_rejected(self) -> None:
+        auth = _delegatable()
+        root = await auth.issue(_DELEGATOR, ["read"])
+        child = await auth.delegate(root, _AUDIENCE, ["read"], ttl=60.0)
+        report = await check_audience_enforced(auth, child, _AUDIENCE, _ATTACKER)
+        assert report.passed, report.detail
+
+
+# ---------------------------------------------------------------------------
+# Adversarial discrimination: jwt MUST FAIL, delegatable MUST PASS
+# ---------------------------------------------------------------------------
+
+
+class TestDiscriminationScopeEscalation:
+    async def test_jwt_cannot_prevent_scope_escalation(self) -> None:
+        report = await check_no_scope_escalation(
+            _jwt(), _DELEGATOR, ["read"], _AUDIENCE, ["read", "admin"]
+        )
+        assert not report.passed, "jwt has no delegate() — it must not be reported as passing"
+
+    async def test_delegatable_prevents_scope_escalation(self) -> None:
+        report = await check_no_scope_escalation(
+            _delegatable(), _DELEGATOR, ["read"], _AUDIENCE, ["read", "admin"]
+        )
+        assert report.passed, report.detail
+
+
+class TestDiscriminationStaleParent:
+    async def test_jwt_tokens_have_no_parent_child_relationship(self) -> None:
+        """Two unrelated jwt tokens: revoking one must never touch the other.
+
+        This *is* the vulnerability: jwt's flat ``_revoked: set[str]`` keyed
+        by exact token string has no notion of lineage, so there is nothing
+        for revocation to cascade through. The "descendant" here is not
+        actually derived from the "parent" (jwt cannot express that at all)
+        -- it is a second, independent token, and it predictably survives.
+        """
+        auth = _jwt()
+        root = await auth.issue(_DELEGATOR, ["read"])
+        unrelated = await auth.issue(_AUDIENCE, ["read"])
+        report = await check_no_stale_parent_use(auth, root, [unrelated])
+        assert not report.passed, "an unrelated jwt token must not be reported as revoked"
+
+    async def test_delegatable_cascades_revocation_through_real_chain(self) -> None:
+        auth = _delegatable()
+        root = await auth.issue(_DELEGATOR, ["read"])
+        child = await auth.delegate(root, _AUDIENCE, ["read"], ttl=60.0)
+        report = await check_no_stale_parent_use(auth, root, [child])
+        assert report.passed, report.detail
+
+
+class TestDiscriminationAudience:
+    async def test_jwt_has_no_audience_concept_at_all(self) -> None:
+        auth = _jwt()
+        token = await auth.issue(_AUDIENCE, ["read"])
+        report = await check_audience_enforced(auth, token, _AUDIENCE, _ATTACKER)
+        assert not report.passed, "jwt has no verify_with_audience() — must not pass"
+
+    async def test_delegatable_enforces_audience(self) -> None:
+        auth = _delegatable()
+        root = await auth.issue(_DELEGATOR, ["read"])
+        child = await auth.delegate(root, _AUDIENCE, ["read"], ttl=60.0)
+        report = await check_audience_enforced(auth, child, _AUDIENCE, _ATTACKER)
+        assert report.passed, report.detail

--- a/scenarios/delegated_auth.yaml
+++ b/scenarios/delegated_auth.yaml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegated capability-token auth scenario.
+#
+# coordinator-0 mints a root token (read/write/deploy/admin) and delegates a
+# narrowed copy (read/write/deploy) to each of 3 intermediaries. Each
+# intermediary narrows further (read only) and delegates to its 4 leaves --
+# 12 leaves total. Every leaf verifies its own grant and reports back to the
+# coordinator; leaf-2-3 (the last leaf, task.config.byzantine_leaf_index)
+# presents its genuine token under the coordinator's identity instead of its
+# own, demonstrating the audience-confusion check firing live.
+#
+# Deterministic under seeds 42, 7, 1337 -- the delegatable plugin's clock is
+# synced to the simulator's logical time (ctx.time) on every issue/delegate/
+# verify call, never wall-clock time, and no step in this scenario reads an
+# unseeded RNG.
+name: delegated_auth
+description: "Coordinator + 3 intermediaries + 12 leaves in a capability delegation tree."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 16
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+    - name: intermediary
+      count: 3
+    - name: leaf
+      count: 12
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: delegatable
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: delegated_auth
+  config:
+    byzantine_leaf_index: 11
+
+duration: "ticks: 100"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/delegated_auth.jsonl


### PR DESCRIPTION
## Problem

Solves `docs/hackathon/problems/04-auth-capability-delegation.md`.

The default `jwt` plugin (`nest_plugins_reference/auth/jwt_auth.py`) tracks
revocation in `_revoked: set[str]` keyed by the *exact token string*, with no
parent-child relationship at all. That makes it impossible to model the most
common real-world capability pattern: agent A holds a long-lived root token
and wants to mint a narrower, short-lived sub-token for agent B *without*
contacting the issuer — and revoking A's token should invalidate every token
B (or anyone B further delegated to) derived from it, at the next verify.

## Design

`delegatable.py` implements a macaroon-style **chained MAC**. A token is a
JSON list of *hops*, one per delegation step from the root. Each hop's HMAC
key is the *previous* hop's MAC (the root hop is keyed by the plugin's
secret):

- A party without the root secret cannot forge any hop — every hop's MAC
  recursively depends on a value only the true issuer could have produced.
- **Scopes only narrow, hop to hop.** `delegate()` refuses to mint a child
  whose scopes aren't a strict subset of its parent's; `verify()` re-checks
  this structurally as defense in depth, so a tampered chain fails even if
  some future code path skipped the mint-time check.
- **Cascading revocation is O(1) to issue and O(depth) to check.** `revoke()`
  adds exactly one MAC to a set. Verifying any descendant walks its own
  embedded hop chain and fails the moment it hits a revoked MAC — no
  per-descendant bookkeeping is needed at revoke time.

`verify_with_audience()` is new API on top of the base `Auth` protocol
(`verify(token) -> AuthContext` has no caller identity to check against),
catching the case where a token is presented by an agent other than the one
it was actually delegated to.

## Tradeoffs

- Revocation state and the root secret live in-process on the plugin
  instance (mirrors `JwtAuth`'s own `_revoked` set) — this is a single
  shared authority per simulation, not a distributed one. Out of scope per
  the problem brief.
- `verify()`'s structural scope/TTL re-check is redundant with what
  `delegate()` already enforces at mint time for any chain that was honestly
  produced by this plugin — it exists as defense in depth, not because the
  crypto alone is insufficient.
- Delegation is a strict tree (single parent per token), as the problem
  brief allows — no DAG support.

## What's shipped

- `nest_plugins_reference/auth/delegatable.py` — the plugin, registered as
  `("auth", "delegatable")` in `nest_core/plugins.py`.
- `nest_plugins_reference/validators/delegation_validators.py` — adversarial
  validators for all 3 required attacks (scope escalation, stale-parent use,
  audience confusion). Each **fails against `jwt`** (no delegation concept to
  even attempt) and **passes against `delegatable`**.
- `scenarios/delegated_auth.yaml` + `scenarios_builtin/delegated_auth.py` —
  coordinator + 3 intermediaries + 12 leaves in a delegation tree, with one
  byzantine leaf attempting audience confusion against the coordinator's own
  identity (correctly rejected). Verified byte-identical traces across seeds
  42, 7, 1337.
- `tests/test_delegatable.py`, `tests/test_delegation_validators.py` — 36
  tests total, including Hypothesis property tests over arbitrary
  scope-narrowing chains of depth 1–5.

## Verification

\`\`\`bash
uv sync
uv run ruff check .
uv run ruff format --check .
uv run pyright
uv run pytest -v
uv run nest doctor
\`\`\`

All green locally: 1017 passed / 1 skipped (pre-existing), 0 pyright errors,
`nest doctor` 7/7 (all 12 default plugins resolve, including `delegatable`).

Runnable end-to-end demo:

\`\`\`bash
uv run python -c "
import asyncio
from nest_core.runner import ScenarioRunner
from nest_core.scenario import ScenarioConfig

async def main():
    config = ScenarioConfig.from_yaml('scenarios/delegated_auth.yaml')
    trace_path = await ScenarioRunner(config).run()
    print('trace:', trace_path)

asyncio.run(main())
"
\`\`\`