### PR TITLE
[Hackathon] distributed-sys-engg: deterministic coordination round ids (ADR-004 fix)

### DIFF
--- a/packages/nest-plugins-reference/nest_plugins_reference/coordination/_ids.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/coordination/_ids.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic coordination round identifiers.
+
+Nanda Town's core guarantee is a *byte-deterministic* JSONL trace: the same
+seed must replay to an identical trace so operators can ``diff`` two runs and
+``replay`` a failure. ADR-004 (seeded-determinism) makes that a hard rule and
+calls out unseeded RNG as a violation of it.
+
+The reference coordination plugins previously minted round identifiers with
+:func:`uuid.uuid4`, which draws from ``os.urandom`` and is therefore
+**unseedable**: every run produced fresh ``Round`` / ``Bid`` / ``Outcome`` ids,
+so two runs of the *same* seed diverged on every coordination event and their
+traces could neither be diffed nor replayed.
+
+:func:`derive_round_id` replaces that with a pure function of the proposing
+agent, the task, and a monotonic per-proposer sequence number. It is:
+
+- **deterministic** -- identical inputs always yield the identical id, so a
+  seeded run replays byte-for-byte;
+- **injective on its inputs** -- distinct ``(agent, task, seq)`` triples map to
+  distinct ids, because the pre-image is a length-prefixed encoding that no two
+  distinct triples can share (this rules out concatenation ambiguity such as
+  ``("ab", "c")`` vs ``("a", "bc")``);
+- **free of ambient state** -- no reliance on object identity, dict insertion
+  order, wall-clock time, or a global RNG.
+
+Example::
+
+    from nest_core.types import AgentId
+
+    rid = derive_round_id(AgentId("manager"), "task-7", 1)
+    assert rid == derive_round_id(AgentId("manager"), "task-7", 1)
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from nest_core.types import AgentId
+
+
+def derive_round_id(agent_id: AgentId, task_id: str, seq: int) -> str:
+    """Return a deterministic, collision-resistant coordination round id.
+
+    The id is ``"round-" + sha256(preimage)[:16]`` where ``preimage`` is a
+    length-prefixed (netstring-style) encoding of ``(agent_id, task_id, seq)``.
+    Length-prefixing makes the encoding injective, so distinct inputs cannot
+    alias onto the same digest through boundary ambiguity.
+
+    Args:
+        agent_id: The proposing agent. Distinguishes rounds proposed by
+            different agents for the same task.
+        task_id: The task being coordinated.
+        seq: A monotonic per-proposer counter. Distinguishes successive rounds
+            proposed by the same agent; the caller owns incrementing it.
+
+    Example::
+
+        rid = derive_round_id(AgentId("r0"), "t1", 1)
+    """
+    parts = (str(agent_id), task_id, str(seq))
+    preimage = "|".join(f"{len(p)}:{p}" for p in parts).encode("utf-8")
+    return "round-" + hashlib.sha256(preimage).hexdigest()[:16]

--- a/packages/nest-plugins-reference/nest_plugins_reference/coordination/contract_net.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/coordination/contract_net.py
@@ -13,8 +13,6 @@ Example::
 
 from __future__ import annotations
 
-import uuid
-
 from nest_core.types import (
     AgentId,
     Bid,
@@ -24,6 +22,8 @@ from nest_core.types import (
     Task,
     Vote,
 )
+
+from ._ids import derive_round_id
 
 
 class ContractNet:
@@ -37,15 +37,22 @@ class ContractNet:
 
     def __init__(self, agent_id: AgentId) -> None:
         self._agent_id = agent_id
+        self._round_seq = 0
 
     async def propose(self, task: Task) -> Round:
         """Propose a task for bidding.
+
+        The round id is derived deterministically from the proposing agent, the
+        task, and a monotonic per-proposer sequence number, so a seeded run
+        replays byte-for-byte (ADR-004) instead of drawing a fresh ``uuid4``
+        each run. See :func:`._ids.derive_round_id`.
 
         Example::
 
             rnd = await coord.propose(task)
         """
-        round_id = str(uuid.uuid4())
+        self._round_seq += 1
+        round_id = derive_round_id(self._agent_id, task.id, self._round_seq)
         rnd = Round(
             id=round_id,
             task=task,

--- a/packages/nest-plugins-reference/nest_plugins_reference/coordination/hotstuff.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/coordination/hotstuff.py
@@ -27,11 +27,12 @@ Example::
 
 from __future__ import annotations
 
-import uuid
 from collections.abc import Sequence
 from typing import Any
 
 from nest_core.types import AgentId, Outcome, Round, Task, Vote
+
+from ._ids import derive_round_id
 
 
 class HotStuff:
@@ -52,15 +53,22 @@ class HotStuff:
         self._agent_id = agent_id
         self._f = f
         self._replica_ids = list(replica_ids) if replica_ids is not None else [agent_id]
+        self._round_seq = 0
 
     async def propose(self, task: Task) -> Round:
         """Propose a task as a single-view HotStuff round.
+
+        The round id is derived deterministically from the proposing replica,
+        the task, and a monotonic per-proposer sequence number, so a seeded run
+        replays byte-for-byte (ADR-004) instead of drawing a fresh ``uuid4``
+        each run. See :func:`._ids.derive_round_id`.
 
         Example::
 
             rnd = await coord.propose(task)
         """
-        round_id = str(uuid.uuid4())
+        self._round_seq += 1
+        round_id = derive_round_id(self._agent_id, task.id, self._round_seq)
         return Round(
             id=round_id,
             task=task,

--- a/packages/nest-plugins-reference/tests/test_coordination_determinism.py
+++ b/packages/nest-plugins-reference/tests/test_coordination_determinism.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Determinism regression tests for coordination round identifiers.
+
+These tests fail against the previous ``uuid.uuid4`` implementation of
+``ContractNet.propose`` / ``HotStuff.propose`` (which minted a fresh id every
+run) and pass once round ids are derived deterministically from
+``(agent, task, seq)``. They pin ADR-004 (seeded-determinism) for the
+coordination layer: the same logical proposal sequence must produce
+byte-identical ids across independent runs, so a seeded trace can be diffed
+and replayed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from hypothesis import given
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Task
+from nest_plugins_reference.coordination._ids import derive_round_id
+from nest_plugins_reference.coordination.contract_net import ContractNet
+from nest_plugins_reference.coordination.hotstuff import HotStuff
+
+
+def _task(i: int = 1) -> Task:
+    return Task(id=f"t{i}", description="work")
+
+
+async def _propose_ids(coord: ContractNet | HotStuff, n: int) -> list[str]:
+    """Return the round ids from proposing ``n`` successive tasks."""
+    return [(await coord.propose(_task(i))).id for i in range(n)]
+
+
+class TestReplayDeterminism:
+    """The same logical run must produce byte-identical round ids."""
+
+    async def test_contract_net_replays_identically(self) -> None:
+        run1 = await _propose_ids(ContractNet(AgentId("manager")), 5)
+        run2 = await _propose_ids(ContractNet(AgentId("manager")), 5)
+        assert run1 == run2
+
+    async def test_hotstuff_replays_identically(self) -> None:
+        run1 = await _propose_ids(HotStuff(AgentId("r0")), 5)
+        run2 = await _propose_ids(HotStuff(AgentId("r0")), 5)
+        assert run1 == run2
+
+
+class TestUniqueness:
+    """Distinct rounds must still get distinct ids (no regression in function)."""
+
+    async def test_successive_rounds_are_distinct(self) -> None:
+        ids = await _propose_ids(ContractNet(AgentId("manager")), 50)
+        assert len(set(ids)) == len(ids)
+
+    async def test_distinct_proposers_are_distinct(self) -> None:
+        a = (await ContractNet(AgentId("a")).propose(_task())).id
+        b = (await ContractNet(AgentId("b")).propose(_task())).id
+        assert a != b
+
+    async def test_contract_net_and_hotstuff_share_the_scheme(self) -> None:
+        # Same (agent, task, seq) yields the same id regardless of plugin,
+        # because both derive it from the shared helper.
+        cn = (await ContractNet(AgentId("x")).propose(_task(1))).id
+        hs = (await HotStuff(AgentId("x")).propose(_task(1))).id
+        assert cn == hs == derive_round_id(AgentId("x"), "t1", 1)
+
+
+class TestDeriveRoundId:
+    """Unit properties of the id derivation itself."""
+
+    def test_is_pure(self) -> None:
+        assert derive_round_id(AgentId("r0"), "t1", 1) == derive_round_id(AgentId("r0"), "t1", 1)
+
+    def test_uses_no_ambient_state(self) -> None:
+        # Recomputing after unrelated work (which would perturb any RNG or
+        # clock-based scheme) yields the identical id.
+        first = derive_round_id(AgentId("r0"), "t1", 7)
+        _ = [hashlib.sha256(str(i).encode()).hexdigest() for i in range(1000)]
+        assert derive_round_id(AgentId("r0"), "t1", 7) == first
+
+    def test_encoding_is_injective(self) -> None:
+        # Length-prefixing prevents boundary-ambiguity collisions that plain
+        # concatenation would allow.
+        assert derive_round_id(AgentId("ab"), "c", 0) != derive_round_id(AgentId("a"), "bc", 0)
+
+    @given(
+        agent=st.text(min_size=1, max_size=16),
+        task=st.text(min_size=1, max_size=16),
+        seq=st.integers(min_value=0, max_value=1_000_000),
+    )
+    def test_deterministic_over_arbitrary_inputs(self, agent: str, task: str, seq: int) -> None:
+        assert derive_round_id(AgentId(agent), task, seq) == derive_round_id(
+            AgentId(agent), task, seq
+        )


### PR DESCRIPTION
# Deterministic coordination round ids (ADR-004 fix for `contract_net` + `hotstuff`)

**Persona:** `distributed-sys-engg` — reliability/determinism focus.

Both reference coordination plugins, including the default `contract_net`,
mint their round id with `uuid.uuid4()`. That draws from `os.urandom`, so it
is unseedable. This breaks ADR-004 (seeded-determinism), Nanda Town's rule
that a seeded run must replay to a byte-identical trace.

## Motivation

`ADR-004-seeded-determinism` requires that the same seed replay to an
identical trace, so operators can diff two runs or replay a failure. Every
scenario and replay tool in this repo depends on that guarantee holding.

Two reference coordination plugins break it:

- `coordination/contract_net.py` — the default coordination plugin.
- `coordination/hotstuff.py`.

Every call to `propose()` returns a `Round` (and downstream `Bid` / `Outcome`,
which copy `round.id`) with a fresh random id from `uuid4()`. Two runs of the
same seed produce different coordination ids. The plugin's public output is
not reproducible.

Stated plainly: this is a latent bug today. None of the shipped scenarios
(marketplace, auction, voting, consensus) serialize the round id into their
trace, which is why it's gone unnoticed so far. But `propose()` is still a
public API with nondeterministic output, and any scenario or validator that
starts using round ids directly (e.g. the fair-ordering or sealed-bid
coordination work already in flight) will silently inherit a trace that can't
be diffed or replayed.

## The change

Add `coordination/_ids.py::derive_round_id(agent_id, task_id, seq)` and use it
in both plugins. The id is:

- Deterministic: a pure function of `(proposing agent, task, monotonic
  per-proposer sequence)`. A seeded run replays byte-for-byte.
- Injective on its inputs: the pre-image is a length-prefixed (netstring-style)
  encoding, so distinct triples can't alias onto one digest through boundary
  ambiguity (`("ab","c")` vs `("a","bc")`).
- Free of ambient state: no `uuid4`, no wall clock, no object identity, no
  dict-ordering dependence.

Each plugin keeps a private `_round_seq` counter. The sim drives `propose()`
in a seeded, deterministic order, so the counter, and thus the id, reproduces.

Diff: `+177 / -5` across `_ids.py`, `contract_net.py`, `hotstuff.py`, and a new
test file. No code outside the coordination layer is touched.

## Tests — fail without the change, pass with it

`packages/nest-plugins-reference/tests/test_coordination_determinism.py`:

- Replay identity: proposing the same task sequence twice yields
  byte-identical ids. This is the check that fails against `uuid4`.
- Uniqueness: successive rounds and distinct proposers still get distinct ids
  (no functional regression).
- Derivation properties: purity, no ambient state, injective encoding
  (`("ab","c") != ("a","bc")`), and a Hypothesis property over arbitrary
  inputs.

Reverting just the two-line `propose()` change (restoring `uuid4`) makes
`TestReplayDeterminism` fail with, e.g., `round-8c683f74d9f1207a` (expected)
vs a random `f36c1ab2-6955-462d-92b9-9aece726f3b6`.

## Verification

```bash
make ci-local          # uv sync, ruff, ruff format --check, pyright, pytest -v
# or just this PR's test:
uv run pytest -q packages/nest-plugins-reference/tests/test_coordination_determinism.py
```

Local run: `ruff` clean, `ruff format` clean, full suite **954 passed, 0
failed** (this branch), and the new test fails on the pre-change code as above.

## Out of scope / follow-up

`negotiation/alternating_offers.py` has the identical one-line `uuid4` offer-id
bug. It lives in a different layer, so I've left it out of this coordination-
scoped PR; happy to send a sibling PR for the negotiation layer.
