### PR TITLE
feat: implement delegatable capability tokens with cascading revocation.

### DIFF
--- a/packages/nest-core/nest_core/layers/auth.py
+++ b/packages/nest-core/nest_core/layers/auth.py
@@ -34,7 +34,7 @@ class Auth(Protocol):
         """
         ...
 
-    async def verify(self, token: Token) -> AuthContext:
+    async def verify(self, token: Token, presenter: AgentId | None = None) -> AuthContext:
         """Verify a token and return its auth context.
 
         Example::

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -27,6 +27,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
+    ("auth", "delegatable_cascading"): f"{_REF}.auth.delegatable_cascading:DelegatableAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_auth.py
@@ -113,9 +113,18 @@ async def _verify(auth: Any, token: Token, presenter: AgentId) -> bool:
 
         ok = await _verify(auth, token, AgentId("leaf-0"))
     """
+    import inspect
     verify_presented = getattr(auth, "verify_presented", None)
     try:
-        if callable(verify_presented):
+        try:
+            sig = inspect.signature(auth.verify)
+            has_presenter = "presenter" in sig.parameters
+        except (ValueError, TypeError):
+            has_presenter = False
+
+        if has_presenter:
+            await auth.verify(token, presenter=presenter)
+        elif callable(verify_presented):
             await cast("Awaitable[object]", verify_presented(token, presenter))
         else:
             await auth.verify(token)

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -4923,6 +4923,39 @@ def validate_sybil_bond_attempts_rejected(
     ]
 
 
+def validate_auth_no_scope_escalation(events: list[dict[str, Any]]) -> list[ValidationResult]:
+    from nest_plugins_reference.validators.delegation_validators import (
+        check_no_scope_escalation,
+        extract_delegation_audits,
+    )
+
+    audits = extract_delegation_audits(events)
+    report = check_no_scope_escalation(audits)
+    return [ValidationResult("auth_no_scope_escalation", report.passed, report.detail)]
+
+
+def validate_auth_no_stale_parent(events: list[dict[str, Any]]) -> list[ValidationResult]:
+    from nest_plugins_reference.validators.delegation_validators import (
+        check_no_stale_ancestor_use,
+        extract_delegation_audits,
+    )
+
+    audits = extract_delegation_audits(events)
+    report = check_no_stale_ancestor_use(audits)
+    return [ValidationResult("auth_no_stale_parent", report.passed, report.detail)]
+
+
+def validate_auth_no_audience_confusion(events: list[dict[str, Any]]) -> list[ValidationResult]:
+    from nest_plugins_reference.validators.delegation_validators import (
+        check_audience_binding,
+        extract_delegation_audits,
+    )
+
+    audits = extract_delegation_audits(events)
+    report = check_audience_binding(audits)
+    return [ValidationResult("auth_no_audience_confusion", report.passed, report.detail)]
+
+
 VALIDATORS: dict[str, list[Any]] = {
     "sybil_bond": [
         validate_sybil_bond_no_free_trust,
@@ -5038,5 +5071,10 @@ VALIDATORS: dict[str, list[Any]] = {
     "rogue_trusted_agent": [
         validate_rogue_trusted_agent_blocked,
         validate_rogue_trusted_agent_reputation,
+    ],
+    "delegated_auth": [
+        validate_auth_no_scope_escalation,
+        validate_auth_no_stale_parent,
+        validate_auth_no_audience_confusion,
     ],
 }

--- a/packages/nest-core/tests/test_delegated_auth.py
+++ b/packages/nest-core/tests/test_delegated_auth.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the delegated_auth validators and scenario.
+
+Verifies that the capability delegation validators FAIL when using the default
+'jwt' auth plugin (which ignores delegation constraints) and PASS when using
+'delegatable'.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.validators import validate_trace
+
+
+def _run(auth: str, out: Path, seed: int = 42) -> None:
+    cfg = ScenarioConfig.from_yaml("scenarios/delegated_auth.yaml")
+    cfg.layers.auth = auth
+    cfg.seed = seed
+    cfg.duration = "ticks: 1000"
+    cfg.output.trace = str(out)
+    asyncio.run(ScenarioRunner(cfg).run())
+
+
+class TestDelegatedAuthScenario:
+    def test_delegatable_passes(self, tmp_path: Path) -> None:
+        out = tmp_path / "delegatable.jsonl"
+        _run("delegatable_cascading", out)
+        results = validate_trace(out, "delegated_auth")
+        assert results, "expected validators to run"
+        for r in results:
+            assert r.passed is True, f"{r.name} failed: {r.detail}"
+
+    def test_jwt_fails_all_checks(self, tmp_path: Path) -> None:
+        out = tmp_path / "jwt.jsonl"
+        _run("jwt", out)
+        results = {r.name: r.passed for r in validate_trace(out, "delegated_auth")}
+        assert results["auth_no_scope_escalation"] is False
+        assert results["auth_no_stale_parent"] is False
+        assert results["auth_no_audience_confusion"] is False
+
+    def test_deterministic_across_seeds(self, tmp_path: Path) -> None:
+        for seed in (42, 7, 1337):
+            a, b = tmp_path / f"{seed}a.jsonl", tmp_path / f"{seed}b.jsonl"
+            _run("delegatable_cascading", a, seed=seed)
+            _run("delegatable_cascading", b, seed=seed)
+            assert a.read_bytes() == b.read_bytes(), f"seed {seed} not deterministic"
+            results = validate_trace(a, "delegated_auth")
+            assert all(r.passed for r in results)

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2013,6 +2013,7 @@ class TestValidatorRegistry:
             "parc_migration",
             "rogue_trusted_agent",
             "sybil_bond",
+            "delegated_auth",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable_cascading.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/delegatable_cascading.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegatable capability tokens with cascading revocation.
+
+Allows offline delegation without contacting the central issuer and verifies
+cascading revocation transitively down the parent chain.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+
+from nest_core.types import AgentId, AuthContext, Token
+
+
+class RevokedAncestorError(ValueError):
+    """Raised when verification fails because a parent or ancestor token was revoked."""
+
+    pass
+
+
+class DelegatableAuth:
+    """Delegatable capability tokens with cascading revocation.
+
+    Example::
+
+        auth = DelegatableAuth(secret=b"secret")
+        root = await auth.issue(AgentId("a1"), ["read", "write"])
+        child = await auth.delegate(root, AgentId("a2"), ["read"], ttl=60)
+        ctx = await auth.verify(child)
+    """
+
+    def __init__(self, secret: bytes = b"nest-default-secret", clock: float | None = None) -> None:
+        self._secret = secret
+        self._clock = clock
+        self._revoked: set[str] = set()
+
+    def _now(self) -> float:
+        clock_val: Any = self._clock
+        if clock_val is not None:
+            if callable(clock_val):
+                res: Any = clock_val()
+                return float(res)
+            return float(clock_val)
+        return time.time()
+
+    def _sign(self, payload: str, key: bytes | None = None) -> str:
+        sign_key = key if key is not None else self._secret
+        return hmac.new(sign_key, payload.encode(), hashlib.sha256).hexdigest()
+
+    async def issue(self, subject: AgentId, scopes: list[str]) -> Token:
+        """Issue a root capability token.
+
+        Example::
+
+            token = await auth.issue(AgentId("a1"), ["read"])
+        """
+        now = self._now()
+        jti = hashlib.sha256(f"root-{subject}-{scopes}-{now}".encode()).hexdigest()[:16]
+        payload = json.dumps(
+            {
+                "jti": jti,
+                "sub": str(subject),
+                "scopes": scopes,
+                "iat": now,
+                "exp": now + 3600,
+            },
+            sort_keys=True,
+        )
+        sig = self._sign(payload)
+        return Token(f"{payload}|{sig}")
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token:
+        """Delegate a subset of capabilities to another agent offline.
+
+        The child's signature is anchored to the parent's signature.
+
+        Example::
+
+            child = await auth.delegate(parent, AgentId("a2"), ["read"], ttl=60)
+        """
+        # First verify parent to check signatures, expiration, and revocation state
+        parent_ctx = await self.verify(parent_token)
+
+        # Enforce strict subset of scopes
+        parent_scopes_set = set(parent_ctx.scopes)
+        for scope in scopes_subset:
+            if scope not in parent_scopes_set:
+                raise ValueError("Escalated scopes: child scope not in parent scopes")
+
+        # Enforce time bounds
+        now = self._now()
+        exp_child = now + ttl
+        if parent_ctx.expires_at is not None and exp_child > parent_ctx.expires_at:
+            raise ValueError("Child TTL exceeds parent expiration")
+
+        # Extract parent signature (the last part of parent token)
+        parent_parts = str(parent_token).split("|")
+        parent_sig = parent_parts[-1]
+
+        # Construct child payload
+        jti_seed = f"delegate-{audience}-{scopes_subset}-{parent_token}".encode()
+        child_jti = hashlib.sha256(jti_seed).hexdigest()[:16]
+        child_payload = json.dumps(
+            {
+                "jti": child_jti,
+                "aud": str(audience),
+                "scopes": scopes_subset,
+                "iat": now,
+                "exp": exp_child,
+            },
+            sort_keys=True,
+        )
+        sig_child = self._sign(child_payload, key=parent_sig.encode())
+        return Token(f"{parent_token}|{child_payload}|{sig_child}")
+
+    async def verify(self, token: Token, presenter: AgentId | None = None) -> AuthContext:
+        """Verify the signature chain, expiration, and transitive revocation of the token.
+
+        Example::
+
+            ctx = await auth.verify(token)
+        """
+        raw = str(token)
+        parts = raw.split("|")
+        if len(parts) % 2 != 0 or len(parts) < 2:
+            raise ValueError("Invalid token format")
+
+        now = self._now()
+
+        # 1. Verify root token
+        payload_0, sig_0 = parts[0], parts[1]
+        expected_sig_0 = self._sign(payload_0)
+        if not hmac.compare_digest(sig_0, expected_sig_0):
+            raise ValueError("Invalid token signature")
+
+        data_0 = json.loads(payload_0)
+        if data_0["exp"] < now:
+            raise ValueError("Token has expired")
+
+        current_sig = sig_0
+        current_sub = data_0["sub"]
+        current_scopes = data_0["scopes"]
+        current_jti = data_0["jti"]
+        current_exp = data_0["exp"]
+
+        jti_list = [current_jti]
+        depth = len(parts) // 2 - 1
+
+        # 2. Verify delegation chain
+        for i in range(1, depth + 1):
+            payload_i, sig_i = parts[2 * i], parts[2 * i + 1]
+            expected_sig_i = self._sign(payload_i, key=current_sig.encode())
+            if not hmac.compare_digest(sig_i, expected_sig_i):
+                raise ValueError("Invalid token signature")
+
+            data_i = json.loads(payload_i)
+            # Enforce scopes subset of the parent block (current_scopes)
+            for s in data_i["scopes"]:
+                if s not in current_scopes:
+                    raise ValueError("Escalated scopes")
+
+            # Enforce expiration <= parent expiration
+            if data_i["exp"] > current_exp:
+                raise ValueError("Child expiration exceeds parent expiration")
+
+            if data_i["exp"] < now:
+                raise ValueError("Token has expired")
+
+            current_sig = sig_i
+            current_sub = data_i["aud"]
+            current_scopes = data_i["scopes"]
+            current_jti = data_i["jti"]
+            current_exp = data_i["exp"]
+            jti_list.append(current_jti)
+
+        # 3. Check transitive revocation
+        for idx, jti in enumerate(jti_list):
+            if jti in self._revoked:
+                if idx < depth:
+                    raise RevokedAncestorError("Ancestor token was revoked")
+                else:
+                    raise ValueError("Token has been revoked")
+
+        # 4. Check audience confusion (presenter must match token subject)
+        if presenter is not None and str(presenter) != str(current_sub):
+            raise ValueError("Audience confusion: presenter does not match token subject")
+
+        return AuthContext(
+            subject=AgentId(current_sub),
+            scopes=current_scopes,
+            issued_at=data_0["iat"],
+            expires_at=current_exp,
+        )
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke a token.
+
+        Example::
+
+            await auth.revoke(token)
+        """
+        # We can pull out the JTI of the final block in the token
+        raw = str(token)
+        parts = raw.split("|")
+        if len(parts) >= 2:
+            try:
+                data = json.loads(parts[-2])
+                self._revoked.add(data["jti"])
+            except Exception:
+                # Fallback to the whole token string if parsing fails
+                self._revoked.add(raw)
+        else:
+            self._revoked.add(raw)

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/jwt_auth.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/jwt_auth.py
@@ -60,7 +60,7 @@ class JwtAuth:
         sig = self._sign(payload)
         return Token(f"{payload}|{sig}")
 
-    async def verify(self, token: Token) -> AuthContext:
+    async def verify(self, token: Token, presenter: AgentId | None = None) -> AuthContext:
         """Verify a token and return its context.
 
         Example::

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -59,6 +59,10 @@ aae_permit_gate = "nest_plugins_reference.trust.aae_permit_gate:AAEPermitGate"
 bonded_trust = "nest_plugins_reference.trust.bonded_trust:BondedTrust"
 attested_peering = "nest_plugins_reference.trust.attested_peering:AttestedPeeringTrust"
 
+[project.entry-points."nest.plugins.auth"]
+delegatable = "nest_plugins_reference.auth.delegatable:DelegatableAuth"
+delegatable_cascading = "nest_plugins_reference.auth.delegatable_cascading:DelegatableAuth"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/nest-plugins-reference/tests/test_delegatable_cascading.py
+++ b/packages/nest-plugins-reference/tests/test_delegatable_cascading.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for DelegatableAuth: happy paths, restrictions, and transitive revocation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from hypothesis import given, strategies as st
+from nest_core.types import AgentId, Token
+from nest_plugins_reference.auth.delegatable_cascading import DelegatableAuth, RevokedAncestorError
+
+
+@pytest.fixture
+def auth() -> DelegatableAuth:
+    return DelegatableAuth(secret=b"test-secret-key")
+
+
+@pytest.mark.asyncio
+async def test_root_issue_and_verify(auth: DelegatableAuth) -> None:
+    subject = AgentId("agent-root")
+    scopes = ["read", "write"]
+    token = await auth.issue(subject, scopes)
+
+    ctx = await auth.verify(token)
+    assert ctx.subject == subject
+    assert ctx.scopes == scopes
+    assert ctx.expires_at is not None
+    assert ctx.issued_at is not None
+    assert ctx.expires_at > ctx.issued_at
+
+
+@pytest.mark.asyncio
+async def test_delegation_happy_path(auth: DelegatableAuth) -> None:
+    root_subject = AgentId("agent-root")
+    root_scopes = ["read", "write", "delete"]
+    root_token = await auth.issue(root_subject, root_scopes)
+
+    # Delegate subset of scopes to agent-child
+    child_subject = AgentId("agent-child")
+    child_scopes = ["read", "write"]
+    child_token = await auth.delegate(root_token, child_subject, child_scopes, ttl=100)
+
+    # Verify child token
+    ctx = await auth.verify(child_token)
+    assert ctx.subject == child_subject
+    assert ctx.scopes == child_scopes
+
+
+@pytest.mark.asyncio
+async def test_delegation_scope_escalation(auth: DelegatableAuth) -> None:
+    root_token = await auth.issue(AgentId("agent-root"), ["read"])
+
+    # Attempting to delegate "write" which parent doesn't have should raise ValueError
+    with pytest.raises(ValueError, match="Escalated scopes"):
+        await auth.delegate(root_token, AgentId("agent-child"), ["read", "write"], ttl=100)
+
+
+@pytest.mark.asyncio
+async def test_delegation_time_bounds(auth: DelegatableAuth) -> None:
+    # Root expires in 3600 seconds by default
+    root_token = await auth.issue(AgentId("agent-root"), ["read"])
+
+    # Attempting to delegate with a TTL of 4000 seconds
+    # (exceeding root's remaining lifetime) should raise ValueError
+    with pytest.raises(ValueError, match="Child TTL exceeds parent expiration"):
+        await auth.delegate(root_token, AgentId("agent-child"), ["read"], ttl=4000)
+
+
+@pytest.mark.asyncio
+async def test_cascading_revocation(auth: DelegatableAuth) -> None:
+    root_token = await auth.issue(AgentId("coordinator"), ["read", "write"])
+    int_token = await auth.delegate(root_token, AgentId("intermediary"), ["read", "write"], ttl=100)
+    leaf_token = await auth.delegate(int_token, AgentId("leaf"), ["read"], ttl=50)
+
+    # Verify both work fine initially
+    await auth.verify(int_token)
+    await auth.verify(leaf_token)
+
+    # Revoke intermediate token
+    await auth.revoke(int_token)
+
+    # Verifying intermediate token itself raises ValueError (direct revocation)
+    with pytest.raises(ValueError, match="Token has been revoked"):
+        await auth.verify(int_token)
+
+    # Verifying leaf token raises RevokedAncestorError (cascading revocation)
+    with pytest.raises(RevokedAncestorError, match="Ancestor token was revoked"):
+        await auth.verify(leaf_token)
+
+    # Revoke leaf token directly
+    leaf_token2 = await auth.delegate(root_token, AgentId("leaf-2"), ["read"], ttl=50)
+    await auth.revoke(leaf_token2)
+    with pytest.raises(ValueError, match="Token has been revoked"):
+        await auth.verify(leaf_token2)
+
+
+@pytest.mark.asyncio
+async def test_signature_tampering(auth: DelegatableAuth) -> None:
+    root_token = await auth.issue(AgentId("agent-root"), ["read"])
+    child_token = await auth.delegate(root_token, AgentId("agent-child"), ["read"], ttl=100)
+
+    # Tamper with the child payload part of the token string
+    parts = str(child_token).split("|")
+    # parts: [root_payload, root_sig, child_payload, child_sig]
+    payload = json.loads(parts[2])
+    payload["scopes"] = ["read", "write"]  # Escalated via tampering!
+    parts[2] = json.dumps(payload, sort_keys=True)
+    tampered_token = Token("|".join(parts))
+
+    with pytest.raises(ValueError, match="Invalid token signature|Escalated scopes"):
+        await auth.verify(tampered_token)
+
+
+@pytest.mark.asyncio
+async def test_expired_token(auth: DelegatableAuth) -> None:
+    # Use custom clock to simulate expiration
+    auth_with_clock = DelegatableAuth(secret=b"test-secret-key", clock=1000.0)
+    token = await auth_with_clock.issue(AgentId("a"), ["read"])
+
+    # Verify at same clock -> OK
+    await auth_with_clock.verify(token)
+
+    # Advance clock beyond expiration (1000 + 3600 = 4600)
+    auth_with_clock._clock = 4700.0  # type: ignore
+    with pytest.raises(ValueError, match="Token has expired"):
+        await auth_with_clock.verify(token)
+
+
+@pytest.mark.asyncio
+@given(chain_len=st.integers(min_value=2, max_value=8), revoke_idx=st.integers(min_value=0, max_value=7))
+async def test_cascading_revocation_property(chain_len: int, revoke_idx: int) -> None:
+    auth = DelegatableAuth(secret=b"test-secret-key")
+    # Ensure revoke_idx is less than chain_len
+    if revoke_idx >= chain_len:
+        return
+
+    tokens = []
+    curr_token = await auth.issue(AgentId("root"), ["read", "write", "admin"])
+    tokens.append(curr_token)
+
+    for i in range(1, chain_len):
+        curr_token = await auth.delegate(
+            curr_token, AgentId(f"agent-{i}"), ["read", "write"], ttl=1000 - i * 10
+        )
+        tokens.append(curr_token)
+
+    # Verify everything works initially
+    for token in tokens:
+        await auth.verify(token)
+
+    # Revoke the token at revoke_idx
+    await auth.revoke(tokens[revoke_idx])
+
+    # Verifying the revoked token or any child should raise either ValueError (if direct)
+    # or RevokedAncestorError (if ancestor was revoked)
+    for idx, token in enumerate(tokens):
+        if idx < revoke_idx:
+            # Ancestors of the revoked token should still be valid!
+            await auth.verify(token)
+        elif idx == revoke_idx:
+            # Direct revocation
+            with pytest.raises(ValueError, match="Token has been revoked"):
+                await auth.verify(token)
+        else:
+            # Cascading revocation
+            with pytest.raises(RevokedAncestorError, match="Ancestor token was revoked"):
+                await auth.verify(token)
+
+
+@pytest.mark.asyncio
+async def test_audience_confusion_protection(auth: DelegatableAuth) -> None:
+    root_token = await auth.issue(AgentId("agent-root"), ["read"])
+    child_token = await auth.delegate(root_token, AgentId("agent-child"), ["read"], ttl=100)
+
+    # Verifying with the correct presenter should succeed
+    await auth.verify(child_token, presenter=AgentId("agent-child"))
+
+    # Verifying with an incorrect presenter should fail with ValueError
+    with pytest.raises(ValueError, match="Audience confusion"):
+        await auth.verify(child_token, presenter=AgentId("agent-attacker"))


### PR DESCRIPTION
### Description
This PR addresses all outstanding auditor and committee feedback for Problem 04 (Delegatable Capability Tokens with Cascading Revocation). 

To ensure complete backward-compatibility and avoid colliding with other merged PRs, our implementation is namespaced under the plugin name `delegatable_cascading`.

### Key Achievements
- **Cascading Revocation**: Implemented path-based validation that walks the ancestor chain via JTI mapping. If any parent token in the delegation chain is revoked, all downstream sub-delegations are automatically invalidated.
- **Audience Protection**: Integrated a `presenter` check into the `verify` method signature of `Auth`, `JwtAuth`, and `DelegatableAuth`. The presenter check is enforced inside the plugin to prevent audience-confusion attacks.
- **Robust testing**:
  - Implemented unit tests validating scope attenuation, expiration, and presenter boundaries.
  - Added a `hypothesis` property-based test checking transitive revocation over random delegation lengths and revocation indices.
  - Wrote scenario tests comparing flat `jwt` baseline (where attacks succeed) against `delegatable_cascading` (where all attacks are blocked) using the official validators.

### Auditor Feedback Remediated
- **Plugin-level Audience Protection**: Moved audience-confusion check from the scenario runner into the plugin by passing the `presenter` parameter to the `verify` protocol.
- **Cleaned Up Workspace Leftovers**: Removed all containerization, `railway.json`, and the `apps/nanda-sandbox/` directory from this Phase 1 PR's commit history (keeping them isolated to Phase 2). Removed duplicate `my_privacy_layer.py` and `test_privacy.py`.
- **Branch Renaming**: Renamed branch to `hackathon/tanishaacodes-delegatable-auth`.
- **JWT baseline & Revocation**: Corrected revocation logic to store the last block's `jti` to ensure correct cascading verification.

### Verification & CI Status
All local CI checks pass cleanly:
- **Pytest**: `1162 passed` (fully green including all reference plugins and core scenarios).
- **Pyright**: `0 errors` (strict type checks pass cleanly).
- **Ruff**: Clean.