### PR TITLE
[Hackathon] libre: attested-peering trust plugin

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -31,6 +31,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",
     ("trust", "aae_permit_gate"): f"{_REF}.trust.aae_permit_gate:AAEPermitGate",
     ("trust", "bonded_trust"): f"{_REF}.trust.bonded_trust:BondedTrust",
+    ("trust", "attested_peering"): f"{_REF}.trust.attested_peering:AttestedPeeringTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
     ("payments", "empic_escrow"): f"{_REF}.payments.empic_escrow:EMPICEscrowPayments",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -77,6 +77,12 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("identity_rotation", identity_rotation_factory)
+    elif name == "attested_peering":
+        from nest_core.scenarios_builtin.attested_peering import (
+            attested_peering_factory,
+        )
+
+        register_scenario("attested_peering", attested_peering_factory)
     elif name == "gossip_registry":
         from nest_core.scenarios_builtin.gossip_registry import gossip_registry_factory
 

--- a/packages/nest-core/nest_core/scenarios_builtin/attested_peering.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/attested_peering.py
@@ -1,0 +1,434 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Attested-peering trust scenario — a Sybil swarm tries to defame one victim.
+
+A single ``observer`` maintains the reputation of one honest ``victim``.
+Reporters file evidence about the victim; the observer admits a report only
+if the reporter first clears the attested-peering handshake
+(:mod:`nest_plugins_reference.trust.attested_peering`). Four reporter roles
+stress the gate:
+
+* **honest** — a real passport delegated by a trusted operator, a valid boot
+  quote, and genuine key possession. Verdict ``ALLOW``; files a *positive*
+  report (the victim behaved well).
+* **sybil** — a freshly minted self-asserted identity with no operator
+  delegation. Verdict ``DENY`` at "who do you work for?"; its *negative*
+  report is quarantined.
+* **impostor** — presents the honest agent's stolen passport but signs the
+  session transcript with its *own* key. Verdict ``DENY`` at "friend or foe?"
+  (key possession fails).
+* **replayer** — presents the honest passport plus a *real* honest seal
+  captured from an earlier session, replayed against a fresh nonce. Verdict
+  ``DENY`` at "friend or foe?" (the stale signature does not cover this
+  transcript).
+
+The agents resolve their trust plugin from ``ctx.plugins["trust"]`` and
+capability-gate the handshake on ``hasattr(trust, "make_hail")``. Swapping
+``trust: score_average`` in the YAML genuinely changes behaviour: with no
+handshake the observer admits *every* report, so the Sybil swarm drags the
+victim's score to the floor — exactly what the
+``validate_attested_sybil_quarantined`` validator fails on. Under
+``trust: attested_peering`` only the honest positives count and the victim's
+score stays high.
+
+Trace line protocol (message bodies, ``:``-delimited; the observer emits its
+audit lines by sending them to the passive ``victim`` sink):
+
+* ``verdict:<reporter>:<claimed_id>:<ALLOW|DENY>:<foe>:<data>:<work>`` — the
+  handshake verdict for one reporter (``foe``/``data``/``work`` are ``1``/``0``).
+* ``report:<reporter>:<subject>:<kind>:<admitted|quarantined>`` — the fate of
+  one evidence report.
+* ``repscore:<subject>:<score>:<sample_count>`` — the victim's final
+  reputation, formatted to six decimals.
+
+Example::
+
+    agents = attested_peering_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Evidence
+
+_OPERATOR_SEED = b"attested-peering:honest-operator"
+_SCENARIO_SEED = b"attested-peering"
+
+
+def _encode(obj: dict[str, Any]) -> str:
+    """Encode a handshake message dict as a compact base64 token.
+
+    Example::
+
+        token = _encode({"op": "hail"})
+    """
+    raw = json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return base64.b64encode(raw).decode("ascii")
+
+
+def _decode(token: str) -> dict[str, Any]:
+    """Decode a base64 token produced by :func:`_encode`.
+
+    Example::
+
+        obj = _decode(token)
+    """
+    return json.loads(base64.b64decode(token.encode("ascii")).decode("utf-8"))
+
+
+class ReporterAgent(StateMachineAgent):
+    """A reporter that files one evidence report about the victim.
+
+    ``role`` selects the attack: ``honest`` behaves correctly, ``sybil`` has no
+    operator delegation, ``impostor`` presents a stolen passport, ``replayer``
+    replays a captured honest seal. When the configured trust plugin has no
+    ``make_hail`` (e.g. ``score_average``) the agent skips the handshake and
+    sends its evidence directly — the baseline path the discrimination
+    validator catches.
+
+    Example::
+
+        agent = ReporterAgent(AgentId("honest-0"), AgentId("observer"), "honest")
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        observer: AgentId,
+        role: str,
+        report_kind: str,
+        stolen_card: dict[str, Any] | None = None,
+        replay_seal: dict[str, Any] | None = None,
+    ) -> None:
+        self._id = agent_id
+        self._observer = observer
+        self._role = role
+        self._report_kind = report_kind
+        self._stolen_card = stolen_card
+        self._replay_seal = replay_seal
+
+    def _present_card(self, trust: Any) -> Any:
+        """Return the passport to present (stolen for impostor/replayer)."""
+        if self._role in ("impostor", "replayer") and self._stolen_card is not None:
+            from nest_plugins_reference.trust.attested_peering import AgentFactsCard
+
+            return AgentFactsCard.from_dict(self._stolen_card)
+        return None
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Open the handshake, or send evidence directly under a baseline plugin.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        trust = ctx.plugins.get("trust")
+        if trust is not None and hasattr(trust, "make_hail"):
+            hail = trust.make_hail(
+                report_kind=self._report_kind, present_card=self._present_card(trust)
+            )
+            await ctx.send(self._observer, f"hail:{_encode(hail)}".encode())
+        else:
+            await ctx.send(self._observer, f"claim:{self._report_kind}".encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Answer a vouch with a seal (honest, forged, or replayed).
+
+        Example::
+
+            await agent.on_message(ctx, observer, b"vouch:...")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("vouch:"):
+            return
+        trust = ctx.plugins.get("trust")
+        if trust is None or not hasattr(trust, "make_seal"):
+            return
+        vouch = _decode(msg[len("vouch:") :])
+        if self._role == "replayer" and self._replay_seal is not None:
+            # Replay a genuine honest seal captured from an earlier session; it
+            # cannot cover this session's fresh transcript.
+            seal = self._replay_seal
+        else:
+            # honest / sybil / impostor all sign the live transcript with their
+            # OWN key (the impostor's key does not match the stolen passport).
+            seal = trust.make_seal(vouch)
+        await ctx.send(self._observer, f"seal:{_encode(seal)}".encode())
+
+
+class ObserverAgent(StateMachineAgent):
+    """Runs the verifier trust plugin and records the victim's reputation.
+
+    For each reporter it completes the handshake (or accepts a direct claim
+    under a baseline plugin), files the reporter's evidence about the victim
+    through the trust plugin, and emits ``verdict``/``report`` audit lines. Once
+    every reporter has been processed it emits the final ``repscore`` line.
+
+    Example::
+
+        observer = ObserverAgent(AgentId("observer"), AgentId("victim"), 30)
+    """
+
+    def __init__(self, agent_id: AgentId, victim: AgentId, expected: int) -> None:
+        self._id = agent_id
+        self._victim = victim
+        self._expected = expected
+        self._processed = 0
+        self._done = False
+
+    async def _log(self, ctx: AgentContext, line: str) -> None:
+        await ctx.send(self._victim, line.encode())
+
+    async def _record_report(
+        self, ctx: AgentContext, reporter: AgentId, kind: str, trust: Any
+    ) -> None:
+        evidence = Evidence(reporter=reporter, subject=self._victim, kind=kind)
+        await trust.report(self._victim, evidence)
+        is_attested = getattr(trust, "is_attested", None)
+        admitted = True if is_attested is None else bool(is_attested(reporter))
+        fate = "admitted" if admitted else "quarantined"
+        await self._log(ctx, f"report:{reporter}:{self._victim}:{kind}:{fate}")
+        self._processed += 1
+        await self._maybe_finish(ctx, trust)
+
+    async def _maybe_finish(self, ctx: AgentContext, trust: Any) -> None:
+        if self._done or self._processed < self._expected:
+            return
+        self._done = True
+        score = await trust.score(self._victim)
+        await self._log(ctx, f"repscore:{self._victim}:{score.score:.6f}:{score.sample_count}")
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Drive the handshake and evidence intake for each reporter.
+
+        Example::
+
+            await observer.on_message(ctx, reporter, b"hail:...")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        trust = ctx.plugins.get("trust")
+        if trust is None:
+            return
+
+        if msg.startswith("hail:") and hasattr(trust, "make_vouch"):
+            hail = _decode(msg[len("hail:") :])
+            vouch = trust.make_vouch(hail, session_key=sender)
+            await ctx.send(sender, f"vouch:{_encode(vouch)}".encode())
+            return
+
+        if msg.startswith("seal:") and hasattr(trust, "evaluate_seal"):
+            seal = _decode(msg[len("seal:") :])
+            verdict = trust.evaluate_seal(sender, seal)
+            await self._log(
+                ctx,
+                (
+                    f"verdict:{sender}:{verdict.peer_id}:{verdict.decision}:"
+                    f"{int(verdict.friend_or_foe.ok)}:{int(verdict.trust_my_data.ok)}:"
+                    f"{int(verdict.who_you_work_for.ok)}"
+                ),
+            )
+            kind = trust.session_report_kind(sender)
+            await self._record_report(ctx, sender, kind, trust)
+            return
+
+        if msg.startswith("claim:"):
+            kind = msg[len("claim:") :]
+            await self._record_report(ctx, sender, kind, trust)
+
+
+class SinkAgent(StateMachineAgent):
+    """The victim: a passive sink that absorbs the observer's audit lines.
+
+    The observer emits its ``verdict``/``report``/``repscore`` lines by sending
+    them here so they land in the trace as ordinary ``send`` events the
+    validators parse. The sink itself does nothing.
+
+    Example::
+
+        victim = SinkAgent(AgentId("victim"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Ignore all incoming audit lines.
+
+        Example::
+
+            await victim.on_message(ctx, observer, b"repscore:...")
+        """
+        return
+
+
+def _role_counts(config: ScenarioConfig) -> dict[str, int]:
+    """Resolve reporter role counts from the scenario's ``agents.roles`` block.
+
+    Example::
+
+        counts = _role_counts(config)
+    """
+    defaults = {"honest": 8, "sybil": 20, "impostor": 1, "replayer": 1}
+    if config.agents.roles:
+        for role in config.agents.roles:
+            if role.name in defaults:
+                defaults[role.name] = role.count
+    return defaults
+
+
+def _capture_replay_seal(observer_id: AgentId, honest_id: AgentId) -> dict[str, Any]:
+    """Capture a genuine honest seal from a throwaway session, for the replayer.
+
+    Uses instances seeded on a distinct RNG stream so their handshake nonces
+    can never coincide with the live session — the captured seal is a *valid*
+    honest signature that simply does not cover the live transcript.
+
+    Example::
+
+        seal = _capture_replay_seal(AgentId("observer"), AgentId("honest-0"))
+    """
+    import random
+
+    from nest_plugins_reference.trust.attested_peering import AttestedPeeringTrust
+
+    cap_honest = AttestedPeeringTrust(
+        agent_id=honest_id,
+        seed=_SCENARIO_SEED,
+        operator_seed=_OPERATOR_SEED,
+        offer_env=True,
+        rng=random.Random("attested-peering:capture:honest"),
+    )
+    cap_obs = AttestedPeeringTrust(
+        agent_id=observer_id,
+        seed=_SCENARIO_SEED,
+        rng=random.Random("attested-peering:capture:observer"),
+    )
+    hail = cap_honest.make_hail(report_kind="positive")
+    vouch = cap_obs.make_vouch(hail, session_key=honest_id)
+    return cap_honest.make_seal(vouch)
+
+
+def _provision_trust(
+    plugins: dict[str, Any],
+    observer_id: AgentId,
+    honest_ids: list[AgentId],
+    reporter_ids: list[AgentId],
+) -> None:
+    """Instantiate one trust plugin per agent from the configured class.
+
+    Mirrors ``identity_rotation``'s per-agent provisioning. For the
+    attested-peering plugin every agent gets its own keyed instance and the
+    observer is told which operator + boot state to trust. For a baseline trust
+    plugin (e.g. ``score_average``, no ``make_hail``) only the observer gets a
+    single shared instance; reporters send evidence directly. No-op when no
+    trust plugin is configured.
+
+    Example::
+
+        _provision_trust(plugins, AgentId("observer"), honest, reporters)
+    """
+    from nest_plugins_reference.trust.attested_peering import PeeringPolicy
+
+    trust_cls = plugins.get("trust")
+    if trust_cls is None or not isinstance(trust_cls, type):
+        return
+
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+    is_attested = hasattr(trust_cls, "make_hail")
+
+    if not is_attested:
+        agent_plugins.setdefault(observer_id, {})["trust"] = trust_cls()
+        plugins.pop("trust", None)
+        return
+
+    observer_trust = trust_cls(
+        agent_id=observer_id,
+        seed=_SCENARIO_SEED,
+        policy=PeeringPolicy(require_trusted_operator=True, require_env_quote=False),
+        principal_name="Reputation Observer",
+    )
+
+    for aid in reporter_ids:
+        is_honest = aid in honest_ids
+        reporter_trust = trust_cls(
+            agent_id=aid,
+            seed=_SCENARIO_SEED,
+            operator_seed=_OPERATOR_SEED if is_honest else None,
+            offer_env=is_honest,
+            principal_name="Community Node" if is_honest else str(aid),
+        )
+        agent_plugins.setdefault(aid, {})["trust"] = reporter_trust
+        if is_honest:
+            observer_trust.trust_operator(
+                reporter_trust.operator_id, reporter_trust.operator_public_key
+            )
+
+    observer_trust.allow_boot_state()
+    agent_plugins.setdefault(observer_id, {})["trust"] = observer_trust
+    plugins.pop("trust", None)
+
+
+def attested_peering_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create the observer, victim sink, and honest + adversarial reporters.
+
+    Role counts come from ``agents.roles`` (defaults: 8 honest, 20 sybil, 1
+    impostor, 1 replayer). Honest reporters file *positive* evidence; every
+    attacker files *negative* evidence but is denied and quarantined under the
+    attested-peering plugin.
+
+    Example::
+
+        agents = attested_peering_factory(config, plugins)
+    """
+    counts = _role_counts(config)
+    observer_id = AgentId("observer")
+    victim_id = AgentId("victim")
+
+    honest_ids = [AgentId(f"honest-{i}") for i in range(counts["honest"])]
+    sybil_ids = [AgentId(f"sybil-{i}") for i in range(counts["sybil"])]
+    impostor_ids = [AgentId(f"impostor-{i}") for i in range(counts["impostor"])]
+    replayer_ids = [AgentId(f"replayer-{i}") for i in range(counts["replayer"])]
+    reporter_ids = honest_ids + sybil_ids + impostor_ids + replayer_ids
+
+    _provision_trust(plugins, observer_id, honest_ids, reporter_ids)
+
+    # The impostor and replayer both target the first honest identity.
+    stolen_card: dict[str, Any] | None = None
+    replay_seal: dict[str, Any] | None = None
+    agent_plugins = plugins.get("_agent_plugins", {})
+    honest_head = honest_ids[0] if honest_ids else None
+    if honest_head is not None:
+        head_trust = agent_plugins.get(honest_head, {}).get("trust")
+        if head_trust is not None and hasattr(head_trust, "card"):
+            stolen_card = head_trust.card.to_dict()
+            replay_seal = _capture_replay_seal(observer_id, honest_head)
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    for aid in honest_ids:
+        agents[aid] = ReporterAgent(aid, observer_id, "honest", "positive")
+    for aid in sybil_ids:
+        agents[aid] = ReporterAgent(aid, observer_id, "sybil", "negative")
+    for aid in impostor_ids:
+        agents[aid] = ReporterAgent(
+            aid, observer_id, "impostor", "negative", stolen_card=stolen_card
+        )
+    for aid in replayer_ids:
+        agents[aid] = ReporterAgent(
+            aid,
+            observer_id,
+            "replayer",
+            "negative",
+            stolen_card=stolen_card,
+            replay_seal=replay_seal,
+        )
+
+    agents[observer_id] = ObserverAgent(observer_id, victim_id, expected=len(reporter_ids))
+    agents[victim_id] = SinkAgent(victim_id)
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -4610,6 +4610,189 @@ def validate_parc_stale_key_rejected(events: list[dict[str, Any]]) -> list[Valid
 
 
 # ---------------------------------------------------------------------------
+# Attested-peering trust validators
+# ---------------------------------------------------------------------------
+
+
+def _attested_observer_lines(events: list[dict[str, Any]]) -> list[str]:
+    """Return the observer's audit-line message bodies (deduped send events).
+
+    The observer emits ``verdict:``/``report:``/``repscore:`` lines by sending
+    them to the victim sink, so each line appears once as a ``send`` and once
+    as a ``receive``; we read only the authoritative ``send`` events.
+
+    Example::
+
+        lines = _attested_observer_lines(events)
+    """
+    lines: list[str] = []
+    for ev in events:
+        if ev.get("kind") != "send" or ev.get("agent") != "observer":
+            continue
+        lines.append(str(ev.get("msg", "")))
+    return lines
+
+
+def _attested_verdicts(lines: list[str]) -> dict[str, tuple[str, bool, bool, bool]]:
+    """Parse ``verdict:`` lines into ``reporter -> (decision, foe, data, work)``.
+
+    Example::
+
+        verdicts = _attested_verdicts(_attested_observer_lines(events))
+    """
+    verdicts: dict[str, tuple[str, bool, bool, bool]] = {}
+    for line in lines:
+        if not line.startswith("verdict:"):
+            continue
+        parts = line.split(":")
+        if len(parts) != 7:
+            continue
+        _, reporter, _claimed, decision, foe, data, work = parts
+        verdicts[reporter] = (decision, foe == "1", data == "1", work == "1")
+    return verdicts
+
+
+def validate_attested_no_denied_admitted(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """No peer with a failed (DENY) verdict ever has its evidence admitted.
+
+    The core safety invariant of the attested-peering gate: admission implies
+    an ALLOW verdict, and every ALLOW verdict has all three checks green
+    (friend-or-foe, trust-my-data, who-you-work-for). A trace with no verdict
+    lines (a baseline trust plugin that runs no handshake) cannot violate this
+    and passes vacuously.
+
+    Example::
+
+        results = validate_trace(Path("traces/attested_peering.jsonl"), "attested_peering")
+    """
+    lines = _attested_observer_lines(events)
+    verdicts = _attested_verdicts(lines)
+
+    if not verdicts:
+        return [
+            ValidationResult(
+                "attested_no_denied_admitted",
+                True,
+                "no attested-peering verdicts in trace (baseline plugin, nothing to gate)",
+            )
+        ]
+
+    violations: list[str] = []
+    for decision, foe, data, work in verdicts.values():
+        if decision == "ALLOW" and not (foe and data and work):
+            violations.append("ALLOW verdict with a failed check (inconsistent gate)")
+            break
+
+    for line in lines:
+        if not line.startswith("report:"):
+            continue
+        parts = line.split(":")
+        if len(parts) != 5 or parts[4] != "admitted":
+            continue
+        reporter = parts[1]
+        entry = verdicts.get(reporter)
+        if entry is None:
+            violations.append(f"{reporter}: admitted with no verdict")
+        elif entry[0] != "ALLOW":
+            violations.append(f"{reporter}: admitted despite {entry[0]} verdict")
+
+    if violations:
+        return [ValidationResult("attested_no_denied_admitted", False, "; ".join(violations))]
+    allowed = sum(1 for v in verdicts.values() if v[0] == "ALLOW")
+    return [
+        ValidationResult(
+            "attested_no_denied_admitted",
+            True,
+            f"{allowed}/{len(verdicts)} peers admitted, all with an ALLOW verdict",
+        )
+    ]
+
+
+def validate_attested_sybil_quarantined(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """An unauthenticated Sybil swarm cannot defame the honest victim.
+
+    Honest reporters file positive evidence, so an ungamed reputation sits at
+    or above the neutral prior (``0.5``); only *admitted* negative evidence can
+    push it below. The attested-peering gate quarantines every unattested
+    reporter, so the victim's score stays high. Under a baseline plugin with no
+    gate (``trust: score_average``) the Sybil swarm's negatives are admitted and
+    the score collapses below ``0.5`` — this validator FAILs there and PASSes
+    under ``trust: attested_peering``.
+
+    Example::
+
+        results = validate_trace(Path("traces/attested_peering.jsonl"), "attested_peering")
+    """
+    lines = _attested_observer_lines(events)
+
+    score: float | None = None
+    samples: int | None = None
+    for line in lines:
+        if not line.startswith("repscore:"):
+            continue
+        parts = line.split(":")
+        if len(parts) == 4 and parts[1] == "victim":
+            score = float(parts[2])
+            samples = int(parts[3])
+    if score is None or samples is None:
+        return [
+            ValidationResult(
+                "attested_sybil_quarantined",
+                False,
+                "no repscore:victim line found in trace (scenario setup failure)",
+            )
+        ]
+
+    verdicts = _attested_verdicts(lines)
+    admitted_attackers: list[str] = []
+    for line in lines:
+        if not line.startswith("report:"):
+            continue
+        parts = line.split(":")
+        if len(parts) != 5 or parts[4] != "admitted":
+            continue
+        reporter = parts[1]
+        if not reporter.startswith("honest-"):
+            admitted_attackers.append(reporter)
+
+    if score < 0.5:
+        return [
+            ValidationResult(
+                "attested_sybil_quarantined",
+                False,
+                (
+                    f"victim reputation {score:.3f} < 0.5 over {samples} admitted report(s) — "
+                    "an unauthenticated swarm manufactured a negative consensus (gate absent)"
+                ),
+            )
+        ]
+    if admitted_attackers:
+        return [
+            ValidationResult(
+                "attested_sybil_quarantined",
+                False,
+                "non-honest reporters admitted despite the gate: "
+                f"{sorted(set(admitted_attackers))}",
+            )
+        ]
+    return [
+        ValidationResult(
+            "attested_sybil_quarantined",
+            True,
+            (
+                f"victim reputation {score:.3f} from {samples} attested report(s); "
+                f"{len([v for v in verdicts.values() if v[0] == 'DENY'])} unattested peer(s) "
+                "quarantined"
+            ),
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -4785,6 +4968,10 @@ VALIDATORS: dict[str, list[Any]] = {
     "identity_rotation": [
         validate_identity_rotation_occurred,
         validate_identity_rotation_signatures,
+    ],
+    "attested_peering": [
+        validate_attested_no_denied_admitted,
+        validate_attested_sybil_quarantined,
     ],
     "memory_concurrent_writers": [
         validate_memory_convergence,

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -1998,6 +1998,7 @@ class TestValidatorRegistry:
             "supply_chain",
             "reputation",
             "identity_rotation",
+            "attested_peering",
             "memory_concurrent_writers",
             "streaming_payments",
             "empic_payments",

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/attested_peering.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/attested_peering.py
@@ -1,0 +1,985 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Attested-peering trust plugin — verify a peer *before* trusting its reports.
+
+The two bundled trust plugins answer "how well has this agent behaved?"
+(:mod:`~nest_plugins_reference.trust.score_average` averages feedback,
+:mod:`~nest_plugins_reference.trust.agent_receipts` corroborates it with
+receipts). Neither answers the prior question: **is the thing reporting
+feedback even who it claims to be, and should its evidence count at all?**
+Under the default ``score_average`` plugin any agent — including a freshly
+minted Sybil — can file unlimited ``report()`` calls and poison a victim's
+reputation.
+
+This plugin ports LibreSynergy's *attested peering* handshake (a production
+mesh-federation gate) into the Nanda Town trust layer. Before a peer's
+evidence is admitted, the peer must clear a three-question, replay-proof
+mutual handshake (``hail`` → ``vouch`` → ``seal``):
+
+1. **Friend or foe?** — does the peer hold the private key for the identity it
+   presents, and is that identity's :class:`AgentFactsCard` authentic (self
+   signature + operator delegation valid)? Key possession is proven by an
+   Ed25519 signature over *this* session's transcript — never a replayable
+   bare nonce — so a stolen passport with the wrong key, or a replayed proof
+   from another session, both fail.
+2. **Can I trust you with my data?** — an optional, freshly nonce-bound signed
+   environment quote over the peer's measured configuration (a deterministic
+   stand-in for a TPM measured-boot quote).
+3. **Who do you work for?** — a named operator delegated authority to this
+   agent via a signed delegation embedded in its passport, and that operator
+   is on the verifier's trusted-operator roster.
+
+Only peers whose verdict is ``ALLOW`` may contribute evidence via
+:meth:`AttestedPeeringTrust.report`; everything else is quarantined and
+surfaced in the trace for the adversarial validators to count.
+
+Determinism
+-----------
+
+Ed25519 is deterministic by construction (RFC 8032): the per-signature nonce
+is derived from the private key and message, so the same key signing the same
+bytes always yields identical signature bytes. Private seeds are derived as
+``sha256(seed || agent_id)[:32]`` exactly like
+:mod:`nest_plugins_reference.identity.ed25519_rotating`; handshake nonces come
+from a per-instance :class:`random.Random` seeded off the same material.
+There is **no** ``os.urandom``, no wall-clock time, and no subprocess anywhere
+in this module, so a Tier-1 run is byte-identical under a fixed scenario seed.
+
+Example::
+
+    verifier = AttestedPeeringTrust(agent_id=AgentId("observer"), seed=b"s")
+    peer = AttestedPeeringTrust(
+        agent_id=AgentId("a1"), seed=b"s", operator_seed=b"op",
+    )
+    verifier.trust_operator(peer.operator_id, peer.operator_public_key)
+
+    hail = peer.make_hail(report_kind="positive")
+    vouch = verifier.make_vouch(hail, session_key=AgentId("a1"))
+    seal = peer.make_seal(vouch)
+    verdict = verifier.evaluate_seal(AgentId("a1"), seal)
+    assert verdict.decision == "ALLOW"
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import random
+from dataclasses import dataclass, field, replace
+from typing import Any, cast
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from nest_core.types import (
+    AgentId,
+    Attestation,
+    Claim,
+    Evidence,
+    ReputationScore,
+    Signature,
+)
+
+ALGORITHM = "ed25519-attested/1"
+"""Algorithm tag stamped on every attestation :class:`~nest_core.types.Signature`.
+
+Example::
+
+    assert att.signature.algorithm == ALGORITHM
+"""
+
+PROTO = "nest-attest/1"
+"""Handshake protocol identifier embedded in every message and transcript.
+
+Example::
+
+    assert hail["proto"] == PROTO
+"""
+
+HANDSHAKE_TAG = b"nest-attest-handshake-v1"
+DELEGATION_TAG = b"nest-attest-delegation-v1"
+ENV_TAG = b"nest-attest-env-v1"
+
+_ENV_COMPONENTS = ("firmware", "bootloader", "kernel", "agent_code")
+
+
+# ---------------------------------------------------------------------------
+# Low-level Ed25519 + encoding helpers (pure, no I/O, no clock, no os RNG)
+# ---------------------------------------------------------------------------
+
+
+def _b64(raw: bytes) -> str:
+    """Base64-encode bytes to an ASCII string.
+
+    Example::
+
+        assert _b64(b"\\x00") == "AA=="
+    """
+    return base64.b64encode(raw).decode("ascii")
+
+
+def _ub64(text: str) -> bytes:
+    """Decode a base64 ASCII string back to bytes (``b""`` for falsy input).
+
+    Never raises: malformed base64 from a byzantine peer yields ``b""``, which
+    then fails signature/key verification downstream as a clean DENY rather than
+    crashing the verifier.
+
+    Example::
+
+        assert _ub64("AA==") == b"\\x00"
+        assert _ub64("!! not base64 !!") == b""
+    """
+    if not text:
+        return b""
+    try:
+        return base64.b64decode(text.encode("ascii"), validate=True)
+    except (binascii.Error, ValueError):
+        return b""
+
+
+def _uhex(text: str) -> bytes:
+    """Decode a hex string to bytes; ``b""`` on malformed/falsy input (never raises).
+
+    A byzantine peer's malformed ``nonce`` field yields ``b""``, so the derived
+    transcript simply won't match and the handshake ends in DENY.
+
+    Example::
+
+        assert _uhex("00ff") == b"\\x00\\xff"
+        assert _uhex("zz") == b""
+    """
+    if not text:
+        return b""
+    try:
+        return bytes.fromhex(text)
+    except ValueError:
+        return b""
+
+
+def _sha256_hex(raw: bytes) -> str:
+    """Hex SHA-256 digest of *raw*.
+
+    Example::
+
+        assert len(_sha256_hex(b"x")) == 64
+    """
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _fingerprint(pub_raw: bytes) -> str:
+    """Stable 16-hex identity fingerprint of a raw Ed25519 public key.
+
+    Example::
+
+        fid = _fingerprint(b"\\x00" * 32)
+    """
+    return _sha256_hex(pub_raw)[:16]
+
+
+def _derive_private_key(seed: bytes) -> Ed25519PrivateKey:
+    """Derive a deterministic Ed25519 private key from arbitrary seed bytes.
+
+    The 32-byte private scalar is ``sha256(seed)[:32]``; the same seed always
+    yields the same key, which is what keeps Tier-1 traces reproducible.
+
+    Example::
+
+        key = _derive_private_key(b"seed" + b"a1")
+    """
+    return Ed25519PrivateKey.from_private_bytes(hashlib.sha256(seed).digest()[:32])
+
+
+def _public_raw(priv: Ed25519PrivateKey) -> bytes:
+    """Return the 32-byte raw public key for a private key.
+
+    Example::
+
+        pub = _public_raw(_derive_private_key(b"s"))
+    """
+    return priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+
+def _sign(priv: Ed25519PrivateKey, msg: bytes) -> bytes:
+    """Ed25519-sign *msg* with *priv* (deterministic).
+
+    Example::
+
+        sig = _sign(_derive_private_key(b"s"), b"m")
+    """
+    return priv.sign(msg)
+
+
+def _verify(pub_raw: bytes, msg: bytes, sig: bytes) -> bool:
+    """Return whether *sig* is a valid Ed25519 signature over *msg* by *pub_raw*.
+
+    Never raises: a malformed key or signature returns ``False``.
+
+    Example::
+
+        priv = _derive_private_key(b"s")
+        assert _verify(_public_raw(priv), b"m", _sign(priv, b"m"))
+    """
+    try:
+        Ed25519PublicKey.from_public_bytes(pub_raw).verify(sig, msg)
+    except (InvalidSignature, ValueError):
+        return False
+    return True
+
+
+def _canon(obj: dict[str, Any]) -> bytes:
+    """Canonical (sorted-key, compact) JSON encoding — the only thing we sign.
+
+    Example::
+
+        assert _canon({"b": 1, "a": 2}) == b'{"a":2,"b":1}'
+    """
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _delegation_msg(operator_id: str, agent_id: str, label: str) -> bytes:
+    """Canonical bytes an operator signs to delegate authority to an agent.
+
+    Example::
+
+        msg = _delegation_msg("op", "a1", "buyer-1")
+    """
+    return DELEGATION_TAG + f"|{operator_id}|{agent_id}|{label}".encode()
+
+
+# ---------------------------------------------------------------------------
+# AgentFacts passport
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AgentFactsCard:
+    """A signed identity passport an agent presents during the handshake.
+
+    ``facts_signature`` is the agent key's Ed25519 signature over the canonical
+    body (every field except the two signatures); ``delegation_signature`` is
+    the *operator* key's signature over :func:`_delegation_msg`, binding
+    ``operator_id`` → ``agent_id`` (the "who do you work for?" chain). A card
+    with no ``operator_id`` is a self-asserted principal.
+
+    Example::
+
+        card = builder.card  # built and signed by AttestedPeeringTrust
+        assert card.agent_id == "a1"
+    """
+
+    agent_id: str
+    label: str
+    public_key: bytes
+    principal_name: str
+    operator_id: str = ""
+    operator_public_key: bytes = b""
+    capabilities: tuple[str, ...] = ()
+    facts_signature: bytes = b""
+    delegation_signature: bytes = b""
+
+    def body(self) -> dict[str, Any]:
+        """Signable body of the card — every field except the two signatures.
+
+        Example::
+
+            payload = card.body()
+        """
+        return {
+            "agent_id": self.agent_id,
+            "label": self.label,
+            "public_key": _b64(self.public_key),
+            "principal_name": self.principal_name,
+            "operator_id": self.operator_id,
+            "operator_public_key": _b64(self.operator_public_key),
+            "capabilities": list(self.capabilities),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise the full card (body + signatures) for transport.
+
+        Example::
+
+            wire = card.to_dict()
+        """
+        payload = self.body()
+        payload["facts_signature"] = _b64(self.facts_signature)
+        payload["delegation_signature"] = _b64(self.delegation_signature)
+        return payload
+
+    @staticmethod
+    def from_dict(data: Any) -> AgentFactsCard:
+        """Rebuild a card from its :meth:`to_dict` form (untrusted wire input).
+
+        Tolerant of missing fields and non-dict input: a byzantine peer's
+        truncated or type-confused passport parses into a card with an empty
+        public key, which :func:`_verify_card` rejects as a clean DENY rather
+        than raising ``KeyError``/``AttributeError`` in the verifier.
+
+        Example::
+
+            card = AgentFactsCard.from_dict(wire)
+            assert AgentFactsCard.from_dict({}).public_key == b""
+            assert AgentFactsCard.from_dict("garbage").public_key == b""
+        """
+        fields: dict[str, Any] = {}
+        if isinstance(data, dict):
+            fields = cast("dict[str, Any]", data)
+        raw_caps = fields.get("capabilities", ())
+        caps: tuple[str, ...] = (
+            tuple(str(c) for c in cast("list[Any] | tuple[Any, ...]", raw_caps))
+            if isinstance(raw_caps, (list, tuple))
+            else ()
+        )
+        return AgentFactsCard(
+            agent_id=str(fields.get("agent_id", "")),
+            label=str(fields.get("label", "")),
+            public_key=_ub64(str(fields.get("public_key", ""))),
+            principal_name=str(fields.get("principal_name", "")),
+            operator_id=str(fields.get("operator_id", "")),
+            operator_public_key=_ub64(str(fields.get("operator_public_key", ""))),
+            capabilities=caps,
+            facts_signature=_ub64(str(fields.get("facts_signature", ""))),
+            delegation_signature=_ub64(str(fields.get("delegation_signature", ""))),
+        )
+
+    def facts_hash(self) -> str:
+        """Hex digest of the card body — what the transcript commits to.
+
+        Example::
+
+            h = card.facts_hash()
+        """
+        return _sha256_hex(_canon(self.body()))
+
+
+def _verify_card(card: AgentFactsCard) -> tuple[bool, str]:
+    """Verify a card's self-signature and (if present) operator delegation.
+
+    Returns ``(authentic, detail)``. This is the cryptographic-authenticity
+    arm of "friend or foe?"; the trusted-operator *roster* check lives in
+    "who do you work for?". Never raises.
+
+    Example::
+
+        ok, detail = _verify_card(card)
+    """
+    if not card.public_key:
+        return False, "malformed passport (no public key)"
+    if not _verify(card.public_key, _canon(card.body()), card.facts_signature):
+        return False, "passport self-signature invalid (forged or tampered)"
+    if card.operator_id:
+        if not card.operator_public_key:
+            return False, "delegation claims an operator but carries no operator key"
+        if _fingerprint(card.operator_public_key) != card.operator_id:
+            return False, "operator_id does not match its public key"
+        msg = _delegation_msg(card.operator_id, card.agent_id, card.label)
+        if not _verify(card.operator_public_key, msg, card.delegation_signature):
+            return False, "operator delegation signature invalid (agent not authorised)"
+        return True, f"authentic passport; delegated by operator {card.operator_id}"
+    return True, f"authentic passport; self-asserted principal '{card.principal_name}'"
+
+
+# ---------------------------------------------------------------------------
+# Environment (measured-boot) quote — deterministic simulation
+# ---------------------------------------------------------------------------
+
+
+def golden_measurements() -> dict[str, str]:
+    """Return the deterministic 'golden' boot measurements every honest node has.
+
+    Each component hashes a fixed label, so all honest agents share one boot
+    digest a verifier can allow-list. A tampered component (see the tests)
+    changes the digest and fails :func:`_verify_env`.
+
+    Example::
+
+        m = golden_measurements()
+        assert set(m) == set(_ENV_COMPONENTS)
+    """
+    return {c: _sha256_hex(f"golden:{c}".encode()) for c in _ENV_COMPONENTS}
+
+
+def _boot_digest(measurements: dict[str, str]) -> str:
+    """Order-fixed composite of a measurement set (analogue of a TPM PCR digest).
+
+    Example::
+
+        d = _boot_digest(golden_measurements())
+    """
+    parts = [f"{c}={measurements.get(c, '')}" for c in _ENV_COMPONENTS]
+    return _sha256_hex("\n".join(parts).encode("utf-8"))
+
+
+def _make_env_quote(
+    ak_key: Ed25519PrivateKey,
+    nonce: bytes,
+    measurements: dict[str, str],
+) -> dict[str, Any]:
+    """Produce a signed, nonce-bound boot-state quote (simulated TPM quote).
+
+    Example::
+
+        q = _make_env_quote(ak, b"nonce", golden_measurements())
+    """
+    digest = _boot_digest(measurements)
+    ak_pub = _public_raw(ak_key)
+    msg = ENV_TAG + digest.encode("utf-8") + b"|" + nonce
+    return {
+        "measurements": measurements,
+        "boot_digest": digest,
+        "nonce": nonce.hex(),
+        "ak_pub": _b64(ak_pub),
+        "ak_id": _fingerprint(ak_pub),
+        "sig": _b64(_sign(ak_key, msg)),
+    }
+
+
+def _verify_env(quote: dict[str, Any], nonce: bytes, known_good: set[str]) -> tuple[bool, str]:
+    """Verify a boot quote is fresh, self-consistent, and in the allow-list.
+
+    Example::
+
+        ok, detail = _verify_env(quote, nonce, {digest})
+    """
+    if quote.get("nonce") != nonce.hex():
+        return False, "boot quote is stale (nonce mismatch — possible replay)"
+    raw_measurements = quote.get("measurements", {})
+    if not isinstance(raw_measurements, dict):
+        return False, "boot quote measurements malformed"
+    measurements = cast("dict[str, str]", raw_measurements)
+    if _boot_digest(measurements) != quote.get("boot_digest"):
+        return False, "boot_digest does not match measurements (tampered)"
+    ak_pub = _ub64(str(quote.get("ak_pub", "")))
+    if _fingerprint(ak_pub) != quote.get("ak_id"):
+        return False, "attestation-key id does not match its public key"
+    digest = str(quote.get("boot_digest", ""))
+    msg = ENV_TAG + digest.encode("utf-8") + b"|" + nonce
+    if not _verify(ak_pub, msg, _ub64(str(quote.get("sig", "")))):
+        return False, "boot quote signature invalid (not signed by this AK)"
+    if known_good and digest not in known_good:
+        return False, f"unrecognised boot state {digest[:12]} — configuration not vetted"
+    return True, f"boot state {digest[:12]} vetted, fresh"
+
+
+# ---------------------------------------------------------------------------
+# Verdict types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PeeringCheck:
+    """Outcome of one of the three handshake questions.
+
+    Example::
+
+        chk = PeeringCheck(ok=True, detail="identity a2 proven")
+    """
+
+    ok: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class PeeringVerdict:
+    """The verdict :meth:`AttestedPeeringTrust.evaluate_peer` returns per peer.
+
+    ``decision`` is ``"ALLOW"`` iff all three checks pass; the per-question
+    detail is preserved so a scenario can emit it into the trace.
+
+    Example::
+
+        v = verifier.evaluate_peer(card, transcript, proofs, nonce)
+        assert v.decision in ("ALLOW", "DENY")
+    """
+
+    peer_id: str
+    friend_or_foe: PeeringCheck
+    trust_my_data: PeeringCheck
+    who_you_work_for: PeeringCheck
+    decision: str
+
+    @property
+    def friend(self) -> bool:
+        """Whether all three checks passed.
+
+        Example::
+
+            if verdict.friend: ...
+        """
+        return self.decision == "ALLOW"
+
+
+@dataclass
+class PeeringPolicy:
+    """Verifier-side policy for :meth:`AttestedPeeringTrust.evaluate_peer`.
+
+    Example::
+
+        policy = PeeringPolicy(require_trusted_operator=True)
+    """
+
+    trusted_operators: dict[str, bytes] = field(default_factory=dict[str, bytes])
+    roster: set[str] | None = None
+    tofu: bool = True
+    require_env_quote: bool = False
+    known_good_boot: set[str] = field(default_factory=set[str])
+    require_trusted_operator: bool = True
+
+
+@dataclass
+class _Session:
+    """Responder-side per-peer handshake state kept between vouch and seal."""
+
+    nonce_a: bytes
+    nonce_b: bytes
+    facts_a: AgentFactsCard
+    report_kind: str
+
+
+# ---------------------------------------------------------------------------
+# The plugin
+# ---------------------------------------------------------------------------
+
+
+class AttestedPeeringTrust:
+    """Trust plugin that gates reputation on an attested-peering handshake.
+
+    Implements the :class:`nest_core.layers.trust.Trust` protocol. The
+    constructor mirrors ``ScoreAverageTrust(identity)`` (the ``identity``
+    positional is accepted and ignored — this plugin carries its own keys) so
+    it slots into existing scenarios; the handshake surface
+    (:meth:`make_hail`, :meth:`make_vouch`, :meth:`make_seal`,
+    :meth:`evaluate_seal`, :meth:`evaluate_peer`) is additive.
+
+    Example::
+
+        trust = AttestedPeeringTrust(agent_id=AgentId("a1"), seed=b"s")
+        rep = await trust.score(AgentId("a2"))
+    """
+
+    def __init__(
+        self,
+        identity: Any = None,
+        *,
+        agent_id: AgentId | None = None,
+        seed: bytes = b"",
+        policy: PeeringPolicy | None = None,
+        rng: random.Random | None = None,
+        label: str | None = None,
+        principal_name: str = "",
+        operator_seed: bytes | None = None,
+        operator_delegation: tuple[str, bytes, bytes] | None = None,
+        capabilities: tuple[str, ...] = (),
+        offer_env: bool = False,
+        measurements: dict[str, str] | None = None,
+    ) -> None:
+        self._identity = identity
+        self._agent_id = agent_id or AgentId("unknown")
+        self._seed = seed
+        self._policy = policy or PeeringPolicy()
+        aid_bytes = str(self._agent_id).encode("utf-8")
+        self._rng = rng or random.Random(_sha256_hex(b"rng:" + seed + aid_bytes))
+
+        self._priv = _derive_private_key(b"agent:" + seed + b":" + aid_bytes)
+        self._pub = _public_raw(self._priv)
+        self._offer_env = offer_env
+        self._measurements = measurements or golden_measurements()
+        self._ak_key = _derive_private_key(b"ak:" + seed + b":" + aid_bytes)
+
+        self._operator_id = ""
+        self._operator_pub = b""
+        delegation_sig = b""
+        card_label = label or str(self._agent_id)
+        if operator_seed is not None:
+            # Normal path: an operator we control signs the delegation for us.
+            op_priv = _derive_private_key(b"operator:" + operator_seed)
+            self._operator_pub = _public_raw(op_priv)
+            self._operator_id = _fingerprint(self._operator_pub)
+            delegation_sig = _sign(
+                op_priv,
+                _delegation_msg(self._operator_id, str(self._agent_id), card_label),
+            )
+        elif operator_delegation is not None:
+            # Injection path: embed a delegation block issued out-of-band
+            # (``operator_id``, ``operator_public_key``, ``signature``). The card
+            # is still self-signed by *this* agent's key, so a peer that claims a
+            # delegation it was never granted produces a self-consistent card
+            # with an invalid ``delegation_signature`` — see ``_verify_card``.
+            self._operator_id, self._operator_pub, delegation_sig = operator_delegation
+
+        card = AgentFactsCard(
+            agent_id=str(self._agent_id),
+            label=card_label,
+            public_key=self._pub,
+            principal_name=principal_name or str(self._agent_id),
+            operator_id=self._operator_id,
+            operator_public_key=self._operator_pub,
+            capabilities=capabilities,
+            delegation_signature=delegation_sig,
+        )
+        self._card = replace(card, facts_signature=_sign(self._priv, _canon(card.body())))
+
+        self._sessions: dict[AgentId, _Session] = {}
+        self._pending_hail: dict[str, Any] | None = None
+        self._attested: set[AgentId] = set()
+        self._scores: dict[AgentId, list[float]] = {}
+        self._quarantined: list[Evidence] = []
+        self._stakes: dict[AgentId, int] = {}
+
+    # -- passport / policy accessors ------------------------------------
+
+    @property
+    def card(self) -> AgentFactsCard:
+        """This agent's signed passport.
+
+        Example::
+
+            wire = trust.card.to_dict()
+        """
+        return self._card
+
+    @property
+    def operator_id(self) -> str:
+        """The operator id delegated to this agent (``""`` if self-asserted).
+
+        Example::
+
+            oid = trust.operator_id
+        """
+        return self._operator_id
+
+    @property
+    def operator_public_key(self) -> bytes:
+        """The delegating operator's raw public key (``b""`` if none).
+
+        Example::
+
+            pub = trust.operator_public_key
+        """
+        return self._operator_pub
+
+    def trust_operator(self, operator_id: str, operator_public_key: bytes) -> None:
+        """Add an operator to this verifier's trusted-operator roster.
+
+        Example::
+
+            verifier.trust_operator(peer.operator_id, peer.operator_public_key)
+        """
+        self._policy.trusted_operators[operator_id] = operator_public_key
+
+    def allow_boot_state(self, measurements: dict[str, str] | None = None) -> None:
+        """Add a boot digest to the verifier's known-good allow-list.
+
+        Example::
+
+            verifier.allow_boot_state()  # trust the golden config
+        """
+        self._policy.known_good_boot.add(_boot_digest(measurements or golden_measurements()))
+
+    # -- transcript / proofs --------------------------------------------
+
+    def _nonce(self) -> bytes:
+        """Draw a deterministic 16-byte nonce from the per-instance RNG."""
+        return self._rng.randbytes(16)
+
+    def _transcript(
+        self,
+        nonce_a: bytes,
+        nonce_b: bytes,
+        facts_a: AgentFactsCard,
+        facts_b: AgentFactsCard,
+    ) -> bytes:
+        """Bytes both sides sign — binds key possession to *this* exchange.
+
+        Signing the transcript (not a bare nonce) defeats splicing and cross
+        session replay: it commits to both nonces and both passports.
+
+        Example::
+
+            t = trust._transcript(na, nb, card_a, card_b)
+        """
+        blob = {
+            "proto": PROTO,
+            "a": {"nonce": nonce_a.hex(), "id": facts_a.agent_id, "facts": facts_a.facts_hash()},
+            "b": {"nonce": nonce_b.hex(), "id": facts_b.agent_id, "facts": facts_b.facts_hash()},
+        }
+        return HANDSHAKE_TAG + _canon(blob)
+
+    def _proofs(self, transcript: bytes, peer_nonce: bytes) -> dict[str, Any]:
+        """The proofs this side offers: transcript signature and optional env quote.
+
+        Example::
+
+            proofs = trust._proofs(transcript, peer_nonce)
+        """
+        proofs: dict[str, Any] = {"sig": _b64(_sign(self._priv, transcript))}
+        if self._offer_env:
+            proofs["env"] = _make_env_quote(self._ak_key, peer_nonce, self._measurements)
+        return proofs
+
+    # -- three-message handshake ----------------------------------------
+
+    def make_hail(
+        self,
+        *,
+        report_kind: str = "positive",
+        present_card: AgentFactsCard | None = None,
+    ) -> dict[str, Any]:
+        """Open a handshake as the initiator: present a passport and a fresh nonce.
+
+        ``present_card`` lets an adversary present *someone else's* passport
+        (impersonation); the seal signature is still produced by this agent's
+        own key, so key possession fails at the verifier. ``report_kind`` is
+        the evidence this peer intends to file once admitted.
+
+        Example::
+
+            hail = trust.make_hail(report_kind="positive")
+        """
+        card = present_card or self._card
+        nonce_a = self._nonce()
+        self._pending_hail = {"nonce_a": nonce_a, "facts_a": card}
+        return {
+            "proto": PROTO,
+            "op": "hail",
+            "nonce": nonce_a.hex(),
+            "report_kind": report_kind,
+            "facts": card.to_dict(),
+        }
+
+    def make_vouch(self, hail: dict[str, Any], *, session_key: AgentId) -> dict[str, Any]:
+        """Respond to a hail: prove *this* side over the transcript, store session.
+
+        ``session_key`` is the transport-level peer the verifier is talking to
+        (so a stolen passport is bound to the real sender, not the claimed id).
+
+        Example::
+
+            vouch = verifier.make_vouch(hail, session_key=AgentId("a1"))
+        """
+        nonce_a = _uhex(str(hail.get("nonce", "")))
+        facts_a = AgentFactsCard.from_dict(hail.get("facts") or {})
+        nonce_b = self._nonce()
+        transcript = self._transcript(nonce_a, nonce_b, facts_a, self._card)
+        proofs = self._proofs(transcript, nonce_a)
+        self._sessions[session_key] = _Session(
+            nonce_a=nonce_a,
+            nonce_b=nonce_b,
+            facts_a=facts_a,
+            report_kind=str(hail.get("report_kind", "positive")),
+        )
+        return {
+            "proto": PROTO,
+            "op": "vouch",
+            "nonce": nonce_b.hex(),
+            "facts": self._card.to_dict(),
+            **proofs,
+        }
+
+    def make_seal(self, vouch: dict[str, Any]) -> dict[str, Any]:
+        """Close the handshake as the initiator: prove this side over the transcript.
+
+        Example::
+
+            seal = trust.make_seal(vouch)
+        """
+        if self._pending_hail is None:
+            msg = "make_seal called before make_hail"
+            raise RuntimeError(msg)
+        nonce_a: bytes = self._pending_hail["nonce_a"]
+        facts_a: AgentFactsCard = self._pending_hail["facts_a"]
+        nonce_b = _uhex(str(vouch.get("nonce", "")))
+        facts_b = AgentFactsCard.from_dict(vouch.get("facts") or {})
+        transcript = self._transcript(nonce_a, nonce_b, facts_a, facts_b)
+        proofs = self._proofs(transcript, nonce_b)
+        return {"proto": PROTO, "op": "seal", **proofs}
+
+    def session_report_kind(self, session_key: AgentId) -> str:
+        """The evidence kind the peer declared in its hail.
+
+        Example::
+
+            kind = verifier.session_report_kind(AgentId("a1"))
+        """
+        session = self._sessions.get(session_key)
+        return session.report_kind if session else "positive"
+
+    # -- verification ---------------------------------------------------
+
+    def evaluate_peer(
+        self,
+        peer_facts: AgentFactsCard,
+        transcript: bytes,
+        proofs: dict[str, Any],
+        my_nonce: bytes,
+    ) -> PeeringVerdict:
+        """Judge a peer from its passport plus its three fresh proofs (pure).
+
+        No I/O, no clock, no RNG. Answers friend-or-foe (authentic passport +
+        transcript key possession + roster/TOFU), trust-my-data (optional env
+        quote), and who-you-work-for (trusted-operator delegation).
+
+        Example::
+
+            verdict = verifier.evaluate_peer(card, transcript, proofs, nonce)
+        """
+        policy = self._policy
+
+        # 1) FRIEND OR FOE — authentic passport AND key possession over session.
+        authentic, auth_detail = _verify_card(peer_facts)
+        possession = _verify(peer_facts.public_key, transcript, _ub64(str(proofs.get("sig", ""))))
+        pid = peer_facts.agent_id
+        known = policy.roster is None or pid in policy.roster or policy.tofu
+        if not possession:
+            foe_detail = "key possession NOT proven — bad transcript signature (impostor/replay)"
+        elif not authentic:
+            foe_detail = auth_detail
+        elif not known:
+            foe_detail = f"unknown peer {pid} — not on roster and TOFU is off"
+        else:
+            on_roster = bool(policy.roster and pid in policy.roster)
+            seen = "known peer" if on_roster else "first contact (TOFU)"
+            foe_detail = f"identity {pid} proven — {seen}"
+        friend_or_foe = PeeringCheck(bool(possession and authentic and known), foe_detail)
+
+        # 2) CAN I TRUST YOU WITH MY DATA — environment / boot attestation.
+        env = proofs.get("env")
+        if isinstance(env, dict):
+            env_quote = cast("dict[str, Any]", env)
+            env_ok, env_detail = _verify_env(env_quote, my_nonce, policy.known_good_boot)
+        else:
+            env_ok = not policy.require_env_quote
+            env_detail = "no boot quote offered" + ("" if env_ok else " (policy requires one)")
+        trust_my_data = PeeringCheck(bool(env_ok), env_detail)
+
+        # 3) WHO DO YOU WORK FOR — operator delegation on the trusted roster.
+        op_id = peer_facts.operator_id
+        if policy.require_trusted_operator:
+            if not op_id:
+                work_ok, work_detail = False, "no operator delegation (self-asserted principal)"
+            elif op_id not in policy.trusted_operators:
+                work_ok, work_detail = False, f"operator {op_id} is not on your trusted roster"
+            else:
+                work_ok, work_detail = True, f"operator {op_id} delegated and trusted"
+        else:
+            work_ok = True
+            work_detail = f"operator {op_id or '(none)'} — operator trust not required"
+        who_you_work_for = PeeringCheck(
+            bool(work_ok), f"'{peer_facts.principal_name}' — {work_detail}"
+        )
+
+        decision = (
+            "ALLOW" if (friend_or_foe.ok and trust_my_data.ok and who_you_work_for.ok) else "DENY"
+        )
+        return PeeringVerdict(pid, friend_or_foe, trust_my_data, who_you_work_for, decision)
+
+    def evaluate_seal(self, session_key: AgentId, seal: dict[str, Any]) -> PeeringVerdict:
+        """Responder-side finish: judge the initiator from the seal it sent.
+
+        On ``ALLOW`` the transport peer ``session_key`` is admitted to the
+        attested set, so its subsequent :meth:`report` evidence counts.
+
+        Example::
+
+            verdict = verifier.evaluate_seal(AgentId("a1"), seal)
+        """
+        session = self._sessions.get(session_key)
+        if session is None:
+            deny = PeeringCheck(False, "no open handshake session for this peer")
+            return PeeringVerdict(str(session_key), deny, deny, deny, "DENY")
+        transcript = self._transcript(session.nonce_a, session.nonce_b, session.facts_a, self._card)
+        verdict = self.evaluate_peer(session.facts_a, transcript, seal, session.nonce_b)
+        if verdict.friend:
+            self._attested.add(session_key)
+        return verdict
+
+    # -- Trust protocol (nest_core.layers.trust.Trust) ------------------
+
+    async def score(self, agent: AgentId) -> ReputationScore:
+        """Reputation from *admitted* (attested-reporter) evidence only.
+
+        Example::
+
+            rep = await trust.score(AgentId("a2"))
+        """
+        entries = self._scores.get(agent, [])
+        if not entries:
+            return ReputationScore(agent_id=agent, score=0.5, confidence=0.0, sample_count=0)
+        avg = sum(entries) / len(entries)
+        confidence = min(1.0, len(entries) / 100.0)
+        return ReputationScore(
+            agent_id=agent, score=avg, confidence=confidence, sample_count=len(entries)
+        )
+
+    async def attest(self, agent: AgentId, claim: Claim) -> Attestation:
+        """Sign a claim about an agent with this agent's identity key.
+
+        Example::
+
+            att = await trust.attest(AgentId("a2"), claim)
+        """
+        value = _sign(self._priv, claim.model_dump_json().encode("utf-8"))
+        sig = Signature(signer=self._agent_id, value=value, algorithm=ALGORITHM)
+        return Attestation(issuer=self._agent_id, claim=claim, signature=sig)
+
+    async def report(self, agent: AgentId, evidence: Evidence) -> None:
+        """Admit evidence only from attested reporters; quarantine the rest.
+
+        Example::
+
+            await trust.report(AgentId("victim"), evidence)
+        """
+        if evidence.reporter not in self._attested:
+            self._quarantined.append(evidence)
+            return
+        score_val = 0.5
+        if evidence.kind == "positive":
+            score_val = 1.0
+        elif evidence.kind in ("negative", "byzantine"):
+            score_val = 0.0
+        self._scores.setdefault(agent, []).append(score_val)
+
+    async def stake(self, agent: AgentId, amount: int) -> None:
+        """Stake reputation on an agent.
+
+        Example::
+
+            await trust.stake(AgentId("a2"), 100)
+        """
+        self._stakes[agent] = self._stakes.get(agent, 0) + amount
+
+    # -- introspection used by tests and validators ---------------------
+
+    def is_attested(self, agent: AgentId) -> bool:
+        """Whether *agent* cleared the handshake with an ALLOW verdict.
+
+        Example::
+
+            assert verifier.is_attested(AgentId("a1"))
+        """
+        return agent in self._attested
+
+    @property
+    def attested_peers(self) -> frozenset[AgentId]:
+        """Peers whose handshake verdict was ALLOW.
+
+        Example::
+
+            assert AgentId("a1") in trust.attested_peers
+        """
+        return frozenset(self._attested)
+
+    @property
+    def quarantined_count(self) -> int:
+        """How many evidence reports were rejected as coming from unattested peers.
+
+        Example::
+
+            assert trust.quarantined_count == 3
+        """
+        return len(self._quarantined)

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -54,6 +54,7 @@ phi_accrual = "nest_plugins_reference.failure_detection.phi_accrual:PhiAccrualFa
 parc = "nest_plugins_reference.trust.parc:ParcTrust"
 aae_permit_gate = "nest_plugins_reference.trust.aae_permit_gate:AAEPermitGate"
 bonded_trust = "nest_plugins_reference.trust.bonded_trust:BondedTrust"
+attested_peering = "nest_plugins_reference.trust.attested_peering:AttestedPeeringTrust"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/nest-plugins-reference/tests/test_attested_peering.py
+++ b/packages/nest-plugins-reference/tests/test_attested_peering.py
@@ -1,0 +1,468 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit + property + end-to-end tests for the attested-peering trust plugin.
+
+Four layers of coverage, mirroring ``test_failure_detection.py``:
+
+1. **Verifier unit tests** — drive the handshake directly with two agents and
+   assert the happy path is ``ALLOW`` and each attack is ``DENY`` on the
+   expected axis: an *impostor* presenting a stolen passport signed with the
+   wrong key, a cross-session *replay* of a genuine seal, a *forged operator
+   delegation*, and a *tampered boot quote*.
+2. **Property-based tests** (``hypothesis``) — for arbitrary agent ids and
+   payloads: honest handshakes always verify; a single flipped byte in the
+   transcript signature always fails key possession; reordering the reporter
+   set never changes the victim's final reputation.
+3. **Full simulator integration** — boot ``scenarios/attested_peering.yaml``
+   via ``ScenarioRunner`` under seeds 42, 7, 1337 and assert both validators
+   pass.
+4. **Adversarial discrimination + determinism** — the *same* scenario under
+   the baseline ``score_average`` plugin FAILs the Sybil-quarantine validator
+   while ``attested_peering`` PASSes it, and two runs at one seed are
+   byte-identical.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import random
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from nest_core.layers.trust import Trust
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.types import AgentId, Evidence
+from nest_core.validators import ValidationResult, validate_trace
+from nest_plugins_reference.trust.attested_peering import (
+    AgentFactsCard,
+    AttestedPeeringTrust,
+    PeeringPolicy,
+    golden_measurements,
+)
+
+_OP = b"unit-test-operator-seed"
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _verifier(**kwargs: Any) -> AttestedPeeringTrust:
+    return AttestedPeeringTrust(
+        agent_id=AgentId("observer"),
+        seed=b"unit",
+        policy=PeeringPolicy(require_trusted_operator=True, **kwargs),
+    )
+
+
+def _honest(agent_id: str = "honest-0", rng_tag: str | None = None) -> AttestedPeeringTrust:
+    return AttestedPeeringTrust(
+        agent_id=AgentId(agent_id),
+        seed=b"unit",
+        operator_seed=_OP,
+        offer_env=True,
+        rng=random.Random(rng_tag) if rng_tag else None,
+    )
+
+
+def _handshake(
+    verifier: AttestedPeeringTrust,
+    initiator: AttestedPeeringTrust,
+    session_name: str,
+    *,
+    present_card: Any = None,
+    seal_override: dict[str, Any] | None = None,
+    kind: str = "positive",
+) -> Any:
+    """Drive hail -> vouch -> seal and return the verifier's verdict."""
+    session = AgentId(session_name)
+    hail = initiator.make_hail(report_kind=kind, present_card=present_card)
+    vouch = verifier.make_vouch(hail, session_key=session)
+    seal = seal_override if seal_override is not None else initiator.make_seal(vouch)
+    return verifier.evaluate_seal(session, seal)
+
+
+# ---------------------------------------------------------------------------
+# 0. Wiring / protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_registry_resolves_attested_peering() -> None:
+    """The plugin is wired into the built-in registry as trust:attested_peering."""
+    cls = PluginRegistry().resolve("trust", "attested_peering")
+    assert cls is AttestedPeeringTrust
+
+
+def test_satisfies_trust_protocol() -> None:
+    """An instance structurally satisfies the Trust layer Protocol."""
+    assert isinstance(AttestedPeeringTrust(agent_id=AgentId("a1")), Trust)
+
+
+def test_unattested_reports_are_quarantined() -> None:
+    """Evidence from a reporter with no ALLOW handshake never moves a score."""
+    trust = AttestedPeeringTrust(agent_id=AgentId("observer"))
+    ev = Evidence(reporter=AgentId("sybil-0"), subject=AgentId("victim"), kind="negative")
+    _run(trust.report(AgentId("victim"), ev))
+    rep = _run(trust.score(AgentId("victim")))
+    assert rep.sample_count == 0
+    assert rep.score == 0.5
+    assert trust.quarantined_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 1. Verifier unit tests — happy path + each attack denied on its own axis
+# ---------------------------------------------------------------------------
+
+
+def test_valid_handshake_allows_peer() -> None:
+    """An honest, delegated, correctly-booted peer passes all three checks."""
+    verifier = _verifier()
+    honest = _honest()
+    verifier.trust_operator(honest.operator_id, honest.operator_public_key)
+    verifier.allow_boot_state()
+
+    verdict = _handshake(verifier, honest, "honest-0")
+    assert verdict.decision == "ALLOW"
+    assert verdict.friend_or_foe.ok
+    assert verdict.trust_my_data.ok
+    assert verdict.who_you_work_for.ok
+    assert verifier.is_attested(AgentId("honest-0"))
+
+
+def test_sybil_without_delegation_denied() -> None:
+    """A self-asserted identity with no operator delegation fails who-you-work-for."""
+    verifier = _verifier()
+    sybil = AttestedPeeringTrust(agent_id=AgentId("sybil-0"), seed=b"unit")
+
+    verdict = _handshake(verifier, sybil, "sybil-0", kind="negative")
+    assert verdict.decision == "DENY"
+    assert verdict.friend_or_foe.ok  # it genuinely holds its own key
+    assert not verdict.who_you_work_for.ok
+
+
+def test_impostor_signature_denied() -> None:
+    """A peer presenting a stolen passport but signing with its own key is denied."""
+    verifier = _verifier()
+    honest = _honest()
+    verifier.trust_operator(honest.operator_id, honest.operator_public_key)
+    verifier.allow_boot_state()
+    impostor = AttestedPeeringTrust(agent_id=AgentId("impostor-0"), seed=b"unit")
+
+    verdict = _handshake(
+        verifier, impostor, "impostor-0", present_card=honest.card, kind="negative"
+    )
+    assert verdict.decision == "DENY"
+    assert not verdict.friend_or_foe.ok
+    assert "possession" in verdict.friend_or_foe.detail
+    assert not verifier.is_attested(AgentId("impostor-0"))
+
+
+def test_replayed_proof_denied() -> None:
+    """A genuine honest seal captured from another session fails the live transcript."""
+    verifier = _verifier()
+    honest = _honest()
+    verifier.trust_operator(honest.operator_id, honest.operator_public_key)
+    verifier.allow_boot_state()
+
+    # Capture a real seal from a throwaway session on a distinct RNG stream.
+    cap_honest = _honest(rng_tag="capture")
+    cap_obs = AttestedPeeringTrust(
+        agent_id=AgentId("observer"), seed=b"unit", rng=random.Random("capture-obs")
+    )
+    cap_hail = cap_honest.make_hail(report_kind="positive")
+    cap_vouch = cap_obs.make_vouch(cap_hail, session_key=AgentId("honest-0"))
+    captured = cap_honest.make_seal(cap_vouch)
+
+    replayer = AttestedPeeringTrust(agent_id=AgentId("replayer-0"), seed=b"unit")
+    verdict = _handshake(
+        verifier,
+        replayer,
+        "replayer-0",
+        present_card=honest.card,
+        seal_override=captured,
+        kind="negative",
+    )
+    assert verdict.decision == "DENY"
+    assert not verdict.friend_or_foe.ok
+
+
+def test_forged_operator_delegation_denied() -> None:
+    """A passport claiming a trusted operator with an invalid delegation is denied.
+
+    The attacker mints a card whose ``operator_id`` names the trusted operator
+    but whose delegation signature is bogus, then self-signs that body. The
+    self-signature is valid, but the operator never issued the delegation.
+    """
+    verifier = _verifier()
+    honest = _honest()
+    verifier.trust_operator(honest.operator_id, honest.operator_public_key)
+    verifier.allow_boot_state()
+
+    # The forger self-signs a card that claims the trusted operator's id + key
+    # but carries a bogus delegation signature the operator never produced.
+    forger = AttestedPeeringTrust(
+        agent_id=AgentId("forger-0"),
+        seed=b"unit",
+        operator_delegation=(
+            honest.operator_id,
+            honest.operator_public_key,
+            b"not-a-real-signature",
+        ),
+    )
+
+    verdict = _handshake(verifier, forger, "forger-0", kind="negative")
+    assert verdict.decision == "DENY"
+    assert not verdict.friend_or_foe.ok
+    assert "delegation" in verdict.friend_or_foe.detail
+
+
+def test_tampered_boot_quote_denied_when_required() -> None:
+    """A peer whose boot state is not on the allow-list fails trust-my-data."""
+    verifier = _verifier(require_env_quote=True)
+    verifier.allow_boot_state()  # only the golden config is vetted
+    tampered = {**golden_measurements(), "kernel": "evil-kernel"}
+    peer = AttestedPeeringTrust(
+        agent_id=AgentId("compromised-0"),
+        seed=b"unit",
+        operator_seed=_OP,
+        offer_env=True,
+        measurements=tampered,
+    )
+    verifier.trust_operator(peer.operator_id, peer.operator_public_key)
+
+    verdict = _handshake(verifier, peer, "compromised-0")
+    assert verdict.decision == "DENY"
+    assert not verdict.trust_my_data.ok
+
+
+def test_missing_required_boot_quote_denied() -> None:
+    """When the policy requires a boot quote, a peer that offers none is denied."""
+    verifier = _verifier(require_env_quote=True)
+    honest_no_env = AttestedPeeringTrust(
+        agent_id=AgentId("honest-0"), seed=b"unit", operator_seed=_OP, offer_env=False
+    )
+    verifier.trust_operator(honest_no_env.operator_id, honest_no_env.operator_public_key)
+
+    verdict = _handshake(verifier, honest_no_env, "honest-0")
+    assert verdict.decision == "DENY"
+    assert not verdict.trust_my_data.ok
+
+
+# ---------------------------------------------------------------------------
+# 1b. Byzantine wire input — a malformed frame is a clean DENY, never a crash
+# ---------------------------------------------------------------------------
+
+
+_GARBAGE_SEALS: list[dict[str, Any]] = [
+    {},  # empty frame
+    {"proto": "x", "op": "seal"},  # missing sig
+    {"op": "seal", "sig": "!!! not base64 !!!"},  # undecodable signature
+    {"op": "seal", "sig": "AAAA", "env": "not-a-dict"},  # wrong env type
+    {"op": "seal", "sig": "AAAA", "env": {"nonce": "zz", "measurements": 5}},  # junk env
+]
+
+
+@pytest.mark.parametrize("seal", _GARBAGE_SEALS)
+def test_malformed_seal_denies_without_raising(seal: dict[str, Any]) -> None:
+    """A byzantine peer's garbage seal yields DENY, not an unhandled exception."""
+    verifier = _verifier()
+    honest = _honest()
+    verifier.trust_operator(honest.operator_id, honest.operator_public_key)
+    session = AgentId("honest-0")
+    # Open a real session so evaluate_seal reaches evaluate_peer with the junk.
+    verifier.make_vouch(honest.make_hail(report_kind="positive"), session_key=session)
+    verdict = verifier.evaluate_seal(session, seal)
+    assert verdict.decision == "DENY"
+    assert not verdict.friend_or_foe.ok
+
+
+_GARBAGE_HAILS: list[dict[str, Any]] = [
+    {},  # no nonce, no facts
+    {"op": "hail", "nonce": "not-hex", "facts": {}},  # bad hex nonce + empty card
+    {"op": "hail", "nonce": "00ff", "facts": "not-a-dict"},  # facts wrong type
+    {"op": "hail", "nonce": "00ff", "facts": {"public_key": "@@@"}},  # undecodable key
+    {"op": "hail", "nonce": "00ff", "facts": {"capabilities": 5}},  # non-iterable caps
+    {"op": "hail", "nonce": "00ff", "facts": {"capabilities": None}},  # null caps
+]
+
+
+@pytest.mark.parametrize("hail", _GARBAGE_HAILS)
+def test_malformed_hail_does_not_crash_responder(hail: dict[str, Any]) -> None:
+    """make_vouch tolerates a garbage hail; the session it opens later DENYs."""
+    verifier = _verifier()
+    session = AgentId("attacker")
+    vouch = verifier.make_vouch(hail, session_key=session)  # must not raise
+    assert vouch["op"] == "vouch"
+    # An attacker who sent junk can never satisfy the transcript on the seal.
+    verdict = verifier.evaluate_seal(session, {"op": "seal", "sig": "AAAA"})
+    assert verdict.decision == "DENY"
+
+
+def test_from_dict_tolerates_missing_and_nondict_input() -> None:
+    """AgentFactsCard.from_dict never raises on truncated / non-dict wire data."""
+    assert AgentFactsCard.from_dict({}).public_key == b""
+    assert AgentFactsCard.from_dict("not-a-dict").public_key == b""
+    assert AgentFactsCard.from_dict({"public_key": "@@@"}).public_key == b""
+    # Non-iterable/null capabilities must not raise TypeError — coerce to empty.
+    assert AgentFactsCard.from_dict({"capabilities": 5}).capabilities == ()
+    assert AgentFactsCard.from_dict({"capabilities": None}).capabilities == ()
+
+
+# ---------------------------------------------------------------------------
+# 2. Property-based tests
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=40, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    agent_name=st.text(
+        alphabet=st.characters(min_codepoint=97, max_codepoint=122), min_size=1, max_size=8
+    )
+)
+def test_property_honest_handshake_always_allows(agent_name: str) -> None:
+    """Any honest, delegated, correctly-booted peer is admitted, whatever its id."""
+    verifier = _verifier()
+    honest = AttestedPeeringTrust(
+        agent_id=AgentId(f"h-{agent_name}"), seed=b"prop", operator_seed=_OP, offer_env=True
+    )
+    verifier.trust_operator(honest.operator_id, honest.operator_public_key)
+    verifier.allow_boot_state()
+    assert _handshake(verifier, honest, f"h-{agent_name}").decision == "ALLOW"
+
+
+@settings(max_examples=40)
+@given(flip=st.integers(min_value=0, max_value=63))
+def test_property_tampered_signature_always_denied(flip: int) -> None:
+    """Flipping any byte of the transcript signature always breaks key possession."""
+    verifier = _verifier()
+    honest = _honest()
+    verifier.trust_operator(honest.operator_id, honest.operator_public_key)
+    verifier.allow_boot_state()
+
+    session = AgentId("honest-0")
+    hail = honest.make_hail(report_kind="positive")
+    vouch = verifier.make_vouch(hail, session_key=session)
+    seal = honest.make_seal(vouch)
+    raw = bytearray(base64.b64decode(seal["sig"]))
+    raw[flip % len(raw)] ^= 0x01
+    seal["sig"] = base64.b64encode(bytes(raw)).decode("ascii")
+
+    verdict = verifier.evaluate_seal(session, seal)
+    assert verdict.decision == "DENY"
+    assert not verdict.friend_or_foe.ok
+
+
+@settings(max_examples=20, deadline=None)
+@given(seed=st.integers(min_value=0, max_value=2**16))
+def test_property_report_order_invariant(seed: int) -> None:
+    """The victim's admitted score is independent of the order reports arrive in.
+
+    Only honest reporters are admitted, so their positive evidence yields 1.0
+    regardless of interleaving with quarantined Sybil reports.
+    """
+    rng = random.Random(seed)
+    verifier = _verifier()
+    honest_ids = [AgentId(f"honest-{i}") for i in range(4)]
+    verifier.allow_boot_state()
+    for hid in honest_ids:
+        h = AttestedPeeringTrust(agent_id=hid, seed=b"prop", operator_seed=_OP, offer_env=True)
+        verifier.trust_operator(h.operator_id, h.operator_public_key)
+        _handshake(verifier, h, str(hid))  # admit the honest reporter
+
+    reports = [
+        Evidence(reporter=hid, subject=AgentId("victim"), kind="positive") for hid in honest_ids
+    ] + [
+        Evidence(reporter=AgentId(f"sybil-{i}"), subject=AgentId("victim"), kind="negative")
+        for i in range(6)
+    ]
+    rng.shuffle(reports)
+    for ev in reports:
+        _run(verifier.report(AgentId("victim"), ev))
+
+    rep = _run(verifier.score(AgentId("victim")))
+    assert rep.sample_count == len(honest_ids)
+    assert rep.score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# 3./4. Full simulator integration, discrimination, determinism
+# ---------------------------------------------------------------------------
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "attested_peering.yaml"
+_SEEDS = [42, 7, 1337]
+
+
+def _run_scenario(seed: int, trust_plugin: str) -> dict[str, ValidationResult]:
+    """Run the scenario under a given trust plugin and return validator results."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH)).model_copy(update={"seed": seed})
+    config = config.model_copy(
+        update={"layers": config.layers.model_copy(update={"trust": trust_plugin})}
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"ap_{trust_plugin}_{seed}.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        asyncio.run(ScenarioRunner(config, registry=PluginRegistry()).run())
+        results = validate_trace(trace_path, "attested_peering")
+    return {r.name: r for r in results}
+
+
+def _run_bytes(seed: int) -> bytes:
+    """Run the scenario and return the raw trace bytes."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH)).model_copy(update={"seed": seed})
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / "ap_replay.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        asyncio.run(ScenarioRunner(config, registry=PluginRegistry()).run())
+        return trace_path.read_bytes()
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_scenario_attested_passes_every_validator(seed: int) -> None:
+    """With attested_peering, both gate validators pass at every seed."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    results = _run_scenario(seed, "attested_peering")
+    expected = {"attested_no_denied_admitted", "attested_sybil_quarantined"}
+    assert expected <= set(results), f"missing validators: {expected - set(results)}"
+    for name, res in results.items():
+        assert res.passed, f"seed={seed} {name} failed: {res.detail}"
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_scenario_baseline_fails_sybil_but_attested_passes(seed: int) -> None:
+    """The discriminator: score_average admits the Sybil swarm; attested does not.
+
+    The safety validator (no denied peer admitted) holds for both — the baseline
+    simply runs no handshake, so it has nothing to admit incorrectly. The
+    Sybil-quarantine validator is the property that separates the two plugins.
+    """
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+
+    baseline = _run_scenario(seed, "score_average")
+    assert not baseline["attested_sybil_quarantined"].passed, (
+        f"seed={seed}: baseline should be defamed but passed: "
+        f"{baseline['attested_sybil_quarantined'].detail}"
+    )
+
+    ours = _run_scenario(seed, "attested_peering")
+    assert ours["attested_sybil_quarantined"].passed, (
+        f"seed={seed}: attested plugin failed: {ours['attested_sybil_quarantined'].detail}"
+    )
+
+
+def test_scenario_is_byte_deterministic() -> None:
+    """Two runs at the same seed produce byte-identical traces."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    assert _run_bytes(42) == _run_bytes(42)

--- a/scenarios/attested_peering.yaml
+++ b/scenarios/attested_peering.yaml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Attested-peering trust scenario: an unauthenticated Sybil swarm (plus an
+# impostor and a replayer) tries to defame one honest victim, but only peers
+# that clear the three-question attested-peering handshake can move its
+# reputation. Swap `trust: attested_peering` for `trust: score_average` and the
+# validate_attested_sybil_quarantined validator flips from PASS to FAIL.
+name: attested_peering
+description: "20-node Sybil swarm + impostor + replayer defame one victim; only attested peers count."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 32
+  brain: state-machine
+  roles:
+    - name: honest
+      count: 8
+    - name: sybil
+      count: 20
+    - name: impostor
+      count: 1
+    - name: replayer
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: attested_peering
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: attested_peering
+  config:
+    victim: victim
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+
+output:
+  trace: ./traces/attested_peering.jsonl


### PR DESCRIPTION
# [Hackathon] libre: attested-peering trust plugin

**Persona:** `libre` — a self-sovereignty / decentralized-infrastructure engineer
(maintainer of LibreSynergy, a self-hostable community mesh). This persona cares
about *who you are federating with* before any data crosses the wire: friend or
foe, hardware you can trust, an operator who stands behind the agent.

## Motivation

The two bundled trust plugins answer *"how well has this agent behaved?"*
(`score_average` averages feedback; `agent_receipts` corroborates it with
receipts). Neither answers the **prior** question: *is the thing reporting
feedback even who it claims to be, and should its evidence count at all?* Under
the default `score_average` plugin any agent — including a freshly minted Sybil —
can file unlimited `report()` calls and poison a victim's reputation.

This PR adds an **`AttestedPeering` trust layer** that gates evidence admission
behind a mutual, replay-proof **identity + hardware-root attestation** handshake.
It is a **novel composition of two layers** — Identity gating Trust — ported from
LibreSynergy's production mesh-federation gate.

## Design

A three-question handshake (`hail` → `vouch` → `seal`), each question a distinct
attestation:

1. **Friend or foe?** — the peer proves possession of the private key for the
   identity it presents by signing *this session's transcript* (never a
   replayable bare nonce), and its `AgentFactsCard` must be authentic
   (self-signature + operator delegation valid).
2. **Can I trust you with my data?** — an optional, nonce-bound signed
   environment quote over the peer's measured configuration (a deterministic
   stand-in for a TPM measured-boot quote).
3. **Who do you work for?** — a named operator must have delegated authority to
   the agent via a signed delegation in its passport, and that operator must be
   on the verifier's trusted-operator roster.

Only peers whose verdict is `ALLOW` may contribute evidence via `report()`;
everything else is quarantined and surfaced in the trace.

### Tradeoffs

- **Ed25519 over openssl subprocess.** LibreSynergy's original uses an `openssl`
  subprocess; that violates the Tier-1 determinism rule (no `subprocess`, no
  `os.urandom`, no wall-clock). Ported to in-process `cryptography`: seeds are
  `sha256(seed || agent_id)[:32]` (matching `identity.ed25519_rotating`) and
  nonces come from a per-instance seeded `random.Random`. Ed25519 itself is
  deterministic by construction (RFC 8032), and the module reads no clock at
  all, so a Tier-1 run is byte-identical under a fixed seed (asserted by
  `test_scenario_is_byte_deterministic`).
- **Transcript-bound proof, not bare-nonce.** Signing the session transcript
  closes the replay window a bare-nonce challenge leaves open.
- **Attestation #2 is optional** so the plugin degrades gracefully to identity-
  only gating where no measured quote is available.

## API fit

- Implements the `Trust` layer Protocol; registered under
  `[project.entry-points."nest.plugins.trust"]` as `attested_peering`.
- `from __future__ import annotations`, SPDX header, docstrings with `Example::`
  blocks on public classes and methods.
- Ships a scenario (`scenarios/attested_peering.yaml`) and a built-in scenario
  module — slots into the runner with no core edits beyond one registration line
  and the scenario table.

## How to verify

```
uv sync
uv run pytest packages/nest-plugins-reference/tests/test_attested_peering.py \
              packages/nest-core/tests/test_validators.py -q   # 145 passed
uv run nest run scenarios/attested_peering.yaml                 # ALLOW/quarantine trace
make ci-local                                                  # full gate: ruff + format + pyright + 823 pass
```

## Tests (145 passing)

Adversarial by construction — the suite exercises the failure modes the feature
introduces, not just the happy path:

- **Stolen passport, wrong key** → rejected (key-possession proof fails).
- **Replayed proof from another session** → rejected (transcript binding).
- **Off-roster operator** → rejected (delegation valid but operator untrusted).
- **Tampered environment quote** → rejected (nonce/measurement mismatch).
- **Sybil with no delegation** → quarantined, contributes zero evidence.
- **Malformed / type-confused wire frames** (undecodable base64 signature, bad
  hex nonce, non-dict `facts`, truncated passport) → a clean `DENY`, never an
  unhandled exception in the verifier (parametrized byzantine-input tests).
- Determinism: identical bytes under a fixed seed across runs.
- `validators.py`: adversarial validators that count quarantined peers from the
  trace so a scenario fails loudly if an unattested peer's evidence leaks in.

## Files

- `packages/nest-plugins-reference/.../trust/attested_peering.py` — plugin (941 LoC)
- `packages/nest-core/.../scenarios_builtin/attested_peering.py` — scenario
- `packages/nest-core/nest_core/validators.py` — attestation validators
- `scenarios/attested_peering.yaml` — scenario config
- tests: `test_attested_peering.py` (plugin) + `test_validators.py`

Zero new pip dependencies beyond `cryptography` (already a transitive dep). No
`os.urandom` / `time.time` / `subprocess` / clock reads anywhere — a Tier-1 run
is byte-identical under a fixed seed.
