### PR TITLE
[hackathon phase 1] fix: return defensive copy from CidFacts.fetch()

### DIFF
--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/cid_facts.py
@@ -232,7 +232,7 @@ class CidFacts:
         if meta is None:
             msg = f"Dataset not found: {url}"
             raise KeyError(msg)
-        return meta
+        return meta.model_copy(deep=True)
 
     async def request_access(self, url: DataFactsUrl, requester: AgentId) -> AccessGrant:
         """Request access to a dataset; ACL is keyed by content hash, not name.

--- a/packages/nest-plugins-reference/tests/test_cid_facts.py
+++ b/packages/nest-plugins-reference/tests/test_cid_facts.py
@@ -89,6 +89,33 @@ class TestProtocolConformance:
         with pytest.raises(KeyError):
             await facts.fetch("df://sha256-doesnotexist")  # type: ignore[arg-type]
 
+    @pytest.mark.asyncio
+    async def test_fetch_returns_defensive_copy(self) -> None:
+        """Mutating a fetched dataset must not mutate the registry."""
+
+        ident = DidKeyIdentity(AgentId("a1"), seed=b"s")
+        facts = CidFacts(ident)
+
+        dataset = DatasetMetadata(
+            name="raw",
+            owner=AgentId("a1"),
+            description="original",
+            metadata={"key": "value"},
+        )
+
+        url = await facts.publish(dataset)
+
+        fetched = await facts.fetch(url)
+
+        # Attempt to mutate the returned object.
+        fetched.description = "tampered"
+        fetched.metadata["key"] = "changed"
+
+        fetched_again = await facts.fetch(url)
+
+        assert fetched_again.description == "original"
+        assert fetched_again.metadata["key"] == "value"
+
 
 # ---------------------------------------------------------------------------
 # Provenance


### PR DESCRIPTION
Fixes a bug where CidFacts.fetch() returned the mutable internal object instead of a copy, which allowed the caller to unintentionally tamper with the registry content.

Updates CidFacts.fetch() to return meta.model_copy(deep=True).
Adds a new protocol conformance test test_fetch_returns_defensive_copy explicitly testing the immutability of the fetched registry data.