### PR TITLE
[Hackathon] dhritimandas: capability-conformance registry gate

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -25,6 +25,9 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("identity", "ed25519_rotating"): (f"{_REF}.identity.ed25519_rotating:Ed25519RotatingIdentity"),
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
+    ("registry", "verified_capabilities"): (
+        f"{_REF}.registry.verified_capabilities:VerifiedCapabilitiesRegistry"
+    ),
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -175,3 +175,9 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.sybil_bond import sybil_bond_factory
 
         register_scenario("sybil_bond", sybil_bond_factory)
+    elif name == "capability_spoofing":
+        from nest_core.scenarios_builtin.capability_spoofing import (
+            capability_spoofing_factory,
+        )
+
+        register_scenario("capability_spoofing", capability_spoofing_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/capability_spoofing.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/capability_spoofing.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Capability-spoofing scenario — buyers discover sellers whose claims are not all true.
+
+Honest sellers, always-silent spoofers, and a bait-and-switch seller all
+register the identical claim ``capabilities=["sell"]``. Buyers discover
+sellers purely through ``registry.lookup(Query(capabilities=["sell"]))`` and
+report what they observe back to the registry: a ``sold:`` response before
+the round's timeout is a fulfillment, the round's self-scheduled
+``TIMEOUT:<round>`` firing first (no response arrived) is a defection.
+
+The same lookup path either keeps returning a silent spoofer forever
+(``registry: in_memory``, which has no concept of a defection) or stops
+returning it once observed defections cross the threshold
+(``registry: verified_capabilities``) -- see
+``nest_plugins_reference.validators.capability_validators``.
+
+Identity, trust, and payments layers are intentionally not wired: this
+scenario isolates the registry-discovery mechanism from every other check a
+real marketplace would layer on top of it.
+
+Example::
+
+    agents = capability_spoofing_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentCard, AgentId, Query
+
+DEFAULT_ROUNDS = 6
+DEFAULT_TIMEOUT = 5.0
+DEFAULT_PRICE = 50
+
+
+def _product_from(msg: str) -> str:
+    parts = msg.split(":")
+    return parts[1] if len(parts) >= 2 else "product"
+
+
+class HonestSellerAgent(StateMachineAgent):
+    """Registers ``sell`` and fulfills every buy request it receives.
+
+    Example::
+
+        agent = HonestSellerAgent(AgentId("honest-0"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Register this seller's ``sell`` capability.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        registry = ctx.plugins.get("registry")
+        if registry is not None:
+            await registry.register(
+                AgentCard(agent_id=ctx.agent_id, name=str(ctx.agent_id), capabilities=["sell"])
+            )
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Respond ``sold:`` to every ``buy:`` request.
+
+        Example::
+
+            await agent.on_message(ctx, sender, b"buy:product-0:50")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("buy:"):
+            return
+        await ctx.send(sender, f"sold:{_product_from(msg)}:{DEFAULT_PRICE}".encode())
+
+
+class SpoofingSellerAgent(StateMachineAgent):
+    """Registers ``sell`` but never responds to a buy request — a pure claim, no fulfillment.
+
+    Example::
+
+        agent = SpoofingSellerAgent(AgentId("spoofer-0"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Register the ``sell`` claim this agent will never honor.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        registry = ctx.plugins.get("registry")
+        if registry is not None:
+            await registry.register(
+                AgentCard(agent_id=ctx.agent_id, name=str(ctx.agent_id), capabilities=["sell"])
+            )
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Ignore every message — silence is the attack.
+
+        Example::
+
+            await agent.on_message(ctx, sender, b"buy:product-0:50")
+        """
+        return
+
+
+class BaitAndSwitchSellerAgent(StateMachineAgent):
+    """Registers ``sell``, fulfills exactly one buy request, then goes silent forever.
+
+    Example::
+
+        agent = BaitAndSwitchSellerAgent(AgentId("baitswitch-0"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+        self._fulfilled_once = False
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Register the ``sell`` claim this agent will honor exactly once.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        registry = ctx.plugins.get("registry")
+        if registry is not None:
+            await registry.register(
+                AgentCard(agent_id=ctx.agent_id, name=str(ctx.agent_id), capabilities=["sell"])
+            )
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Fulfill the first buy request only; go silent on every one after.
+
+        Example::
+
+            await agent.on_message(ctx, sender, b"buy:product-0:50")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("buy:") or self._fulfilled_once:
+            return
+        self._fulfilled_once = True
+        await ctx.send(sender, f"sold:{_product_from(msg)}:{DEFAULT_PRICE}".encode())
+
+
+class SpoofCheckBuyerAgent(StateMachineAgent):
+    """Buyer that discovers sellers via the registry and reports fulfillment/defection.
+
+    Sends exactly one outstanding ``buy:`` at a time, so a round's outcome
+    can never be mis-attributed to a different in-flight round. A ``sold:``
+    response before the round's timeout is a fulfillment; the round's
+    self-scheduled ``TIMEOUT:<round>`` firing first (no response in time) is
+    a defection. A ``reject:`` response is a business decision, not a
+    discovery-layer lie, and is reported as neither.
+
+    Example::
+
+        agent = SpoofCheckBuyerAgent(AgentId("buyer-0"), rounds=6)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        rounds: int = DEFAULT_ROUNDS,
+        timeout: float = DEFAULT_TIMEOUT,
+        price: int = DEFAULT_PRICE,
+    ) -> None:
+        self._id = agent_id
+        self._rounds = rounds
+        self._timeout = timeout
+        self._price = price
+        self._round = 0
+        self._resolved: set[int] = set()
+        self._round_seller: dict[int, AgentId] = {}
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Discover a seller and send the first buy request.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        await self._send_buy(ctx)
+
+    async def _pick_seller(self, ctx: AgentContext) -> AgentId | None:
+        """Return a seller discovered via the registry, or ``None`` if none is visible."""
+        registry = ctx.plugins.get("registry")
+        if registry is None:
+            return None
+        sellers = await registry.lookup(Query(capabilities=["sell"]))
+        if not sellers:
+            return None
+        return sellers[ctx.rng.randint(0, len(sellers) - 1)].agent_id
+
+    async def _send_buy(self, ctx: AgentContext) -> None:
+        """Send a buy request for the current round, or skip it if no seller is visible."""
+        seller = await self._pick_seller(ctx)
+        if seller is None:
+            self._round += 1
+            if self._round < self._rounds:
+                await self._send_buy(ctx)
+            return
+        round_num = self._round
+        self._round_seller[round_num] = seller
+        await ctx.send(seller, f"buy:product-{round_num}:{self._price}".encode())
+        await ctx.schedule(self._timeout, f"TIMEOUT:{round_num}".encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Route a self-timeout to defection handling, everything else to response handling.
+
+        Example::
+
+            await agent.on_message(ctx, sender, b"sold:product-0:50")
+        """
+        if sender == ctx.agent_id:
+            await self._on_timeout(ctx, payload)
+        else:
+            await self._on_response(ctx, sender, payload)
+
+    async def _on_timeout(self, ctx: AgentContext, payload: bytes) -> None:
+        """Report a defection if the round's timeout fires before any response."""
+        msg = payload.decode()
+        if not msg.startswith("TIMEOUT:"):
+            return
+        round_num = int(msg.split(":", 1)[1])
+        if round_num in self._resolved:
+            return
+        self._resolved.add(round_num)
+        seller = self._round_seller.get(round_num)
+        registry = ctx.plugins.get("registry")
+        if seller is not None and registry is not None and hasattr(registry, "report_defection"):
+            registry.report_defection(seller, "sell")
+        self._round += 1
+        if self._round < self._rounds:
+            await self._send_buy(ctx)
+
+    async def _on_response(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Report a fulfillment on ``sold:``; advance the round on any resolving reply."""
+        round_num = self._round
+        if round_num in self._resolved or self._round_seller.get(round_num) != sender:
+            return
+        self._resolved.add(round_num)
+        msg = payload.decode("utf-8", errors="replace")
+        if msg.startswith("sold:"):
+            registry = ctx.plugins.get("registry")
+            if registry is not None and hasattr(registry, "report_fulfillment"):
+                registry.report_fulfillment(sender, "sell")
+        self._round += 1
+        if self._round < self._rounds:
+            await self._send_buy(ctx)
+
+
+def _setup_plugins(plugins: dict[str, Any]) -> None:
+    """Instantiate the registry plugin; drop identity/trust/payments (out of scope).
+
+    Example::
+
+        _setup_plugins(plugins)
+    """
+    if not plugins:
+        return
+    registry_cls = plugins.get("registry")
+    if registry_cls is not None and isinstance(registry_cls, type):
+        plugins["registry"] = registry_cls()
+    plugins.pop("identity", None)
+    plugins.pop("trust", None)
+    plugins.pop("payments", None)
+
+
+def capability_spoofing_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create honest sellers, spoofers, a bait-and-switch seller, and buyers.
+
+    Example::
+
+        agents = capability_spoofing_factory(config, plugins)
+    """
+    task_config = config.task.config
+    rounds = task_config.get("rounds", DEFAULT_ROUNDS)
+    timeout = task_config.get("timeout", DEFAULT_TIMEOUT)
+    price = task_config.get("price", DEFAULT_PRICE)
+
+    role_counts = {role.name: role.count for role in config.agents.roles}
+    honest_count = role_counts.get("honest_seller", 0)
+    spoofer_count = role_counts.get("spoofer", 0)
+    bait_switch_count = role_counts.get("bait_switch", 0)
+    buyer_count = role_counts.get("buyer", 0)
+
+    _setup_plugins(plugins)
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    for i in range(honest_count):
+        aid = AgentId(f"honest-{i}")
+        agents[aid] = HonestSellerAgent(aid)
+    for i in range(spoofer_count):
+        aid = AgentId(f"spoofer-{i}")
+        agents[aid] = SpoofingSellerAgent(aid)
+    for i in range(bait_switch_count):
+        aid = AgentId(f"baitswitch-{i}")
+        agents[aid] = BaitAndSwitchSellerAgent(aid)
+    for i in range(buyer_count):
+        aid = AgentId(f"buyer-{i}")
+        agents[aid] = SpoofCheckBuyerAgent(aid, rounds=rounds, timeout=timeout, price=price)
+
+    return agents

--- a/packages/nest-plugins-reference/nest_plugins_reference/registry/verified_capabilities.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/registry/verified_capabilities.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Capability-conformance registry gate — a signature is not a verified skill.
+
+``AgentCard.capabilities`` (``nest_core.types``) is a bare, self-asserted
+``list[str]``. Every existing defense in this repo — signed cards
+(``ed25519_rotating``, ``byzantine_gossip``), scored reputation
+(``agent_receipts``, ``score_average``) — proves who published a claim or how
+an agent behaves *overall*. None of them checks a claim against the specific
+behavior it names: an agent can register ``capabilities=["sell"]`` with a
+perfectly valid signature and keep being discovered forever even if it never
+completes a single sale. That gap is the one A2A v1.0's signed Agent Cards
+and NANDA's Verified AgentFacts layer both name and neither closes: signing
+proves the publisher, not the capability.
+
+This plugin closes it at the discovery boundary. It wraps an inner registry
+and tracks fulfillment/defection evidence **per ``(agent_id, capability)``
+pair**, not per agent:
+
+* **Bootstrap allowance.** A pair with no evidence yet is never excluded —
+  discovery cannot punish a claim nobody has tested.
+* **Per-capability exclusion.** Once a pair accumulates
+  ``defection_threshold`` defections, ``lookup`` stops returning that agent
+  for queries naming that capability. A defection on ``"sell"`` does not
+  affect the same agent's ``"deliver"`` capability — the gate is on the
+  claim, not the identity.
+* **Re-admission, not blacklisting.** A single ``report_fulfillment`` call
+  resets that pair's defection count to zero. This is a known trade-off, not
+  an oversight: an attacker who fulfills once per ``defection_threshold - 1``
+  defections evades exclusion indefinitely. Closing that requires a
+  windowed or decaying counter, out of scope for this gate.
+
+``report_fulfillment``/``report_defection`` are not part of the ``Registry``
+Protocol — callers (agents, scenario factories, tests) call them directly on
+the concrete instance, the same way ``GossipRegistry`` exposes
+``gossip_round`` beyond the interface it implements.
+
+Registered as ``("registry", "verified_capabilities")`` in
+``nest_core.plugins``.
+
+Example::
+
+    reg = VerifiedCapabilitiesRegistry()
+    await reg.register(AgentCard(agent_id=AgentId("a1"), name="a1", capabilities=["sell"]))
+    reg.report_defection(AgentId("a1"), "sell")
+    results = await reg.lookup(Query(capabilities=["sell"]))  # [] once excluded
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from nest_core.types import AgentCard, AgentId, Query
+
+from nest_plugins_reference.registry.in_memory import InMemoryRegistry
+
+DEFAULT_DEFECTION_THRESHOLD = 1
+"""Defections on a single ``(agent, capability)`` pair before it is excluded.
+
+The reference scenario runs at zero message drop, so there is no transient
+noise a legitimate defection could be confused with — one observed silence
+past a buyer's timeout is already a real signal, not jitter. Set higher for
+a lossy transport, mirroring how ``gossip.py`` ties its convergence bound to
+its configured drop rate.
+"""
+
+
+class VerifiedCapabilitiesRegistry:
+    """Registry wrapper that gates capability discovery on fulfillment evidence.
+
+    Example::
+
+        reg = VerifiedCapabilitiesRegistry(defection_threshold=1)
+        await reg.register(card)
+    """
+
+    def __init__(
+        self,
+        inner: Any = None,
+        *,
+        defection_threshold: int = DEFAULT_DEFECTION_THRESHOLD,
+    ) -> None:
+        self._inner = inner if inner is not None else InMemoryRegistry()
+        self._threshold = defection_threshold
+        self._defections: dict[tuple[AgentId, str], int] = {}
+
+    def _is_excluded(self, agent_id: AgentId, capability: str) -> bool:
+        return self._defections.get((agent_id, capability), 0) >= self._threshold
+
+    def _passes_gate(self, card: AgentCard, query: Query) -> bool:
+        return not any(self._is_excluded(card.agent_id, cap) for cap in query.capabilities)
+
+    async def register(self, card: AgentCard) -> None:
+        """Register an agent card with the inner registry.
+
+        Example::
+
+            await reg.register(card)
+        """
+        await self._inner.register(card)
+
+    async def lookup(self, query: Query) -> list[AgentCard]:
+        """Look up agents matching *query*, excluding gated capability claims.
+
+        A card is dropped iff, for at least one capability named in
+        ``query.capabilities``, that ``(agent_id, capability)`` pair has
+        reached ``defection_threshold``. Capabilities not named in the query
+        never affect inclusion.
+
+        Example::
+
+            results = await reg.lookup(Query(capabilities=["sell"]))
+        """
+        candidates = await self._inner.lookup(query)
+        return [card for card in candidates if self._passes_gate(card, query)]
+
+    async def subscribe(self, query: Query) -> AsyncIterator[AgentCard]:
+        """Subscribe to new registrations matching *query*, applying the same gate.
+
+        The gate is evaluated at yield time, so a card excluded when it
+        registers but re-admitted later is still delivered once fulfillment
+        evidence clears it on a subsequent registration.
+
+        Example::
+
+            async for card in reg.subscribe(query):
+                print(card.name)
+        """
+        async for card in self._inner.subscribe(query):
+            if self._passes_gate(card, query):
+                yield card
+
+    async def deregister(self, agent: AgentId) -> None:
+        """Remove an agent from the inner registry.
+
+        Example::
+
+            await reg.deregister(AgentId("a1"))
+        """
+        await self._inner.deregister(agent)
+
+    def report_fulfillment(self, agent_id: AgentId, capability: str) -> None:
+        """Record that *agent_id* fulfilled an observed *capability* interaction.
+
+        Resets that pair's defection count to zero, re-admitting it to
+        ``lookup`` results for that capability if it had been excluded.
+
+        Example::
+
+            reg.report_fulfillment(AgentId("a1"), "sell")
+        """
+        self._defections[(agent_id, capability)] = 0
+
+    def report_defection(self, agent_id: AgentId, capability: str) -> None:
+        """Record that *agent_id* defected on an observed *capability* interaction.
+
+        Increments that pair's defection count; once it reaches
+        ``defection_threshold``, the agent stops appearing in ``lookup``
+        results for queries naming that capability.
+
+        Example::
+
+            reg.report_defection(AgentId("a1"), "sell")
+        """
+        key = (agent_id, capability)
+        self._defections[key] = self._defections.get(key, 0) + 1

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/capability_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/capability_validators.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validator for the capability-conformance registry gate.
+
+The attack this catches: an agent registers a capability claim
+(``capabilities=["sell"]``) with a perfectly valid registration and never
+honors it. Every existing defense in this repo verifies the *publisher* of
+a claim (signatures, identity) or an agent's *overall* reputation
+(``agent_receipts``, ``score_average``); none of them checks a claim
+against the specific behavior it names. ``check_capability_conformance``
+asserts the one property that actually distinguishes a real skill from an
+advertised one: after enough observed defections, the registry must stop
+returning the claimant for that capability.
+
+Registry ``lookup`` calls are not recorded in the trace (see
+``nest_core.sim.simulator``, which traces send/broadcast/deliver/receive
+events only), so this validator is not a trace parser. It is a pure
+function over a live registry instance -- the same pattern
+``registry_byzantine_validators`` and ``gossip_validators`` use for
+properties that live in plugin state rather than message content. Callers
+obtain the instance from ``ScenarioRunner.resolved_plugins["registry"]``
+after running ``scenarios/capability_spoofing.yaml``.
+
+By construction:
+
+* against ``registry: in_memory`` (no concept of a defection), the
+  spoofers and the bait-and-switch seller are still returned by
+  ``lookup`` at the end of the run -- the check fails;
+* against ``registry: verified_capabilities``, they are excluded once
+  their defection count crosses the threshold, while every honest seller
+  remains discoverable throughout -- the check passes.
+
+Example::
+
+    report = await check_capability_conformance(
+        registry, spoofer_ids={AgentId("spoofer-0")}, honest_ids={AgentId("honest-0")},
+    )
+    assert report.passed, report.detail
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from nest_core.types import Query
+
+if TYPE_CHECKING:
+    from nest_core.types import AgentId
+
+
+@dataclass
+class ValidatorReport:
+    """Pass/fail report with a short human-readable explanation.
+
+    Example::
+
+        report = ValidatorReport(passed=True, detail="2 spoofers excluded")
+        assert report.passed, report.detail
+    """
+
+    passed: bool
+    detail: str
+    evidence: dict[str, object] = field(default_factory=dict[str, object])
+
+
+async def check_capability_conformance(
+    registry: Any,
+    *,
+    spoofer_ids: set[AgentId],
+    honest_ids: set[AgentId],
+    capability: str = "sell",
+) -> ValidatorReport:
+    """Assert defecting claimants are excluded and honest claimants are not.
+
+    Runs a single ``lookup(Query(capabilities=[capability]))`` against
+    *registry* and checks two properties together, so a gate that blocks
+    everyone cannot pass by accident:
+
+    1. No id in *spoofer_ids* appears in the result (the adversarial
+       property this validator exists for).
+    2. Every id in *honest_ids* still appears in the result (no
+       over-blocking -- a gate that excludes indiscriminately is not a
+       fix).
+
+    Example::
+
+        report = await check_capability_conformance(
+            registry, spoofer_ids={AgentId("spoofer-0")}, honest_ids={AgentId("honest-0")},
+        )
+    """
+    results = await registry.lookup(Query(capabilities=[capability]))
+    visible_ids = {card.agent_id for card in results}
+
+    leaked = sorted(spoofer_ids & visible_ids)
+    over_blocked = sorted(honest_ids - visible_ids)
+
+    if leaked or over_blocked:
+        problems: list[str] = []
+        if leaked:
+            problems.append(f"still discoverable for {capability!r}: {leaked}")
+        if over_blocked:
+            problems.append(f"honest agents wrongly excluded from {capability!r}: {over_blocked}")
+        return ValidatorReport(
+            passed=False,
+            detail="; ".join(problems),
+            evidence={
+                "visible": sorted(visible_ids),
+                "spoofers": sorted(spoofer_ids),
+                "honest": sorted(honest_ids),
+            },
+        )
+    return ValidatorReport(
+        passed=True,
+        detail=(
+            f"{len(spoofer_ids)} spoofer(s) excluded from {capability!r}, "
+            f"{len(honest_ids)} honest agent(s) still discoverable"
+        ),
+    )

--- a/packages/nest-plugins-reference/tests/test_capability_spoofing_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_capability_spoofing_scenario.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end FAIL/PASS gate: capability_spoofing scenario vs the reference registry.
+
+Runs the same ``scenarios/capability_spoofing.yaml`` under
+``registry: in_memory`` and ``registry: verified_capabilities`` -- same
+seed, only ``layers.registry`` differs -- and proves
+``check_capability_conformance`` FAILs against ``in_memory`` (spoofers stay
+discoverable forever; ``in_memory`` has no concept of a defection) and
+PASSes against ``verified_capabilities`` (every spoofer excluded, every
+honest seller still discoverable), deterministically across seeds 42, 7,
+1337.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.types import AgentId
+from nest_plugins_reference.validators.capability_validators import (
+    check_capability_conformance,
+)
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "capability_spoofing.yaml"
+
+_SEEDS = [42, 7, 1337]
+
+_SPOOFER_IDS = {AgentId("spoofer-0"), AgentId("spoofer-1"), AgentId("baitswitch-0")}
+_HONEST_IDS = {AgentId("honest-0"), AgentId("honest-1"), AgentId("honest-2")}
+
+
+def _run(registry_plugin: str, seed: int, trace_path: Path) -> dict[str, object]:
+    """Run the scenario under *registry_plugin* at *seed*; return resolved plugins.
+
+    Example::
+
+        plugins = _run("in_memory", 42, trace_path)
+    """
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    config = config.model_copy(
+        update={
+            "seed": seed,
+            "layers": config.layers.model_copy(update={"registry": registry_plugin}),
+            "output": config.output.model_copy(update={"trace": str(trace_path)}),
+        }
+    )
+    runner = ScenarioRunner(config)
+    asyncio.run(runner.run())
+    return runner.resolved_plugins
+
+
+def _run_bytes(registry_plugin: str, seed: int, trace_path: Path) -> bytes:
+    """Run the scenario and return the raw trace bytes.
+
+    Example::
+
+        data = _run_bytes("verified_capabilities", 42, trace_path)
+    """
+    _run(registry_plugin, seed, trace_path)
+    return trace_path.read_bytes()
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_in_memory_registry_fails_conformance(seed: int) -> None:
+    """The reference in_memory registry has no defection concept -- spoofers stay visible."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"in_memory_{seed}.jsonl"
+        plugins = _run("in_memory", seed, trace_path)
+        report = asyncio.run(
+            check_capability_conformance(
+                plugins["registry"], spoofer_ids=_SPOOFER_IDS, honest_ids=_HONEST_IDS
+            )
+        )
+    assert not report.passed, (
+        f"expected in_memory to fail conformance (spoofers should still be "
+        f"discoverable); got passed=True: {report.detail}"
+    )
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_verified_capabilities_passes_conformance(seed: int) -> None:
+    """verified_capabilities excludes every spoofer while keeping honest sellers discoverable."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"verified_{seed}.jsonl"
+        plugins = _run("verified_capabilities", seed, trace_path)
+        report = asyncio.run(
+            check_capability_conformance(
+                plugins["registry"], spoofer_ids=_SPOOFER_IDS, honest_ids=_HONEST_IDS
+            )
+        )
+    assert report.passed, report.detail
+
+
+def test_scenario_is_byte_for_byte_deterministic() -> None:
+    """Two runs at the same seed under verified_capabilities yield identical trace bytes."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_a = Path(tmp) / "a.jsonl"
+        trace_b = Path(tmp) / "b.jsonl"
+        first = _run_bytes("verified_capabilities", 42, trace_a)
+        second = _run_bytes("verified_capabilities", 42, trace_b)
+    assert first == second

--- a/packages/nest-plugins-reference/tests/test_verified_capabilities.py
+++ b/packages/nest-plugins-reference/tests/test_verified_capabilities.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the capability-conformance registry gate.
+
+``VerifiedCapabilitiesRegistry`` wraps an inner registry and filters
+``lookup`` results per ``(agent_id, capability)`` pair based on observed
+fulfillment/defection evidence, not the agent's self-asserted card alone.
+These tests exercise the gate directly, without a scenario, so they pin
+the exclusion/re-admission semantics before any scenario-level proof is
+built on top of them.
+
+Example::
+
+    reg = VerifiedCapabilitiesRegistry()
+    await reg.register(AgentCard(agent_id=AgentId("a1"), name="a1", capabilities=["sell"]))
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.types import AgentCard, AgentId, Query
+from nest_plugins_reference.registry.verified_capabilities import (
+    VerifiedCapabilitiesRegistry,
+)
+
+
+def _card(agent_id: str, capabilities: list[str]) -> AgentCard:
+    return AgentCard(agent_id=AgentId(agent_id), name=agent_id, capabilities=capabilities)
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_first_contact_is_discoverable() -> None:
+    """A never-reported agent is discoverable — no evidence yet is not a strike."""
+    reg = VerifiedCapabilitiesRegistry()
+    await reg.register(_card("seller-0", ["sell"]))
+
+    results = await reg.lookup(Query(capabilities=["sell"]))
+
+    assert [c.agent_id for c in results] == [AgentId("seller-0")]
+
+
+@pytest.mark.asyncio
+async def test_defection_excludes_from_lookup_after_threshold() -> None:
+    """After enough observed defections on a capability, the agent stops appearing."""
+    reg = VerifiedCapabilitiesRegistry(defection_threshold=1)
+    await reg.register(_card("spoofer-0", ["sell"]))
+
+    reg.report_defection(AgentId("spoofer-0"), "sell")
+    results = await reg.lookup(Query(capabilities=["sell"]))
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_defection_on_one_capability_does_not_affect_another() -> None:
+    """Exclusion is per-capability: a defection on 'sell' must not hide 'deliver'."""
+    reg = VerifiedCapabilitiesRegistry(defection_threshold=1)
+    await reg.register(_card("agent-0", ["sell", "deliver"]))
+
+    reg.report_defection(AgentId("agent-0"), "sell")
+
+    sell_results = await reg.lookup(Query(capabilities=["sell"]))
+    deliver_results = await reg.lookup(Query(capabilities=["deliver"]))
+
+    assert sell_results == []
+    assert [c.agent_id for c in deliver_results] == [AgentId("agent-0")]
+
+
+@pytest.mark.asyncio
+async def test_fulfillment_re_admits_after_defection() -> None:
+    """Exclusion is not a permanent blacklist: a later fulfillment clears it."""
+    reg = VerifiedCapabilitiesRegistry(defection_threshold=1)
+    await reg.register(_card("agent-0", ["sell"]))
+
+    reg.report_defection(AgentId("agent-0"), "sell")
+    assert await reg.lookup(Query(capabilities=["sell"])) == []
+
+    reg.report_fulfillment(AgentId("agent-0"), "sell")
+    results = await reg.lookup(Query(capabilities=["sell"]))
+
+    assert [c.agent_id for c in results] == [AgentId("agent-0")]
+
+
+@pytest.mark.asyncio
+async def test_defections_below_threshold_do_not_exclude() -> None:
+    """A single defection under a higher threshold is tolerated, not punished."""
+    reg = VerifiedCapabilitiesRegistry(defection_threshold=2)
+    await reg.register(_card("agent-0", ["sell"]))
+
+    reg.report_defection(AgentId("agent-0"), "sell")
+    results = await reg.lookup(Query(capabilities=["sell"]))
+
+    assert [c.agent_id for c in results] == [AgentId("agent-0")]
+
+
+@pytest.mark.asyncio
+async def test_honest_agent_never_reported_remains_discoverable() -> None:
+    """An agent with no defections ever reported against it is unaffected."""
+    reg = VerifiedCapabilitiesRegistry(defection_threshold=1)
+    await reg.register(_card("honest-0", ["sell"]))
+    await reg.register(_card("spoofer-0", ["sell"]))
+
+    reg.report_defection(AgentId("spoofer-0"), "sell")
+    results = await reg.lookup(Query(capabilities=["sell"]))
+
+    assert [c.agent_id for c in results] == [AgentId("honest-0")]
+
+
+@pytest.mark.asyncio
+async def test_deregister_delegates_to_inner_registry() -> None:
+    """deregister removes the card from lookups, same as the inner registry."""
+    reg = VerifiedCapabilitiesRegistry()
+    await reg.register(_card("agent-0", ["sell"]))
+
+    await reg.deregister(AgentId("agent-0"))
+    results = await reg.lookup(Query(capabilities=["sell"]))
+
+    assert results == []

--- a/scenarios/capability_spoofing.yaml
+++ b/scenarios/capability_spoofing.yaml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Capability-spoofing scenario: a signed registration is not a verified skill.
+#
+# 3 honest sellers, 2 silent spoofers, and 1 bait-and-switch seller all
+# register the identical claim capabilities=["sell"]. 5 buyers discover
+# sellers purely via registry.lookup(Query(capabilities=["sell"])) and
+# report what they observe: a "sold:" response is a fulfillment, a round's
+# timeout firing with no response is a defection.
+#
+# Under registry: in_memory, defections are never recorded anywhere -- the
+# spoofers stay discoverable and keep being selected for the whole run.
+# Under registry: verified_capabilities, each spoofer is excluded from
+# "sell" lookups once its defection count crosses the threshold, and the
+# bait-and-switch seller is excluded after its first silent round. Honest
+# sellers remain discoverable throughout either way.
+#
+# message_drop is 0, so there is no transient noise a real defection could
+# be confused with; the run is byte-for-byte deterministic for a fixed seed
+# (the only randomness is each buyer's seeded RNG picking among discovered
+# sellers).
+name: capability_spoofing
+description: "3 honest + 2 silent spoofers + 1 bait-and-switch seller vs 5 buyers."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 11
+  brain: state-machine
+  roles:
+    - name: honest_seller
+      count: 3
+    - name: spoofer
+      count: 2
+    - name: bait_switch
+      count: 1
+    - name: buyer
+      count: 5
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: verified_capabilities
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: capability_spoofing
+  config:
+    rounds: 6
+    timeout: 5.0
+    price: 50
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 500"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/capability_spoofing.jsonl


### PR DESCRIPTION
## Problem

`AgentCard.capabilities` (`nest_core/types.py:82`) is a bare, self-asserted `list[str]`. `Registry.lookup()` does string matching against this list. Every existing defense in the repo verifies who published a card (signatures, identity, `ed25519_rotating`) or scores an agent's overall behavior (`agent_receipts`, `score_average`), but nothing checks a specific capability claim against whether the agent has ever fulfilled it. An agent can register `capabilities=["sell"]` and remain discoverable via that claim forever, even if it never completes a single sale.

## Change

- `VerifiedCapabilitiesRegistry` (`nest_plugins_reference/registry/verified_capabilities.py`), registered as `("registry", "verified_capabilities")`: wraps an inner registry and tracks defection counts per `(agent_id, capability)` pair. A pair with no evidence is never excluded (bootstrap allowance). Once a pair reaches `defection_threshold` (default 1, justified in the docstring against the scenario's zero message-drop rate) defections, `lookup` stops returning that agent for queries naming that capability — other capabilities of the same agent are unaffected. `report_fulfillment` resets the count to zero (re-admission, not a permanent blacklist); this is a documented trade-off, not an oversight — a periodic fulfiller could evade indefinitely, out of scope here.
- `scenarios/capability_spoofing.yaml` + `capability_spoofing_factory`: 3 honest sellers, 2 always-silent spoofers, 1 bait-and-switch seller (fulfills once, then goes silent), 5 buyers. Buyers discover sellers via `registry.lookup(Query(capabilities=["sell"]))`, send one outstanding `buy:` at a time, and self-schedule a `TIMEOUT:<round>` tick. A `sold:` response before the timeout reports a fulfillment; the timeout firing first reports a defection.
- `check_capability_conformance` (`nest_plugins_reference/validators/capability_validators.py`): registry lookups aren't traced (confirmed against `nest_core/sim/simulator.py`), so this validates directly against `ScenarioRunner.resolved_plugins["registry"]`, following the same `ValidatorReport` pattern as `registry_byzantine_validators`/`gossip_validators`. Checks two things together, so a gate that blocks everyone can't pass by accident: no spoofer is still discoverable, and every honest seller still is.

## Test

Literal output, same scenario YAML, only `layers.registry` overridden:

```
registry='in_memory'             passed=False detail="still discoverable for 'sell': ['baitswitch-0', 'spoofer-0', 'spoofer-1']"
registry='verified_capabilities' passed=True  detail="3 spoofer(s) excluded from 'sell', 3 honest agent(s) still discoverable"
```

`test_verified_capabilities.py` (7 unit tests): collection error (`ModuleNotFoundError`) before the plugin existed; all 7 pass after — bootstrap allowance, per-capability exclusion isolation, re-admission on fulfillment, below-threshold tolerance, honest-agent non-interference, deregister delegation. `test_capability_spoofing_scenario.py`: FAIL/PASS matrix above at seeds 42/7/1337, plus a byte-identical-trace determinism test. Full `make ci-local`: 1164 passed, 1 skipped, 1 deselected.

## Fit

A2A v1.0 ships signed Agent Cards and NANDA's Verified AgentFacts paper names capability spoofing as an open problem; a signature proves the publisher, not the capability. `agent_receipts` scores an agent's overall reputation from receipts — this gates *discovery*, per *capability*, independent of an agent's standing on any other claim.