### PR TITLE
[Hackathon] Redeem_Grimm: authenticate failure-detector heartbeats against a forgery attack

### DIFF
--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -159,6 +159,12 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("failure_detection", failure_detection_factory)
+    elif name == "failure_detection_forgery":
+        from nest_core.scenarios_builtin.failure_detection import (
+            failure_detection_factory,
+        )
+
+        register_scenario("failure_detection_forgery", failure_detection_factory)
     elif name == "parc_migration":
         from nest_core.scenarios_builtin.parc_migration import (
             parc_migration_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/failure_detection.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/failure_detection.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Failure-detection scenario — silence that heals, with a ground-truth oracle.
+"""Failure-detection scenarios — silence that heals, plus a Byzantine forger.
 
-Topology (see ``scenarios/failure_detection.yaml``):
+Topology of the base scenario (see ``scenarios/failure_detection.yaml``):
 
 * ``observer-0`` runs a :class:`~nest_core.layers.failure_detector.FailureDetector`
   instance (injected per-agent via the ``_agent_plugins`` override channel) and
@@ -22,11 +22,35 @@ and stays quiet through the jitter while still catching the genuine outage.
 The accuracy validator in :mod:`nest_core.validators` is tuned to separate the
 two: the baseline fails it, phi-accrual passes.
 
+**Authenticated heartbeats.**  Every heartbeat is signed with the emitter's
+identity plugin and carries its emission timestamp:
+``FDHB|<id>|<ts>|<sig-hex>``.  The observer verifies the signature against the
+claimed peer's registered public key and requires the signed timestamp to be
+strictly newer than the last accepted one from that peer (and not from the
+future), so both fabricated and replayed heartbeats are rejected.  Verification
+lives in the observing agent, not in the detector: the
+:class:`~nest_core.layers.failure_detector.FailureDetector` contract stays a
+pure liveness oracle over *accepted* observations.
+
+The forgery scenario (``scenarios/failure_detection_forgery.yaml``, task type
+``failure_detection_forgery``) adds a Byzantine ``forger`` role that mounts the
+keep-alive attack: while the victim is genuinely down, the forger keeps
+broadcasting heartbeats that *claim* to be the victim — both fabricated
+payloads signed with the forger's own key and byte-exact replays of captured
+genuine beats.  With ``verify_heartbeats: true`` (the default) the observer
+rejects every forgery and the outage is detected; with the trusting mode
+(``verify_heartbeats: false``, the foil) the forged liveness masks the crash
+and the ``failure_detection_no_forged_liveness`` validator fails.  This is the
+same discriminator pattern the base scenario uses against the fixed-timeout
+baseline, applied to an attack class instead of an implementation mistake.
+
 Ground truth is not inferred — the emitters broadcast ``fd:phase`` marker events
-at start and on every reachability transition, so the validators know exactly
-which intervals were truly reachable versus truly down.  Heartbeats and status
-reports are plain broadcasts at ``failures.message_drop == 0``, so no redundancy
-is needed and the run is fully deterministic for a fixed seed.
+at start and on every reachability transition, and the observer broadcasts one
+``fd:config`` marker carrying the scenario's heartbeat bounds, so the
+validators derive their thresholds from the trace instead of hardcoding the
+scenario configuration.  Heartbeats and status reports are plain broadcasts at
+``failures.message_drop == 0``, so no redundancy is needed and the run is fully
+deterministic for a fixed seed.
 
 Example::
 
@@ -46,7 +70,7 @@ from typing import Any, cast
 from nest_core.layers.failure_detector import FailureDetector
 from nest_core.scenario import ScenarioConfig
 from nest_core.sim.agent import AgentContext, StateMachineAgent
-from nest_core.types import AgentId
+from nest_core.types import AgentId, Signature
 
 HB_TICK = b"FD_HB_TICK"
 """Payload tag for an emitter's periodic self-message that triggers a heartbeat."""
@@ -54,8 +78,21 @@ HB_TICK = b"FD_HB_TICK"
 EVAL_TICK = b"FD_EVAL_TICK"
 """Payload tag for the observer's periodic self-message that triggers an evaluation."""
 
+FORGE_TICK = b"FD_FORGE_TICK"
+"""Payload tag for the forger's periodic self-message that triggers an attack round."""
+
 _HB_PREFIX = "FDHB|"
-"""Marker prefix identifying a heartbeat broadcast; the suffix is the sender id."""
+"""Marker prefix identifying a heartbeat broadcast."""
+
+_HB_ALGORITHM = "sim-rsa-sha256"
+"""Algorithm tag stamped on reconstructed heartbeat signatures.
+
+The reference identity plugins verify by key material and ignore this field;
+it is carried for trace forensics only.
+"""
+
+IDENTITY_SEED = b"fd-heartbeat-v1"
+"""Deterministic key-derivation seed shared by every agent's identity instance."""
 
 DEFAULT_HB_MIN = 10.0
 """Default lower bound on the jittered heartbeat interval, in logical time units."""
@@ -75,28 +112,102 @@ DEFAULT_SILENT_UNTIL = 320.0
 DEFAULT_FD_PLUGIN = "phi_accrual"
 """Default failure-detector plugin name used by the observer."""
 
+DEFAULT_VERIFY_HEARTBEATS = True
+"""Default authentication mode: observers verify heartbeat signatures."""
 
-def _hb_payload(agent_id: AgentId) -> bytes:
-    """Return the heartbeat broadcast payload for *agent_id*.
+DEFAULT_FORGERY_VICTIM = "target-0"
+"""Default peer the forger impersonates in the forgery scenario."""
+
+
+def heartbeat_payload(identity: Any, agent_id: AgentId, now: float) -> bytes:
+    """Return a signed heartbeat payload ``FDHB|<id>|<ts>|<sig-hex>``.
+
+    The signature covers ``FDHB|<id>|<ts>`` exactly as serialized, so a
+    verifier can rebuild the signed bytes from the wire text without float
+    round-tripping.  When *identity* is ``None`` the unsigned prefix form is
+    emitted (usable only by a trusting observer).
 
     Example::
 
-        payload = _hb_payload(AgentId("peer-0"))
+        payload = heartbeat_payload(identity, AgentId("peer-0"), 12.5)
     """
-    return f"{_HB_PREFIX}{agent_id}".encode()
+    base = f"{_HB_PREFIX}{agent_id}|{round(now, 6)}"
+    if identity is None:
+        return base.encode()
+    sig = identity.sign(base.encode())
+    return f"{base}|{sig.value.hex()}".encode()
 
 
-def _parse_hb(payload: bytes) -> AgentId | None:
-    """Return the sender id if *payload* is a heartbeat broadcast, else ``None``.
+def claimed_peer(payload: bytes) -> AgentId | None:
+    """Return the peer id a heartbeat payload *claims*, with no authentication.
+
+    This is the trusting parse: it believes whatever id the payload names,
+    which is exactly the spoofable behavior the forgery scenario attacks.
 
     Example::
 
-        peer = _parse_hb(b"FDHB|peer-0")
+        peer = claimed_peer(b"FDHB|peer-0|12.5|abcd")
     """
     text = payload.decode("utf-8", "replace")
     if not text.startswith(_HB_PREFIX):
         return None
-    return AgentId(text[len(_HB_PREFIX) :])
+    claimed = text[len(_HB_PREFIX) :].split("|", 1)[0]
+    if not claimed:
+        return None
+    return AgentId(claimed)
+
+
+def verify_heartbeat(
+    identity: Any,
+    payload: bytes,
+    last_ts: dict[AgentId, float],
+    now: float,
+) -> tuple[AgentId, float] | None:
+    """Return ``(peer, ts)`` if *payload* is an authentic, fresh heartbeat.
+
+    Rejects the payload unless every check passes:
+
+    * well-formed ``FDHB|<id>|<ts>|<sig-hex>`` wire format;
+    * the signed timestamp is not from the future and is strictly newer than
+      the last accepted heartbeat from that peer (defeats replay);
+    * the signature verifies against the *claimed* peer's registered public
+      key (defeats fabrication — a forger signing with its own key fails).
+
+    Verification does not consult transport metadata, so it holds even on a
+    transport whose sender field cannot be trusted.
+
+    Example::
+
+        accepted = verify_heartbeat(identity, payload, last_ts={}, now=12.5)
+    """
+    text = payload.decode("utf-8", "replace")
+    if not text.startswith(_HB_PREFIX):
+        return None
+    fields = text[len(_HB_PREFIX) :].split("|")
+    if len(fields) != 3:
+        return None
+    claimed, ts_text, sig_hex = fields
+    if not claimed:
+        return None
+    try:
+        ts = float(ts_text)
+        sig_bytes = bytes.fromhex(sig_hex)
+    except ValueError:
+        return None
+    peer = AgentId(claimed)
+    # The signed ts is quantized to 6 dp, so it can round a hair above the
+    # observer's exact ``now`` on the same zero-latency tick; compare against
+    # the same quantum rather than raw ``now`` so genuine beats are not read as
+    # future-dated.  Replays are still caught by the strict freshness check.
+    if ts > round(now, 6) or ts <= last_ts.get(peer, float("-inf")):
+        return None
+    if identity is None:
+        return None
+    base = f"{_HB_PREFIX}{claimed}|{ts_text}"
+    sig = Signature(signer=peer, value=sig_bytes, algorithm=_HB_ALGORITHM)
+    if not identity.verify(base.encode(), sig, peer):
+        return None
+    return peer, ts
 
 
 def _phase_payload(peer: AgentId, reachable: bool, now: float) -> bytes:
@@ -115,14 +226,59 @@ def _phase_payload(peer: AgentId, reachable: bool, now: float) -> bytes:
     return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode()
 
 
+def _config_payload(hb_max: float, verify: bool, now: float) -> bytes:
+    """Return the ``fd:config`` marker carrying the scenario's heartbeat bound.
+
+    The validators derive the longest silence a live peer can plausibly
+    produce from this marker instead of hardcoding the scenario's ``hb_max``.
+
+    Example::
+
+        payload = _config_payload(20.0, verify=True, now=0.0)
+    """
+    obj: dict[str, Any] = {
+        "fd": "config",
+        "hb_max": round(hb_max, 6),
+        "verify": verify,
+        "ts": round(now, 6),
+    }
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _build_identities(
+    identity_cls: Any, agent_ids: list[AgentId], seed: bytes
+) -> dict[AgentId, Any]:
+    """Build one identity instance per agent, cross-registering every public key.
+
+    Structural copy of the wiring block used by ``gossip_byzantine`` and
+    ``bft_hotstuff`` (private helpers are not imported across scenario module
+    boundaries).  Identities are built for every agent, forger included: the
+    forger needs a real keypair so its impersonation attempt is the strongest
+    available — a genuine signature by the *wrong* key, not malformed bytes.
+
+    Example::
+
+        identities = _build_identities(DidKeyIdentity, [AgentId("a")], b"seed")
+    """
+    identities: dict[AgentId, Any] = {aid: identity_cls(aid, seed=seed) for aid in agent_ids}
+    for aid, ident in identities.items():
+        if not hasattr(ident, "register_peer"):
+            continue
+        for peer_id, peer_ident in identities.items():
+            if peer_id != aid:
+                ident.register_peer(peer_id, peer_ident.public_key)
+    return identities
+
+
 class HeartbeatEmitterAgent(StateMachineAgent):
-    """Broadcast jittered heartbeats, going silent for one bounded window.
+    """Broadcast signed jittered heartbeats, going silent for one bounded window.
 
     The agent emits a ``fd:phase`` marker at start and on every transition
     between reachable and unreachable, so the trace carries ground truth that
     the validators can check the detector against.  During the silence window
     ``[silent_from, silent_until)`` heartbeats are suppressed but the agent
     keeps re-arming its tick chain, so emission resumes cleanly afterwards.
+    Heartbeats are signed with the agent's injected ``identity`` plugin.
 
     A non-silent emitter is configured with ``silent_from == silent_until``
     (an empty window), so it never goes silent and only ever emits the initial
@@ -185,19 +341,95 @@ class HeartbeatEmitterAgent(StateMachineAgent):
             self._reachable = reachable
             await ctx.broadcast(_phase_payload(self._id, reachable, ctx.time))
         if reachable:
-            await ctx.broadcast(_hb_payload(self._id))
+            identity = ctx.plugins.get("identity")
+            await ctx.broadcast(heartbeat_payload(identity, self._id, ctx.time))
+        await self._arm_next(ctx)
+
+
+class ByzantineForgerAgent(StateMachineAgent):
+    """Impersonate *victim* with fabricated and replayed heartbeats.
+
+    Two attacks per jittered tick, running for the whole scenario:
+
+    * **Fabrication** — build a fresh heartbeat that *claims* the victim's id
+      but is signed with the forger's own (real) key.  Fools any observer that
+      trusts the claimed id; fails signature verification against the victim's
+      public key.
+    * **Replay** — rebroadcast, byte for byte, the most recent genuine signed
+      heartbeat captured from the victim.  The signature verifies, so only the
+      freshness check (signed timestamp strictly newer than the last accepted
+      one) rejects it.
+
+    The point of the attack is *keep-alive forgery*: while the victim is truly
+    silent, forged liveness keeps arriving, and a spoofable observer will never
+    suspect the dead peer.
+
+    Example::
+
+        agent = ByzantineForgerAgent(
+            AgentId("forger-0"), victim=AgentId("target-0"),
+            hb_min=10.0, hb_max=20.0,
+        )
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        victim: AgentId,
+        hb_min: float = DEFAULT_HB_MIN,
+        hb_max: float = DEFAULT_HB_MAX,
+    ) -> None:
+        self._id = agent_id
+        self._victim = victim
+        self._hb_min = hb_min
+        self._hb_max = hb_max
+        self._captured: bytes | None = None
+
+    async def _arm_next(self, ctx: AgentContext) -> None:
+        await ctx.schedule(ctx.rng.uniform(self._hb_min, self._hb_max), FORGE_TICK)
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Arm the first attack tick.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        await self._arm_next(ctx)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Capture the victim's genuine beats; on attack ticks, forge and replay.
+
+        Example::
+
+            await agent.on_message(ctx, sender, payload)
+        """
+        if sender == self._victim:
+            if claimed_peer(payload) == self._victim:
+                self._captured = payload
+            return
+        if sender != ctx.agent_id or payload != FORGE_TICK:
+            return
+        identity = ctx.plugins.get("identity")
+        await ctx.broadcast(heartbeat_payload(identity, self._victim, ctx.time))
+        if self._captured is not None:
+            await ctx.broadcast(self._captured)
         await self._arm_next(ctx)
 
 
 class FailureMonitorAgent(StateMachineAgent):
     """Drive one failure detector and periodically publish suspicion verdicts.
 
-    The detector is injected as the per-agent ``failure_detector`` plugin.  On
-    each heartbeat broadcast the agent feeds the detector; on each evaluation
-    self-tick it reports, for every watched peer, a ``fd:status`` broadcast
-    carrying the boolean verdict plus the current ``phi`` and elapsed silence
-    (the latter two are informational — the validators key off the verdict and
-    the broadcast's own timestamp).
+    The detector is injected as the per-agent ``failure_detector`` plugin and
+    the observer's identity (with every peer's public key registered) as the
+    ``identity`` plugin.  In the default verifying mode, a heartbeat is fed to
+    the detector only after its signature and freshness pass
+    :func:`verify_heartbeat`; in the trusting mode (``verify=False``, the forgery
+    scenario's foil) the claimed peer id is believed outright.  On each
+    evaluation self-tick the agent reports, for every watched peer, a
+    ``fd:status`` broadcast carrying the boolean verdict plus the current
+    ``phi`` and elapsed silence (the latter two are informational — the
+    validators key off the verdict and the broadcast's own timestamp).
 
     Example::
 
@@ -207,22 +439,30 @@ class FailureMonitorAgent(StateMachineAgent):
     """
 
     def __init__(
-        self, watched: list[AgentId], eval_interval: float = DEFAULT_EVAL_INTERVAL
+        self,
+        watched: list[AgentId],
+        eval_interval: float = DEFAULT_EVAL_INTERVAL,
+        hb_max: float = DEFAULT_HB_MAX,
+        verify: bool = DEFAULT_VERIFY_HEARTBEATS,
     ) -> None:
         self._watched = watched
         self._eval_interval = eval_interval
+        self._hb_max = hb_max
+        self._verify = verify
+        self._last_hb_ts: dict[AgentId, float] = {}
 
     async def on_start(self, ctx: AgentContext) -> None:
-        """Arm the first evaluation tick.
+        """Broadcast the ``fd:config`` marker and arm the first evaluation tick.
 
         Example::
 
             await agent.on_start(ctx)
         """
+        await ctx.broadcast(_config_payload(self._hb_max, self._verify, ctx.time))
         await ctx.schedule(self._eval_interval, EVAL_TICK)
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
-        """Feed heartbeats into the detector; on eval ticks publish verdicts.
+        """Feed authenticated heartbeats into the detector; publish verdicts.
 
         Example::
 
@@ -249,7 +489,19 @@ class FailureMonitorAgent(StateMachineAgent):
                 await ctx.broadcast(body)
             await ctx.schedule(self._eval_interval, EVAL_TICK)
             return
-        hb_peer = _parse_hb(payload)
+        if self._verify:
+            accepted = verify_heartbeat(
+                ctx.plugins.get("identity"), payload, self._last_hb_ts, ctx.time
+            )
+            if accepted is None:
+                return
+            hb_peer, hb_ts = accepted
+            if hb_peer == ctx.agent_id:
+                return
+            self._last_hb_ts[hb_peer] = hb_ts
+            await fd.heartbeat(hb_peer, now=ctx.time)
+            return
+        hb_peer = claimed_peer(payload)
         if hb_peer is not None and hb_peer != ctx.agent_id:
             await fd.heartbeat(hb_peer, now=ctx.time)
 
@@ -257,14 +509,20 @@ class FailureMonitorAgent(StateMachineAgent):
 def failure_detection_factory(
     config: ScenarioConfig, plugins: dict[str, Any]
 ) -> dict[AgentId, Any]:
-    """Build the agent fleet for the failure-detection scenario.
+    """Build the agent fleet for the failure-detection scenarios.
 
     Roles are read from ``config.agents.roles``: an ``observer`` role becomes a
-    :class:`FailureMonitorAgent` (each gets its own freshly-built detector), a
-    ``target`` role becomes a silence-then-heal :class:`HeartbeatEmitterAgent`,
-    and any other emitter role (e.g. ``peer``) becomes a never-silent emitter.
-    The detector kind and its parameters come from ``task.config`` so the same
-    scenario can be re-run with the baseline or the accrual detector.
+    :class:`FailureMonitorAgent` (each gets its own freshly-built detector and
+    identity), a ``target`` role becomes a silence-then-heal
+    :class:`HeartbeatEmitterAgent`, a ``forger`` role becomes a
+    :class:`ByzantineForgerAgent` impersonating ``forgery_victim``, and any
+    other emitter role (e.g. ``peer``) becomes a never-silent emitter.  The
+    detector kind, its parameters, and the ``verify_heartbeats`` mode come from
+    ``task.config`` so the same scenario can be re-run with the baseline or the
+    accrual detector, and with or without heartbeat authentication.  The same
+    factory serves both the ``failure_detection`` and
+    ``failure_detection_forgery`` task types; the difference is purely which
+    roles the YAML declares.
 
     Example::
 
@@ -289,6 +547,8 @@ def failure_detection_factory(
     silent_from = float(task_cfg.get("silent_from", DEFAULT_SILENT_FROM))
     silent_until = float(task_cfg.get("silent_until", DEFAULT_SILENT_UNTIL))
     fd_plugin = str(task_cfg.get("fd_plugin", DEFAULT_FD_PLUGIN))
+    verify_heartbeats = bool(task_cfg.get("verify_heartbeats", DEFAULT_VERIFY_HEARTBEATS))
+    forgery_victim = AgentId(str(task_cfg.get("forgery_victim", DEFAULT_FORGERY_VICTIM)))
     raw_fd_params = task_cfg.get("fd_params", {})
     fd_params: dict[str, Any] = (
         cast("dict[str, Any]", raw_fd_params) if isinstance(raw_fd_params, dict) else {}
@@ -296,18 +556,29 @@ def failure_detection_factory(
 
     emitter_ids: list[AgentId] = []
     observer_ids: list[AgentId] = []
+    forger_ids: list[AgentId] = []
     emitter_silence: dict[AgentId, tuple[float, float]] = {}
     for role in config.agents.roles:
         for i in range(role.count):
             aid = AgentId(f"{role.name}-{i}")
             if role.name == "observer":
                 observer_ids.append(aid)
+            elif role.name == "forger":
+                forger_ids.append(aid)
             else:
                 emitter_ids.append(aid)
                 if role.name == "target":
                     emitter_silence[aid] = (silent_from, silent_until)
                 else:
                     emitter_silence[aid] = (0.0, 0.0)
+
+    identity_cls = plugins.get("identity")
+    if identity_cls is None:
+        from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+        identity_cls = DidKeyIdentity
+    all_ids = observer_ids + emitter_ids + forger_ids
+    identities = _build_identities(identity_cls, all_ids, IDENTITY_SEED)
 
     def _make_detector() -> Any:
         if fd_plugin == "heartbeat":
@@ -323,15 +594,23 @@ def failure_detection_factory(
 
     detectors: dict[AgentId, Any] = {oid: _make_detector() for oid in observer_ids}
     overrides: dict[AgentId, dict[str, Any]] = {
-        oid: {"failure_detector": det} for oid, det in detectors.items()
+        aid: {"identity": identities[aid]} for aid in all_ids
     }
+    for oid, det in detectors.items():
+        overrides[oid]["failure_detector"] = det
     plugins["_agent_plugins"] = overrides
     plugins["_fd_detectors"] = detectors
     plugins["_fd_watched"] = list(emitter_ids)
+    plugins["_fd_identities"] = identities
 
     agents: dict[AgentId, Any] = {}
     for oid in observer_ids:
-        agents[oid] = FailureMonitorAgent(watched=list(emitter_ids), eval_interval=eval_interval)
+        agents[oid] = FailureMonitorAgent(
+            watched=list(emitter_ids),
+            eval_interval=eval_interval,
+            hb_max=hb_max,
+            verify=verify_heartbeats,
+        )
     for eid in emitter_ids:
         sfrom, suntil = emitter_silence[eid]
         agents[eid] = HeartbeatEmitterAgent(
@@ -340,5 +619,12 @@ def failure_detection_factory(
             hb_max=hb_max,
             silent_from=sfrom,
             silent_until=suntil,
+        )
+    for fid in forger_ids:
+        agents[fid] = ByzantineForgerAgent(
+            agent_id=fid,
+            victim=forgery_victim,
+            hb_min=hb_min,
+            hb_max=hb_max,
         )
     return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/failure_detection.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/failure_detection.py
@@ -65,6 +65,7 @@ Example::
 from __future__ import annotations
 
 import json
+import math
 from typing import Any, cast
 
 from nest_core.layers.failure_detector import FailureDetector
@@ -193,6 +194,10 @@ def verify_heartbeat(
         ts = float(ts_text)
         sig_bytes = bytes.fromhex(sig_hex)
     except ValueError:
+        return None
+    # A non-finite timestamp (nan/inf) would slip the IEEE-754 comparisons
+    # below, so reject it outright.  Genuine beats always carry ``round(now, 6)``.
+    if not math.isfinite(ts):
         return None
     peer = AgentId(claimed)
     # The signed ts is quantized to 6 dp, so it can round a hair above the

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -4081,14 +4081,24 @@ def validate_bft_no_stuck_view(
 # ---------------------------------------------------------------------------
 
 
-_MAX_PLAUSIBLE_GAP = 22.0
-"""Longest silence (logical time) that a *live* peer can plausibly produce.
+_GAP_MARGIN = 2.0
+"""Safety margin added to ``hb_max`` when deriving the plausible-gap bound.
 
-Heartbeats are jittered on ``uniform(hb_min, hb_max)`` with ``hb_max == 20`` and
-zero message drop, so consecutive observer receipts from a living peer are at
-most 20 apart.  A 2-unit margin gives 22: if the observer received a heartbeat
-within this window, the peer was provably alive and any suspicion of it is a
-false positive.
+Heartbeats are jittered on ``uniform(hb_min, hb_max)`` with zero message drop,
+so consecutive observer receipts from a living peer are at most ``hb_max``
+apart; the margin absorbs event-queue rounding.  If the observer received a
+heartbeat within ``hb_max + _GAP_MARGIN``, the peer was provably alive and any
+suspicion of it is a false positive.
+"""
+
+_MAX_PLAUSIBLE_GAP = 22.0
+"""Fallback plausible-gap bound for traces without an ``fd:config`` marker.
+
+Current scenario runs carry their heartbeat bound in an ``fd:config`` marker
+and :func:`_fd_max_plausible_gap` derives the bound from it, so re-running with
+different ``hb_max`` values cannot silently invalidate the accuracy check.
+This constant (the default ``hb_max == 20`` plus the margin) applies only to
+traces recorded before the marker existed.
 """
 
 _ACCURACY_WARMUP = 100.0
@@ -4119,6 +4129,27 @@ def _parse_fd_record(ev: dict[str, Any]) -> dict[str, Any] | None:
     if not isinstance(obj, dict):
         return None
     return cast("dict[str, Any]", obj)
+
+
+def _fd_max_plausible_gap(events: list[dict[str, Any]]) -> float:
+    """Derive the live-peer plausible-gap bound from the trace itself.
+
+    The observer broadcasts one ``fd:config`` marker carrying the scenario's
+    ``hb_max``; the bound is ``hb_max + _GAP_MARGIN``.  Traces without the
+    marker fall back to :data:`_MAX_PLAUSIBLE_GAP`.
+
+    Example::
+
+        gap = _fd_max_plausible_gap(events)
+    """
+    for ev in events:
+        rec = _parse_fd_record(ev)
+        if rec is None or rec.get("fd") != "config":
+            continue
+        hb_max = rec.get("hb_max")
+        if isinstance(hb_max, (int, float)):
+            return float(hb_max) + _GAP_MARGIN
+    return _MAX_PLAUSIBLE_GAP
 
 
 def _fd_observer_ids(events: list[dict[str, Any]]) -> set[str]:
@@ -4386,9 +4417,10 @@ def validate_failure_detection_accuracy(
 
     Accuracy: after a warm-up, while a peer is provably reachable -- it is inside
     a reachable ``fd:phase`` segment *and* the observer received a heartbeat from
-    it no longer than ``_MAX_PLAUSIBLE_GAP`` ago -- the detector must not suspect
-    it.  A tight fixed timeout violates this on the upper tail of normal
-    heartbeat jitter; an accrual detector does not.
+    it no longer than the plausible-gap bound ago (derived from the trace's
+    ``fd:config`` marker by :func:`_fd_max_plausible_gap`) -- the detector must
+    not suspect it.  A tight fixed timeout violates this on the upper tail of
+    normal heartbeat jitter; an accrual detector does not.
 
     Recovery: a peer that genuinely went down and came back must end its final
     reachable segment un-suspected.
@@ -4400,6 +4432,7 @@ def validate_failure_detection_accuracy(
     statuses = _fd_statuses(events)
     observer_ids = _fd_observer_ids(events)
     receipts = _fd_hb_receipts(events, observer_ids)
+    max_gap = _fd_max_plausible_gap(events)
     watched = sorted(statuses.keys())
 
     # ----- accuracy: no false suspicion of a provably-live peer -----
@@ -4423,7 +4456,7 @@ def validate_failure_detection_accuracy(
             if not _in_any_interval(t, intervals):
                 continue
             recent = _last_leq(peer_receipts, t)
-            if recent is not None and (t - recent) <= _MAX_PLAUSIBLE_GAP:
+            if recent is not None and (t - recent) <= max_gap:
                 false_positives.append(
                     f"{peer}: suspected at t={t} but a heartbeat arrived {round(t - recent, 3)} ago"
                 )
@@ -4482,6 +4515,95 @@ def validate_failure_detection_accuracy(
         )
 
     return [accuracy, recovery]
+
+
+def validate_failure_detection_no_forged_liveness(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Forged heartbeats must not keep a genuinely dead peer looking alive.
+
+    The attack: while a peer is inside an unreachable ground-truth segment, a
+    Byzantine agent keeps broadcasting heartbeats that *claim* the dead peer's
+    id.  A forged receipt is any observer-received ``FDHB|`` payload whose
+    claimed id differs from the transport-level sender.  For every outage
+    segment during which such forgeries arrived, the detector must still have
+    the peer suspected at the last in-segment status update -- forged liveness
+    must not mask the crash.
+
+    A trace with no forged receipt at all, or whose forgeries never overlap an
+    outage, is a scenario setup failure: this validator is only registered for
+    the forgery scenario, whose entire point is that the attack fires.
+    """
+    transitions, last_ts = _fd_transitions(events)
+    statuses = _fd_statuses(events)
+    observer_ids = _fd_observer_ids(events)
+
+    forged: dict[str, list[float]] = defaultdict(list)
+    for ev in events:
+        if ev.get("kind") != "receive" or ev.get("agent") not in observer_ids:
+            continue
+        msg = str(ev.get("msg", ""))
+        if not msg.startswith("FDHB|"):
+            continue
+        claimed = msg[len("FDHB|") :].split("|", 1)[0]
+        sender = ev.get("from")
+        ts = ev.get("ts")
+        if not claimed or not isinstance(sender, str) or not isinstance(ts, (int, float)):
+            continue
+        if claimed != sender:
+            forged[claimed].append(float(ts))
+
+    if not forged:
+        return [
+            ValidationResult(
+                "failure_detection_no_forged_liveness",
+                False,
+                "no forged heartbeat received in trace",
+            )
+        ]
+
+    failures: list[str] = []
+    checked = 0
+    for victim in sorted(forged):
+        forged_ts = forged[victim]
+        downs = [
+            (start, end)
+            for start, end, reachable in _segments_for_peer(transitions.get(victim, []), last_ts)
+            if not reachable
+        ]
+        victim_statuses = statuses.get(victim, [])
+        for u_start, u_end in downs:
+            if not any(u_start < t <= u_end for t in forged_ts):
+                continue
+            checked += 1
+            in_window = [(t, s) for (t, s) in victim_statuses if u_start < t <= u_end]
+            if not in_window:
+                failures.append(f"{victim}: no status during attacked outage [{u_start}, {u_end}]")
+            elif not in_window[-1][1]:
+                failures.append(
+                    f"{victim}: forged heartbeats masked the outage [{u_start}, {u_end}] "
+                    "(not suspected at segment end)"
+                )
+
+    if checked == 0:
+        return [
+            ValidationResult(
+                "failure_detection_no_forged_liveness",
+                False,
+                "forged heartbeats never overlapped an outage segment",
+            )
+        ]
+    if failures:
+        return [
+            ValidationResult("failure_detection_no_forged_liveness", False, "; ".join(failures))
+        ]
+    return [
+        ValidationResult(
+            "failure_detection_no_forged_liveness",
+            True,
+            f"forged liveness rejected across {checked} attacked outage segment(s)",
+        )
+    ]
 
 
 def validate_parc_honest_admitted(events: list[dict[str, Any]]) -> list[ValidationResult]:
@@ -5026,6 +5148,11 @@ VALIDATORS: dict[str, list[Any]] = {
     "failure_detection": [
         validate_failure_detection_completeness,
         validate_failure_detection_accuracy,
+    ],
+    "failure_detection_forgery": [
+        validate_failure_detection_completeness,
+        validate_failure_detection_accuracy,
+        validate_failure_detection_no_forged_liveness,
     ],
     "parc_migration": [
         validate_parc_honest_admitted,

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -4131,18 +4131,23 @@ def _parse_fd_record(ev: dict[str, Any]) -> dict[str, Any] | None:
     return cast("dict[str, Any]", obj)
 
 
-def _fd_max_plausible_gap(events: list[dict[str, Any]]) -> float:
+def _fd_max_plausible_gap(events: list[dict[str, Any]], observer_ids: set[str]) -> float:
     """Derive the live-peer plausible-gap bound from the trace itself.
 
     The observer broadcasts one ``fd:config`` marker carrying the scenario's
-    ``hb_max``; the bound is ``hb_max + _GAP_MARGIN``.  Traces without the
-    marker fall back to :data:`_MAX_PLAUSIBLE_GAP`.
+    ``hb_max``; the bound is ``hb_max + _GAP_MARGIN``.  Only a marker emitted by
+    an observer (an agent that also publishes ``fd:status`` verdicts) is
+    trusted, so a Byzantine emitter cannot broadcast a spoofed ``fd:config`` to
+    inflate the bound.  Traces without a trusted marker fall back to
+    :data:`_MAX_PLAUSIBLE_GAP`.
 
     Example::
 
-        gap = _fd_max_plausible_gap(events)
+        gap = _fd_max_plausible_gap(events, _fd_observer_ids(events))
     """
     for ev in events:
+        if ev.get("agent") not in observer_ids:
+            continue
         rec = _parse_fd_record(ev)
         if rec is None or rec.get("fd") != "config":
             continue
@@ -4432,7 +4437,7 @@ def validate_failure_detection_accuracy(
     statuses = _fd_statuses(events)
     observer_ids = _fd_observer_ids(events)
     receipts = _fd_hb_receipts(events, observer_ids)
-    max_gap = _fd_max_plausible_gap(events)
+    max_gap = _fd_max_plausible_gap(events, observer_ids)
     watched = sorted(statuses.keys())
 
     # ----- accuracy: no false suspicion of a provably-live peer -----

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2010,6 +2010,7 @@ class TestValidatorRegistry:
             "bft_hotstuff",
             "escrow_marketplace",
             "failure_detection",
+            "failure_detection_forgery",
             "parc_migration",
             "rogue_trusted_agent",
             "sybil_bond",

--- a/packages/nest-plugins-reference/tests/test_failure_detection.py
+++ b/packages/nest-plugins-reference/tests/test_failure_detection.py
@@ -24,6 +24,7 @@ mocking past the plugin boundary.
 from __future__ import annotations
 
 import asyncio
+import json
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -33,10 +34,21 @@ from nest_core.layers.failure_detector import FailureDetector
 from nest_core.plugins import PluginRegistry
 from nest_core.runner import ScenarioRunner
 from nest_core.scenario import ScenarioConfig
+from nest_core.scenarios_builtin.failure_detection import (
+    IDENTITY_SEED,
+    claimed_peer,
+    heartbeat_payload,
+    verify_heartbeat,
+)
 from nest_core.types import AgentId
-from nest_core.validators import ValidationResult, validate_trace
+from nest_core.validators import (
+    ValidationResult,
+    validate_failure_detection_accuracy,
+    validate_trace,
+)
 from nest_plugins_reference.failure_detection.heartbeat import HeartbeatFailureDetector
 from nest_plugins_reference.failure_detection.phi_accrual import PhiAccrualFailureDetector
+from nest_plugins_reference.identity.did_key import DidKeyIdentity
 
 # ---------------------------------------------------------------------------
 # Async helpers (sync tests, like the gossip suite, drive coroutines inline)
@@ -249,3 +261,218 @@ def test_scenario_is_byte_for_byte_deterministic() -> None:
     if not SCENARIO_PATH.exists():
         pytest.skip(f"scenario not found at {SCENARIO_PATH}")
     assert _run_bytes(42) == _run_bytes(42)
+
+
+# ---------------------------------------------------------------------------
+# Signed-heartbeat unit tests
+# ---------------------------------------------------------------------------
+
+_VICTIM = AgentId("target-0")
+_FORGER = AgentId("forger-0")
+_OBSERVER = AgentId("observer-0")
+
+
+def _fd_identities() -> dict[AgentId, Any]:
+    """Build cross-registered identities for the observer, victim, and forger."""
+    ids: dict[AgentId, Any] = {
+        aid: DidKeyIdentity(aid, seed=IDENTITY_SEED) for aid in (_OBSERVER, _VICTIM, _FORGER)
+    }
+    for aid, ident in ids.items():
+        for peer, peer_ident in ids.items():
+            if peer != aid:
+                ident.register_peer(peer, peer_ident.public_key)
+    return ids
+
+
+def test_signed_heartbeat_authentic_is_accepted() -> None:
+    """A heartbeat signed by the claimed peer verifies and returns (peer, ts)."""
+    ids = _fd_identities()
+    payload = heartbeat_payload(ids[_VICTIM], _VICTIM, now=10.0)
+    assert verify_heartbeat(ids[_OBSERVER], payload, last_ts={}, now=10.0) == (_VICTIM, 10.0)
+
+
+def test_fabricated_heartbeat_signed_with_wrong_key_is_rejected() -> None:
+    """A heartbeat that claims the victim but is signed by the forger fails verification."""
+    ids = _fd_identities()
+    forged = heartbeat_payload(ids[_FORGER], _VICTIM, now=10.0)  # claims victim, forger's key
+    assert claimed_peer(forged) == _VICTIM  # the trusting parse is fooled...
+    assert (
+        verify_heartbeat(ids[_OBSERVER], forged, last_ts={}, now=10.0) is None
+    )  # ...verify is not
+
+
+def test_replayed_heartbeat_is_rejected_by_freshness() -> None:
+    """A byte-exact replay of an accepted heartbeat is stale and rejected."""
+    ids = _fd_identities()
+    payload = heartbeat_payload(ids[_VICTIM], _VICTIM, now=10.0)
+    last: dict[AgentId, float] = {}
+    assert verify_heartbeat(ids[_OBSERVER], payload, last, now=10.0) == (_VICTIM, 10.0)
+    last[_VICTIM] = 10.0
+    assert verify_heartbeat(ids[_OBSERVER], payload, last, now=25.0) is None
+
+
+def test_future_dated_heartbeat_is_rejected() -> None:
+    """A heartbeat whose signed timestamp is ahead of now is rejected."""
+    ids = _fd_identities()
+    payload = heartbeat_payload(ids[_VICTIM], _VICTIM, now=50.0)
+    assert verify_heartbeat(ids[_OBSERVER], payload, last_ts={}, now=10.0) is None
+
+
+def test_malformed_or_unsigned_heartbeat_is_rejected() -> None:
+    """Unsigned, truncated, and non-heartbeat payloads all fail verification."""
+    ids = _fd_identities()
+    assert verify_heartbeat(ids[_OBSERVER], b"FDHB|target-0|10.0", last_ts={}, now=10.0) is None
+    assert verify_heartbeat(ids[_OBSERVER], b"FDHB|target-0|bad|zz", last_ts={}, now=10.0) is None
+    assert verify_heartbeat(ids[_OBSERVER], b"not-a-heartbeat", last_ts={}, now=10.0) is None
+    assert claimed_peer(b"FDHB|target-0|10.0|ab") == _VICTIM
+    assert claimed_peer(b"nope") is None
+
+
+def _accuracy_probe_events(hb_max: float, gap: float) -> list[dict[str, Any]]:
+    """Trace where peer 'p' is reachable, beats at t=200, and is suspected `gap` later."""
+
+    def bcast(agent: str, obj: dict[str, Any], ts: float) -> dict[str, Any]:
+        return {
+            "agent": agent,
+            "kind": "broadcast",
+            "ts": ts,
+            "msg": json.dumps(obj, sort_keys=True, separators=(",", ":")),
+        }
+
+    return [
+        bcast("observer-0", {"fd": "config", "hb_max": hb_max, "verify": True, "ts": 0.0}, 0.0),
+        bcast("p", {"fd": "phase", "peer": "p", "reachable": True, "ts": 0.0}, 0.0),
+        {
+            "agent": "observer-0",
+            "from": "p",
+            "kind": "receive",
+            "ts": 200.0,
+            "msg": "FDHB|p|200.0|ab",
+        },
+        bcast(
+            "observer-0",
+            {
+                "fd": "status",
+                "peer": "p",
+                "suspected": True,
+                "phi": 9.0,
+                "elapsed": gap,
+                "ts": 200.0 + gap,
+            },
+            200.0 + gap,
+        ),
+    ]
+
+
+def test_accuracy_bound_is_derived_from_config_marker() -> None:
+    """A suspicion `gap` after a beat is a false positive only within the derived bound.
+
+    With ``hb_max=40`` the derived plausible gap is 42, so a 30-unit gap is a
+    false positive and accuracy fails.  The same trace with the pre-marker
+    fallback (22) would have judged 30 as a real outage and passed, so the
+    failure proves the bound is read from the ``fd:config`` marker, not
+    hardcoded.
+    """
+    results = {
+        r.name: r for r in validate_failure_detection_accuracy(_accuracy_probe_events(40.0, 30.0))
+    }
+    assert not results["failure_detection_accuracy"].passed, results[
+        "failure_detection_accuracy"
+    ].detail
+    # A gap beyond the derived bound (45 > 42) is a real outage, not a false positive.
+    ok = {
+        r.name: r for r in validate_failure_detection_accuracy(_accuracy_probe_events(40.0, 45.0))
+    }
+    assert ok["failure_detection_accuracy"].passed, ok["failure_detection_accuracy"].detail
+
+
+# ---------------------------------------------------------------------------
+# Forgery scenario: signed heartbeats defeat a keep-alive attack
+# ---------------------------------------------------------------------------
+
+FORGERY_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "failure_detection_forgery.yaml"
+
+
+def _forgery_config(seed: int, verify: bool | None) -> ScenarioConfig:
+    config = ScenarioConfig.from_yaml(str(FORGERY_PATH))
+    updates: dict[str, Any] = {"seed": seed}
+    if verify is not None:
+        task_cfg = dict(config.task.config)
+        task_cfg["verify_heartbeats"] = verify
+        updates["task"] = config.task.model_copy(update={"config": task_cfg})
+    return config.model_copy(update=updates)
+
+
+def _run_forgery(seed: int, verify: bool | None = None) -> dict[str, ValidationResult]:
+    """Run the forgery scenario and return validator results by name."""
+    config = _forgery_config(seed, verify)
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"fdf_{seed}.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        asyncio.run(runner.run())
+        results = validate_trace(trace_path, "failure_detection_forgery")
+    return {r.name: r for r in results}
+
+
+def _run_forgery_bytes(seed: int) -> bytes:
+    config = _forgery_config(seed, verify=None)
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / "fdf_replay.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        asyncio.run(runner.run())
+        return trace_path.read_bytes()
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_forgery_signed_heartbeats_defeat_the_attack(seed: int) -> None:
+    """With verification on, every validator passes despite the forger."""
+    if not FORGERY_PATH.exists():
+        pytest.skip(f"scenario not found at {FORGERY_PATH}")
+
+    results = _run_forgery(seed)
+    expected = {
+        "failure_detection_completeness",
+        "failure_detection_accuracy",
+        "failure_detection_recovery",
+        "failure_detection_no_forged_liveness",
+    }
+    assert expected <= set(results), f"missing validators: {expected - set(results)}"
+    for name, res in results.items():
+        assert res.passed, f"seed={seed} {name} failed: {res.detail}"
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_forgery_discriminator_trusting_observer_is_fooled(seed: int) -> None:
+    """The discriminator: a payload-trusting observer is fooled; a verifying one is not.
+
+    Verification is the property that separates them.  The trusting observer
+    (verify_heartbeats=False) accepts the forged beats and never suspects the
+    dead victim, so no_forged_liveness fails; the verifying observer rejects
+    every forgery and passes it.
+    """
+    if not FORGERY_PATH.exists():
+        pytest.skip(f"scenario not found at {FORGERY_PATH}")
+
+    trusting = _run_forgery(seed, verify=False)
+    assert not trusting["failure_detection_no_forged_liveness"].passed, (
+        "a payload-trusting observer should be fooled by forged heartbeats, "
+        f"but no_forged_liveness passed: {trusting['failure_detection_no_forged_liveness'].detail}"
+    )
+
+    verifying = _run_forgery(seed, verify=True)
+    assert verifying["failure_detection_no_forged_liveness"].passed, verifying[
+        "failure_detection_no_forged_liveness"
+    ].detail
+
+
+def test_forgery_scenario_is_byte_for_byte_deterministic() -> None:
+    """Two runs of the signed forgery scenario at the same seed match byte for byte."""
+    if not FORGERY_PATH.exists():
+        pytest.skip(f"scenario not found at {FORGERY_PATH}")
+    assert _run_forgery_bytes(42) == _run_forgery_bytes(42)

--- a/packages/nest-plugins-reference/tests/test_failure_detection.py
+++ b/packages/nest-plugins-reference/tests/test_failure_detection.py
@@ -328,6 +328,21 @@ def test_malformed_or_unsigned_heartbeat_is_rejected() -> None:
     assert claimed_peer(b"nope") is None
 
 
+def test_non_finite_timestamp_heartbeat_is_rejected() -> None:
+    """A validly-signed but non-finite (nan/inf) timestamp is rejected.
+
+    ``nan`` would otherwise slip both IEEE-754 freshness comparisons.  The
+    signature here is genuine over the ``nan`` base, so only the explicit
+    finiteness guard rejects it.
+    """
+    ids = _fd_identities()
+    for ts_text in ("nan", "inf", "-inf"):
+        base = f"FDHB|{_VICTIM}|{ts_text}".encode()
+        sig = ids[_VICTIM].sign(base)
+        payload = base + b"|" + sig.value.hex().encode()
+        assert verify_heartbeat(ids[_OBSERVER], payload, last_ts={}, now=10_000.0) is None
+
+
 def _accuracy_probe_events(hb_max: float, gap: float) -> list[dict[str, Any]]:
     """Trace where peer 'p' is reachable, beats at t=200, and is suspected `gap` later."""
 
@@ -384,6 +399,33 @@ def test_accuracy_bound_is_derived_from_config_marker() -> None:
         r.name: r for r in validate_failure_detection_accuracy(_accuracy_probe_events(40.0, 45.0))
     }
     assert ok["failure_detection_accuracy"].passed, ok["failure_detection_accuracy"].detail
+
+
+def test_accuracy_bound_ignores_spoofed_config_from_non_observer() -> None:
+    """A forged fd:config from a non-observer cannot inflate the plausible gap.
+
+    Only the observer (an agent that also emits fd:status) is trusted for the
+    bound.  Here the honest observer marker says hb_max=20 (gap 22), so a
+    60-unit suspicion is a genuine outage and accuracy passes.  A Byzantine
+    ``forger-0`` also broadcasts fd:config with hb_max=1000; if that were
+    trusted the bound would be 1002 and the 60-unit suspicion would be
+    misjudged a false positive and accuracy would fail.
+    """
+    events = _accuracy_probe_events(20.0, 60.0)
+    forged = {
+        "agent": "forger-0",
+        "kind": "broadcast",
+        "ts": 0.0,
+        "msg": json.dumps(
+            {"fd": "config", "hb_max": 1000.0, "verify": True, "ts": 0.0},
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    }
+    results = {r.name: r for r in validate_failure_detection_accuracy([forged, *events])}
+    assert results["failure_detection_accuracy"].passed, results[
+        "failure_detection_accuracy"
+    ].detail
 
 
 # ---------------------------------------------------------------------------

--- a/scenarios/failure_detection_forgery.yaml
+++ b/scenarios/failure_detection_forgery.yaml
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Failure-detection forgery scenario: keep-alive attack on a dead peer.
+#
+# 4 agents, no partitions, zero message drop:
+#   * observer-0 — runs a FailureDetector; verifies heartbeat signatures and
+#                  freshness before feeding the detector (verify_heartbeats)
+#   * target-0   — heartbeat emitter that goes silent in [silent_from, silent_until)
+#                  and then resumes; the forger's victim
+#   * peer-0     — heartbeat emitter that is never silent (always-alive control)
+#   * forger-0   — Byzantine: while target-0 is genuinely down, keeps broadcasting
+#                  heartbeats that claim to be target-0 — fabricated payloads signed
+#                  with its own key, plus byte-exact replays of captured genuine beats
+#
+# The attack class is keep-alive forgery: an observer that believes the peer id
+# a heartbeat payload claims (rather than authenticating it) will never suspect
+# the dead target, because forged liveness keeps arriving throughout the outage.
+# The failure_detection_no_forged_liveness validator fails that observer; the
+# verifying observer rejects every forgery (bad signature for fabrications,
+# stale signed timestamp for replays) and passes all validators.  Re-run with
+# task.config.verify_heartbeats: false to watch the trusting foil get fooled.
+#
+# message_drop is 0 and all randomness comes from each agent's seeded RNG, so
+# the run is byte-for-byte deterministic for a fixed seed.
+name: failure_detection_forgery
+description: "4 agents; a forger fakes a dead peer's heartbeats; signed heartbeats defeat it."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 4
+  brain: state-machine
+  roles:
+    - name: observer
+      count: 1
+    - name: target
+      count: 1
+    - name: peer
+      count: 1
+    - name: forger
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: failure_detection_forgery
+  config:
+    hb_min: 10.0
+    hb_max: 20.0
+    eval_interval: 3.0
+    silent_from: 200.0
+    silent_until: 320.0
+    fd_plugin: phi_accrual
+    verify_heartbeats: true
+    forgery_victim: target-0
+    fd_params:
+      window_size: 200
+      min_samples: 5
+      min_std: 1.0
+      threshold: 8.0
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 1600"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/failure_detection_forgery.jsonl


### PR DESCRIPTION
## Problem

This is a direct follow-up to the failure-detector layer merged in #46. In the review on merge, @Skyrider3  flagged two gaps, and both are worth fixing:

1. Heartbeat identity was spoofable by design. The observer read the peer id out of the heartbeat payload (`FDHB|<id>`) rather than authenticating it. A Byzantine agent could broadcast `FDHB|target-0` while the real `target-0` was down and keep it looking alive indefinitely. The base scenario ran with zero Byzantine agents, so this never fired, but the whole point of the framework is to prove a protocol holds up under attack, and the shipped accuracy validator only discriminated a naive implementation (the fixed-timeout foil), not an attacker.
2. The accuracy validator hardcoded `_MAX_PLAUSIBLE_GAP = 22.0`, which is the scenario's `hb_max` (20) plus a margin. Re-running the scenario with a different heartbeat bound would silently invalidate the threshold.

This PR closes both, and it does so with the same discriminator discipline the original used: a validator that fails against the weak implementation and passes against the hardened one.

## Persona

The keep-alive attack is the failure a real detector has to survive, so authentication belongs in the heartbeat path, not in an appendix. The design question is where to put it. A failure detector should stay a pure liveness oracle over observations it can trust, so I put verification in the observing agent and left the `FailureDetector` contract untouched. That mirrors how the rest of the stack works: the identity layer is already right there, and the gossip and HotStuff scenarios already sign their writes with it, so a heartbeat is just one more signed message. I used the existing `did_key` identity plugin rather than inventing anything.

## What is in the diff

| Path | Purpose |
|---|---|
| `.../scenarios_builtin/failure_detection.py` | Heartbeats are now signed and timestamped: `FDHB|<id>|<ts>|<sig-hex>`. New public helpers `heartbeat_payload`, `claimed_peer`, and `verify_heartbeat` form the wire-and-verify surface. `verify_heartbeat` rejects anything that is not well formed, not signed by the claimed peer's key, from the future, or not strictly newer than the last accepted beat from that peer. A new `ByzantineForgerAgent` mounts the attack (fabricated beats signed with its own key, plus byte-exact replays of captured genuine beats). The observer runs in verifying mode by default and a trusting mode as the foil. The observer also emits one `fd:config` marker so the validators can read the scenario's heartbeat bound from the trace. |
| `scenarios/failure_detection_forgery.yaml` | The forgery scenario: observer, target, always-live peer, and one forger impersonating the target during its outage. Task type `failure_detection_forgery`, four agents, zero message drop, deterministic. |
| `packages/nest-core/nest_core/validators.py` | New `validate_failure_detection_no_forged_liveness`: for every outage segment during which forged beats arrived (a received `FDHB|` whose claimed id differs from the transport sender), the victim must still be suspected at the last in-segment status update. Plus `_fd_max_plausible_gap`, which derives the accuracy bound from the `fd:config` marker (`hb_max + margin`) with the old constant kept only as a fallback for pre-marker traces. |
| `packages/nest-core/nest_core/scenarios.py` | Registers the `failure_detection_forgery` task type (same factory, different roles). |
| `packages/nest-plugins-reference/tests/test_failure_detection.py` | Twelve new tests: signed-heartbeat unit tests (authentic accepted; fabricated, replayed, future-dated, and malformed rejected), the three-seed forgery integration pass, the trusting-vs-verifying discriminator, the config-derived accuracy bound, and forgery-scenario determinism. |
| `packages/nest-core/tests/test_validators.py` | Adds `failure_detection_forgery` to the registry-completeness assertion. |

The base `failure_detection` scenario keeps its behavior: it now signs heartbeats too, and still passes completeness, accuracy, and recovery on every seed.

## Why this matters

The original layer proved an accrual detector beats a naive timeout, which is a class of implementation mistake. This adds the property the reviewer actually asked for: the layer now proves it survives a class of attack. The forgery scenario is a real test, not a demo. With verification on, the observer rejects every forged and replayed beat and the outage is detected; with verification off, the forged liveness masks the crash and the peer is never suspected. The `failure_detection_no_forged_liveness` validator fails the trusting observer and passes the verifying one, so it discriminates by construction, the same way the accuracy validator discriminates the fixed timeout.

It also composes cleanly with a second layer. The heartbeat authentication is the identity layer doing exactly what it exists for, with no new crypto and no change to the `FailureDetector` contract.

## Verification

`make ci-local` runs the same five gates as CI and passes:

```
ruff check:          All checks passed!
ruff format --check: 211 files already formatted
pyright:             0 errors, 0 warnings, 0 informations
pytest:              1165 passed, 1 skipped, 1 deselected
```

Running the forgery scenario with verification on (the default), every validator passes:

```
uv run nest run scenarios/failure_detection_forgery.yaml

PASS failure_detection_completeness       all 1 outage segment(s) detected and still suspected at end
PASS failure_detection_accuracy           no false suspicion of a provably-live peer across 2 peer(s)
PASS failure_detection_recovery           all 1 recovered peer(s) cleared by end
PASS failure_detection_no_forged_liveness forged liveness rejected across 1 attacked outage segment(s)
```

The same scenario with `verify_heartbeats: false` is the foil: the forger keeps the dead peer alive, so completeness and `no_forged_liveness` both fail:

```
FAIL failure_detection_completeness       target-0: never suspected during outage [215.6, 331.3]
FAIL failure_detection_no_forged_liveness target-0: forged heartbeats masked the outage [215.6, 331.3]
```

The verifying observer passes on seeds 42, 7, and 1337, asserted in `test_forgery_signed_heartbeats_defeat_the_attack`; the trusting-vs-verifying split is asserted in `test_forgery_discriminator_trusting_observer_is_fooled`. Runs are byte-for-byte deterministic per seed, asserted in `test_forgery_scenario_is_byte_for_byte_deterministic`.

## Reviewer notes worth surfacing

- **Verification is three independent checks.** Signature (defeats fabrication: a forger signing with its own key fails against the victim's public key), strict-newer timestamp (defeats replay: a captured genuine beat is stale once accepted), and a not-from-the-future check. None of them consults the transport sender field, so the guarantee holds even on a transport whose sender cannot be trusted.
- **Timestamp quantization.** The signed timestamp is rounded to six decimals for byte-stable traces. Because the reference transport is zero-latency, a rounded timestamp can land a hair above the observer's exact `now` on the same tick, so the future check compares against `round(now, 6)` rather than raw `now`. Without this, roughly half of genuine beats read as future-dated and get dropped. There is a regression test for the accepted-beat path through the full simulator.
- **The forger has a real key.** It is built with its own `did_key` identity, so its impersonation is the strongest available: a genuine signature by the wrong key, not malformed bytes. That is what makes signature verification, rather than a well-formedness check, the thing that stops it.
- **Config-derived threshold.** The accuracy bound now comes from the `fd:config` marker in the trace, following the same recorded-not-inferred principle the ground-truth `fd:phase` markers already use. `test_accuracy_bound_is_derived_from_config_marker` proves a non-default `hb_max` changes the verdict, which the old hardcoded constant could not have done.
- **No change to existing behavior.** The base `failure_detection` scenario and its validators are unchanged in outcome; the only visible difference in its trace is that heartbeats now carry a signature and a timestamp.
- **Two defense-in-depth guards.** Verification rejects a non-finite (`nan`/`inf`) timestamp outright, since a `nan` would otherwise slip both IEEE-754 freshness comparisons. And the accuracy bound is taken only from an `fd:config` marker emitted by an observer (an agent that also publishes `fd:status`), so a Byzantine emitter cannot broadcast a spoofed `fd:config` to skew the threshold. Neither was reachable by the in-scenario forger, but both are cheap and remove a latent footgun. Each has a dedicated test.
