### PR TITLE
Hackathon/parsa noah mesh revocable auth

### DIFF
--- a/docs/layers/mesh_revocable_auth.md
+++ b/docs/layers/mesh_revocable_auth.md
@@ -1,0 +1,124 @@
+# Mesh-Revocable Auth: revocation that survives the network
+
+Plugin: `("auth", "mesh_revocable")` —
+[`nest_plugins_reference/auth/mesh_revocable.py`](../../packages/nest-plugins-reference/nest_plugins_reference/auth/mesh_revocable.py)
+
+## Problem
+
+The delegation problem was solved by the merged `delegatable` plugin: real
+macaroon chains, offline attenuation, audience binding, and cascading
+revocation. But that plugin's revocation knowledge is a single in-process
+`set[str]`, and the `delegated_auth` scenario hands **one plugin instance to
+all sixteen agents**. Under that wiring cascading revocation is trivially
+global — it is one Python object.
+
+Give every agent its own replica (the only shape a real network permits) and
+the guarantee evaporates: a revocation performed at the issuer is invisible
+to every other verifier, forever. Nothing in the plugin propagates it, and
+nothing in the merged scenario notices, because no second verifier exists.
+The layer has correct capability *semantics* and no capability
+*distribution*.
+
+## Solution
+
+`MeshRevocableAuth` supplies the missing half by **composition, not
+re-implementation**. It subclasses `DelegatableAuth` — token format, HMAC
+chain, attenuation rules, and all five exception types inherited verbatim,
+zero overrides of `issue` / `delegate` / `verify` / `verify_presented` /
+`revoke` — and reinterprets the inherited revocation set as one replica of a
+**grow-only set CRDT** (G-Set). Two additive methods are the replication
+channel:
+
+| Method | Contract |
+|---|---|
+| `export_revocations() -> bytes` | Canonical, sorted JSON (`{"crdt": "revocation_gset", "revoked": [...]}`). Identical state exports identical bytes, so traces stay replay-deterministic. |
+| `merge_revocations(state) -> bool` | Set union with a peer's state; returns whether anything new arrived. Malformed or foreign state raises `RevocationStateError` and leaves the replica untouched — gossip input is attacker-adjacent. |
+
+Union is commutative, associative, and idempotent, so replicas converge
+under **any** delivery order and duplicated gossip is a no-op. That is
+enforced by Hypothesis property tests, not merely asserted. A revocation
+recorded anywhere reaches every replica, directly or through any chain of
+intermediaries, once gossip has flowed.
+
+Because delegation semantics live in the shared secret, all replicas are
+constructed with the same one: tokens minted at any replica verify at every
+replica; only *revocation knowledge* is replica-local until gossiped.
+
+## The CAP position, stated and validated
+
+Partition-tolerant revocation cannot be instantly consistent. This plugin
+chooses availability during the split, and bounded convergence after it —
+and the [`delegated_auth_partition`](../../scenarios/delegated_auth_partition.yaml)
+scenario enforces **both halves** with a validator each, so neither can rot:
+
+- `check_partition_liveness` — during the split, a verifier cut off from the
+  revoker **must still accept** the revoked lineage. A design that denied
+  instantly would be exhibiting knowledge the network never delivered. This
+  check fails against the shared-single-instance shortcut.
+- `check_revocation_converges` — after the heal plus a gossip-propagation
+  bound, **no verifier anywhere** accepts the revoked lineage, and at least
+  one verifier *other than the revoker* explicitly denied it (so a scenario
+  where presentations merely stopped cannot pass vacuously).
+
+Deliberately **not** asserted here: `check_no_stale_ancestor_use`'s global
+"no success at or after the revoke tick". Under a partition that property is
+unattainable; the bounded convergence check is its honest replacement. The
+merged `check_no_scope_escalation` and `check_audience_binding` do run green
+on this trace — the scenario reuses `delegated_auth`'s audit vocabulary on
+purpose.
+
+## Measured behavior
+
+`nest run delegated_auth_partition` (10 agents, seed 42, byte-deterministic
+across runs). The mesh splits at t=10, the coordinator revokes
+intermediary-1's grant at t=20 — while that subtree is unreachable — and the
+network heals at t=55. Gossip runs every 5 ticks. The far-side gateway's
+verdicts on the revoked lineage:
+
+```
+t= 3..51  accept   (partition open from t=10; the gateway cannot know)
+t=57..87  DENY     (heal at t=55; converged within one gossip round)
+```
+
+The healthy subtree verifies 69/69 throughout. Swap in per-replica
+`delegatable` and the gateway accepts the revoked lineage at every tick to
+the end of the run:
+
+| Wiring | partition liveness | revocation converges |
+|---|---|---|
+| `delegatable`, one shared instance | ✗ (denies impossibly fast) | ✓ (vacuously — one object) |
+| `delegatable`, one replica per agent | ✓ | **✗ stale forever** |
+| `mesh_revocable`, one replica per agent | ✓ | ✓ |
+
+That middle row is the gap this plugin closes.
+
+## Supporting core change
+
+Partitions previously activated at event 0, with only the heal tick-gated,
+so no scenario could establish cross-boundary state before the split. This
+adds `partition_start_at_time` / `partition_heal_at_time` to `FailureConfig`,
+gating on **simulation time** rather than processed-event count. Event counts
+drift with message volume — a gossiping plugin processes far more events per
+simulated tick, so an event-count window would put the two plugins under
+different partitions and void the comparison. The pre-existing
+`partition_heal_at_tick` keeps its event-count meaning; both are tested.
+
+## Limits
+
+- **Revocation window.** A revoked token remains usable on an isolated
+  replica for the partition's duration plus up to one gossip interval. That
+  is the CAP price, made explicit and bounded rather than hidden. Shrink the
+  gossip interval to shrink the window; you cannot reach zero.
+- **Grow-only, by design.** Revocations are never removed, matching the
+  base plugin's no-unrevoke semantics. State is bounded by the number of
+  revocations, each a 16-hex-character tid — not by traffic.
+- **Gossip is the scenario's job.** The plugin exposes the channel; it does
+  not own a transport. The scenario broadcasts `export_revocations()` on a
+  cadence. A deployment that never gossips converges never.
+- **Symmetric secret, inherited.** Verification requires the shared HMAC
+  secret, so any holder can also mint. Public-key verification across trust
+  domains is out of scope here (it would change the token format, which this
+  plugin deliberately does not touch).
+- **Couples to the base plugin's revocation set.** `_revoked` is inherited
+  private state. Inherited-behavior regression tests guard the coupling, so
+  an upstream refactor fails loudly rather than silently.

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -27,6 +27,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
+    ("auth", "mesh_revocable"): f"{_REF}.auth.mesh_revocable:MeshRevocableAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",

--- a/packages/nest-core/nest_core/runner.py
+++ b/packages/nest-core/nest_core/runner.py
@@ -166,6 +166,8 @@ class ScenarioRunner:
             byzantine_fraction=failures.byzantine_agents,
             partition_groups=partition_groups,
             partition_heal_at=failures.partition_heal_at_tick,
+            partition_start_at_time=failures.partition_start_at_time,
+            partition_heal_at_time=failures.partition_heal_at_time,
             plugins=plugins,
         )
 

--- a/packages/nest-core/nest_core/scenario.py
+++ b/packages/nest-core/nest_core/scenario.py
@@ -108,6 +108,12 @@ class FailureConfig(BaseModel):
     byzantine_agents: float = 0.0
     network_partition: dict[str, Any] | None = None
     partition_heal_at_tick: int | None = None
+    # The ``_at_time`` variants gate on simulation time (what agents see as
+    # ``ctx.time``) rather than the count of processed events. Prefer them:
+    # event counts vary with message volume, so the same event number lands at
+    # a different simulated instant when a scenario's plugins chatter more.
+    partition_start_at_time: float | None = None
+    partition_heal_at_time: float | None = None
 
     @field_validator("message_drop", "byzantine_agents")
     @classmethod

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -131,6 +131,12 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.delegated_auth import delegated_auth_factory
 
         register_scenario("delegated_auth", delegated_auth_factory)
+    elif name == "delegated_auth_partition":
+        from nest_core.scenarios_builtin.delegated_auth_partition import (
+            delegated_auth_partition_factory,
+        )
+
+        register_scenario("delegated_auth_partition", delegated_auth_partition_factory)
     elif name == "multi_attribute_market":
         from nest_core.scenarios_builtin.multi_attribute_market import (
             multi_attribute_market_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_auth_partition.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_auth_partition.py
@@ -208,12 +208,24 @@ class CoordinatorAgent(_GossipMixin):
         self._grants: dict[AgentId, Token] = {}
 
     async def on_start(self, ctx: AgentContext) -> None:
+        """Schedule the bootstrap grant, the revocation, and gossip rounds.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
         await ctx.schedule(1.0, _json({"type": "bootstrap"}))
         await ctx.schedule(float(self._revoke_tick), _json({"type": "revoke"}))
         for when, payload in self._schedule_gossip():
             await ctx.schedule(when, payload)
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Handle gossip, the bootstrap/revoke ticks, and access requests.
+
+        Example::
+
+            await agent.on_message(ctx, sender, b'{"type": "access_request"}')
+        """
         data = _load(payload)
         _pin_clock(self._auth, ctx.time)
         if await self._handle_gossip(ctx, sender, data):
@@ -302,10 +314,22 @@ class GatewayAgent(_GossipMixin):
         self._auth = auth
 
     async def on_start(self, ctx: AgentContext) -> None:
+        """Schedule this replica's gossip rounds.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
         for when, payload in self._schedule_gossip():
             await ctx.schedule(when, payload)
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Merge incoming gossip, or gate an access request against this replica.
+
+        Example::
+
+            await agent.on_message(ctx, sender, b'{"type": "access_request"}')
+        """
         data = _load(payload)
         _pin_clock(self._auth, ctx.time)
         if await self._handle_gossip(ctx, sender, data):
@@ -353,10 +377,22 @@ class IntermediaryAgent(_GossipMixin):
         self._leaves = leaves
 
     async def on_start(self, ctx: AgentContext) -> None:
+        """Schedule this replica's gossip rounds.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
         for when, payload in self._schedule_gossip():
             await ctx.schedule(when, payload)
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Merge incoming gossip, or attenuate a received grant for each leaf.
+
+        Example::
+
+            await agent.on_message(ctx, coordinator, b'{"type": "grant", ...}')
+        """
         data = _load(payload)
         _pin_clock(self._auth, ctx.time)
         if await self._handle_gossip(ctx, sender, data):
@@ -413,6 +449,12 @@ class LeafAgent(StateMachineAgent):
         self._lineage: list[str] = []
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Store a received grant, then present it to every verifier on cadence.
+
+        Example::
+
+            await agent.on_message(ctx, intermediary, b'{"type": "grant", ...}')
+        """
         data = _load(payload)
         kind = data.get("type")
         if kind == "grant":

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_auth_partition.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_auth_partition.py
@@ -1,0 +1,498 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegated-auth partition scenario: revocation during a network split.
+
+The ``delegated_auth`` scenario proves capability *semantics* (attenuation,
+cascade, audience binding) with every agent sharing one auth instance. This
+scenario proves capability *distribution*: every verifier owns its own auth
+replica, and revocation knowledge travels only by gossip.
+
+A coordinator delegates to two intermediaries, which sub-delegate to three
+leaves each. Leaves present their tokens to two independent verifiers -- the
+coordinator and a gateway -- on a fixed cadence. The mesh then splits into
+two groups (coordinator + intermediary-0's subtree vs gateway +
+intermediary-1's subtree), and *during* the split the coordinator revokes
+intermediary-1's grant:
+
+- the gateway, cut off from the revoker, keeps accepting that subtree's
+  tokens -- honest partition behavior (availability), asserted by
+  ``check_partition_liveness``;
+- once the partition heals, gossiped revocation state converges and the
+  revoked subtree is denied by **every** verifier within a bounded number
+  of gossip rounds, asserted by ``check_revocation_converges``.
+
+Under ``auth: mesh_revocable`` both properties hold. Under per-replica
+``auth: delegatable`` the gossip channel does not exist, the gateway never
+learns of the revocation, and convergence fails -- that is the gap this
+scenario exists to expose.
+
+Every delegate / revoke / verify emits a ``delegation_audit`` event using
+the same vocabulary as ``delegated_auth`` (plus a ``verifier`` field and a
+``gossip_merge`` op), so the escalation and audience validators from
+``nest_plugins_reference.validators.delegation_validators`` run green on
+this trace too.
+
+The scenario is deliberately **seed-invariant**: agents draw nothing from
+``ctx.rng``; all behavior is structural (fixed roles, fixed ticks).
+
+Example::
+
+    agents = delegated_auth_partition_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Awaitable
+from typing import Any, cast
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Token
+
+ROOT_SCOPES: list[str] = ["read", "write", "pay"]
+MID_SCOPES: list[str] = ["read", "write"]
+LEAF_SCOPES: list[str] = ["read"]
+
+
+def _json(data: dict[str, Any]) -> bytes:
+    return json.dumps(data, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _load(payload: bytes) -> dict[str, Any]:
+    try:
+        data: object = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+    return cast("dict[str, Any]", data) if isinstance(data, dict) else {}
+
+
+def _tid(token: Token) -> str:
+    """Correlation id for a token, uniform across auth plugins.
+
+    Example::
+
+        tid = _tid(token)
+    """
+    return hashlib.sha256(str(token).encode()).hexdigest()[:16]
+
+
+async def _audit(ctx: AgentContext, data: dict[str, Any]) -> None:
+    event = {"type": "delegation_audit", "tick": int(ctx.time), **data}
+    await ctx.send(ctx.agent_id, _json(event))
+
+
+def _pin_clock(auth: Any, now: float) -> None:
+    set_clock = getattr(auth, "set_clock", None)
+    if callable(set_clock):
+        set_clock(now)
+
+
+async def _delegate(
+    auth: Any,
+    parent_token: Token,
+    audience: AgentId,
+    scopes: list[str],
+    ttl: float,
+) -> Token | None:
+    """Delegate via the plugin if it can, else fall back to re-issuance.
+
+    Example::
+
+        child = await _delegate(auth, root, AgentId("leaf-0"), ["read"], 300.0)
+    """
+    delegate = getattr(auth, "delegate", None)
+    if callable(delegate):
+        try:
+            pending = cast("Awaitable[Token]", delegate(parent_token, audience, scopes, ttl))
+            return await pending
+        except ValueError:
+            return None
+    return cast("Token", await auth.issue(audience, scopes))
+
+
+async def _verify(auth: Any, token: Token, presenter: AgentId) -> bool:
+    """Verify a presented token, audience-bound when the plugin can.
+
+    Example::
+
+        ok = await _verify(auth, token, AgentId("leaf-0"))
+    """
+    verify_presented = getattr(auth, "verify_presented", None)
+    try:
+        if callable(verify_presented):
+            await cast("Awaitable[object]", verify_presented(token, presenter))
+        else:
+            await auth.verify(token)
+    except ValueError:
+        return False
+    return True
+
+
+class _GossipMixin(StateMachineAgent):
+    """Shared gossip behavior for every agent that owns an auth replica.
+
+    On each self-scheduled ``rvk_tick`` the replica's revocation state is
+    broadcast (duck-typed: a plugin without ``export_revocations`` -- e.g.
+    plain ``delegatable`` -- simply never gossips, which *is* the baseline
+    under test). Incoming states are merged defensively.
+
+    Example::
+
+        class MyAgent(_GossipMixin): ...
+    """
+
+    _auth: Any
+
+    def _schedule_gossip(self) -> list[tuple[float, bytes]]:
+        return [
+            (float(t), _json({"type": "rvk_tick"}))
+            for t in range(self._gossip_interval, self._gossip_until, self._gossip_interval)
+        ]
+
+    def __init__(self, *, gossip_interval: int, gossip_until: int) -> None:
+        self._gossip_interval = gossip_interval
+        self._gossip_until = gossip_until
+
+    async def _handle_gossip(
+        self, ctx: AgentContext, sender: AgentId, data: dict[str, Any]
+    ) -> bool:
+        kind = data.get("type")
+        if kind == "rvk_tick" and sender == ctx.agent_id:
+            export = getattr(self._auth, "export_revocations", None)
+            if callable(export):
+                state = cast("bytes", export())
+                await ctx.broadcast(_json({"type": "rvk_state", "state": state.decode("utf-8")}))
+            return True
+        if kind == "rvk_state":
+            merge = getattr(self._auth, "merge_revocations", None)
+            if callable(merge):
+                try:
+                    changed = bool(merge(str(data.get("state", "")).encode("utf-8")))
+                except ValueError:
+                    return True
+                if changed:
+                    await _audit(ctx, {"op": "gossip_merge", "source": str(sender)})
+            return True
+        return False
+
+
+class CoordinatorAgent(_GossipMixin):
+    """Issues the root, delegates, revokes mid-partition, and verifies.
+
+    Example::
+
+        agent = CoordinatorAgent(AgentId("coordinator-0"), auth=auth,
+                                 intermediaries=[AgentId("intermediary-0")],
+                                 revoke_tick=20, revoke_target=1,
+                                 gossip_interval=5, gossip_until=95)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        auth: Any,
+        intermediaries: list[AgentId],
+        revoke_tick: int,
+        revoke_target: int,
+        gossip_interval: int,
+        gossip_until: int,
+    ) -> None:
+        super().__init__(gossip_interval=gossip_interval, gossip_until=gossip_until)
+        self._id = agent_id
+        self._auth = auth
+        self._intermediaries = intermediaries
+        self._revoke_tick = revoke_tick
+        self._revoke_target = revoke_target
+        self._grants: dict[AgentId, Token] = {}
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        await ctx.schedule(1.0, _json({"type": "bootstrap"}))
+        await ctx.schedule(float(self._revoke_tick), _json({"type": "revoke"}))
+        for when, payload in self._schedule_gossip():
+            await ctx.schedule(when, payload)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        data = _load(payload)
+        _pin_clock(self._auth, ctx.time)
+        if await self._handle_gossip(ctx, sender, data):
+            return
+        kind = data.get("type")
+        if kind == "bootstrap" and sender == ctx.agent_id:
+            root = cast("Token", await self._auth.issue(ctx.agent_id, ROOT_SCOPES))
+            for mid in self._intermediaries:
+                token = await _delegate(self._auth, root, mid, MID_SCOPES, ttl=6000.0)
+                granted = token is not None
+                await _audit(
+                    ctx,
+                    {
+                        "op": "delegate",
+                        "delegator": str(ctx.agent_id),
+                        "audience": str(mid),
+                        "parent_scopes": ROOT_SCOPES,
+                        "child_scopes": MID_SCOPES,
+                        "granted": granted,
+                    },
+                )
+                if token is None:
+                    continue
+                self._grants[mid] = token
+                lineage = [_tid(root), _tid(token)]
+                grant = {"type": "grant", "token": str(token), "lineage": lineage}
+                await ctx.send(mid, _json(grant))
+        elif kind == "revoke" and sender == ctx.agent_id:
+            target = self._intermediaries[self._revoke_target]
+            token = self._grants.get(target)
+            if token is None:
+                return
+            await self._auth.revoke(token)
+            await _audit(
+                ctx,
+                {
+                    "op": "revoke",
+                    "tid": _tid(token),
+                    "target": str(target),
+                    "revoker": str(ctx.agent_id),
+                },
+            )
+        elif kind == "access_request":
+            await self._gate(ctx, sender, data)
+
+    async def _gate(self, ctx: AgentContext, sender: AgentId, data: dict[str, Any]) -> None:
+        token = Token(str(data.get("token", "")))
+        lineage = [str(t) for t in cast("list[Any]", data.get("lineage", []))]
+        verified = await _verify(self._auth, token, sender)
+        await _audit(
+            ctx,
+            {
+                "op": "verify",
+                "verifier": str(ctx.agent_id),
+                "presenter": str(sender),
+                "audience": str(data.get("audience", "")),
+                "chain_tids": [*lineage, _tid(token)],
+                "verified": verified,
+            },
+        )
+
+
+class GatewayAgent(_GossipMixin):
+    """A second, independent verifier with its own auth replica.
+
+    Its whole purpose is to sit on the far side of the partition from the
+    revoker: its verify audits are the evidence for both partition
+    liveness and post-heal convergence.
+
+    Example::
+
+        agent = GatewayAgent(AgentId("gateway-0"), auth=auth,
+                             gossip_interval=5, gossip_until=95)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        auth: Any,
+        gossip_interval: int,
+        gossip_until: int,
+    ) -> None:
+        super().__init__(gossip_interval=gossip_interval, gossip_until=gossip_until)
+        self._id = agent_id
+        self._auth = auth
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        for when, payload in self._schedule_gossip():
+            await ctx.schedule(when, payload)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        data = _load(payload)
+        _pin_clock(self._auth, ctx.time)
+        if await self._handle_gossip(ctx, sender, data):
+            return
+        if data.get("type") != "access_request":
+            return
+        token = Token(str(data.get("token", "")))
+        lineage = [str(t) for t in cast("list[Any]", data.get("lineage", []))]
+        verified = await _verify(self._auth, token, sender)
+        await _audit(
+            ctx,
+            {
+                "op": "verify",
+                "verifier": str(ctx.agent_id),
+                "presenter": str(sender),
+                "audience": str(data.get("audience", "")),
+                "chain_tids": [*lineage, _tid(token)],
+                "verified": verified,
+            },
+        )
+
+
+class IntermediaryAgent(_GossipMixin):
+    """Sub-delegates its grant to a block of leaf agents; carries a replica.
+
+    Example::
+
+        agent = IntermediaryAgent(AgentId("intermediary-0"), auth=auth,
+                                  leaves=[AgentId("leaf-0")],
+                                  gossip_interval=5, gossip_until=95)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        auth: Any,
+        leaves: list[AgentId],
+        gossip_interval: int,
+        gossip_until: int,
+    ) -> None:
+        super().__init__(gossip_interval=gossip_interval, gossip_until=gossip_until)
+        self._id = agent_id
+        self._auth = auth
+        self._leaves = leaves
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        for when, payload in self._schedule_gossip():
+            await ctx.schedule(when, payload)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        data = _load(payload)
+        _pin_clock(self._auth, ctx.time)
+        if await self._handle_gossip(ctx, sender, data):
+            return
+        if data.get("type") != "grant":
+            return
+        parent = Token(str(data.get("token", "")))
+        lineage = [str(t) for t in cast("list[Any]", data.get("lineage", []))]
+        for leaf in self._leaves:
+            token = await _delegate(self._auth, parent, leaf, LEAF_SCOPES, ttl=3000.0)
+            granted = token is not None
+            await _audit(
+                ctx,
+                {
+                    "op": "delegate",
+                    "delegator": str(ctx.agent_id),
+                    "audience": str(leaf),
+                    "parent_scopes": MID_SCOPES,
+                    "child_scopes": LEAF_SCOPES,
+                    "granted": granted,
+                },
+            )
+            if token is None:
+                continue
+            await ctx.send(
+                leaf,
+                _json({"type": "grant", "token": str(token), "lineage": [*lineage, _tid(token)]}),
+            )
+
+
+class LeafAgent(StateMachineAgent):
+    """Presents its token to both verifiers on a fixed cadence.
+
+    Example::
+
+        agent = LeafAgent(AgentId("leaf-0"),
+                          verifiers=[AgentId("coordinator-0"), AgentId("gateway-0")],
+                          presents=15, interval=6)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        verifiers: list[AgentId],
+        presents: int,
+        interval: int,
+    ) -> None:
+        self._id = agent_id
+        self._verifiers = verifiers
+        self._presents = presents
+        self._interval = interval
+        self._token: str | None = None
+        self._lineage: list[str] = []
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        data = _load(payload)
+        kind = data.get("type")
+        if kind == "grant":
+            self._token = str(data.get("token", ""))
+            self._lineage = [str(t) for t in cast("list[Any]", data.get("lineage", []))]
+            for step in range(self._presents):
+                await ctx.schedule(2.0 + step * self._interval, _json({"type": "present"}))
+        elif kind == "present" and sender == ctx.agent_id and self._token is not None:
+            request = {
+                "type": "access_request",
+                "token": self._token,
+                "lineage": self._lineage,
+                "audience": str(ctx.agent_id),
+            }
+            for verifier in self._verifiers:
+                await ctx.send(verifier, _json(request))
+
+
+def delegated_auth_partition_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create the partitioned delegation mesh with per-agent auth replicas.
+
+    Unlike ``delegated_auth_factory``, every verifier and delegator gets its
+    **own** instance of the configured auth plugin (same secret, so tokens
+    verify everywhere) -- the deployment shape a real network forces. Leaves
+    hold only token strings.
+
+    Example::
+
+        agents = delegated_auth_partition_factory(config, plugins)
+    """
+    task_config = config.task.config
+    revoke_tick = int(cast("int", task_config.get("revoke_tick", 20)))
+    gossip_interval = int(cast("int", task_config.get("gossip_interval", 5)))
+    gossip_until = int(cast("int", task_config.get("gossip_until", 95)))
+    presents = int(cast("int", task_config.get("presents", 15)))
+    interval = int(cast("int", task_config.get("present_interval", 6)))
+
+    auth_cls = cast("Any", plugins.get("auth"))
+
+    def _new_replica() -> Any:
+        return auth_cls(secret=b"delegated-auth-partition", clock=0.0)
+
+    coordinator_id = AgentId("coordinator-0")
+    gateway_id = AgentId("gateway-0")
+    intermediary_ids = [AgentId("intermediary-0"), AgentId("intermediary-1")]
+    leaf_ids = [AgentId(f"leaf-{i}") for i in range(6)]
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    agents[coordinator_id] = CoordinatorAgent(
+        coordinator_id,
+        auth=_new_replica(),
+        intermediaries=intermediary_ids,
+        revoke_tick=revoke_tick,
+        revoke_target=1,  # intermediary-1: the subtree on the far side of the split
+        gossip_interval=gossip_interval,
+        gossip_until=gossip_until,
+    )
+    agents[gateway_id] = GatewayAgent(
+        gateway_id,
+        auth=_new_replica(),
+        gossip_interval=gossip_interval,
+        gossip_until=gossip_until,
+    )
+    for index, mid in enumerate(intermediary_ids):
+        block = leaf_ids[index * 3 : (index + 1) * 3]
+        agents[mid] = IntermediaryAgent(
+            mid,
+            auth=_new_replica(),
+            leaves=block,
+            gossip_interval=gossip_interval,
+            gossip_until=gossip_until,
+        )
+    for leaf in leaf_ids:
+        agents[leaf] = LeafAgent(
+            leaf,
+            verifiers=[coordinator_id, gateway_id],
+            presents=presents,
+            interval=interval,
+        )
+    return agents

--- a/packages/nest-core/nest_core/sim/simulator.py
+++ b/packages/nest-core/nest_core/sim/simulator.py
@@ -150,6 +150,8 @@ class Simulator:
         byzantine_fraction: float = 0.0,
         partition_groups: list[list[str]] | None = None,
         partition_heal_at: int | None = None,
+        partition_start_at_time: float | None = None,
+        partition_heal_at_time: float | None = None,
         plugins: dict[str, Any] | None = None,
     ) -> None:
         if not 0.0 <= message_drop_rate <= 1.0:
@@ -174,9 +176,15 @@ class Simulator:
         self._byzantine_fraction = byzantine_fraction
         self._partition_groups = partition_groups
         self._partition_heal_at = partition_heal_at
+        self._partition_start_at_time = partition_start_at_time
+        self._partition_heal_at_time = partition_heal_at_time
+        # With no start time the partition is active from the first event
+        # (legacy behavior); otherwise it stays pending until that instant.
+        self._partition_started = partition_start_at_time is None
         self._partition_healed = False
         self._byzantine_agents: set[AgentId] = set()
         self._partition_map: dict[AgentId, int] = {}
+        self._pending_partition_map: dict[AgentId, int] = {}
         self._failure_rng = random.Random(self._master_rng.randint(0, 2**63))
         self._plugins: dict[str, Any] = plugins or {}
         self._agent_plugins: dict[AgentId, dict[str, Any]] = {}
@@ -251,7 +259,9 @@ class Simulator:
                 for agent_name in group:
                     aid = AgentId(agent_name)
                     if aid in self._agents:
-                        self._partition_map[aid] = group_idx
+                        self._pending_partition_map[aid] = group_idx
+            if self._partition_started:
+                self._partition_map = dict(self._pending_partition_map)
 
     def _should_drop(self, sender: AgentId, target: AgentId) -> bool:
         if self._message_drop_rate > 0 and self._failure_rng.random() < self._message_drop_rate:
@@ -310,9 +320,31 @@ class Simulator:
             self._tick_count += 1
 
             if (
-                self._partition_heal_at is not None
+                self._partition_start_at_time is not None
+                and not self._partition_started
                 and not self._partition_healed
-                and self._tick_count >= self._partition_heal_at
+                and self._clock.now >= self._partition_start_at_time
+            ):
+                self._partition_map = dict(self._pending_partition_map)
+                self._partition_started = True
+                if self._trace:
+                    self._trace.record(
+                        {
+                            "ts": self._clock.now,
+                            "agent": "_simulator",
+                            "kind": "partition_started",
+                        }
+                    )
+
+            if not self._partition_healed and (
+                (
+                    self._partition_heal_at is not None
+                    and self._tick_count >= self._partition_heal_at
+                )
+                or (
+                    self._partition_heal_at_time is not None
+                    and self._clock.now >= self._partition_heal_at_time
+                )
             ):
                 self._partition_map = {}
                 self._partition_healed = True

--- a/packages/nest-core/tests/test_delegated_auth_partition_scenario.py
+++ b/packages/nest-core/tests/test_delegated_auth_partition_scenario.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end tests for the delegated_auth_partition scenario.
+
+Runs the real ScenarioRunner -- per-agent auth replicas, real partition
+machinery, real gossip -- under both auth plugins and asserts:
+
+- ``mesh_revocable``: partition records present, the merged escalation and
+  audience validators green, partition liveness AND bounded revocation
+  convergence both hold, and the audit stream is identical across two runs
+  (determinism);
+- per-replica ``delegatable`` (the baseline): liveness still holds (it is
+  honest during the split) but convergence FAILS -- remote replicas never
+  learn of the revocation. That flip is the scenario's whole point.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import (
+    FailureConfig,
+    OutputConfig,
+    RoleConfig,
+    ScenarioConfig,
+    TaskConfig,
+)
+from nest_plugins_reference.validators import (
+    check_audience_binding,
+    check_no_scope_escalation,
+    check_partition_liveness,
+    check_revocation_converges,
+    extract_delegation_audits,
+    find_partition_ticks,
+)
+
+_GOSSIP_INTERVAL = 5
+
+
+def _config(auth: str, trace: Path) -> ScenarioConfig:
+    config = ScenarioConfig(
+        name="delegated_auth_partition",
+        seed=42,
+        task=TaskConfig(
+            type="delegated_auth_partition",
+            config={
+                "revoke_tick": 20,
+                "gossip_interval": _GOSSIP_INTERVAL,
+                "gossip_until": 95,
+                "presents": 15,
+                "present_interval": 6,
+            },
+        ),
+        failures=FailureConfig(
+            network_partition={
+                "groups": [
+                    ["coordinator-0", "intermediary-0", "leaf-0", "leaf-1", "leaf-2"],
+                    ["gateway-0", "intermediary-1", "leaf-3", "leaf-4", "leaf-5"],
+                ]
+            },
+            partition_start_at_time=10.0,
+            partition_heal_at_time=55.0,
+        ),
+        output=OutputConfig(trace=str(trace)),
+    )
+    config.agents.count = 10
+    config.agents.roles = [
+        RoleConfig(name="coordinator", count=1),
+        RoleConfig(name="gateway", count=1),
+        RoleConfig(name="intermediary", count=2),
+        RoleConfig(name="leaf", count=6),
+    ]
+    config.layers.auth = auth
+    return config
+
+
+async def _run(auth: str, trace: Path) -> list[dict[str, Any]]:
+    result = await ScenarioRunner(_config(auth, trace)).run()
+    assert result.exists()
+    return [json.loads(line) for line in result.read_text().splitlines() if line]
+
+
+@pytest.mark.asyncio
+async def test_mesh_revocable_liveness_and_convergence(tmp_path: Path) -> None:
+    events = await _run("mesh_revocable", tmp_path / "mesh.jsonl")
+    started, healed = find_partition_ticks(events)
+    assert started is not None and healed is not None
+    assert started < healed
+
+    audits = extract_delegation_audits(events)
+    revoke_ticks = [a["tick"] for a in audits if a.get("op") == "revoke"]
+    assert revoke_ticks, "scenario must actually revoke"
+    # The revocation must land inside the partition window, else the
+    # scenario is not testing what it claims to test.
+    assert started < revoke_ticks[0] < healed
+
+    # The merged delegation validators still hold on this trace.
+    assert check_no_scope_escalation(audits).passed
+    assert check_audience_binding(audits).passed
+
+    deadline = healed + 2 * _GOSSIP_INTERVAL
+    assert check_partition_liveness(audits, heal_tick=healed).passed
+    assert check_revocation_converges(audits, deadline_tick=deadline).passed
+
+
+@pytest.mark.asyncio
+async def test_per_replica_delegatable_baseline_never_converges(tmp_path: Path) -> None:
+    events = await _run("delegatable", tmp_path / "baseline.jsonl")
+    _, healed = find_partition_ticks(events)
+    assert healed is not None
+
+    audits = extract_delegation_audits(events)
+    # Honest during the split (a stale replica cannot deny)...
+    assert check_partition_liveness(audits, heal_tick=healed).passed
+    # ...but with no replication channel it stays stale forever.
+    deadline = healed + 2 * _GOSSIP_INTERVAL
+    assert not check_revocation_converges(audits, deadline_tick=deadline).passed
+
+
+@pytest.mark.asyncio
+async def test_trace_is_deterministic(tmp_path: Path) -> None:
+    first = await _run("mesh_revocable", tmp_path / "one.jsonl")
+    second = await _run("mesh_revocable", tmp_path / "two.jsonl")
+    assert extract_delegation_audits(first) == extract_delegation_audits(second)
+    assert (tmp_path / "one.jsonl").read_bytes() == (tmp_path / "two.jsonl").read_bytes()

--- a/packages/nest-core/tests/test_failures.py
+++ b/packages/nest-core/tests/test_failures.py
@@ -193,3 +193,92 @@ class TestFailureViaRunner:
 
         assert dropped > 0
         assert received > 0
+
+
+class ChatterAgent(StateMachineAgent):
+    """Sends one message per scheduled tick, independent of replies."""
+
+    def __init__(self, target: AgentId, sends: int) -> None:
+        self._target = target
+        self._sends = sends
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        for i in range(self._sends):
+            await ctx.schedule(float(i + 1), f"tick-{i}".encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        if sender == ctx.agent_id and payload.startswith(b"tick-"):
+            await ctx.send(self._target, b"msg-" + payload)
+
+
+class TestDelayedPartition:
+    @pytest.mark.asyncio
+    async def test_partition_starts_at_time_and_heals(self, tmp_path: Path) -> None:
+        trace_file = tmp_path / "t.jsonl"
+        sim = Simulator(
+            seed=42,
+            trace_path=trace_file,
+            partition_groups=[["a"], ["b"]],
+            partition_start_at_time=20.0,
+            partition_heal_at_time=40.0,
+        )
+        sim.add_agent(AgentId("a"), ChatterAgent(AgentId("b"), sends=60))
+        sim.add_agent(AgentId("b"), ChatterAgent(AgentId("a"), sends=0))
+        await sim.run(max_ticks=10_000)
+
+        events = [json.loads(ln) for ln in trace_file.read_text().strip().split("\n") if ln]
+        started = [e for e in events if e["kind"] == "partition_started"]
+        healed = [e for e in events if e["kind"] == "partition_healed"]
+        assert len(started) == 1
+        assert len(healed) == 1
+        started_ts = float(started[0]["ts"])
+        healed_ts = float(healed[0]["ts"])
+        assert started_ts <= healed_ts
+
+        # Self-scheduled ticks are receives too; only b's receives crossed groups.
+        receives = [float(e["ts"]) for e in events if e["kind"] == "receive" and e["agent"] == "b"]
+        dropped = [float(e["ts"]) for e in events if e["kind"] == "dropped"]
+        # Phase 1: cross-group delivery works before the partition starts.
+        assert any(ts < started_ts for ts in receives)
+        # Phase 2: with message_drop=0, every drop is the partition's doing
+        # and falls inside the partition window.
+        assert dropped
+        assert all(started_ts <= ts <= healed_ts for ts in dropped)
+        # Phase 3: delivery resumes after heal.
+        assert any(ts > healed_ts for ts in receives)
+
+    @pytest.mark.asyncio
+    async def test_event_count_heal_still_supported(self, tmp_path: Path) -> None:
+        """The pre-existing event-count heal field keeps its meaning."""
+        trace_file = tmp_path / "t.jsonl"
+        sim = Simulator(
+            seed=42,
+            trace_path=trace_file,
+            partition_groups=[["a"], ["b"]],
+            partition_heal_at=30,
+        )
+        sim.add_agent(AgentId("a"), ChatterAgent(AgentId("b"), sends=60))
+        sim.add_agent(AgentId("b"), ChatterAgent(AgentId("a"), sends=0))
+        await sim.run(max_ticks=10_000)
+
+        events = [json.loads(ln) for ln in trace_file.read_text().strip().split("\n") if ln]
+        assert len([e for e in events if e["kind"] == "partition_healed"]) == 1
+        assert [e for e in events if e["kind"] == "dropped"]
+
+    @pytest.mark.asyncio
+    async def test_no_start_time_preserves_legacy_behavior(self, tmp_path: Path) -> None:
+        trace_file = tmp_path / "t.jsonl"
+        sim = Simulator(
+            seed=42,
+            trace_path=trace_file,
+            partition_groups=[["a"], ["b"]],
+        )
+        sim.add_agent(AgentId("a"), ChatterAgent(AgentId("b"), sends=10))
+        sim.add_agent(AgentId("b"), ChatterAgent(AgentId("a"), sends=0))
+        await sim.run(max_ticks=10_000)
+
+        events = [json.loads(ln) for ln in trace_file.read_text().strip().split("\n") if ln]
+        # Partition active from tick 0: no cross-group receive, no start event.
+        assert not [e for e in events if e["kind"] == "partition_started"]
+        assert not [e for e in events if e["kind"] == "receive" and e["agent"] == "b"]
+        assert [e for e in events if e["kind"] == "dropped"]

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/mesh_revocable.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/mesh_revocable.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Mesh-revocable capability tokens: delegatable auth whose revocations gossip.
+
+The merged ``delegatable`` plugin gives every verifier real macaroon-style
+capability chains -- offline attenuation, cascading revocation, audience
+binding. But its revocation knowledge lives in one in-process ``set``: run
+one honest replica per agent and a revocation performed at the issuer is
+invisible to every other verifier, forever. The only deployment in which
+its cascade reaches the whole mesh is the one where all agents share a
+single Python object -- which no real network can do.
+
+``MeshRevocableAuth`` fixes exactly that, by composition: it subclasses
+:class:`~nest_plugins_reference.auth.delegatable.DelegatableAuth` -- token
+format, HMAC chain, attenuation rules, and all exception types unchanged --
+and treats the inherited revocation set as a replica of a **grow-only set
+CRDT** (G-Set). Two additive methods, :meth:`export_revocations` and
+:meth:`merge_revocations`, are the replication channel; gossip them over
+any transport and every replica converges on the union of all revocations,
+in any delivery order, because set union is commutative, associative, and
+idempotent.
+
+The CAP trade is stated, not hidden: a replica partitioned away from the
+revoker keeps honoring not-yet-propagated revocations (availability), and
+becomes consistent within one gossip round of the partition healing. The
+``delegated_auth_partition`` scenario demonstrates -- and its validators
+enforce -- both halves of that sentence.
+
+All replicas must be constructed with the same ``secret``: tokens minted
+by any replica verify at every replica; only *revocation knowledge* is
+replica-local until gossiped.
+
+Example::
+
+    issuer = MeshRevocableAuth(secret=b"s", clock=0.0)
+    gateway = MeshRevocableAuth(secret=b"s", clock=0.0)
+    root = await issuer.issue(AgentId("coord"), ["read", "write"])
+    child = await issuer.delegate(root, AgentId("worker"), ["read"], ttl=60.0)
+    await gateway.verify(child)              # any replica can verify
+    await issuer.revoke(root)
+    await gateway.verify(child)              # still passes: not yet gossiped
+    gateway.merge_revocations(issuer.export_revocations())
+    await gateway.verify(child)              # raises RevokedAncestorError
+"""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+from .delegatable import DelegatableAuth
+
+CRDT_KIND = "revocation_gset"
+"""Schema tag stamped into every serialized revocation set, used to detect
+and validate G-Set state when it is read back from a trace or the wire."""
+
+
+class RevocationStateError(ValueError):
+    """Raised when a byte string is not a valid serialized revocation G-Set.
+
+    Subclasses :class:`ValueError` so existing ``except ValueError`` handlers
+    keep working while callers that care can catch the specific type.
+
+    Example::
+
+        try:
+            auth.merge_revocations(b"not json")
+        except RevocationStateError:
+            ...
+    """
+
+
+class MeshRevocableAuth(DelegatableAuth):
+    """Delegatable capability tokens with gossip-propagated revocation.
+
+    Each instance is an independent **replica**. ``issue`` / ``delegate`` /
+    ``verify`` / ``verify_presented`` / ``revoke`` are inherited verbatim
+    from :class:`DelegatableAuth`; the inherited ``_revoked`` set doubles as
+    this replica's G-Set state, so a revocation recorded anywhere reaches
+    every replica once :meth:`export_revocations` output has been merged --
+    directly or through any chain of intermediate replicas.
+
+    The replication channel is additive: a caller that only speaks the base
+    ``Auth`` protocol never has to know revocations are replicated.
+
+    Example::
+
+        a = MeshRevocableAuth(secret=b"s", clock=0.0)
+        b = MeshRevocableAuth(secret=b"s", clock=0.0)
+        root = await a.issue(AgentId("a1"), ["read"])
+        await a.revoke(root)
+        b.merge_revocations(a.export_revocations())
+    """
+
+    # -- G-Set replication channel --------------------------------------
+
+    def export_revocations(self) -> bytes:
+        """Serialize this replica's revocation set for gossip.
+
+        The member list is sorted, so identical states export identical
+        bytes -- keeping traces replay-deterministic and making state
+        comparison in tests a byte comparison.
+
+        Example::
+
+            state = auth.export_revocations()
+            peer.merge_revocations(state)
+        """
+        data = {"crdt": CRDT_KIND, "revoked": sorted(self._revoked)}
+        return json.dumps(data, sort_keys=True).encode("utf-8")
+
+    def merge_revocations(self, state: bytes) -> bool:
+        """Union a peer's serialized revocation set into this replica.
+
+        Returns ``True`` if the merge added at least one new revocation
+        (useful for gossip loops that only re-broadcast on change).
+        Malformed or foreign state raises :class:`RevocationStateError`
+        and leaves this replica untouched -- gossip input is
+        attacker-adjacent and must never corrupt local state.
+
+        Union is commutative, associative, and idempotent, so replicas
+        converge under any delivery order and duplicated gossip is a no-op.
+
+        Example::
+
+            changed = auth.merge_revocations(peer.export_revocations())
+        """
+        try:
+            decoded: object = json.loads(state.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as err:
+            msg = "revocation state is not valid JSON"
+            raise RevocationStateError(msg) from err
+        if not isinstance(decoded, dict):
+            msg = "revocation state must be a JSON object"
+            raise RevocationStateError(msg)
+        data = cast("dict[str, object]", decoded)
+        if data.get("crdt") != CRDT_KIND:
+            msg = f"revocation state kind must be {CRDT_KIND!r}"
+            raise RevocationStateError(msg)
+        revoked = data.get("revoked")
+        if not isinstance(revoked, list):
+            msg = "revocation state 'revoked' must be a list of strings"
+            raise RevocationStateError(msg)
+        members = cast("list[object]", revoked)
+        if not all(isinstance(tid, str) for tid in members):
+            msg = "revocation state 'revoked' must be a list of strings"
+            raise RevocationStateError(msg)
+        incoming = set(cast("list[str]", members))
+        new = incoming - self._revoked
+        self._revoked |= new
+        return bool(new)

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -36,6 +36,11 @@ from nest_plugins_reference.validators.privacy_validators import (
     check_stale_revocation_blocked,
     corrupt_proof,
 )
+from nest_plugins_reference.validators.revocation_propagation_validators import (
+    check_partition_liveness,
+    check_revocation_converges,
+    find_partition_ticks,
+)
 from nest_plugins_reference.validators.trust_gate_validators import (
     check_denial_receipt_auditable,
     check_gate_tamper_rejected,
@@ -59,9 +64,12 @@ __all__ = [
     "check_no_scope_escalation",
     "check_no_stale_ancestor_use",
     "check_partial_redaction_enforced",
+    "check_partition_liveness",
     "check_replay_rejected",
+    "check_revocation_converges",
     "check_stale_revocation_blocked",
     "corrupt_proof",
     "extract_delegation_audits",
+    "find_partition_ticks",
     "forge_tier_upgrade",
 ]

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/revocation_propagation_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/revocation_propagation_validators.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validators for revocation propagation across a partitioned mesh.
+
+The ``delegation_validators`` prove capability *semantics* against a single
+verifier. These two checks prove capability *distribution* -- what happens
+when every verifier owns its own auth replica and the network splits. They
+are pure functions over the same ``delegation_audit`` events (as emitted by
+the ``delegated_auth_partition`` scenario, whose verify audits carry a
+``verifier`` field and whose revoke audits carry a ``revoker`` field).
+
+1. **Convergence.** ``check_revocation_converges`` asserts that after a
+   deadline (partition heal + a gossip-propagation bound) no verifier
+   anywhere accepts a revoked lineage -- and, anti-vacuously, that at least
+   one verifier *other than the revoker* explicitly denied it after the
+   deadline. Against per-replica ``delegatable`` the gossip channel does
+   not exist, remote replicas stay stale forever, and this check FAILS;
+   against ``mesh_revocable`` it passes.
+2. **Partition liveness.** ``check_partition_liveness`` asserts that a
+   verifier other than the revoker accepted the revoked lineage *during*
+   the partition window. That is honest CAP behavior -- a replica that
+   cannot have heard of the revocation must not magically deny it. The
+   check fails against the shared-single-instance wiring (which exhibits
+   physically impossible instant knowledge), keeping the scenario honest.
+
+Deliberately NOT asserted here: ``check_no_stale_ancestor_use``'s global
+"no success at/after the revoke tick" -- under a partition that property is
+unattainable (CAP); the bounded convergence check above is its honest
+replacement.
+
+Example::
+
+    events = [json.loads(line) for line in trace.open()]
+    audits = extract_delegation_audits(events)
+    started, healed = find_partition_ticks(events)
+    assert healed is not None
+    assert check_partition_liveness(audits, heal_tick=healed).passed
+    assert check_revocation_converges(audits, deadline_tick=healed + 10).passed
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from nest_plugins_reference.validators.delegation_validators import (
+    AuditEvent,
+    ValidatorReport,
+)
+
+
+def find_partition_ticks(events: list[dict[str, Any]]) -> tuple[float | None, float | None]:
+    """Read the simulator's partition window from raw trace events.
+
+    Returns ``(started_ts, healed_ts)``; either is ``None`` if the
+    corresponding ``_simulator`` record is absent.
+
+    Example::
+
+        started, healed = find_partition_ticks(events)
+    """
+    started: float | None = None
+    healed: float | None = None
+    for event in events:
+        kind = event.get("kind")
+        if kind == "partition_started" and started is None:
+            started = float(cast("float", event.get("ts", 0.0)))
+        elif kind == "partition_healed" and healed is None:
+            healed = float(cast("float", event.get("ts", 0.0)))
+    return started, healed
+
+
+def _revocations(audits: list[AuditEvent]) -> dict[str, tuple[int, str]]:
+    """Map each revoked tid to ``(revoke_tick, revoker)``.
+
+    Example::
+
+        revoked = _revocations(audits)
+    """
+    revoked: dict[str, tuple[int, str]] = {}
+    for audit in audits:
+        if audit.get("op") == "revoke":
+            tid = str(audit.get("tid", ""))
+            revoked[tid] = (int(cast("int", audit.get("tick", 0))), str(audit.get("revoker", "")))
+    return revoked
+
+
+def _chain(audit: AuditEvent) -> list[str]:
+    return [str(t) for t in cast("list[Any]", audit.get("chain_tids", []))]
+
+
+def _verifies_of(audits: list[AuditEvent], tid: str) -> list[AuditEvent]:
+    return [a for a in audits if a.get("op") == "verify" and tid in _chain(a)]
+
+
+def check_revocation_converges(
+    audits: list[AuditEvent],
+    *,
+    deadline_tick: float,
+) -> ValidatorReport:
+    """Assert every revocation is mesh-wide fatal after the deadline.
+
+    For each revoked tid: no verifier anywhere reports ``verified=True``
+    for a lineage containing it at ``tick >= deadline_tick``, AND at least
+    one verifier other than the revoker explicitly denied that lineage
+    after the deadline (so a scenario where presentations simply stopped
+    cannot pass vacuously).
+
+    Example::
+
+        report = check_revocation_converges(audits, deadline_tick=67.0)
+        assert report.passed, report.detail
+    """
+    revoked = _revocations(audits)
+    if not revoked:
+        return ValidatorReport(passed=False, detail="no revocation audits found")
+    stale: list[AuditEvent] = []
+    for tid, (_, revoker) in revoked.items():
+        remote_denials = 0
+        for audit in _verifies_of(audits, tid):
+            tick = int(cast("int", audit.get("tick", 0)))
+            if tick < deadline_tick:
+                continue
+            if audit.get("verified"):
+                stale.append(audit)
+            elif str(audit.get("verifier", "")) != revoker:
+                remote_denials += 1
+        if remote_denials == 0:
+            detail = (
+                f"no verifier other than the revoker ever denied lineage {tid} "
+                f"after tick {deadline_tick} — convergence unproven"
+            )
+            return ValidatorReport(passed=False, detail=detail)
+    if stale:
+        detail = (
+            f"{len(stale)} verification(s) accepted a revoked lineage after "
+            f"tick {deadline_tick} — revocation never converged"
+        )
+        return ValidatorReport(passed=False, detail=detail, evidence=stale)
+    return ValidatorReport(
+        passed=True,
+        detail=f"every revocation is mesh-wide fatal from tick {deadline_tick}",
+    )
+
+
+def check_partition_liveness(
+    audits: list[AuditEvent],
+    *,
+    heal_tick: float,
+) -> ValidatorReport:
+    """Assert the isolated side stayed available during the partition.
+
+    For each revoked tid: at least one verifier other than the revoker
+    reported ``verified=True`` for that lineage between the revoke tick
+    and the heal -- i.e. a replica that could not yet know about the
+    revocation kept serving. A deployment where remote verifiers deny
+    *instantly* is exhibiting knowledge the network cannot have delivered
+    (the shared-single-instance shortcut) and fails this check.
+
+    Example::
+
+        report = check_partition_liveness(audits, heal_tick=57.0)
+        assert report.passed, report.detail
+    """
+    revoked = _revocations(audits)
+    if not revoked:
+        return ValidatorReport(passed=False, detail="no revocation audits found")
+    for tid, (revoke_tick, revoker) in revoked.items():
+        window_accepts = [
+            a
+            for a in _verifies_of(audits, tid)
+            if a.get("verified")
+            and str(a.get("verifier", "")) != revoker
+            and revoke_tick <= int(cast("int", a.get("tick", 0))) < heal_tick
+        ]
+        if not window_accepts:
+            detail = (
+                f"no verifier other than the revoker accepted lineage {tid} between "
+                f"revocation (tick {revoke_tick}) and heal (tick {heal_tick}) — either "
+                "the partition never isolated a verifier or revocation knowledge "
+                "traveled faster than the network allows"
+            )
+            return ValidatorReport(passed=False, detail=detail)
+    return ValidatorReport(
+        passed=True,
+        detail="isolated verifiers stayed available until revocation state reached them",
+    )

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -33,6 +33,9 @@ Repository = "https://github.com/projnanda/nandatown"
 # package. The PluginRegistry also keeps built-in defaults keyed by
 # (layer, name), but declaring the entry point here is the documented,
 # install-time discovery path described in CONTRIBUTING.md.
+[project.entry-points."nest.plugins.auth"]
+mesh_revocable = "nest_plugins_reference.auth.mesh_revocable:MeshRevocableAuth"
+
 [project.entry-points."nest.plugins.comms"]
 authenticated = "nest_plugins_reference.comms.authenticated:AuthenticatedComms"
 

--- a/packages/nest-plugins-reference/tests/test_mesh_revocable_auth.py
+++ b/packages/nest-plugins-reference/tests/test_mesh_revocable_auth.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the mesh-revocable auth plugin.
+
+Covers base ``Auth`` protocol conformance, inherited delegatable behavior
+(the subclass must not disturb attenuation / cascade semantics), the
+two-replica revoke -> gossip -> deny flow, G-Set algebra at the plugin
+surface (idempotent re-merge, grow-only, empty merge), the malformed-state
+hardening matrix, and a deep-chain cross-replica stress case.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.layers.auth import Auth
+from nest_core.types import AgentId
+from nest_plugins_reference.auth.delegatable import (
+    RevokedAncestorError,
+    ScopeEscalationError,
+)
+from nest_plugins_reference.auth.mesh_revocable import (
+    CRDT_KIND,
+    MeshRevocableAuth,
+    RevocationStateError,
+)
+
+ROOT = AgentId("coordinator")
+MID = AgentId("intermediary")
+LEAF = AgentId("leaf")
+
+_SECRET = b"test-secret"
+
+
+def _replica(clock: float = 0.0) -> MeshRevocableAuth:
+    return MeshRevocableAuth(secret=_SECRET, clock=clock)
+
+
+@pytest.mark.asyncio
+async def test_satisfies_auth_protocol() -> None:
+    assert isinstance(_replica(), Auth)
+
+
+# -- Inherited delegatable behavior (regression against upstream drift) ----
+
+
+@pytest.mark.asyncio
+async def test_inherited_attenuation_still_enforced() -> None:
+    auth = _replica()
+    root = await auth.issue(ROOT, ["read"])
+    with pytest.raises(ScopeEscalationError):
+        await auth.delegate(root, MID, ["read", "admin"], ttl=60.0)
+
+
+@pytest.mark.asyncio
+async def test_inherited_local_cascade_still_works() -> None:
+    auth = _replica()
+    root = await auth.issue(ROOT, ["read", "write"])
+    child = await auth.delegate(root, MID, ["read"], ttl=60.0)
+    grandchild = await auth.delegate(child, LEAF, ["read"], ttl=30.0)
+    await auth.revoke(root)
+    with pytest.raises(RevokedAncestorError):
+        await auth.verify(grandchild)
+
+
+# -- Cross-replica flow ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_any_replica_verifies_tokens_minted_elsewhere() -> None:
+    issuer = _replica()
+    gateway = _replica()
+    root = await issuer.issue(ROOT, ["read", "write"])
+    child = await issuer.delegate(root, MID, ["read"], ttl=60.0)
+    ctx = await gateway.verify(child)
+    assert ctx.scopes == ["read"]
+
+
+@pytest.mark.asyncio
+async def test_revocation_reaches_peer_only_after_merge() -> None:
+    issuer = _replica()
+    gateway = _replica()
+    root = await issuer.issue(ROOT, ["read", "write"])
+    child = await issuer.delegate(root, MID, ["read"], ttl=60.0)
+
+    await issuer.revoke(root)
+    # Not yet gossiped: the gateway honestly still accepts.
+    await gateway.verify(child)
+
+    changed = gateway.merge_revocations(issuer.export_revocations())
+    assert changed is True
+    with pytest.raises(RevokedAncestorError):
+        await gateway.verify(child)
+
+
+@pytest.mark.asyncio
+async def test_revocation_propagates_transitively_via_intermediate() -> None:
+    a, b, c = _replica(), _replica(), _replica()
+    root = await a.issue(ROOT, ["read"])
+    child = await a.delegate(root, MID, ["read"], ttl=60.0)
+    await a.revoke(root)
+    # a -> b -> c; c never talks to a directly.
+    b.merge_revocations(a.export_revocations())
+    c.merge_revocations(b.export_revocations())
+    with pytest.raises(RevokedAncestorError):
+        await c.verify(child)
+
+
+@pytest.mark.asyncio
+async def test_deep_chain_cross_replica_cascade() -> None:
+    issuer = _replica()
+    verifier = _replica()
+    tokens = [await issuer.issue(AgentId("agent-0"), ["read"])]
+    for depth in range(1, 21):
+        tokens.append(
+            await issuer.delegate(tokens[-1], AgentId(f"agent-{depth}"), ["read"], ttl=600.0)
+        )
+    await verifier.verify(tokens[-1])
+    await issuer.revoke(tokens[3])
+    verifier.merge_revocations(issuer.export_revocations())
+    with pytest.raises(RevokedAncestorError):
+        await verifier.verify(tokens[-1])
+    # Above the cut survives.
+    await verifier.verify(tokens[2])
+
+
+# -- G-Set algebra at the plugin surface ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remerge_is_idempotent_and_reports_no_change() -> None:
+    a, b = _replica(), _replica()
+    root = await a.issue(ROOT, ["read"])
+    await a.revoke(root)
+    state = a.export_revocations()
+    assert b.merge_revocations(state) is True
+    before = b.export_revocations()
+    assert b.merge_revocations(state) is False
+    assert b.export_revocations() == before
+
+
+@pytest.mark.asyncio
+async def test_merging_empty_state_removes_nothing() -> None:
+    a = _replica()
+    root = await a.issue(ROOT, ["read"])
+    await a.revoke(root)
+    before = a.export_revocations()
+    assert a.merge_revocations(_replica().export_revocations()) is False
+    assert a.export_revocations() == before
+
+
+def test_export_is_deterministic_bytes() -> None:
+    a, b = _replica(), _replica()
+    for tid in ("cc", "aa", "bb"):
+        a.merge_revocations(f'{{"crdt": "{CRDT_KIND}", "revoked": ["{tid}"]}}'.encode())
+    b.merge_revocations(f'{{"crdt": "{CRDT_KIND}", "revoked": ["bb", "aa", "cc"]}}'.encode())
+    assert a.export_revocations() == b.export_revocations()
+
+
+# -- Hardening ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        b"",
+        b"not json",
+        b"\xff\xfe",
+        b"[]",
+        b'"revoked"',
+        b"{}",
+        b'{"crdt": "lww_register", "revoked": []}',
+        b'{"crdt": "revocation_gset", "revoked": "ab"}',
+        b'{"crdt": "revocation_gset", "revoked": [1, 2]}',
+        b'{"crdt": "revocation_gset", "revoked": [["ab"]]}',
+    ],
+)
+def test_malformed_state_rejected_and_replica_untouched(state: bytes) -> None:
+    auth = _replica()
+    auth.merge_revocations(b'{"crdt": "revocation_gset", "revoked": ["keep"]}')
+    before = auth.export_revocations()
+    with pytest.raises(RevocationStateError):
+        auth.merge_revocations(state)
+    assert auth.export_revocations() == before
+
+
+def test_revocation_state_error_is_a_value_error() -> None:
+    assert issubclass(RevocationStateError, ValueError)

--- a/packages/nest-plugins-reference/tests/test_mesh_revocable_auth_properties.py
+++ b/packages/nest-plugins-reference/tests/test_mesh_revocable_auth_properties.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Property tests for the mesh-revocable auth plugin.
+
+Two families of invariants: (1) the replication channel is a genuine
+semilattice join at the plugin surface -- merge is commutative,
+associative, and idempotent over exported bytes for arbitrary
+revocation sets; (2) *eventual fatality* -- after one revocation and
+any Hypothesis-drawn sequence of pairwise gossips that ends with a full
+round-robin pass, every replica denies the revoked lineage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Coroutine
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId
+from nest_plugins_reference.auth.delegatable import RevokedAncestorError
+from nest_plugins_reference.auth.mesh_revocable import CRDT_KIND, MeshRevocableAuth
+
+_TIDS = st.sets(st.text(alphabet="0123456789abcdef", min_size=1, max_size=8), max_size=8)
+
+
+def _run(coro: Coroutine[Any, Any, None]) -> None:
+    asyncio.run(coro)
+
+
+def _state(tids: set[str]) -> bytes:
+    return json.dumps({"crdt": CRDT_KIND, "revoked": sorted(tids)}).encode()
+
+
+def _loaded(tids: set[str]) -> MeshRevocableAuth:
+    auth = MeshRevocableAuth(secret=b"s", clock=0.0)
+    if tids:
+        auth.merge_revocations(_state(tids))
+    return auth
+
+
+@given(a=_TIDS, b=_TIDS)
+@settings(max_examples=50)
+def test_merge_commutative(a: set[str], b: set[str]) -> None:
+    left = _loaded(a)
+    left.merge_revocations(_state(b))
+    right = _loaded(b)
+    right.merge_revocations(_state(a))
+    assert left.export_revocations() == right.export_revocations()
+
+
+@given(a=_TIDS, b=_TIDS, c=_TIDS)
+@settings(max_examples=50)
+def test_merge_associative(a: set[str], b: set[str], c: set[str]) -> None:
+    ab_then_c = _loaded(a)
+    ab_then_c.merge_revocations(_state(b))
+    ab_then_c.merge_revocations(_state(c))
+
+    bc = _loaded(b)
+    bc.merge_revocations(_state(c))
+    a_then_bc = _loaded(a)
+    a_then_bc.merge_revocations(bc.export_revocations())
+
+    assert ab_then_c.export_revocations() == a_then_bc.export_revocations()
+
+
+@given(a=_TIDS)
+@settings(max_examples=50)
+def test_merge_idempotent(a: set[str]) -> None:
+    auth = _loaded(a)
+    once = auth.export_revocations()
+    assert auth.merge_revocations(once) is False
+    assert auth.export_revocations() == once
+
+
+@given(
+    gossip_pairs=st.lists(
+        st.tuples(st.integers(min_value=0, max_value=3), st.integers(min_value=0, max_value=3)),
+        max_size=12,
+    )
+)
+@settings(max_examples=30, deadline=None)
+def test_revocation_eventually_fatal_under_any_gossip_order(
+    gossip_pairs: list[tuple[int, int]],
+) -> None:
+    async def scenario() -> None:
+        replicas = [MeshRevocableAuth(secret=b"s", clock=0.0) for _ in range(4)]
+        issuer = replicas[0]
+        root = await issuer.issue(AgentId("coordinator"), ["read", "write"])
+        child = await issuer.delegate(root, AgentId("worker"), ["read"], ttl=600.0)
+        await issuer.revoke(root)
+
+        # Arbitrary partial gossip drawn by Hypothesis...
+        for src, dst in gossip_pairs:
+            if src != dst:
+                replicas[dst].merge_revocations(replicas[src].export_revocations())
+        # ...then one full round-robin pass (a heal): 0->1->2->3 then 3->0.
+        for i in range(3):
+            replicas[i + 1].merge_revocations(replicas[i].export_revocations())
+        replicas[0].merge_revocations(replicas[3].export_revocations())
+
+        for replica in replicas:
+            with pytest.raises(RevokedAncestorError):
+                await replica.verify(child)
+
+    _run(scenario())

--- a/packages/nest-plugins-reference/tests/test_revocation_propagation_validators.py
+++ b/packages/nest-plugins-reference/tests/test_revocation_propagation_validators.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the revocation-propagation validators.
+
+Hand-built audit streams cover every verdict path of both checks --
+converged / stale-forever / vacuous for ``check_revocation_converges``,
+and available / impossibly-instant / missing-revocation for
+``check_partition_liveness`` -- plus ``find_partition_ticks`` extraction.
+The full-runner discrimination test (both auth plugins through the real
+simulator and partition machinery) lives in
+``packages/nest-core/tests/test_delegated_auth_partition_scenario.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_plugins_reference.validators import (
+    check_partition_liveness,
+    check_revocation_converges,
+    find_partition_ticks,
+)
+
+REVOKED_TID = "aaaa000011112222"
+
+
+def _revoke(tick: int = 20) -> dict[str, Any]:
+    return {
+        "type": "delegation_audit",
+        "op": "revoke",
+        "tick": tick,
+        "tid": REVOKED_TID,
+        "target": "intermediary-1",
+        "revoker": "coordinator-0",
+    }
+
+
+def _verify(tick: int, verifier: str, verified: bool, tid: str = REVOKED_TID) -> dict[str, Any]:
+    return {
+        "type": "delegation_audit",
+        "op": "verify",
+        "tick": tick,
+        "verifier": verifier,
+        "presenter": "leaf-3",
+        "audience": "leaf-3",
+        "chain_tids": ["rootroot", tid, "leafleaf"],
+        "verified": verified,
+    }
+
+
+# -- check_revocation_converges ---------------------------------------------
+
+
+def test_converges_passes_when_all_verifiers_deny_after_deadline() -> None:
+    audits = [
+        _revoke(),
+        _verify(30, "gateway-0", verified=True),  # during partition: allowed
+        _verify(70, "gateway-0", verified=False),
+        _verify(76, "coordinator-0", verified=False),
+    ]
+    report = check_revocation_converges(audits, deadline_tick=67.0)
+    assert report.passed, report.detail
+
+
+def test_converges_fails_on_stale_accept_after_deadline() -> None:
+    audits = [
+        _revoke(),
+        _verify(70, "gateway-0", verified=True),
+        _verify(76, "gateway-0", verified=False),
+    ]
+    report = check_revocation_converges(audits, deadline_tick=67.0)
+    assert not report.passed
+    assert report.evidence
+
+
+def test_converges_fails_vacuously_without_remote_denial() -> None:
+    # Presentations simply stopped after the deadline: convergence unproven.
+    audits = [
+        _revoke(),
+        _verify(30, "gateway-0", verified=True),
+        _verify(70, "coordinator-0", verified=False),  # revoker's own denial doesn't count
+    ]
+    report = check_revocation_converges(audits, deadline_tick=67.0)
+    assert not report.passed
+    assert "unproven" in report.detail
+
+
+def test_converges_fails_without_any_revocation() -> None:
+    report = check_revocation_converges([_verify(70, "gateway-0", False)], deadline_tick=67.0)
+    assert not report.passed
+
+
+def test_converges_ignores_unrelated_lineages() -> None:
+    audits = [
+        _revoke(),
+        _verify(70, "gateway-0", verified=True, tid="ffff999988887777"),  # different lineage
+        _verify(72, "gateway-0", verified=False),
+    ]
+    report = check_revocation_converges(audits, deadline_tick=67.0)
+    assert report.passed, report.detail
+
+
+# -- check_partition_liveness ------------------------------------------------
+
+
+def test_liveness_passes_when_isolated_side_kept_serving() -> None:
+    audits = [_revoke(tick=20), _verify(30, "gateway-0", verified=True)]
+    report = check_partition_liveness(audits, heal_tick=57.0)
+    assert report.passed, report.detail
+
+
+def test_liveness_fails_on_impossibly_instant_denial() -> None:
+    # The shared-single-instance shortcut: the remote verifier denies within
+    # the partition window despite never having been reachable.
+    audits = [
+        _revoke(tick=20),
+        _verify(30, "gateway-0", verified=False),
+        _verify(40, "gateway-0", verified=False),
+    ]
+    report = check_partition_liveness(audits, heal_tick=57.0)
+    assert not report.passed
+
+
+def test_liveness_ignores_revokers_own_denials() -> None:
+    audits = [
+        _revoke(tick=20),
+        _verify(30, "coordinator-0", verified=False),  # the revoker knows, of course
+        _verify(36, "gateway-0", verified=True),
+    ]
+    report = check_partition_liveness(audits, heal_tick=57.0)
+    assert report.passed, report.detail
+
+
+def test_liveness_fails_without_any_revocation() -> None:
+    report = check_partition_liveness([_verify(30, "gateway-0", True)], heal_tick=57.0)
+    assert not report.passed
+
+
+# -- find_partition_ticks -----------------------------------------------------
+
+
+def test_find_partition_ticks_reads_simulator_records() -> None:
+    events = [
+        {"ts": 1.0, "agent": "a", "kind": "receive", "msg": "{}"},
+        {"ts": 9.0, "agent": "_simulator", "kind": "partition_started"},
+        {"ts": 57.0, "agent": "_simulator", "kind": "partition_healed"},
+    ]
+    assert find_partition_ticks(events) == (9.0, 57.0)
+
+
+def test_find_partition_ticks_handles_absence() -> None:
+    assert find_partition_ticks([{"ts": 1.0, "kind": "receive"}]) == (None, None)

--- a/scenarios/delegated_auth_partition.yaml
+++ b/scenarios/delegated_auth_partition.yaml
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegated-auth partition scenario: revocation during a network split.
+# Every verifier owns its own auth replica; revocation knowledge travels
+# only by gossip. The coordinator revokes intermediary-1's grant WHILE the
+# mesh is partitioned: the far-side gateway keeps honoring that subtree
+# (partition liveness), then denies it mesh-wide within a bounded number
+# of gossip rounds after the heal (revocation convergence). Under
+# auth: mesh_revocable both validators pass; under per-replica
+# auth: delegatable convergence fails (see
+# nest_plugins_reference.validators.revocation_propagation_validators).
+#
+# The partition window is expressed in simulation time, so it is identical
+# whichever auth plugin is swapped in -- an event-count window would drift,
+# because a gossiping plugin processes far more events per simulated tick.
+
+name: delegated_auth_partition
+description: |
+  A coordinator delegates through 2 intermediaries to 6 leaves, which
+  present tokens to 2 independent verifiers. The mesh partitions; the
+  coordinator revokes the far-side subtree's grant during the split.
+  After the heal, gossiped revocation state must converge mesh-wide.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 10
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+    - name: gateway
+      count: 1
+    - name: intermediary
+      count: 2
+    - name: leaf
+      count: 6
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: mesh_revocable
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: delegated_auth_partition
+  config:
+    revoke_tick: 20
+    gossip_interval: 5
+    gossip_until: 95
+    presents: 15
+    present_interval: 6
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+  network_partition:
+    groups:
+      - [coordinator-0, intermediary-0, leaf-0, leaf-1, leaf-2]
+      - [gateway-0, intermediary-1, leaf-3, leaf-4, leaf-5]
+  # Grants are delivered by t=2; revocation lands at t=20, inside the split.
+  partition_start_at_time: 10.0
+  partition_heal_at_time: 55.0
+
+duration: "ticks: 100000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/delegated_auth_partition.jsonl


### PR DESCRIPTION
# auth: `mesh_revocable` — revocation that survives a network partition

## Problem

`delegatable` (#138) solved delegation, but its revocation set is one in-process
`set[str]`, and `delegated_auth` hands **a single plugin instance to all sixteen
agents** — so the cascade is global for free. It's one Python object.

Give each agent its own replica, the only shape a real network permits, and the
guarantee vanishes: a revocation at the issuer is invisible to every other
verifier, forever.

## Solution

`MeshRevocableAuth` subclasses `DelegatableAuth` — token format, HMAC chain,
attenuation, exceptions all inherited verbatim, zero overrides — and reinterprets
the inherited revocation set as a replica of a **grow-only set CRDT**.
`export_revocations()` / `merge_revocations()` are the gossip channel. Union is
commutative, associative and idempotent, so replicas converge under any delivery
order (Hypothesis enforces the laws). Malformed gossip raises
`RevocationStateError` and leaves the replica untouched. 150 lines.

## Evidence

`nest run delegated_auth_partition` — 10 agents, seed 42, byte-identical across
runs. Split at t=10; revoke the far subtree's grant at t=20 while it's
unreachable; heal at t=55; gossip every 5 ticks. Far-side gateway on that lineage:

```
t= 3..51   accept   (split open from t=10 — it cannot know)
t=57..87   DENY     (healed t=55; converged within one gossip round)
```

Same scenario, swapped plugin:

| Wiring | liveness | converges |
|---|---|---|
| `delegatable`, one shared instance | ✗ denies impossibly fast | ✓ vacuously |
| `delegatable`, one replica per agent | ✓ | **✗ stale forever** |
| `mesh_revocable`, one replica per agent | ✓ | ✓ |

That middle row is the gap. An end-to-end test drives the real simulator under
both plugins and locks the flip into CI.

Two validators encode both halves of the CAP position, so neither can rot:
`check_partition_liveness` (an isolated verifier **must** keep accepting — denying
instantly claims knowledge the network never delivered) and
`check_revocation_converges` (after heal + a gossip bound nobody accepts, **and** a
verifier other than the revoker explicitly denied — no vacuous pass).
`check_no_stale_ancestor_use` is deliberately not asserted: unattainable under
partition. The merged escalation and audience validators run green here.

## Supporting core change

Partitions activated at the first event, so no scenario could establish
cross-boundary state before the split. Adds `partition_start_at_time` /
`partition_heal_at_time`, gating on **simulation time** — a gossiping plugin burns
more events per tick, so `t=55` is event 702 under `mesh_revocable` and 339 under
`delegatable`; an event-count window would put the two under *different*
partitions and void the comparison. `partition_heal_at_tick` keeps its meaning and
its test; `None` preserves today's behavior.

## Verification

`make ci-local` green: ruff + format clean, pyright strict **0 errors**, **1192
passed** (`main` collects 1151; +42 here). `nest doctor` 7/7. `nest run
delegated_auth` unchanged. Registered in `_BUILTINS` and as a `nest.plugins.auth`
entry point. Docs: [`docs/layers/mesh_revocable_auth.md`](docs/layers/mesh_revocable_auth.md).

## Limits

- **Revocation window** = partition duration + up to one gossip interval. The CAP
  price, bounded and explicit.
- **Grow-only**, matching the base plugin's no-unrevoke semantics.
- **Gossip is the deployment's job** — the plugin exposes the channel, not a
  transport.
- **Symmetric secret, inherited** — any holder can also mint.
- **Couples to the base plugin's private `_revoked`** — regression tests make an
  upstream refactor fail loudly, not silently.
