### PR TITLE
[Hackathon] rajpatilrobotics: fail closed on empty scenario traces

### DIFF
--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -72,7 +72,18 @@ def validate_events(
 
         results = validate_events(event_list, "auction")
     """
-    validators = VALIDATORS.get(scenario_type, [])
+    validators = VALIDATORS.get(scenario_type)
+    if validators is None:
+        return []
+    if not events:
+        return [
+            ValidationResult(
+                "trace_nonempty",
+                False,
+                "trace contains no events and therefore cannot prove the scenario invariants",
+            )
+        ]
+
     results: list[ValidationResult] = []
     for validator_fn in validators:
         results.extend(validator_fn(events))

--- a/packages/nest-core/tests/test_metrics.py
+++ b/packages/nest-core/tests/test_metrics.py
@@ -11,6 +11,7 @@ from nest_core.metrics import (
     ALL_METRICS,
     compute_metrics,
     generate_html_report,
+    validate_protocol,
 )
 from nest_core.runner import ScenarioRunner
 from nest_core.scenario import ScenarioConfig
@@ -243,6 +244,33 @@ class TestMarketplaceMetrics:
         assert results["deal_rate"] == 0.0
         assert results["rejection_rate"] == 0.0
         assert results["mean_rounds_to_deal"] == 0.0
+
+
+class TestValidateProtocol:
+    def test_empty_trace_fails_closed_only_for_registered_scenarios(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        trace = tmp_path / "empty.jsonl"
+        trace.touch()
+
+        assert validate_protocol(trace, "marketplace") == {
+            "validations": [
+                {
+                    "name": "trace_nonempty",
+                    "passed": False,
+                    "detail": (
+                        "trace contains no events and therefore cannot prove "
+                        "the scenario invariants"
+                    ),
+                }
+            ],
+            "all_passed": False,
+        }
+        assert validate_protocol(trace, "unknown_scenario") == {
+            "validations": [],
+            "all_passed": True,
+        }
 
 
 class TestHtmlReport:

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
 from nest_core.validators import (
     VALIDATORS,
     ValidationResult,
@@ -659,13 +660,33 @@ class TestValidateEvents:
             _send("seller-0", "buyer-0", "sold:product-0:50"),
         ]
         results = validate_events(events, "marketplace")
-        assert len(results) == 3
+        assert [result.name for result in results] == [
+            "marketplace_no_double_sell",
+            "marketplace_all_responded",
+            "marketplace_price_agreement",
+        ]
         assert all(r.passed for r in results)
+        assert all(result.name != "trace_nonempty" for result in results)
+
+    @pytest.mark.parametrize("scenario_type", sorted(VALIDATORS))
+    def test_empty_events_fail_closed_for_registered_scenario(
+        self,
+        scenario_type: str,
+    ) -> None:
+        results = validate_events([], scenario_type)
+
+        assert len(results) == 1
+        assert results[0].name == "trace_nonempty"
+        assert results[0].passed is False
+        assert (
+            results[0].detail
+            == "trace contains no events and therefore cannot prove the scenario invariants"
+        )
 
     def test_unknown_scenario(self) -> None:
         events = [_send("a", "b", "hello")]
-        results = validate_events(events, "unknown_scenario")
-        assert results == []
+        assert validate_events(events, "unknown_scenario") == []
+        assert validate_events([], "unknown_scenario") == []
 
 
 class TestValidateTrace:
@@ -677,8 +698,28 @@ class TestValidateTrace:
         trace = tmp_path / "trace.jsonl"
         trace.write_text("\n".join(json.dumps(e) for e in events))
         results = validate_trace(trace, "marketplace")
-        assert len(results) == 3
+        assert [result.name for result in results] == [
+            "marketplace_no_double_sell",
+            "marketplace_all_responded",
+            "marketplace_price_agreement",
+        ]
         assert all(r.passed for r in results)
+        assert all(result.name != "trace_nonempty" for result in results)
+
+    def test_empty_file_fails_closed_for_registered_scenario(self, tmp_path: Path) -> None:
+        trace = tmp_path / "empty.jsonl"
+        trace.touch()
+
+        results = validate_trace(trace, "marketplace")
+
+        assert len(results) == 1
+        assert results[0].name == "trace_nonempty"
+        assert results[0].passed is False
+        assert (
+            results[0].detail
+            == "trace contains no events and therefore cannot prove the scenario invariants"
+        )
+        assert validate_trace(trace, "unknown_scenario") == []
 
 
 class TestValidationResult:


### PR DESCRIPTION
## Summary

NANDA Town is a protocol test rig, so a successful validation must be backed by actual trace evidence.

This change adds a shared fail-closed invariant: every registered scenario now rejects an empty event trace with:

- `name`: `trace_nonempty`
- `passed`: `false`
- `detail`: `trace contains no events and therefore cannot prove the scenario invariants`

## Why this matters

Before this change, 9 of 22 registered scenarios returned only passing results for an empty event list:

`comms_versioning`, `marketplace`, `auction`, `voting`, `consensus`,
`supply_chain`, `reputation`, `streaming_payments`, and `empic_payments`.

A zero-byte marketplace JSONL file therefore produced three passing validator
results, and `validate_protocol()` reported `all_passed=true`.

From my distributed edge, IoT, and LoRa experience, missing telemetry is not
evidence of successful operation. A silent or incorrectly generated trace must
not certify protocol invariants.

## Root cause

`validate_trace()` loads a zero-byte file as an empty list and delegates to
`validate_events()`. The shared dispatcher previously invoked scenario
validators immediately. Several validators looped over zero events and passed
through vacuous conditions.

## Design

The invariant is enforced once in `validate_events()`, after distinguishing
unknown scenario names and before invoking scenario-specific validators.

This keeps the change:

- deterministic and dependency-free;
- shared across `validate_events()`, `validate_trace()`, and
  `validate_protocol()`;
- compatible with existing unknown-scenario behavior;
- compatible with all valid non-empty result names, details, and ordering;
- independent of individual scenario validator semantics.

## Testing

Added coverage for:

- every registered scenario through a parameterized registry test;
- an empty event list through `validate_events()`;
- a zero-byte JSONL file through `validate_trace()`;
- `validate_protocol()` serialization and `all_passed=false`;
- empty and non-empty unknown scenarios;
- an existing valid marketplace trace retaining its original passing results.

Test-first evidence before implementation:

    24 failed, 142 deselected

After implementation:

    24 passed, 142 deselected
    166 targeted tests passed

Full repository gate:

    make ci-local
    1174 passed, 1 skipped, 1 deselected
    Ruff clean
    Ruff formatting clean
    Pyright: 0 errors

## Compatibility and limitations

Missing files and malformed JSON already fail by exception. This change handles
the global empty-evidence case. Syntactically valid but non-empty incomplete
traces still depend on scenario-specific evidence validators.

Unknown scenario names preserve their existing behavior.
