### PR TITLE
[Hackathon] tony-nexartis: delegated_admission — evidence admission gated on human-anchored, cascade-revocable delegation grants (production port)

### DIFF
--- a/docs/layers/trust.md
+++ b/docs/layers/trust.md
@@ -245,6 +245,68 @@ Spend *real* bond, gain real influence — intended ("most at stake, most say"),
 [`sybil_bond.yaml`](../../scenarios/sybil_bond.yaml) · `sybil_bond_*` in
 [`validators.py`](../../packages/nest-core/nest_core/validators.py)
 
+## `delegated_admission` — gate evidence on live proof-of-human grants
+
+Every other trust plugin here scores evidence *after* accepting it.
+`delegated_admission` decides which evidence is even eligible for
+scoring: a reporter's evidence is admitted iff, at the current
+injected logical clock, the reporter holds a delegation grant from a
+trusted principal, the grant is not revoked (directly or via a
+revoked ancestor within `MAX_HOPS`), its scope contains the
+verifier's `required_scope`, its proof-of-human envelope is fresh
+within `PUH_FRESHNESS_MS` (with `PUH_SKEW_MS` slack), and — by
+default in this port — that proof carries a valid Ed25519 signature
+by the principal's trusted key over the canonical envelope bytes.
+
+**What it does.** Ports `nexartis-nanda-node/src/lib/server/delegation-grants.ts`
+byte-for-byte for the canonical proof envelope
+(a fixed test vector locks that), including the CRITICAL-3 patch that
+narrows a grant's effective expiry to any earlier ancestor expiry.
+Nothing calls a wall clock, no OS randomness is used, and delegation
+ids are `del-<sha256(canonical || counter)[:24]>` — the same scenario
+seed produces the same delegation graph run-to-run.
+
+**Policy knobs** (`AdmissionPolicy`):
+
+- `trusted_principals: dict[str, bytes]` — `pk-...` handle → raw 32-byte
+  Ed25519 public key.
+- `require_signed_puh: bool = True` — this Python port is stricter than
+  the production toggle; see honest limitations below.
+- `puh_freshness_ms: int = 300_000` and `puh_skew_ms: int = 30_000` —
+  the forward-age and clock-skew bounds against the injected `now_ms`.
+- `required_scope: str = "trust.report"` — the scope string a grant
+  must contain for its holder's evidence to be admitted.
+
+**Trace lines** (emitted by the scenario observer to the victim sink):
+
+- `cascade:<root_id>:<n_descendants>` — the plugin's own report of a
+  parent revocation (root + BFS descendants, cycle-safe). Absent under
+  a baseline plugin because there is nothing to revoke.
+- `admission:<reporter>:<live|no-grant|revoked|scope-invalid|stale-proof>:<admitted|quarantined>`
+  — the role the scenario assigned this reporter, plus what the
+  configured plugin actually did with its report.
+- `report:<reporter>:<subject>:<kind>:<admitted|quarantined>` — the
+  fate of one evidence report (identical structure to the
+  attested-peering observer's line).
+- `repscore:<victim>:<score>:<sample_count>` — the victim's final
+  reputation, formatted to six decimals.
+
+**Provenance.** Deterministic port of nexartis-nanda-node
+`src/lib/server/delegation-grants.ts` (functions
+`canonicalProofEnvelope`, `verifyPuhProof`, `grantDelegation`,
+`revokeDelegation`, `checkDelegation`, `assertChainNarrowing`, and
+`collectDescendants`, together with the CRITICAL-3 ancestor-expiry
+narrowing patch). A companion `delegated_trust_market` scenario plus
+four `validate_delegated_...` trace validators red-team the
+`score_average` baseline against this plugin.
+
+**Source:**
+[`delegated_admission.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/delegated_admission.py) ·
+[`delegated_trust_market.yaml`](../../scenarios/delegated_trust_market.yaml) ·
+`delegated_*` in
+[`validators.py`](../../packages/nest-core/nest_core/validators.py) ·
+[`VERIFICATION.md`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/VERIFICATION.md).
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under entry point group `nest.plugins.trust`.

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -33,6 +33,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("trust", "aae_permit_gate"): f"{_REF}.trust.aae_permit_gate:AAEPermitGate",
     ("trust", "bonded_trust"): f"{_REF}.trust.bonded_trust:BondedTrust",
     ("trust", "attested_peering"): f"{_REF}.trust.attested_peering:AttestedPeeringTrust",
+    ("trust", "delegated_admission"): f"{_REF}.trust.delegated_admission:DelegatedAdmissionTrust",
     ("payments", "prepaid_credits"): f"{_REF}.payments.prepaid_credits:PrepaidCredits",
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
     ("payments", "empic_escrow"): f"{_REF}.payments.empic_escrow:EMPICEscrowPayments",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -175,3 +175,9 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.sybil_bond import sybil_bond_factory
 
         register_scenario("sybil_bond", sybil_bond_factory)
+    elif name == "delegated_admission":
+        from nest_core.scenarios_builtin.delegated_admission import (
+            delegated_admission_factory,
+        )
+
+        register_scenario("delegated_admission", delegated_admission_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/delegated_admission.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/delegated_admission.py
@@ -1,0 +1,544 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegated-admission trust scenario — five reporter roles stress a live-grant gate.
+
+A single ``observer`` maintains the reputation of one ``victim`` and admits
+evidence about that victim iff the reporter holds a live, unrevoked,
+in-scope delegation from a trusted principal — the property enforced by
+:mod:`nest_plugins_reference.trust.delegated_admission` (the Python port of
+``nexartis-nanda-node/src/lib/server/delegation-grants.ts``).
+
+Five reporter roles stress five distinct failure modes of the gate:
+
+* **honest** — holds a fresh grant from the fixture principal covering
+  ``trust.report``. Verdict ``admitted``; files a *positive* report so the
+  victim's admitted-evidence average sits at 1.0.
+* **sybil** — no grant at all in the plugin's store. Verdict ``no-grant``.
+  Its *negative* report is quarantined; under a baseline plugin the same
+  reporter's negatives are admitted and drag the victim's score under 0.5.
+* **revoked** — child of a chain-root that the observer revokes mid-scenario.
+  A cascade line in the trace surfaces the exact ``(root_id, n_descendants)``
+  the plugin computed; every descendant's later report is quarantined.
+* **escalator** — grant with an in-scope tool string that does **not** contain
+  the required scope ``trust.report``. Verdict ``scope-mismatch``.
+* **stale** — grant issued at a logical clock in the past; by report time the
+  proof's freshness window has closed. Verdict ``puh-proof-stale``.
+
+The agents resolve their trust plugin from ``ctx.plugins["trust"]`` and
+capability-gate the grant surface on ``hasattr(trust, "revoke")``. Swapping
+``trust: delegated_admission`` for ``trust: score_average`` in the YAML
+genuinely changes behaviour: without a gate every reporter — including all
+four attack classes — is admitted, the victim's score collapses under 0.5,
+and no cascade line ever appears. This is what the flip test in
+``test_delegated_admission.py`` catches.
+
+Trace line protocol (message bodies, ``:``-delimited; the observer emits its
+audit lines by sending them to the passive ``victim`` sink so they land in
+the trace as ordinary ``send`` events the validators parse):
+
+* ``cascade:<root_id>:<n_descendants>`` — emitted once, in the observer's
+  ``on_start``, after the plugin performs the cascade revocation. Under a
+  baseline plugin (no ``revoke``) this line is absent, so the cascade
+  validator fails on baseline.
+* ``admission:<reporter>:<live|no-grant|revoked|scope-invalid|stale-proof>:<admitted|quarantined>``
+  — the role label the scenario assigned this reporter, plus what the
+  configured plugin actually did with its report. Under the delegated
+  plugin, only ``live`` ever comes with ``admitted``; under a baseline
+  plugin every kind comes with ``admitted``.
+* ``report:<reporter>:<subject>:<kind>:<admitted|quarantined>`` — the fate
+  of one evidence report (structurally identical to attested_peering).
+* ``repscore:<victim>:<score>:<samples>`` — the victim's final reputation,
+  formatted to six decimals.
+
+Example::
+
+    agents = delegated_admission_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Evidence
+
+if TYPE_CHECKING:
+    from nest_plugins_reference.trust.delegated_admission import (
+        DelegatedAdmissionTrust,
+    )
+
+# A fixed logical epoch (ms) at which the observer's trust plugin operates.
+# The plugin's PuhProof freshness comparisons subtract this value from the
+# proof's ``bound_at_ms``; the constant is far enough in the future that no
+# real-world reference date bleeds in and small enough that the ``expires_at``
+# unix-seconds field never overflows a reasonable integer window.
+_NOW_MS: int = 1_700_000_000_000
+_NOW_S: int = _NOW_MS // 1000
+
+# Roles the trace admission line surfaces (role → machine string). Public
+# so both the factory and :mod:`nest_core.validators` can import a single
+# truth (both live in ``nest-core``; the plugin's own reason strings —
+# ``no-grant``, ``revoked``, ``puh-proof-stale`` etc. — are a different
+# vocabulary owned by the plugin module).
+ADMISSION_KIND_LIVE = "live"
+"""Role tag stamped on trace ``admission:`` lines for honest reporters.
+
+Example::
+
+    assert ADMISSION_KIND_LIVE == "live"
+"""
+
+ADMISSION_KIND_NO_GRANT = "no-grant"
+"""Role tag for reporters with no grant at all (Sybil swarm).
+
+Example::
+
+    assert ADMISSION_KIND_NO_GRANT == "no-grant"
+"""
+
+ADMISSION_KIND_REVOKED = "revoked"
+"""Role tag for reporters whose grant was revoked (cascade victims).
+
+Example::
+
+    assert ADMISSION_KIND_REVOKED == "revoked"
+"""
+
+ADMISSION_KIND_SCOPE_INVALID = "scope-invalid"
+"""Role tag for reporters whose grant lacks the required scope.
+
+Example::
+
+    assert ADMISSION_KIND_SCOPE_INVALID == "scope-invalid"
+"""
+
+ADMISSION_KIND_STALE = "stale-proof"
+"""Role tag for reporters whose proof-of-human aged out of the freshness window.
+
+Example::
+
+    assert ADMISSION_KIND_STALE == "stale-proof"
+"""
+
+# Factory magic numbers → named constants.
+_GRANT_TTL_S = 3600
+"""One-hour TTL applied to every scenario-seeded grant, in seconds."""
+
+_STALE_SLACK_MS = 60_000
+"""Extra past-slack (ms) applied on top of ``PUH_FRESHNESS_MS`` to place
+``bound_at`` firmly outside the freshness window for stale reporters."""
+
+# Scope strings used across the factory. Kept as module constants so the
+# admission policy and grant issuance can't drift.
+_REQUIRED_SCOPE = "trust.report"
+"""The scope every admitted grant must carry."""
+
+_OFF_SCOPE_ESCALATOR = "tool.echo"
+"""The escalator role's grant carries this in-scope tool; because it is not
+``_REQUIRED_SCOPE``, admission fails with ``scope-mismatch``."""
+
+_VICTIM_CONFIG_KEY = "victim"
+"""``task.config`` key holding the victim agent id (default: ``"victim"``)."""
+
+_DEFAULT_VICTIM_ID = "victim"
+"""Default victim id when ``task.config`` omits ``victim``."""
+
+
+class ReporterAgent(StateMachineAgent):
+    """A reporter that files one evidence report about the victim.
+
+    The reporter is stateless: on start it sends a single ``claim:<kind>``
+    message to the observer and never speaks again. The observer decides
+    the fate of the report — the reporter never inspects its own grant, so
+    the same agent class works under every role.
+
+    Example::
+
+        agent = ReporterAgent(AgentId("honest-0"), AgentId("observer"), "positive")
+    """
+
+    def __init__(self, agent_id: AgentId, observer: AgentId, report_kind: str) -> None:
+        self._id = agent_id
+        self._observer = observer
+        self._report_kind = report_kind
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Emit the one claim message this reporter will ever send.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        await ctx.send(self._observer, f"claim:{self._report_kind}".encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Ignore any inbound traffic — reporters do not participate further.
+
+        Example::
+
+            await agent.on_message(ctx, observer, b"anything")
+        """
+        return
+
+
+class ObserverAgent(StateMachineAgent):
+    """Runs the delegated-admission plugin and records the victim's reputation.
+
+    On start it performs the cascade revocation of the pre-seeded chain-root
+    (if the configured trust plugin exposes ``revoke``) and emits a single
+    ``cascade:<root_id>:<n_descendants>`` line reflecting exactly what the
+    plugin returned. On each inbound ``claim:<kind>`` from a reporter it
+    files evidence through the trust plugin, looks up the verdict via
+    ``last_verdict`` when available, and emits paired
+    ``admission:``/``report:`` lines with the reporter's role kind and the
+    plugin's actual admission fate. When the last expected reporter has been
+    processed it emits the final ``repscore:`` line.
+
+    Example::
+
+        observer = ObserverAgent(AgentId("observer"), AgentId("victim"), {}, None, 32)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        victim: AgentId,
+        role_map: dict[AgentId, str],
+        cascade_root_id: str | None,
+        expected: int,
+    ) -> None:
+        self._id = agent_id
+        self._victim = victim
+        self._role_map = role_map
+        self._cascade_root_id = cascade_root_id
+        self._expected = expected
+        self._processed = 0
+        self._done = False
+
+    async def _log(self, ctx: AgentContext, line: str) -> None:
+        await ctx.send(self._victim, line.encode())
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Perform the cascade revocation and log its footprint.
+
+        Example::
+
+            await observer.on_start(ctx)
+        """
+        trust = ctx.plugins.get("trust")
+        if trust is None:
+            return
+        # Reaffirm the clock in case a future runner ever resets it — the
+        # plugin's freshness/expiry gates all key off this millisecond value.
+        if hasattr(trust, "set_clock"):
+            trust.set_clock(_NOW_MS)
+        if self._cascade_root_id is None or not hasattr(trust, "revoke"):
+            return
+        result = trust.revoke(self._cascade_root_id)
+        # ``cascaded`` includes the root itself; descendants are the remainder.
+        cascaded = getattr(result, "cascaded", ())
+        n_descendants = max(0, len(cascaded) - 1)
+        await self._log(ctx, f"cascade:{self._cascade_root_id}:{n_descendants}")
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Ingest one reporter's claim, file evidence, and log the fate.
+
+        Example::
+
+            await observer.on_message(ctx, sender, b"claim:positive")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if not msg.startswith("claim:"):
+            return
+        trust = ctx.plugins.get("trust")
+        if trust is None:
+            return
+        kind = msg[len("claim:") :]
+        # The plugin's ``report`` is defensive: it never raises on adversarial
+        # input; it appends to its quarantine list and records a verdict we
+        # can query below.
+        evidence = Evidence(reporter=sender, subject=self._victim, kind=kind)
+        await trust.report(self._victim, evidence)
+
+        last_verdict = getattr(trust, "last_verdict", None)
+        if callable(last_verdict):
+            verdict = last_verdict(sender)
+            admitted = verdict is not None and bool(getattr(verdict, "admitted", False))
+        else:
+            # Baseline path — score_average admits every report unconditionally,
+            # so the trace faithfully reports that behaviour.
+            admitted = True
+        fate = "admitted" if admitted else "quarantined"
+        role_kind = self._role_map.get(sender, ADMISSION_KIND_LIVE)
+        await self._log(ctx, f"admission:{sender}:{role_kind}:{fate}")
+        await self._log(ctx, f"report:{sender}:{self._victim}:{kind}:{fate}")
+
+        self._processed += 1
+        await self._maybe_finish(ctx, trust)
+
+    async def _maybe_finish(self, ctx: AgentContext, trust: Any) -> None:
+        if self._done or self._processed < self._expected:
+            return
+        self._done = True
+        score = await trust.score(self._victim)
+        await self._log(ctx, f"repscore:{self._victim}:{score.score:.6f}:{score.sample_count}")
+
+
+class SinkAgent(StateMachineAgent):
+    """The victim: a passive sink that absorbs the observer's audit lines.
+
+    Example::
+
+        victim = SinkAgent(AgentId("victim"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Ignore all incoming audit lines.
+
+        Example::
+
+            await victim.on_message(ctx, observer, b"repscore:...")
+        """
+        return
+
+
+def _role_counts(config: ScenarioConfig) -> dict[str, int]:
+    """Resolve reporter role counts from the scenario's ``agents.roles`` block.
+
+    Example::
+
+        counts = _role_counts(config)
+    """
+    defaults = {"honest": 8, "sybil": 20, "revoked": 2, "escalator": 1, "stale": 1}
+    if config.agents.roles:
+        for role in config.agents.roles:
+            if role.name in defaults:
+                defaults[role.name] = role.count
+    return defaults
+
+
+def _issue_grant_or_raise(
+    trust: DelegatedAdmissionTrust,
+    principal_id: str,
+    principal_key: Any,
+    delegate_id: str,
+    *,
+    scope: tuple[str, ...],
+    parent_delegation_id: str | None,
+    now_ms: int,
+) -> str:
+    """Mint one grant against *trust*'s current clock; return its delegation id.
+
+    Example::
+
+        did = _issue_grant_or_raise(
+            trust, pid, priv, "honest-0",
+            scope=("trust.report",), parent_delegation_id=None, now_ms=NOW,
+        )
+    """
+    from nest_plugins_reference.trust.delegated_admission import (
+        DelegationSubject,
+        build_proof,
+        envelope_hash,
+    )
+
+    subject = DelegationSubject(
+        delegate_id=delegate_id,
+        granted_scope=scope,
+        expires_at=_NOW_S + _GRANT_TTL_S,
+        parent_delegation_id=parent_delegation_id,
+        revocable=True,
+    )
+    envelope, proof = build_proof(principal_id, principal_key, subject, now_ms=now_ms)
+    result = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    if not result.ok or result.delegation_id is None:
+        msg = f"scenario setup failed: grant({delegate_id}) rejected with reason={result.reason!r}"
+        raise RuntimeError(msg)
+    return result.delegation_id
+
+
+def _provision_trust(
+    plugins: dict[str, Any],
+    observer_id: AgentId,
+    honest_ids: list[AgentId],
+    revoked_ids: list[AgentId],
+    escalator_ids: list[AgentId],
+    stale_ids: list[AgentId],
+) -> str | None:
+    """Instantiate the observer's trust plugin and seed every grant.
+
+    Returns the chain-root delegation id when the configured plugin exposes
+    the delegated-admission surface; ``None`` under a baseline plugin (no
+    grants exist, so nothing to cascade). Mirrors the capability-gated
+    per-agent provisioning attested_peering uses.
+
+    Example::
+
+        root_id = _provision_trust(plugins, observer_id, honest, revoked, escalator, stale)
+    """
+    trust_cls = plugins.get("trust")
+    if trust_cls is None or not isinstance(trust_cls, type):
+        return None
+
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+
+    # Capability gate: baseline plugins (score_average) have no grant surface.
+    if not (
+        hasattr(trust_cls, "grant")
+        and hasattr(trust_cls, "revoke")
+        and hasattr(trust_cls, "set_clock")
+    ):
+        agent_plugins.setdefault(observer_id, {})["trust"] = trust_cls()
+        plugins.pop("trust", None)
+        return None
+
+    from nest_plugins_reference.trust.delegated_admission import (
+        PUH_FRESHNESS_MS,
+        AdmissionPolicy,
+        _public_raw,  # pyright: ignore[reportPrivateUsage]  # scenario setup only
+        derive_principal,
+    )
+
+    principal_id, principal_key = derive_principal(b"delegated-admission:scenario:principal")
+    policy = AdmissionPolicy(
+        trusted_principals={principal_id: _public_raw(principal_key)},
+        required_scope=_REQUIRED_SCOPE,
+    )
+    trust = trust_cls(
+        agent_id=observer_id,
+        seed=b"delegated-admission",
+        policy=policy,
+    )
+    trust.set_clock(_NOW_MS)
+
+    # Chain root — a grant with a synthetic delegate id nobody will report as,
+    # used exclusively as the parent to revoke for the cascade demonstration.
+    root_id = _issue_grant_or_raise(
+        trust,
+        principal_id,
+        principal_key,
+        "chain-root",
+        scope=(_REQUIRED_SCOPE,),
+        parent_delegation_id=None,
+        now_ms=_NOW_MS,
+    )
+
+    # Honest grants (direct from the principal, in scope, fresh).
+    for aid in honest_ids:
+        _issue_grant_or_raise(
+            trust,
+            principal_id,
+            principal_key,
+            str(aid),
+            scope=(_REQUIRED_SCOPE,),
+            parent_delegation_id=None,
+            now_ms=_NOW_MS,
+        )
+
+    # Revoked grants (children of chain-root — cascade will kill them).
+    for aid in revoked_ids:
+        _issue_grant_or_raise(
+            trust,
+            principal_id,
+            principal_key,
+            str(aid),
+            scope=(_REQUIRED_SCOPE,),
+            parent_delegation_id=root_id,
+            now_ms=_NOW_MS,
+        )
+
+    # Escalator grants (in-scope for something else, missing the required scope).
+    for aid in escalator_ids:
+        _issue_grant_or_raise(
+            trust,
+            principal_id,
+            principal_key,
+            str(aid),
+            scope=(_OFF_SCOPE_ESCALATOR,),
+            parent_delegation_id=None,
+            now_ms=_NOW_MS,
+        )
+
+    # Stale grants: mint them at a clock in the past so the proof's
+    # ``bound_at_ms`` falls outside PUH_FRESHNESS_MS when reports arrive.
+    stale_now_ms = _NOW_MS - PUH_FRESHNESS_MS - _STALE_SLACK_MS
+    trust.set_clock(stale_now_ms)
+    for aid in stale_ids:
+        _issue_grant_or_raise(
+            trust,
+            principal_id,
+            principal_key,
+            str(aid),
+            scope=(_REQUIRED_SCOPE,),
+            parent_delegation_id=None,
+            now_ms=stale_now_ms,
+        )
+    trust.set_clock(_NOW_MS)
+
+    agent_plugins.setdefault(observer_id, {})["trust"] = trust
+    plugins.pop("trust", None)
+    return root_id
+
+
+def delegated_admission_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create the observer, victim sink, and honest + four adversarial reporter roles.
+
+    Role counts come from ``agents.roles`` (defaults: 8 honest, 20 sybil, 2
+    revoked, 1 escalator, 1 stale). Honest reporters file *positive* evidence;
+    every attacker files *negative* evidence but is quarantined by the
+    delegated-admission gate — under a baseline plugin those negatives are
+    admitted and the victim's score collapses.
+
+    Example::
+
+        agents = delegated_admission_factory(config, plugins)
+    """
+    counts = _role_counts(config)
+    observer_id = AgentId("observer")
+    task_config = config.task.config
+    victim_id = AgentId(str(task_config.get(_VICTIM_CONFIG_KEY, _DEFAULT_VICTIM_ID)))
+
+    honest_ids = [AgentId(f"honest-{i}") for i in range(counts["honest"])]
+    sybil_ids = [AgentId(f"sybil-{i}") for i in range(counts["sybil"])]
+    revoked_ids = [AgentId(f"revoked-{i}") for i in range(counts["revoked"])]
+    escalator_ids = [AgentId(f"escalator-{i}") for i in range(counts["escalator"])]
+    stale_ids = [AgentId(f"stale-{i}") for i in range(counts["stale"])]
+    reporter_ids = honest_ids + sybil_ids + revoked_ids + escalator_ids + stale_ids
+
+    role_map: dict[AgentId, str] = {}
+    for aid in honest_ids:
+        role_map[aid] = ADMISSION_KIND_LIVE
+    for aid in sybil_ids:
+        role_map[aid] = ADMISSION_KIND_NO_GRANT
+    for aid in revoked_ids:
+        role_map[aid] = ADMISSION_KIND_REVOKED
+    for aid in escalator_ids:
+        role_map[aid] = ADMISSION_KIND_SCOPE_INVALID
+    for aid in stale_ids:
+        role_map[aid] = ADMISSION_KIND_STALE
+
+    cascade_root_id = _provision_trust(
+        plugins, observer_id, honest_ids, revoked_ids, escalator_ids, stale_ids
+    )
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    for aid in honest_ids:
+        agents[aid] = ReporterAgent(aid, observer_id, "positive")
+    for aid in sybil_ids + revoked_ids + escalator_ids + stale_ids:
+        agents[aid] = ReporterAgent(aid, observer_id, "negative")
+
+    agents[observer_id] = ObserverAgent(
+        observer_id,
+        victim_id,
+        role_map=role_map,
+        cascade_root_id=cascade_root_id,
+        expected=len(reporter_ids),
+    )
+    agents[victim_id] = SinkAgent(victim_id)
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -24,6 +24,14 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
+from nest_core.scenarios_builtin.delegated_admission import (
+    ADMISSION_KIND_LIVE,
+    ADMISSION_KIND_NO_GRANT,
+    ADMISSION_KIND_REVOKED,
+    ADMISSION_KIND_SCOPE_INVALID,
+    ADMISSION_KIND_STALE,
+)
+
 
 class ValidationResult:
     """Result of a protocol validation check."""
@@ -4793,6 +4801,362 @@ def validate_attested_sybil_quarantined(
 
 
 # ---------------------------------------------------------------------------
+# Delegated-admission trust validators
+# ---------------------------------------------------------------------------
+
+
+def _delegated_observer_lines(events: list[dict[str, Any]]) -> list[str]:
+    """Return the observer's audit-line message bodies in trace order.
+
+    The observer emits ``cascade:``/``admission:``/``report:``/``repscore:``
+    lines by sending them to the victim sink, so each appears once as a
+    ``send`` and once as a ``receive``; we read only the authoritative
+    ``send`` events (which preserves emission order).
+
+    Example::
+
+        lines = _delegated_observer_lines(events)
+    """
+    lines: list[str] = []
+    for ev in events:
+        if ev.get("kind") != "send" or ev.get("agent") != "observer":
+            continue
+        lines.append(str(ev.get("msg", "")))
+    return lines
+
+
+def _delegated_admission_kinds(lines: list[str]) -> dict[str, str]:
+    """Return ``reporter -> role_kind`` parsed from ``admission:`` trace lines.
+
+    Example::
+
+        kinds = _delegated_admission_kinds(_delegated_observer_lines(events))
+    """
+    kinds: dict[str, str] = {}
+    for line in lines:
+        if not line.startswith("admission:"):
+            continue
+        parts = line.split(":")
+        if len(parts) != 4:
+            continue
+        _, reporter, role_kind, _fate = parts
+        kinds[reporter] = role_kind
+    return kinds
+
+
+def _delegated_admitted_reporters(lines: list[str]) -> set[str]:
+    """Reporters that have at least one ``admission:...:admitted`` line.
+
+    Example::
+
+        admitted = _delegated_admitted_reporters(lines)
+    """
+    admitted: set[str] = set()
+    for line in lines:
+        if not line.startswith("admission:"):
+            continue
+        parts = line.split(":")
+        if len(parts) == 4 and parts[3] == "admitted":
+            admitted.add(parts[1])
+    return admitted
+
+
+def _delegated_repscore(lines: list[str]) -> tuple[float, int] | None:
+    """Return ``(score, sample_count)`` from the ``repscore:victim:`` line.
+
+    Example::
+
+        rep = _delegated_repscore(lines)
+    """
+    for line in lines:
+        if not line.startswith("repscore:"):
+            continue
+        parts = line.split(":")
+        if len(parts) == 4 and parts[1] == "victim":
+            try:
+                return float(parts[2]), int(parts[3])
+            except ValueError:
+                return None
+    return None
+
+
+def validate_delegated_unattested_quarantined(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """No reporter without a grant is admitted, and honest reporters *are* admitted.
+
+    This is the discriminating safety property of the delegated-admission
+    gate: reporters labelled ``no-grant`` in the trace must never produce
+    an ``admitted`` report line, the victim's final ``repscore`` must sit
+    at or above the neutral prior ``0.5`` (a Sybil swarm's negatives cannot
+    have polluted the average), and — the anti-degenerate guard — honest
+    reporters (``live``) must actually appear as admitted, so a plugin
+    that quarantines *everything* cannot pass this validator trivially.
+
+    Under ``trust: score_average`` every negative is admitted; the victim's
+    average collapses to (well) under 0.5 and this validator FAILs. Under
+    ``trust: delegated_admission`` only ``live`` reporters are admitted and
+    it PASSes.
+
+    Example::
+
+        results = validate_trace(Path("traces/delegated_admission.jsonl"), "delegated_admission")
+    """
+    lines = _delegated_observer_lines(events)
+    kinds = _delegated_admission_kinds(lines)
+    admitted = _delegated_admitted_reporters(lines)
+
+    if not kinds:
+        return [
+            ValidationResult(
+                "delegated_unattested_quarantined",
+                False,
+                "no admission: trace lines observed (scenario setup failure)",
+            )
+        ]
+
+    no_grant_reporters = {r for r, k in kinds.items() if k == ADMISSION_KIND_NO_GRANT}
+    honest_reporters = {r for r, k in kinds.items() if k == ADMISSION_KIND_LIVE}
+    admitted_sybils = sorted(no_grant_reporters & admitted)
+
+    problems: list[str] = []
+    if admitted_sybils:
+        problems.append(
+            f"no-grant reporters admitted: {admitted_sybils[:5]}"
+            f"{'…' if len(admitted_sybils) > 5 else ''}"
+        )
+
+    rep = _delegated_repscore(lines)
+    if rep is None:
+        problems.append("no repscore:victim line found")
+    else:
+        score, samples = rep
+        if score < 0.5:
+            problems.append(
+                f"victim reputation {score:.3f} < 0.5 over {samples} admitted report(s) — "
+                "unattested reporters polluted the average"
+            )
+
+    # Anti-degenerate guard: a plugin that quarantines *everyone* cannot pass.
+    if honest_reporters:
+        quarantined_honest = sorted(honest_reporters - admitted)
+        if quarantined_honest:
+            problems.append(
+                f"honest reporters not admitted (degenerate gate): "
+                f"{quarantined_honest[:5]}"
+                f"{'…' if len(quarantined_honest) > 5 else ''}"
+            )
+
+    if problems:
+        return [
+            ValidationResult(
+                "delegated_unattested_quarantined",
+                False,
+                "; ".join(problems),
+            )
+        ]
+
+    score_str = f"{rep[0]:.3f}" if rep is not None else "?"
+    return [
+        ValidationResult(
+            "delegated_unattested_quarantined",
+            True,
+            (
+                f"{len(honest_reporters)} honest reporter(s) admitted, "
+                f"{len(no_grant_reporters)} no-grant reporter(s) quarantined, "
+                f"victim reputation {score_str}"
+            ),
+        )
+    ]
+
+
+def validate_delegated_revocation_cascade(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """After the cascade line, no ``revoked`` reporter is ever admitted.
+
+    Enforcement-not-assumption: the trace must contain at least one
+    ``cascade:<root>:<n_descendants>`` line with ``n_descendants >= 1``
+    (proving the plugin actually revoked a parent grant and propagated the
+    revocation), and any ``admission:<r>:revoked:admitted`` line that
+    appears strictly after that cascade line is a violation. Under a
+    baseline plugin without a ``revoke`` surface no cascade line is
+    emitted, so this validator FAILs on baseline.
+
+    Example::
+
+        results = validate_trace(Path("traces/delegated_admission.jsonl"), "delegated_admission")
+    """
+    lines = _delegated_observer_lines(events)
+
+    cascade_indices: list[tuple[int, int]] = []
+    for i, line in enumerate(lines):
+        if not line.startswith("cascade:"):
+            continue
+        parts = line.split(":")
+        if len(parts) != 3:
+            continue
+        try:
+            n_desc = int(parts[2])
+        except ValueError:
+            continue
+        cascade_indices.append((i, n_desc))
+
+    if not cascade_indices:
+        return [
+            ValidationResult(
+                "delegated_revocation_cascade",
+                False,
+                "no cascade: line found in trace — revocation was never exercised",
+            )
+        ]
+
+    max_n_desc = max(n for _i, n in cascade_indices)
+    if max_n_desc < 1:
+        return [
+            ValidationResult(
+                "delegated_revocation_cascade",
+                False,
+                f"cascade line has n_descendants={max_n_desc}; the attack did not touch any child",
+            )
+        ]
+
+    first_cascade_idx = cascade_indices[0][0]
+    violations: list[str] = []
+    for i, line in enumerate(lines):
+        if i <= first_cascade_idx:
+            continue
+        if not line.startswith("admission:"):
+            continue
+        parts = line.split(":")
+        if len(parts) != 4:
+            continue
+        _, reporter, role_kind, fate = parts
+        if role_kind == ADMISSION_KIND_REVOKED and fate == "admitted":
+            violations.append(f"{reporter} admitted after cascade (line #{i})")
+
+    if violations:
+        return [
+            ValidationResult(
+                "delegated_revocation_cascade",
+                False,
+                "; ".join(violations),
+            )
+        ]
+    return [
+        ValidationResult(
+            "delegated_revocation_cascade",
+            True,
+            f"cascade revoked {max_n_desc} descendant(s); no revoked reporter admitted afterwards",
+        )
+    ]
+
+
+def _validate_delegated_role_denied(
+    events: list[dict[str, Any]],
+    *,
+    validator_name: str,
+    role_kind: str,
+) -> list[ValidationResult]:
+    """Common shape for ``scope-invalid`` / ``stale-proof`` gate validators.
+
+    Requires at least one ``admission:<r>:<role_kind>:...`` line in the
+    trace (enforcement-not-assumption: the attempt must be present) and
+    fails if any such reporter appears with fate ``admitted``.
+
+    Example::
+
+        results = _validate_delegated_role_denied(
+            events,
+            validator_name="delegated_scope_escalation_blocked",
+            role_kind="scope-invalid",
+        )
+    """
+    lines = _delegated_observer_lines(events)
+
+    attempts = 0
+    admitted: list[str] = []
+    for line in lines:
+        if not line.startswith("admission:"):
+            continue
+        parts = line.split(":")
+        if len(parts) != 4:
+            continue
+        _, reporter, kind, fate = parts
+        if kind != role_kind:
+            continue
+        attempts += 1
+        if fate == "admitted":
+            admitted.append(reporter)
+
+    if attempts == 0:
+        return [
+            ValidationResult(
+                validator_name,
+                False,
+                f"no {role_kind} admission attempts in trace — cannot prove enforcement",
+            )
+        ]
+    if admitted:
+        return [
+            ValidationResult(
+                validator_name,
+                False,
+                f"{role_kind} reporter(s) admitted despite the gate: {sorted(set(admitted))}",
+            )
+        ]
+    return [
+        ValidationResult(
+            validator_name,
+            True,
+            f"{attempts} {role_kind} attempt(s) present, all quarantined",
+        )
+    ]
+
+
+def validate_delegated_scope_escalation_blocked(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """A grant that does not carry the required scope cannot admit evidence.
+
+    Requires at least one ``admission:<r>:scope-invalid:...`` line and
+    fails on any ``scope-invalid`` admission with fate ``admitted``. Under
+    a baseline plugin the required scope is never consulted so every
+    scope-invalid attempt is admitted and this validator FAILs.
+
+    Example::
+
+        results = validate_trace(Path("traces/delegated_admission.jsonl"), "delegated_admission")
+    """
+    return _validate_delegated_role_denied(
+        events,
+        validator_name="delegated_scope_escalation_blocked",
+        role_kind=ADMISSION_KIND_SCOPE_INVALID,
+    )
+
+
+def validate_delegated_stale_proof_rejected(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """A proof outside the freshness window cannot admit evidence.
+
+    Requires at least one ``admission:<r>:stale-proof:...`` line and fails
+    on any ``stale-proof`` admission with fate ``admitted``. Under a
+    baseline plugin the proof clock is never consulted so every stale
+    attempt is admitted and this validator FAILs.
+
+    Example::
+
+        results = validate_trace(Path("traces/delegated_admission.jsonl"), "delegated_admission")
+    """
+    return _validate_delegated_role_denied(
+        events,
+        validator_name="delegated_stale_proof_rejected",
+        role_kind=ADMISSION_KIND_STALE,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
 
@@ -4972,6 +5336,12 @@ VALIDATORS: dict[str, list[Any]] = {
     "attested_peering": [
         validate_attested_no_denied_admitted,
         validate_attested_sybil_quarantined,
+    ],
+    "delegated_admission": [
+        validate_delegated_unattested_quarantined,
+        validate_delegated_revocation_cascade,
+        validate_delegated_scope_escalation_blocked,
+        validate_delegated_stale_proof_rejected,
     ],
     "memory_concurrent_writers": [
         validate_memory_convergence,

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2013,6 +2013,7 @@ class TestValidatorRegistry:
             "parc_migration",
             "rogue_trusted_agent",
             "sybil_bond",
+            "delegated_admission",
         }
         assert set(VALIDATORS.keys()) == expected
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/VERIFICATION.md
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/VERIFICATION.md
@@ -1,0 +1,182 @@
+# delegated_admission — verification guide
+
+## What this is
+
+`delegated_admission` is a Tier-1, deterministic Python port of the
+audited nexartis-nanda-node delegation-grant verifier
+(`nexartis-nanda-node/src/lib/server/delegation-grants.ts`) plugged
+into Nanda Town's `trust` layer. Evidence from a reporter is admitted
+into reputation scoring iff, at the currently injected logical clock:
+
+1. The reporter is bound to a delegation grant in the plugin's local
+   store.
+2. The grant is not revoked, not expired, and not transitively
+   invalidated by a revoked or earlier-expiring ancestor within
+   `MAX_HOPS` hops (cycle-safe).
+3. The grant's scope contains `AdmissionPolicy.required_scope`.
+4. The grant's `PuhProof` re-canonicalises to the same envelope bytes,
+   its `bound_at_ms` / `issued_at_ms` fall inside
+   `[now_ms - PUH_FRESHNESS_MS, now_ms + PUH_SKEW_MS]`, and (by default)
+   the proof carries an Ed25519 signature by the principal's trusted
+   public key over those bytes.
+
+Everything else is quarantined with a stable machine-string reason so
+adversarial validators can gate on the reason byte-exactly.
+
+Bundled companions:
+
+- `nest_core/scenarios_builtin/delegated_admission.py` — the scenario
+  factory (five reporter roles).
+- `scenarios/delegated_trust_market.yaml` — the Tier-1 YAML.
+- `validate_delegated_*` in `nest_core/validators.py` — four
+  discriminating trace validators.
+
+## How to verify
+
+Everything below runs offline, deterministically, and requires only
+the workspace's `uv` toolchain. All commands are run from the
+repository root (`nandatown-lane3` here — the branch worktree).
+
+Run the plugin's own 60-plus-test suite (unit + property + Byzantine
+input + integration):
+
+```bash
+uv run pytest packages/nest-plugins-reference/tests/test_delegated_admission.py -v
+```
+
+Run the scenario end-to-end under the delegated plugin and inspect the
+trace:
+
+```bash
+uv run nest run scenarios/delegated_trust_market.yaml
+uv run nest validate --trace ./traces/delegated_admission.jsonl --type delegated_admission
+```
+
+Invoke the four validators programmatically (same result the CLI's
+`nest validate` produces):
+
+```bash
+uv run python - <<'PY'
+from pathlib import Path
+from nest_core.validators import validate_trace
+for r in validate_trace(Path("./traces/delegated_admission.jsonl"), "delegated_admission"):
+    print(f"{'PASS' if r.passed else 'FAIL'}: {r.name} — {r.detail}")
+PY
+```
+
+Byte-determinism (same seed → identical trace bytes):
+
+```bash
+uv run pytest packages/nest-plugins-reference/tests/test_delegated_admission.py::test_delegated_scenario_is_byte_deterministic -v
+```
+
+Flip test (swap `trust: delegated_admission` for `trust: score_average`
+in memory and rerun the validators):
+
+```bash
+uv run pytest packages/nest-plugins-reference/tests/test_delegated_admission.py::test_scenario_baseline_fails_unattested_quarantined -v
+```
+
+## Adversarial validators
+
+Four validators live in `nest_core/validators.py` under the
+`"delegated_admission"` key. Each is chosen to fail in a distinct,
+useful way when the trust layer is `score_average` instead of
+`delegated_admission`:
+
+1. **`validate_delegated_unattested_quarantined`** — the primary
+   discriminator. Every reporter labelled `no-grant` in the trace's
+   `admission:` lines must have its report quarantined, the victim's
+   final `repscore` must sit at or above the neutral prior `0.5`, and
+   every reporter labelled `live` (the anti-degenerate guard) *must*
+   appear as admitted. Under `score_average` every `no-grant`
+   reporter's negatives are admitted, the victim's average collapses
+   under 0.5, and this validator FAILs.
+2. **`validate_delegated_revocation_cascade`** — requires at least one
+   `cascade:<root>:<n_descendants>` line in the trace with
+   `n_descendants >= 1`, and forbids any `admission:<r>:revoked:admitted`
+   line strictly after the cascade line. Under `score_average` no
+   cascade line exists (baseline has no `revoke` surface), so this
+   validator FAILs on the "cascade never happened" branch.
+3. **`validate_delegated_scope_escalation_blocked`** — requires at
+   least one `admission:<r>:scope-invalid:...` attempt and forbids any
+   `scope-invalid` reporter from appearing as admitted. Under
+   `score_average` the required scope is never consulted so every
+   scope-invalid attempt is admitted and this validator FAILs.
+4. **`validate_delegated_stale_proof_rejected`** — requires at least
+   one `admission:<r>:stale-proof:...` attempt and forbids any
+   `stale-proof` reporter from appearing as admitted. Under
+   `score_average` the proof clock is never consulted so every stale
+   attempt is admitted and this validator FAILs.
+
+The paired scenario+plugin passes all four at seeds `[42, 7, 1337]`.
+The baseline `score_average` fails all four; the flip test
+(`test_scenario_baseline_fails_unattested_quarantined`) only asserts
+the primary discriminator flips, matching how the attested-peering
+suite writes the same shape.
+
+## Honest limitations
+
+These are the intentional divergences from the production system this
+plugin ports. They are consequential — a production reviewer should
+know them before treating the Tier-1 plugin as a drop-in replacement.
+
+1. **`require_signed_puh=True` is stricter than production.** The
+   audited nanda-node treats proof-of-human signatures as optional at
+   runtime, pending the ceremony's mobile signing rollout. The Python
+   port defaults to *requiring* the Ed25519 signature over the
+   canonical envelope. Set `AdmissionPolicy(require_signed_puh=False)`
+   for parity with production's current toggle.
+2. **`trusted_principals` roster is an enhancement.** The production
+   verifier trusts a *single* configured principal key. The Python
+   port carries a `dict[principal_id, public_key]` so scenarios can
+   express multi-principal fixtures and unknown-principal rejection
+   independently of the roster shape. Configuring exactly one entry
+   reproduces the production behaviour.
+3. **Cascading revocation composes with the trust layer.** In the
+   production KYM VC pipeline, revocation is flat and per-credential:
+   revoking one credential does not revoke child credentials it issued.
+   The Python port ports the nanda-node grant semantics
+   (`collectDescendants` + `MAX_HOPS`), which do cascade. If the
+   plugin is deployed against a real KYM registry, the cascade must
+   either be disabled at the policy layer or the underlying registry
+   must be extended with a parent field — this is not a swap-in.
+4. **The biometric principal is a deterministic fixture in Tier 1.**
+   `derive_principal(seed)` fabricates a stable Ed25519 keypair for a
+   test/scenario principal from arbitrary seed bytes. In production
+   the principal key is bound to a live Yanez proof-of-human ceremony
+   over an out-of-band biometric channel that is deliberately not
+   modelled here — the ceremony's transport is out of scope for a
+   protocol-level simulator, and the fixture buys the discriminating
+   trace + validator set at Tier 1 without pretending otherwise.
+5. **As-of binding: admission evaluates at report time.** When
+   `report()` is called, the plugin re-verifies the stored proof
+   against the *current* clock, not the clock at which the grant was
+   issued. This is what lets the stale-proof role fail
+   deterministically (issue at `now - freshness - 60_000`, advance
+   clock, present evidence, watch the plugin reject with
+   `puh-proof-stale`). It also means a proof that was fresh at grant
+   time but is stale by report time is rejected — matching
+   `verifyPuhProof`'s behaviour but worth stating explicitly for any
+   consumer that thinks in terms of certificate-style
+   "issued=valid-forever" semantics.
+6. **Ancestor-expiry narrowing is strictly tighter than production.**
+   The TS `checkDelegation` narrows a child's reported `expiresAt` only
+   when it encounters an ancestor that is *currently expired*, then
+   stops walking. The Python port computes the effective expiry as the
+   minimum across the whole ancestor chain unconditionally, so
+   `CheckResult.expires_at_effective` can be earlier than production
+   would report even while the grant is still valid. The `valid` /
+   `expired` verdicts — the security-relevant outputs, including the
+   production CRITICAL-3 fix — are identical in both implementations;
+   only the reported effective-expiry timestamp is more conservative
+   here.
+7. **Chain depth is capped at mint time (`chain-too-deep`) — production
+   does not cap it.** The TS source bounds the revocation cascade and
+   the check-time ancestor walk at 32 hops each but allows unbounded
+   mint depth, so a grant more than 64 hops below a revoked ancestor
+   would evade both bounded walks and remain valid (fail-open). The
+   Python port refuses to mint a grant whose ancestor chain would
+   exceed `MAX_HOPS` (32), guaranteeing every legal chain is fully
+   covered by both walks. Stricter than production, by design;
+   regression-tested (`test_chain_too_deep_rejected_at_mint`).

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/delegated_admission.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/delegated_admission.py
@@ -1,0 +1,1160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegated-admission trust plugin — gate evidence on live proof-of-human grants.
+
+The two attestation-flavoured trust plugins already answer *"has this peer
+proven itself right now?"* (:mod:`~nest_plugins_reference.trust.attested_peering`
+runs a three-question mutual handshake per session). They do not answer the
+adjacent question that a production federated node has to answer *before* it
+lets a reporter file evidence at all: *"does this reporter hold a live,
+unrevoked, appropriately-scoped delegation from a human principal — and is the
+proof-of-human it dangled at us fresh?"*
+
+This plugin is the Python port of the audited production model that lives in
+the NANDA node's TypeScript source
+(``nexartis-nanda-node/src/lib/server/delegation-grants.ts``). Evidence from a
+reporter is admitted into reputation scoring iff **all** of the following
+hold at the injected logical clock ``now_ms``:
+
+1. The reporter is bound to a delegation grant in this trust's local store.
+2. The grant is not revoked, not expired, and has not been transitively
+   invalidated by a revoked/expired ancestor (chain check up to
+   :data:`MAX_HOPS` deep; cycle-safe).
+3. The grant's scope contains :attr:`AdmissionPolicy.required_scope`.
+4. The grant carries a fresh :class:`PuhProof` whose canonical envelope hash
+   matches byte-exactly and whose freshness bound is satisfied against
+   ``now_ms`` (:data:`PUH_FRESHNESS_MS` with :data:`PUH_SKEW_MS` slack).
+5. If :attr:`AdmissionPolicy.require_signed_puh` (the default — this Python
+   port is intentionally stricter than the production toggle it derives
+   from), the proof must additionally carry a valid Ed25519 signature by the
+   principal's trusted public key over the canonical envelope bytes.
+
+Everything else is *quarantined* with a stable machine-string reason so the
+scenario's adversarial validators can red-team both the plugin and its
+baseline (:mod:`~nest_plugins_reference.trust.score_average`). The
+canonicalisation is byte-for-byte compatible with the production TS
+``canonicalProofEnvelope`` — a fixed vector locks that in the test suite.
+
+Determinism
+-----------
+
+Every observable output is a deterministic function of scenario inputs:
+
+- **No wall clock.** All freshness comparisons use an injected
+  ``now_ms`` (:meth:`DelegatedAdmissionTrust.set_clock`); nothing calls
+  :func:`time.time` / :func:`time.monotonic` / :func:`datetime.now`.
+- **No OS randomness.** Ed25519 seeds derive as ``sha256(seed)[:32]`` exactly
+  like :mod:`~nest_plugins_reference.trust.attested_peering`. Ed25519 is
+  RFC 8032 deterministic, so the same key over the same bytes always
+  yields the same signature.
+- **No network / subprocess / filesystem.** The delegation store is a
+  per-instance in-memory :class:`dict`.
+- **Deterministic delegation ids.** ``del-<hex>`` where the hex is
+  ``sha256(canonical_envelope || counter.to_bytes(8,'big'))`` — a
+  per-instance counter guarantees uniqueness across two grants with
+  identical envelopes without touching a random source.
+
+Provenance
+----------
+
+Ported from the production NANDA node source
+``nexartis-nanda-node/src/lib/server/delegation-grants.ts`` (functions
+``canonicalProofEnvelope``/``verifyPuhProof``/``grantDelegation``/
+``revokeDelegation``/``checkDelegation``/``assertChainNarrowing``/
+``collectDescendants``, together with the CRITICAL-3 ancestor-expiry
+narrowing patch). A companion scenario + trace validators (added by a
+sibling change) red-team the score-average baseline against this plugin.
+
+Example::
+
+    principal_id, principal_key = derive_principal(b"scenario-principal")
+    policy = AdmissionPolicy(
+        trusted_principals={principal_id: _public_raw(principal_key)},
+        required_scope="trust.report",
+    )
+    trust = DelegatedAdmissionTrust(agent_id=AgentId("observer"), policy=policy)
+    trust.set_clock(now_ms=1_000_000_000_000)
+
+    subject = DelegationSubject(
+        delegate_id="agent-1", granted_scope=("trust.report",),
+        expires_at=1_000_100, parent_delegation_id=None, revocable=True,
+    )
+    envelope, proof = build_proof(principal_id, principal_key, subject, now_ms=trust.now_ms)
+    verdict = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert verdict.ok
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from nest_core.types import (
+    AgentId,
+    Attestation,
+    Claim,
+    Evidence,
+    ReputationScore,
+    Signature,
+)
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+ALGORITHM = "ed25519-delegated-admission/1"
+"""Algorithm tag stamped on :meth:`DelegatedAdmissionTrust.attest` outputs.
+
+Example::
+
+    att = await trust.attest(AgentId("a1"), claim)
+    assert att.signature.algorithm == ALGORITHM
+"""
+
+PUH_FRESHNESS_MS = 300_000
+"""Maximum forward age of a proof-of-human, in milliseconds.
+
+A ``bound_at`` older than ``now_ms - PUH_FRESHNESS_MS`` is stale — the human
+must re-attest. Matches the TS constant of the same name.
+
+Example::
+
+    assert PUH_FRESHNESS_MS == 300_000
+"""
+
+PUH_SKEW_MS = 30_000
+"""Allowed clock skew for proof-of-human freshness comparisons.
+
+A ``bound_at`` slightly *ahead* of the observed ``now_ms`` (by at most this
+many ms) is admissible; anything more is rejected as a forward-dated proof.
+
+Example::
+
+    assert PUH_SKEW_MS == 30_000
+"""
+
+MAX_HOPS = 32
+"""Maximum parent-chain / descendant-tree depth explored during check/revoke.
+
+Bounds worst-case work at 32 iterations and makes malformed graphs (cycles
+or extreme chains) safe to serve without stack overflow. Matches the TS
+constant of the same name.
+
+Example::
+
+    assert MAX_HOPS == 32
+"""
+
+_PRINCIPAL_ID_PREFIX = "pk-"
+"""Prefix stamped on principal ids minted by :func:`derive_principal`.
+
+Example::
+
+    assert _PRINCIPAL_ID_PREFIX == "pk-"
+"""
+
+_PRINCIPAL_ID_HEX_LEN = 16
+"""Hex-digit length of the principal id suffix (16 hex ≈ 64 bits of key handle).
+
+Example::
+
+    assert _PRINCIPAL_ID_HEX_LEN == 16
+"""
+
+_DELEGATION_ID_PREFIX = "del-"
+"""Prefix stamped on delegation ids minted by :meth:`DelegatedAdmissionTrust._next_delegation_id`.
+
+Example::
+
+    assert _DELEGATION_ID_PREFIX == "del-"
+"""
+
+_DELEGATION_ID_HEX_LEN = 24
+"""Hex-digit length of the delegation id suffix (24 hex ≈ 96 bits).
+
+Example::
+
+    assert _DELEGATION_ID_HEX_LEN == 24
+"""
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers (pure, deterministic; never raise on adversarial input)
+# ---------------------------------------------------------------------------
+
+
+def _derive_private_key(seed: bytes) -> Ed25519PrivateKey:
+    """Derive a deterministic Ed25519 private key from arbitrary seed bytes.
+
+    The 32-byte scalar is ``sha256(seed)[:32]``; the same seed always yields
+    the same key. Matches the derivation used by attested_peering so the
+    two plugins interoperate under a single scenario seed.
+
+    Example::
+
+        key = _derive_private_key(b"principal:test")
+    """
+    return Ed25519PrivateKey.from_private_bytes(hashlib.sha256(seed).digest()[:32])
+
+
+def _public_raw(priv: Ed25519PrivateKey) -> bytes:
+    """Return the 32-byte raw public key for a private key.
+
+    Example::
+
+        pub = _public_raw(_derive_private_key(b"s"))
+        assert len(pub) == 32
+    """
+    return priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+
+def _sign(priv: Ed25519PrivateKey, msg: bytes) -> bytes:
+    """Ed25519-sign *msg* with *priv* (deterministic per RFC 8032).
+
+    Example::
+
+        sig = _sign(_derive_private_key(b"s"), b"m")
+    """
+    return priv.sign(msg)
+
+
+def _verify_sig(pub_raw: bytes, msg: bytes, sig: bytes) -> bool:
+    """Return whether *sig* is a valid Ed25519 signature by *pub_raw* on *msg*.
+
+    Never raises on malformed keys / signatures — an adversarial input
+    simply returns ``False`` so the caller can emit a clean rejection reason.
+
+    Example::
+
+        priv = _derive_private_key(b"s")
+        assert _verify_sig(_public_raw(priv), b"m", _sign(priv, b"m"))
+        assert not _verify_sig(b"", b"m", b"")
+    """
+    if not pub_raw or not sig:
+        return False
+    try:
+        Ed25519PublicKey.from_public_bytes(pub_raw).verify(sig, msg)
+    except (InvalidSignature, ValueError):
+        return False
+    return True
+
+
+def derive_principal(seed: bytes) -> tuple[str, Ed25519PrivateKey]:
+    """Deterministically derive a ``(principal_id, private_key)`` pair from a seed.
+
+    ``principal_id`` is the string that appears as ``principalPk`` inside the
+    canonical envelope — a stable ``pk-<16 hex>`` handle derived from the
+    raw public key so trust configuration only ever carries opaque strings.
+    The private key is what a test fixture uses to
+    :func:`sign_proof_envelope` a :class:`PuhProof`.
+
+    Example::
+
+        pid, priv = derive_principal(b"scenario:principal")
+        assert pid.startswith("pk-")
+    """
+    priv = _derive_private_key(seed)
+    pub = _public_raw(priv)
+    principal_id = _PRINCIPAL_ID_PREFIX + hashlib.sha256(pub).hexdigest()[:_PRINCIPAL_ID_HEX_LEN]
+    return principal_id, priv
+
+
+def sign_proof_envelope(priv: Ed25519PrivateKey, envelope: bytes) -> bytes:
+    """Sign the canonical envelope bytes with a principal's private key.
+
+    Public helper so scenario factories and tests can mint valid PuhProof
+    signatures without importing the private ``_sign`` helper.
+
+    Example::
+
+        sig = sign_proof_envelope(priv, canonical_proof_envelope(proof, subject))
+    """
+    return _sign(priv, envelope)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PuhProof:
+    """A frozen record of a proof-of-human bound to a delegation request.
+
+    Fields mirror the TS ``PuhProof`` type exactly. Timestamps are
+    **milliseconds** (matching the JS wall-clock convention the production
+    node uses); the trust plugin's clock (:meth:`DelegatedAdmissionTrust
+    .set_clock`) also takes milliseconds.
+
+    Example::
+
+        proof = PuhProof(
+            principal_pk="pk-abcd1234abcd1234", device_did="did:key:z6Mk",
+            request_id="req-01", bound_at_ms=1_700_000_000_000,
+            issued_at_ms=1_700_000_001_000, signature=None,
+        )
+    """
+
+    principal_pk: str
+    device_did: str
+    request_id: str
+    bound_at_ms: int
+    issued_at_ms: int
+    signature: bytes | None = None
+
+
+@dataclass(frozen=True)
+class DelegationSubject:
+    """The subject of a delegation grant — what is being delegated, to whom.
+
+    Kept structurally identical to the TS ``subject`` argument to
+    ``canonicalProofEnvelope``. ``expires_at`` is **unix seconds**
+    (production TTL is coarse), ``parent_delegation_id`` is ``None`` for a
+    root grant and never omitted from the canonicalisation.
+
+    Example::
+
+        subject = DelegationSubject(
+            delegate_id="agent-1", granted_scope=("tool.echo", "tool.summarize"),
+            expires_at=1_000_000_000, parent_delegation_id=None, revocable=True,
+        )
+    """
+
+    delegate_id: str
+    granted_scope: tuple[str, ...]
+    expires_at: int
+    parent_delegation_id: str | None = None
+    revocable: bool = True
+
+
+@dataclass(frozen=True)
+class AdmissionPolicy:
+    """Verifier-side policy consumed by :class:`DelegatedAdmissionTrust`.
+
+    ``trusted_principals`` maps a principal id (as it appears in
+    :attr:`PuhProof.principal_pk`) to the raw 32-byte Ed25519 public key we
+    require signatures to verify against. ``required_scope`` is the scope
+    string a grant must contain for its holder's evidence to be admitted.
+
+    Example::
+
+        pid, priv = derive_principal(b"seed")
+        policy = AdmissionPolicy(
+            trusted_principals={pid: _public_raw(priv)},
+            required_scope="trust.report",
+        )
+    """
+
+    trusted_principals: dict[str, bytes] = field(default_factory=dict[str, bytes])
+    require_signed_puh: bool = True
+    puh_freshness_ms: int = PUH_FRESHNESS_MS
+    puh_skew_ms: int = PUH_SKEW_MS
+    required_scope: str = "trust.report"
+
+
+@dataclass(frozen=True)
+class AdmissionVerdict:
+    """Outcome of an admission check on a single :class:`Evidence` report.
+
+    ``reason`` is one of a small closed set of stable machine strings so the
+    scenario's validators can gate on it byte-for-byte.
+
+    Example::
+
+        v = trust.last_verdict(AgentId("a1"))
+        assert v is not None and v.reason == "admitted"
+    """
+
+    admitted: bool
+    reason: str
+    delegation_id: str | None = None
+
+
+@dataclass(frozen=True)
+class GrantResult:
+    """Result of :meth:`DelegatedAdmissionTrust.grant`.
+
+    On success ``ok`` is ``True`` and ``delegation_id`` is the id assigned to
+    the new grant; on failure ``ok`` is ``False`` and ``reason`` names the
+    stable rejection code.
+
+    Example::
+
+        r = trust.grant(subject, proof, granted_by_proof_hash=h)
+        if r.ok: use(r.delegation_id)
+    """
+
+    ok: bool
+    reason: str
+    delegation_id: str | None = None
+
+
+@dataclass(frozen=True)
+class RevokeResult:
+    """Result of :meth:`DelegatedAdmissionTrust.revoke` (idempotent).
+
+    ``cascaded`` includes the target itself and every descendant that
+    transitioned from ``granted`` to ``revoked`` on this call. A repeated
+    revoke returns an empty tuple with ``ok=True``.
+
+    Example::
+
+        r = trust.revoke(delegation_id)
+        assert r.ok
+    """
+
+    ok: bool
+    reason: str
+    cascaded: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Result of :meth:`DelegatedAdmissionTrust.check`.
+
+    ``expires_at_effective`` reflects the CRITICAL-3 narrowing behaviour:
+    when a nearer ancestor's expiry is earlier than the target's, this
+    result surfaces the ancestor's expiry rather than the target's own.
+
+    Example::
+
+        c = trust.check(delegation_id)
+        assert c.valid
+    """
+
+    valid: bool
+    revoked: bool
+    expired: bool
+    expires_at_effective: int
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Canonicalisation (byte-exact port of TS canonicalProofEnvelope)
+# ---------------------------------------------------------------------------
+
+
+def canonical_proof_envelope(proof: PuhProof, subject: DelegationSubject) -> bytes:
+    """Serialise a ``(proof, subject)`` pair to the exact bytes the TS node hashes.
+
+    Field order is fixed by insertion (**never** sorted); ``toolNames`` are
+    trimmed, dropped if empty or non-string, and sorted alphabetically;
+    ``parentDelegationId=None`` serialises to JSON ``null`` and is never
+    omitted. The encoded string matches production byte-for-byte — a fixed
+    test vector locks that invariant.
+
+    Example::
+
+        subject = DelegationSubject(
+            delegate_id="agent-delegate-1",
+            granted_scope=("tool.echo", "tool.summarize"),
+            expires_at=1000000000, parent_delegation_id=None, revocable=True,
+        )
+        proof = PuhProof(
+            principal_pk="yz-principal-01", device_did="did:key:z6Mkdevice",
+            request_id="yz-req-01", bound_at_ms=0, issued_at_ms=999500000,
+        )
+        blob = canonical_proof_envelope(proof, subject)
+        assert blob.startswith(b'{"principalPk":"yz-principal-01"')
+    """
+    tool_names = sorted(
+        s.strip()
+        for s in subject.granted_scope
+        # Defensive: the type says ``tuple[str, ...]`` but wire input via a
+        # scenario factory can smuggle non-strings; drop them cleanly rather
+        # than raising ``AttributeError`` on ``.strip``.
+        if isinstance(s, str) and s.strip()  # pyright: ignore[reportUnnecessaryIsInstance]
+    )
+    envelope: dict[str, Any] = {
+        "principalPk": proof.principal_pk,
+        "deviceDid": proof.device_did,
+        "requestId": proof.request_id,
+        "grantee": subject.delegate_id,
+        "scope": {"toolNames": tool_names},
+        "expiresAt": subject.expires_at,
+        "parentDelegationId": subject.parent_delegation_id,
+        "revocable": subject.revocable,
+        "issuedAt": proof.issued_at_ms,
+    }
+    return json.dumps(envelope, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def envelope_hash(envelope: bytes) -> str:
+    """Lowercase hex SHA-256 of a canonical envelope — the ``granted_by_proof_hash``.
+
+    Example::
+
+        h = envelope_hash(canonical_proof_envelope(proof, subject))
+        assert len(h) == 64
+    """
+    return hashlib.sha256(envelope).hexdigest()
+
+
+def build_proof(
+    principal_id: str,
+    principal_key: Ed25519PrivateKey,
+    subject: DelegationSubject,
+    *,
+    now_ms: int,
+    device_did: str = "did:key:z6MkFixture",
+    request_id: str = "req-fixture",
+    signed: bool = True,
+) -> tuple[bytes, PuhProof]:
+    """Test/scenario helper: build a valid signed :class:`PuhProof` and its envelope.
+
+    Returns ``(canonical_envelope_bytes, proof)`` so callers can compute the
+    hash and hand both to :meth:`DelegatedAdmissionTrust.grant`. This is
+    scenario glue — real callers construct proofs from live human input.
+
+    Example::
+
+        env, proof = build_proof(pid, priv, subject, now_ms=1_700_000_000_000)
+        h = envelope_hash(env)
+    """
+    proof_unsigned = PuhProof(
+        principal_pk=principal_id,
+        device_did=device_did,
+        request_id=request_id,
+        bound_at_ms=now_ms,
+        issued_at_ms=now_ms,
+        signature=None,
+    )
+    envelope = canonical_proof_envelope(proof_unsigned, subject)
+    signature = _sign(principal_key, envelope) if signed else None
+    return envelope, PuhProof(
+        principal_pk=principal_id,
+        device_did=device_did,
+        request_id=request_id,
+        bound_at_ms=now_ms,
+        issued_at_ms=now_ms,
+        signature=signature,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal grant record
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Grant:
+    """Internal mutable delegation record — private to the plugin."""
+
+    delegation_id: str
+    # retained for parity with the TS grant row; not read by admission logic
+    delegator_id: str
+    delegate_id: str
+    granted_scope: tuple[str, ...]
+    expires_at: int
+    parent_delegation_id: str | None
+    revocable: bool
+    granted_by_proof_hash: str
+    proof: PuhProof
+    status: Literal["granted", "revoked"] = "granted"
+    revoked_at_ms: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# The plugin
+# ---------------------------------------------------------------------------
+
+
+class DelegatedAdmissionTrust:
+    """Trust plugin: admit evidence iff the reporter holds a live delegation grant.
+
+    Implements the :class:`nest_core.layers.trust.Trust` protocol
+    (:meth:`score`, :meth:`attest`, :meth:`report`, :meth:`stake`). The
+    handshake / grant surface (:meth:`grant`, :meth:`revoke`, :meth:`check`,
+    :meth:`set_clock`) is additive. The constructor accepts an ``identity``
+    positional and ignores it for compatibility with
+    :class:`~nest_plugins_reference.trust.score_average.ScoreAverageTrust`.
+
+    Example::
+
+        trust = DelegatedAdmissionTrust(agent_id=AgentId("observer"))
+        trust.set_clock(1_700_000_000_000)
+        # ...seed grants, then...
+        await trust.report(AgentId("victim"), evidence)
+        rep = await trust.score(AgentId("victim"))
+    """
+
+    def __init__(
+        self,
+        identity: Any = None,
+        *,
+        agent_id: AgentId | None = None,
+        seed: bytes = b"",
+        policy: AdmissionPolicy | None = None,
+        delegator_id: str = "self",
+    ) -> None:
+        self._identity = identity
+        self._agent_id = agent_id or AgentId("unknown")
+        self._seed = seed
+        self._policy = policy or AdmissionPolicy()
+        self._delegator_id = delegator_id
+
+        aid_bytes = str(self._agent_id).encode("utf-8")
+        self._priv = _derive_private_key(b"delegated-admission:" + seed + b":" + aid_bytes)
+
+        # Grants indexed two ways: by their id, and by their delegate_id
+        # (the reporter AgentId string) -> latest granted id, which is what
+        # `report()` consults per the module docstring's admission flow.
+        self._grants: dict[str, _Grant] = {}
+        self._delegate_index: dict[str, str] = {}
+        self._grant_counter: int = 0
+
+        # Trust protocol state — same shape as score_average.
+        self._scores: dict[AgentId, list[float]] = {}
+        self._stakes: dict[AgentId, int] = {}
+        self._quarantined: list[Evidence] = []
+        self._admitted_count: int = 0
+        self._verdicts: dict[AgentId, AdmissionVerdict] = {}
+
+        # Logical clock in **milliseconds**. Callers must set it before
+        # issuing a grant or reporting; the default 0 corresponds to
+        # "epoch" and rejects every real-world dated proof as stale.
+        self._now_ms: int = 0
+
+    # -- clock -----------------------------------------------------------
+
+    def set_clock(self, now_ms: int | float) -> None:
+        """Advance the plugin's logical clock (never a wall clock).
+
+        Rounded down to an integer millisecond — production code passes
+        integer ms and the scenario runner likewise; a float argument is
+        tolerated for parity with the failure-detector clock API.
+
+        Example::
+
+            trust.set_clock(1_700_000_000_000)
+        """
+        self._now_ms = int(now_ms)
+
+    @property
+    def now_s(self) -> int:
+        """Current logical clock in seconds (integer, floor-divided).
+
+        Example::
+
+            trust.set_clock(10_000)
+            assert trust.now_s == 10
+        """
+        return self._now_ms // 1000
+
+    # -- policy accessors -----------------------------------------------
+
+    @property
+    def policy(self) -> AdmissionPolicy:
+        """The admission policy this plugin was constructed with.
+
+        Example::
+
+            assert trust.policy.required_scope == "trust.report"
+        """
+        return self._policy
+
+    def trust_principal(self, principal_id: str, public_key: bytes) -> None:
+        """Add / replace a trusted principal → public key binding.
+
+        Convenience for tests and scenario factories; the same effect is
+        achievable by passing ``AdmissionPolicy(trusted_principals=...)``.
+
+        Example::
+
+            trust.trust_principal(pid, _public_raw(priv))
+        """
+        self._policy.trusted_principals[principal_id] = public_key
+
+    # -- PuhProof verification (port of verifyPuhProof) -----------------
+
+    def _verify_puh(
+        self,
+        proof: Any,
+        subject: DelegationSubject,
+        granted_by_proof_hash: str | None,
+    ) -> tuple[bool, str, str, bytes]:
+        """Verify a PuhProof at the current clock.
+
+        Returns ``(ok, reason, envelope_hash_used, envelope_bytes)``. On any
+        early rejection ``envelope_bytes`` is ``b""``; from the hash step
+        onwards it is the canonical envelope bytes so callers (e.g.
+        :meth:`grant`) can reuse them without re-serialising. ``reason`` is
+        one of the stable strings ``missing-proof``, ``invalid-proof``,
+        ``puh-proof-stale``, ``missing-proof-hash``, ``proof-hash-mismatch``,
+        ``unknown-principal``, ``missing-signature``, ``bad-signature``.
+
+        Example::
+
+            ok, reason, h, env = trust._verify_puh(proof, subject, hash_or_None)
+        """
+        # 1. Field validity. ``proof`` is typed as ``Any`` because a
+        # byzantine wire path (or a test) can hand us anything at all; we
+        # never raise, we classify.
+        if proof is None:
+            return False, "missing-proof", "", b""
+        if not isinstance(proof, PuhProof):
+            return False, "invalid-proof", "", b""
+        for field_val in (proof.principal_pk, proof.device_did, proof.request_id):
+            if not field_val:
+                return False, "invalid-proof", "", b""
+
+        # 2. Freshness against the injected clock.
+        now = self._now_ms
+        skew = self._policy.puh_skew_ms
+        freshness = self._policy.puh_freshness_ms
+        delta_bound = now - proof.bound_at_ms
+        delta_issued = now - proof.issued_at_ms
+        if delta_bound < -skew or delta_bound > freshness:
+            return False, "puh-proof-stale", "", b""
+        if delta_issued < -skew or delta_issued > freshness:
+            return False, "puh-proof-stale", "", b""
+        if proof.issued_at_ms < proof.bound_at_ms - skew:
+            # Ordering violation is a malformed proof, not a stale one --
+            # mirrors the production verifier, which rejects this case with
+            # ``invalid-proof`` (delegation-grants.ts, verifyPuhProof).
+            return False, "invalid-proof", "", b""
+
+        # 3. Envelope hash byte-for-byte.
+        envelope = canonical_proof_envelope(proof, subject)
+        computed_hash = envelope_hash(envelope)
+        if not granted_by_proof_hash:
+            return False, "missing-proof-hash", computed_hash, envelope
+        if granted_by_proof_hash != computed_hash:
+            return False, "proof-hash-mismatch", computed_hash, envelope
+
+        # 4. Principal recognised.
+        pub = self._policy.trusted_principals.get(proof.principal_pk)
+        if pub is None:
+            return False, "unknown-principal", computed_hash, envelope
+
+        # 5. Signature — required by policy, or verified when present.
+        if proof.signature is None:
+            if self._policy.require_signed_puh:
+                return False, "missing-signature", computed_hash, envelope
+        elif not _verify_sig(pub, envelope, bytes(proof.signature)):
+            return False, "bad-signature", computed_hash, envelope
+
+        return True, "ok", computed_hash, envelope
+
+    # -- grant / revoke / check -----------------------------------------
+
+    def _next_delegation_id(self, envelope: bytes) -> str:
+        """Deterministically mint a new delegation id (no randomness)."""
+        self._grant_counter += 1
+        seed = envelope + self._grant_counter.to_bytes(8, "big")
+        return _DELEGATION_ID_PREFIX + hashlib.sha256(seed).hexdigest()[:_DELEGATION_ID_HEX_LEN]
+
+    def _check_chain_narrowing(self, parent: _Grant, subject: DelegationSubject) -> str | None:
+        """Enforce parent-narrowing invariants; return a rejection reason or ``None``.
+
+        Ports the TS ``assertChainNarrowing`` checks: a child may not add
+        scope its parent lacks, live longer than its parent, or flip a
+        revocable parent to irrevocable.
+
+        Example::
+
+            reason = self._check_chain_narrowing(parent, subject)
+            if reason is not None: return GrantResult(ok=False, reason=reason)
+        """
+        parent_scope = set(parent.granted_scope)
+        if not set(subject.granted_scope).issubset(parent_scope):
+            return "scope-widens-parent"
+        if subject.expires_at > parent.expires_at:
+            return "ttl-widens-parent"
+        if parent.revocable and not subject.revocable:
+            return "revocable-flip-forbidden"
+        return None
+
+    def _ancestor_depth(self, grant: _Grant) -> int:
+        """Count the ancestors above ``grant`` (cycle-safe, unbounded).
+
+        Used at mint time to keep every chain shallow enough that the
+        bounded revocation cascade and ancestor walk provably cover it.
+
+        Example::
+
+            depth = self._ancestor_depth(parent)  # 0 for a root grant
+        """
+        depth = 0
+        seen: set[str] = set()
+        cursor = grant.parent_delegation_id
+        while cursor is not None and cursor not in seen:
+            seen.add(cursor)
+            ancestor = self._grants.get(cursor)
+            if ancestor is None:
+                break
+            depth += 1
+            cursor = ancestor.parent_delegation_id
+        return depth
+
+    def grant(
+        self,
+        subject: DelegationSubject,
+        proof: PuhProof,
+        *,
+        granted_by_proof_hash: str | None,
+    ) -> GrantResult:
+        """Issue a new delegation grant after validating scope, TTL, proof, chain.
+
+        On success the reporter identified by ``subject.delegate_id`` is
+        auto-indexed as the holder of this grant (the newest issued grant
+        wins on collisions). On failure nothing mutates.
+
+        Chains are capped at :data:`MAX_HOPS` ancestors at mint time
+        (``chain-too-deep``) so the bounded revocation cascade and the
+        ``check()`` ancestor walk always cover every legal chain — the
+        production TS source bounds both walks but not mint depth, which
+        fails open past twice the bound; we close that (stricter,
+        disclosed in VERIFICATION.md).
+
+        Rejection reasons (stable strings): ``empty-scope``,
+        ``expired-at-grant``, any :meth:`_verify_puh` reason,
+        ``parent-not-found``, ``parent-revoked``, ``chain-too-deep``,
+        ``scope-widens-parent``, ``ttl-widens-parent``,
+        ``revocable-flip-forbidden``.
+
+        Example::
+
+            r = trust.grant(subject, proof, granted_by_proof_hash=h)
+            assert r.ok
+        """
+        # 1. Non-empty scope after normalisation (defensively drops
+        # non-string entries — see :func:`canonical_proof_envelope`).
+        norm_scope = tuple(
+            sorted(
+                s.strip()
+                for s in subject.granted_scope
+                if isinstance(s, str)  # pyright: ignore[reportUnnecessaryIsInstance]
+                and s.strip()
+            )
+        )
+        if not norm_scope:
+            return GrantResult(ok=False, reason="empty-scope")
+
+        # Re-canonicalise on the normalised subject so hash comparison uses
+        # the same shape callers already computed.
+        normalised = DelegationSubject(
+            delegate_id=subject.delegate_id,
+            granted_scope=norm_scope,
+            expires_at=subject.expires_at,
+            parent_delegation_id=subject.parent_delegation_id,
+            revocable=subject.revocable,
+        )
+
+        # 2. Not already expired (compare seconds, matching TS behaviour).
+        if subject.expires_at <= self.now_s:
+            return GrantResult(ok=False, reason="expired-at-grant")
+
+        # 3. Proof verification (freshness + envelope + signature).
+        ok, reason, computed_hash, envelope = self._verify_puh(
+            proof, normalised, granted_by_proof_hash
+        )
+        if not ok:
+            return GrantResult(ok=False, reason=reason)
+
+        # 4. Chain narrowing (only when a parent is claimed).
+        if subject.parent_delegation_id is not None:
+            parent = self._grants.get(subject.parent_delegation_id)
+            if parent is None:
+                return GrantResult(ok=False, reason="parent-not-found")
+            if parent.status == "revoked":
+                return GrantResult(ok=False, reason="parent-revoked")
+            # Fail closed on depth: the new grant would have
+            # ``_ancestor_depth(parent) + 1`` ancestors; past MAX_HOPS the
+            # bounded cascade/ancestor walks could no longer cover it.
+            if self._ancestor_depth(parent) + 1 > MAX_HOPS:
+                return GrantResult(ok=False, reason="chain-too-deep")
+            narrowing_reason = self._check_chain_narrowing(parent, normalised)
+            if narrowing_reason is not None:
+                return GrantResult(ok=False, reason=narrowing_reason)
+
+        # 5. Assign a deterministic id and commit — reuse the envelope
+        # bytes/hash already produced by ``_verify_puh`` (no double hash).
+        delegation_id = self._next_delegation_id(envelope)
+        record = _Grant(
+            delegation_id=delegation_id,
+            delegator_id=self._delegator_id,
+            delegate_id=subject.delegate_id,
+            granted_scope=norm_scope,
+            expires_at=subject.expires_at,
+            parent_delegation_id=subject.parent_delegation_id,
+            revocable=subject.revocable,
+            granted_by_proof_hash=computed_hash,
+            proof=proof,
+        )
+        self._grants[delegation_id] = record
+        self._delegate_index[subject.delegate_id] = delegation_id
+        return GrantResult(ok=True, reason="granted", delegation_id=delegation_id)
+
+    def _collect_descendants(self, root_id: str) -> list[str]:
+        """BFS descendants of a grant, cycle-safe, bounded by :data:`MAX_HOPS`."""
+        # Adjacency: parent_id -> list of child ids. Build once per call
+        # (grants collection is small in practice and this keeps mutation
+        # locality tight).
+        children: dict[str, list[str]] = {}
+        for gid, g in self._grants.items():
+            if g.parent_delegation_id is not None:
+                children.setdefault(g.parent_delegation_id, []).append(gid)
+
+        seen: set[str] = {root_id}
+        out: list[str] = []
+        queue: deque[tuple[str, int]] = deque([(root_id, 0)])
+        while queue:
+            node, depth = queue.popleft()
+            if depth >= MAX_HOPS:
+                continue
+            for child in children.get(node, ()):
+                if child in seen:
+                    continue
+                seen.add(child)
+                out.append(child)
+                queue.append((child, depth + 1))
+        return out
+
+    def revoke(self, delegation_id: str) -> RevokeResult:
+        """Revoke a delegation and cascade to every descendant (idempotent).
+
+        Repeated revocation returns ``ok=True`` with empty ``cascaded`` — no
+        error, no double-transition. Cycles in the parent graph (which
+        should never form on happy paths but are defensively tolerated) are
+        broken by the ``seen`` set inside :meth:`_collect_descendants`.
+
+        Example::
+
+            r = trust.revoke(delegation_id)
+            assert r.ok
+        """
+        target = self._grants.get(delegation_id)
+        if target is None:
+            return RevokeResult(ok=False, reason="not-found")
+        if target.status == "revoked":
+            return RevokeResult(ok=True, reason="already-revoked", cascaded=())
+
+        cascaded: list[str] = [delegation_id]
+        cascaded.extend(self._collect_descendants(delegation_id))
+
+        for gid in cascaded:
+            g = self._grants[gid]
+            if g.status != "revoked":
+                g.status = "revoked"
+                g.revoked_at_ms = self._now_ms
+                # If this delegate's currently-indexed grant is the one
+                # being revoked, clear the index so `report()` sees no
+                # live grant on the next call.
+                if self._delegate_index.get(g.delegate_id) == gid:
+                    del self._delegate_index[g.delegate_id]
+        return RevokeResult(ok=True, reason="revoked", cascaded=tuple(cascaded))
+
+    def check(self, delegation_id: str) -> CheckResult:
+        """Compute the effective validity of a grant at the current clock.
+
+        Walks the parent chain up to :data:`MAX_HOPS` deep with a seen-set.
+        A revoked ancestor makes the grant revoked; an expired ancestor
+        makes it expired and narrows :attr:`CheckResult.expires_at_effective`
+        to the ancestor's earlier bound (the production CRITICAL-3 patch).
+
+        Example::
+
+            c = trust.check(delegation_id)
+            assert c.valid or c.revoked or c.expired
+        """
+        target = self._grants.get(delegation_id)
+        if target is None:
+            return CheckResult(
+                valid=False,
+                revoked=False,
+                expired=False,
+                expires_at_effective=0,
+                reason="not-found",
+            )
+
+        revoked = target.status == "revoked"
+        effective_expiry = target.expires_at
+
+        # Ancestor walk.
+        seen: set[str] = {target.delegation_id}
+        current: str | None = target.parent_delegation_id
+        for _ in range(MAX_HOPS):
+            if current is None or current in seen:
+                # Cycle guard — treat as a break, matching TS behaviour.
+                break
+            seen.add(current)
+            ancestor = self._grants.get(current)
+            if ancestor is None:
+                break
+            if ancestor.status == "revoked":
+                revoked = True
+            if ancestor.expires_at < effective_expiry:
+                effective_expiry = ancestor.expires_at
+            current = ancestor.parent_delegation_id
+
+        expired = (not revoked) and self.now_s >= effective_expiry
+        valid = not revoked and not expired
+        if revoked:
+            reason = "revoked"
+        elif expired:
+            reason = "expired"
+        else:
+            reason = "valid"
+        return CheckResult(
+            valid=valid,
+            revoked=revoked,
+            expired=expired,
+            expires_at_effective=effective_expiry,
+            reason=reason,
+        )
+
+    # -- Trust protocol -------------------------------------------------
+
+    async def score(self, agent: AgentId) -> ReputationScore:
+        """Reputation from *admitted* evidence only — same shape as score_average.
+
+        Example::
+
+            rep = await trust.score(AgentId("a1"))
+        """
+        entries = self._scores.get(agent, [])
+        if not entries:
+            return ReputationScore(agent_id=agent, score=0.5, confidence=0.0, sample_count=0)
+        avg = sum(entries) / len(entries)
+        confidence = min(1.0, len(entries) / 100.0)
+        return ReputationScore(
+            agent_id=agent, score=avg, confidence=confidence, sample_count=len(entries)
+        )
+
+    async def attest(self, agent: AgentId, claim: Claim) -> Attestation:
+        """Sign a claim about an agent with this plugin's identity key.
+
+        Example::
+
+            att = await trust.attest(AgentId("a2"), claim)
+        """
+        _ = agent  # `agent` is the subject inside `claim`; kept in signature for the Protocol.
+        value = _sign(self._priv, claim.model_dump_json().encode("utf-8"))
+        sig = Signature(signer=self._agent_id, value=value, algorithm=ALGORITHM)
+        return Attestation(issuer=self._agent_id, claim=claim, signature=sig)
+
+    async def report(self, agent: AgentId, evidence: Evidence) -> None:
+        """Admit evidence iff the reporter holds a live, in-scope, fresh grant.
+
+        Defensive: never raises. Every rejection appends to the quarantine
+        list with a stable machine reason recorded in
+        :meth:`last_verdict`; admitted evidence contributes a score in the
+        same way as :mod:`~nest_plugins_reference.trust.score_average`.
+
+        Example::
+
+            await trust.report(AgentId("victim"), evidence)
+        """
+        verdict = self._evaluate(evidence)
+        # ``_evaluate`` is the single defense layer for objects that lack a
+        # ``reporter`` attribute; if it returned a verdict, we know the
+        # attribute access below succeeded there and will succeed here.
+        reporter = evidence.reporter
+        self._verdicts[reporter] = verdict
+
+        if not verdict.admitted:
+            self._quarantined.append(evidence)
+            return
+
+        self._admitted_count += 1
+        score_val = 0.5
+        if evidence.kind == "positive":
+            score_val = 1.0
+        elif evidence.kind in ("negative", "byzantine"):
+            score_val = 0.0
+        self._scores.setdefault(agent, []).append(score_val)
+
+    async def stake(self, agent: AgentId, amount: int) -> None:
+        """Stake reputation on an agent (delegates to the same ledger as the baseline).
+
+        Example::
+
+            await trust.stake(AgentId("a1"), 100)
+        """
+        self._stakes[agent] = self._stakes.get(agent, 0) + amount
+
+    # -- introspection --------------------------------------------------
+
+    def _evaluate(self, evidence: Evidence) -> AdmissionVerdict:
+        """Return an :class:`AdmissionVerdict` for *evidence*; never raises."""
+        try:
+            reporter_str = str(evidence.reporter)
+        except (AttributeError, TypeError):
+            return AdmissionVerdict(admitted=False, reason="malformed-evidence")
+
+        delegation_id = self._delegate_index.get(reporter_str)
+        if delegation_id is None:
+            return AdmissionVerdict(admitted=False, reason="no-grant")
+
+        grant = self._grants.get(delegation_id)
+        if grant is None:  # pragma: no cover — index is kept in sync
+            return AdmissionVerdict(admitted=False, reason="no-grant", delegation_id=delegation_id)
+
+        check = self.check(delegation_id)
+        if check.revoked:
+            return AdmissionVerdict(admitted=False, reason="revoked", delegation_id=delegation_id)
+        if check.expired:
+            return AdmissionVerdict(admitted=False, reason="expired", delegation_id=delegation_id)
+
+        if self._policy.required_scope not in grant.granted_scope:
+            return AdmissionVerdict(
+                admitted=False, reason="scope-mismatch", delegation_id=delegation_id
+            )
+
+        # Re-verify the stored proof against the *current* clock — a proof
+        # that was fresh at grant time may have aged out by the time evidence
+        # is filed.
+        subject = DelegationSubject(
+            delegate_id=grant.delegate_id,
+            granted_scope=grant.granted_scope,
+            expires_at=grant.expires_at,
+            parent_delegation_id=grant.parent_delegation_id,
+            revocable=grant.revocable,
+        )
+        ok, reason, _, _ = self._verify_puh(grant.proof, subject, grant.granted_by_proof_hash)
+        if not ok:
+            return AdmissionVerdict(admitted=False, reason=reason, delegation_id=delegation_id)
+
+        return AdmissionVerdict(admitted=True, reason="admitted", delegation_id=delegation_id)
+
+    def last_verdict(self, reporter: AgentId) -> AdmissionVerdict | None:
+        """The verdict from the most recent :meth:`report` for *reporter*.
+
+        Returns ``None`` if this reporter has never been evaluated. Used by
+        scenario trace validators to gate on stable rejection reasons.
+
+        Example::
+
+            v = trust.last_verdict(AgentId("a1"))
+            if v: assert v.reason in ("admitted", "no-grant", "revoked")
+        """
+        return self._verdicts.get(reporter)
+
+    @property
+    def quarantined_count(self) -> int:
+        """How many evidence reports have been quarantined so far.
+
+        Example::
+
+            assert trust.quarantined_count >= 0
+        """
+        return len(self._quarantined)
+
+    @property
+    def admitted_count(self) -> int:
+        """How many evidence reports have been admitted so far.
+
+        Example::
+
+            assert trust.admitted_count >= 0
+        """
+        return self._admitted_count

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -58,6 +58,7 @@ parc = "nest_plugins_reference.trust.parc:ParcTrust"
 aae_permit_gate = "nest_plugins_reference.trust.aae_permit_gate:AAEPermitGate"
 bonded_trust = "nest_plugins_reference.trust.bonded_trust:BondedTrust"
 attested_peering = "nest_plugins_reference.trust.attested_peering:AttestedPeeringTrust"
+delegated_admission = "nest_plugins_reference.trust.delegated_admission:DelegatedAdmissionTrust"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/nest-plugins-reference/tests/test_delegated_admission.py
+++ b/packages/nest-plugins-reference/tests/test_delegated_admission.py
@@ -1,0 +1,1120 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit + property tests for the delegated-admission trust plugin.
+
+Layers of coverage:
+
+1. Byte-exact parity with the TS ``canonicalProofEnvelope`` (fixed vector).
+2. Trust protocol conformance + registry resolution.
+3. PuhProof verification (freshness, hash, signature, principal).
+4. Grant chain narrowing, cascade revoke, ancestor-expiry narrowing.
+5. ``report()`` admission end-to-end.
+6. Hypothesis property tests.
+7. Byzantine-input parametrization.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import random
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from nest_core.layers.trust import Trust
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.types import AgentId, Evidence
+from nest_core.validators import ValidationResult, validate_trace
+from nest_plugins_reference.trust.delegated_admission import (
+    ALGORITHM,
+    MAX_HOPS,
+    PUH_FRESHNESS_MS,
+    PUH_SKEW_MS,
+    AdmissionPolicy,
+    AdmissionVerdict,
+    DelegatedAdmissionTrust,
+    DelegationSubject,
+    PuhProof,
+    _public_raw,  # pyright: ignore[reportPrivateUsage]  # test-only inspection
+    build_proof,
+    canonical_proof_envelope,
+    derive_principal,
+    envelope_hash,
+    sign_proof_envelope,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+# A fixed "now" comfortably inside PuhProof freshness for every test that
+# doesn't specifically test the freshness window.
+NOW_MS = 1_700_000_000_000
+NOW_S = NOW_MS // 1000
+
+DEFAULT_TTL_S = NOW_S + 3600  # one hour ahead
+
+# PuhProof identity fixture literals, reused across every proof-building test.
+_FIXTURE_DEVICE_DID = "did:key:z6MkFixture"
+_FIXTURE_REQUEST_ID = "req-fixture"
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _cast_scope(items: Any) -> tuple[str, ...]:
+    """Test helper: accept a heterogeneous iterable as the scope tuple."""
+    return tuple(items)
+
+
+def _principal_seed(tag: str = "pri") -> tuple[str, Any]:
+    """Deterministic principal for tests."""
+    return derive_principal(f"delegated-admission-tests:{tag}".encode())
+
+
+def _make_trust(*, tag: str = "pri", scope: str = "trust.report") -> DelegatedAdmissionTrust:
+    pid, priv = _principal_seed(tag)
+    trust = DelegatedAdmissionTrust(
+        agent_id=AgentId("observer"),
+        seed=b"test",
+        policy=AdmissionPolicy(
+            trusted_principals={pid: _public_raw(priv)},
+            required_scope=scope,
+        ),
+    )
+    trust.set_clock(NOW_MS)
+    return trust
+
+
+def _default_subject(
+    delegate_id: str = "agent-delegate-1",
+    scope: tuple[str, ...] = ("trust.report", "tool.echo"),
+    expires_at: int | None = None,
+    parent: str | None = None,
+    revocable: bool = True,
+) -> DelegationSubject:
+    return DelegationSubject(
+        delegate_id=delegate_id,
+        granted_scope=scope,
+        expires_at=expires_at if expires_at is not None else DEFAULT_TTL_S,
+        parent_delegation_id=parent,
+        revocable=revocable,
+    )
+
+
+def _issue_grant(
+    trust: DelegatedAdmissionTrust,
+    *,
+    tag: str = "pri",
+    subject: DelegationSubject | None = None,
+    now_ms: int | None = None,
+) -> str:
+    """Issue a valid grant and return the delegation id."""
+    pid, priv = _principal_seed(tag)
+    subj = subject or _default_subject()
+    envelope, proof = build_proof(pid, priv, subj, now_ms=now_ms if now_ms is not None else NOW_MS)
+    result = trust.grant(subj, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert result.ok, f"expected grant success, got {result.reason}"
+    assert result.delegation_id is not None
+    return result.delegation_id
+
+
+# ---------------------------------------------------------------------------
+# 0. Wiring — registry resolution, Trust protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_registry_resolves_delegated_admission() -> None:
+    """The plugin is wired into the built-in registry as trust:delegated_admission."""
+    cls = PluginRegistry().resolve("trust", "delegated_admission")
+    assert cls is DelegatedAdmissionTrust
+
+
+def test_satisfies_trust_protocol() -> None:
+    """An instance structurally satisfies the Trust layer Protocol."""
+    assert isinstance(DelegatedAdmissionTrust(agent_id=AgentId("a1")), Trust)
+
+
+def test_attest_uses_algorithm_tag() -> None:
+    """attest() stamps the module's ALGORITHM constant onto the signature."""
+    from nest_core.types import Claim  # local import — Claim is only needed here
+
+    trust = _make_trust()
+    claim = Claim(subject=AgentId("a1"), predicate="p", value="v")
+    att = _run(trust.attest(AgentId("a1"), claim))
+    assert att.signature.algorithm == ALGORITHM
+
+
+def test_constructor_ignores_identity_positional() -> None:
+    """The identity positional is accepted-and-ignored for baseline compat."""
+    trust = DelegatedAdmissionTrust("some-identity-stub", agent_id=AgentId("a1"))
+    assert isinstance(trust, DelegatedAdmissionTrust)
+
+
+# ---------------------------------------------------------------------------
+# 1. Canonical envelope — byte-exact TS parity
+# ---------------------------------------------------------------------------
+
+
+_FIXED_VECTOR_CANONICAL = (
+    b'{"principalPk":"yz-principal-01",'
+    b'"deviceDid":"did:key:z6Mkdevice",'
+    b'"requestId":"yz-req-01",'
+    b'"grantee":"agent-delegate-1",'
+    b'"scope":{"toolNames":["tool.echo","tool.summarize"]},'
+    b'"expiresAt":1000000000,'
+    b'"parentDelegationId":null,'
+    b'"revocable":true,'
+    b'"issuedAt":999500000}'
+)
+
+
+def _fixed_vector_subject_proof() -> tuple[PuhProof, DelegationSubject]:
+    subject = DelegationSubject(
+        delegate_id="agent-delegate-1",
+        granted_scope=("tool.echo", "tool.summarize"),
+        expires_at=1_000_000_000,
+        parent_delegation_id=None,
+        revocable=True,
+    )
+    proof = PuhProof(
+        principal_pk="yz-principal-01",
+        device_did="did:key:z6Mkdevice",
+        request_id="yz-req-01",
+        bound_at_ms=0,
+        issued_at_ms=999_500_000,
+    )
+    return proof, subject
+
+
+def test_canonical_envelope_matches_ts_fixed_vector() -> None:
+    """The exact TS byte sequence is what canonical_proof_envelope emits."""
+    proof, subject = _fixed_vector_subject_proof()
+    assert canonical_proof_envelope(proof, subject) == _FIXED_VECTOR_CANONICAL
+
+
+def test_canonical_envelope_hash_matches_computed_sha256() -> None:
+    """The envelope hash is the plain sha256 of the canonical bytes."""
+    proof, subject = _fixed_vector_subject_proof()
+    canonical = canonical_proof_envelope(proof, subject)
+    assert envelope_hash(canonical) == hashlib.sha256(_FIXED_VECTOR_CANONICAL).hexdigest()
+
+
+def test_canonical_envelope_sorts_tool_names_regardless_of_input_order() -> None:
+    """Scope order is not a signal — reversed input yields the same envelope."""
+    proof, subject_fwd = _fixed_vector_subject_proof()
+    subject_rev = DelegationSubject(
+        delegate_id=subject_fwd.delegate_id,
+        granted_scope=tuple(reversed(subject_fwd.granted_scope)),
+        expires_at=subject_fwd.expires_at,
+        parent_delegation_id=subject_fwd.parent_delegation_id,
+        revocable=subject_fwd.revocable,
+    )
+    assert canonical_proof_envelope(proof, subject_fwd) == canonical_proof_envelope(
+        proof, subject_rev
+    )
+
+
+def test_canonical_envelope_trims_and_drops_empty_scope_entries() -> None:
+    """Whitespace is trimmed; empty / non-string entries are dropped entirely."""
+    proof, subject_ref = _fixed_vector_subject_proof()
+    dirty = DelegationSubject(
+        delegate_id=subject_ref.delegate_id,
+        granted_scope=_cast_scope(("  tool.echo  ", "", "  ", "tool.summarize")),
+        expires_at=subject_ref.expires_at,
+        parent_delegation_id=subject_ref.parent_delegation_id,
+        revocable=subject_ref.revocable,
+    )
+    assert canonical_proof_envelope(proof, dirty) == _FIXED_VECTOR_CANONICAL
+
+
+def test_canonical_envelope_drops_non_string_scope_entries() -> None:
+    """Non-string scope entries (dict, int, None) don't crash and are ignored."""
+    proof, subject_ref = _fixed_vector_subject_proof()
+    dirty = DelegationSubject(
+        delegate_id=subject_ref.delegate_id,
+        # Cast through Any so the type checker accepts a mixed tuple only in tests.
+        granted_scope=_cast_scope(("tool.echo", 42, None, {"x": 1}, "tool.summarize")),  # type: ignore[arg-type]
+        expires_at=subject_ref.expires_at,
+        parent_delegation_id=subject_ref.parent_delegation_id,
+        revocable=subject_ref.revocable,
+    )
+    assert canonical_proof_envelope(proof, dirty) == _FIXED_VECTOR_CANONICAL
+
+
+# ---------------------------------------------------------------------------
+# 2. PuhProof verification
+# ---------------------------------------------------------------------------
+
+
+def test_puh_fresh_proof_admits_grant() -> None:
+    """A freshly-signed, correctly-hashed proof from a trusted principal is admissible."""
+    trust = _make_trust()
+    _ = _issue_grant(trust)
+
+
+def test_puh_stale_bound_at_rejected() -> None:
+    """A bound_at older than PUH_FRESHNESS_MS is rejected as puh-proof-stale."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    subject = _default_subject()
+    envelope, proof = build_proof(
+        pid, priv, subject, now_ms=NOW_MS - (PUH_FRESHNESS_MS + PUH_SKEW_MS + 1)
+    )
+    r = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "puh-proof-stale"
+
+
+def test_puh_stale_issued_at_rejected() -> None:
+    """issued_at older than freshness window is rejected even when bound_at is fresh."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    subject = _default_subject()
+    stale_issued = NOW_MS - (PUH_FRESHNESS_MS + PUH_SKEW_MS + 1)
+    proof_unsigned = PuhProof(
+        principal_pk=pid,
+        device_did=_FIXTURE_DEVICE_DID,
+        request_id=_FIXTURE_REQUEST_ID,
+        bound_at_ms=NOW_MS,
+        issued_at_ms=stale_issued,
+        signature=None,
+    )
+    envelope = canonical_proof_envelope(proof_unsigned, subject)
+    proof = PuhProof(
+        principal_pk=pid,
+        device_did=_FIXTURE_DEVICE_DID,
+        request_id=_FIXTURE_REQUEST_ID,
+        bound_at_ms=NOW_MS,
+        issued_at_ms=stale_issued,
+        signature=sign_proof_envelope(priv, envelope),
+    )
+    r = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "puh-proof-stale"
+
+
+def test_puh_future_dated_beyond_skew_rejected() -> None:
+    """A bound_at further ahead than PUH_SKEW_MS is rejected as stale/future."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    subject = _default_subject()
+    envelope, proof = build_proof(pid, priv, subject, now_ms=NOW_MS + (PUH_SKEW_MS + 1))
+    r = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "puh-proof-stale"
+
+
+def test_puh_issued_before_bound_beyond_skew_rejected() -> None:
+    """issued_at < bound_at - skew is rejected (contradictory ordering)."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    subject = _default_subject()
+    bound = NOW_MS
+    issued = bound - PUH_SKEW_MS - 1
+    proof_unsigned = PuhProof(
+        principal_pk=pid,
+        device_did=_FIXTURE_DEVICE_DID,
+        request_id=_FIXTURE_REQUEST_ID,
+        bound_at_ms=bound,
+        issued_at_ms=issued,
+        signature=None,
+    )
+    envelope = canonical_proof_envelope(proof_unsigned, subject)
+    proof = PuhProof(
+        principal_pk=pid,
+        device_did=_FIXTURE_DEVICE_DID,
+        request_id=_FIXTURE_REQUEST_ID,
+        bound_at_ms=bound,
+        issued_at_ms=issued,
+        signature=sign_proof_envelope(priv, envelope),
+    )
+    r = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    # Production parity: the TS verifier rejects contradictory ordering with
+    # ``invalid-proof`` (not a staleness reason).
+    assert not r.ok and r.reason == "invalid-proof"
+
+
+def test_puh_hash_mismatch_when_grantee_altered() -> None:
+    """A proof hash computed for a different grantee is rejected."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    subject_a = _default_subject(delegate_id="agent-A")
+    subject_b = _default_subject(delegate_id="agent-B")
+    env_a, _ = build_proof(pid, priv, subject_a, now_ms=NOW_MS)
+    # Present subject_a's hash on a grant for subject_b.
+    _, proof_b = build_proof(pid, priv, subject_b, now_ms=NOW_MS)
+    r = trust.grant(subject_b, proof_b, granted_by_proof_hash=envelope_hash(env_a))
+    assert not r.ok and r.reason == "proof-hash-mismatch"
+
+
+def test_puh_hash_mismatch_when_scope_widened() -> None:
+    """Widened scope makes the recomputed hash diverge from a preimage hash."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    narrow = _default_subject(scope=("trust.report",))
+    wide = _default_subject(scope=("trust.report", "tool.dangerous"))
+    env_narrow, _ = build_proof(pid, priv, narrow, now_ms=NOW_MS)
+    _, proof_wide = build_proof(pid, priv, wide, now_ms=NOW_MS)
+    r = trust.grant(wide, proof_wide, granted_by_proof_hash=envelope_hash(env_narrow))
+    assert not r.ok and r.reason == "proof-hash-mismatch"
+
+
+def test_puh_missing_hash_rejected() -> None:
+    """A grant call without any granted_by_proof_hash is rejected."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    subject = _default_subject()
+    _, proof = build_proof(pid, priv, subject, now_ms=NOW_MS)
+    r = trust.grant(subject, proof, granted_by_proof_hash=None)
+    assert not r.ok and r.reason == "missing-proof-hash"
+
+
+def test_puh_missing_signature_rejected_when_required() -> None:
+    """require_signed_puh=True rejects an unsigned proof."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    subject = _default_subject()
+    envelope, _ = build_proof(pid, priv, subject, now_ms=NOW_MS, signed=False)
+    unsigned = PuhProof(
+        principal_pk=pid,
+        device_did=_FIXTURE_DEVICE_DID,
+        request_id=_FIXTURE_REQUEST_ID,
+        bound_at_ms=NOW_MS,
+        issued_at_ms=NOW_MS,
+        signature=None,
+    )
+    r = trust.grant(subject, unsigned, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "missing-signature"
+
+
+def test_puh_tampered_signature_rejected() -> None:
+    """Flipping a byte of the signature causes bad-signature."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    subject = _default_subject()
+    envelope, proof = build_proof(pid, priv, subject, now_ms=NOW_MS)
+    assert proof.signature is not None
+    tampered = bytearray(proof.signature)
+    tampered[0] ^= 0x01
+    bad = PuhProof(
+        principal_pk=proof.principal_pk,
+        device_did=proof.device_did,
+        request_id=proof.request_id,
+        bound_at_ms=proof.bound_at_ms,
+        issued_at_ms=proof.issued_at_ms,
+        signature=bytes(tampered),
+    )
+    r = trust.grant(subject, bad, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "bad-signature"
+
+
+def test_puh_unknown_principal_rejected() -> None:
+    """A principal_pk not on the trusted roster fails admission."""
+    trust = _make_trust()
+    _, priv_evil = derive_principal(b"evil-principal")
+    # Impersonation attempt: proof carries an unknown principal id.
+    subject = _default_subject()
+    proof_unsigned = PuhProof(
+        principal_pk="unknown-pk",
+        device_did=_FIXTURE_DEVICE_DID,
+        request_id=_FIXTURE_REQUEST_ID,
+        bound_at_ms=NOW_MS,
+        issued_at_ms=NOW_MS,
+    )
+    envelope = canonical_proof_envelope(proof_unsigned, subject)
+    proof = PuhProof(
+        principal_pk="unknown-pk",
+        device_did=_FIXTURE_DEVICE_DID,
+        request_id=_FIXTURE_REQUEST_ID,
+        bound_at_ms=NOW_MS,
+        issued_at_ms=NOW_MS,
+        signature=sign_proof_envelope(priv_evil, envelope),
+    )
+    r = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "unknown-principal"
+
+
+def test_puh_signature_present_but_not_required_still_verified() -> None:
+    """If policy tolerates unsigned proofs, a present-but-bad signature still fails."""
+    pid, priv = _principal_seed()
+    trust = DelegatedAdmissionTrust(
+        agent_id=AgentId("observer"),
+        policy=AdmissionPolicy(
+            trusted_principals={pid: _public_raw(priv)},
+            require_signed_puh=False,
+        ),
+    )
+    trust.set_clock(NOW_MS)
+    subject = _default_subject()
+    envelope, proof = build_proof(pid, priv, subject, now_ms=NOW_MS)
+    assert proof.signature is not None
+    tampered_bytes = bytearray(proof.signature)
+    tampered_bytes[0] ^= 0x01  # deterministic single-byte flip → invalid
+    tampered = bytes(tampered_bytes)
+    bad = PuhProof(
+        principal_pk=proof.principal_pk,
+        device_did=proof.device_did,
+        request_id=proof.request_id,
+        bound_at_ms=proof.bound_at_ms,
+        issued_at_ms=proof.issued_at_ms,
+        signature=tampered,
+    )
+    r = trust.grant(subject, bad, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "bad-signature"
+
+
+# ---------------------------------------------------------------------------
+# 3. Grant chain narrowing
+# ---------------------------------------------------------------------------
+
+
+def test_grant_rejects_empty_scope() -> None:
+    """Empty scope (after normalisation) is rejected at grant time."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    subject = _default_subject(scope=())
+    _, proof = build_proof(pid, priv, subject, now_ms=NOW_MS)
+    r = trust.grant(subject, proof, granted_by_proof_hash="")
+    assert not r.ok and r.reason == "empty-scope"
+
+
+def test_grant_rejects_already_expired() -> None:
+    """A grant whose expires_at <= now_s is rejected as expired-at-grant."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    subject = _default_subject(expires_at=NOW_S - 1)
+    envelope, proof = build_proof(pid, priv, subject, now_ms=NOW_MS)
+    r = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "expired-at-grant"
+
+
+def test_chain_parent_not_found() -> None:
+    """A child claiming a parent that doesn't exist is rejected."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    subject = _default_subject(delegate_id="child-1", parent="del-ghost-nonexistent")
+    envelope, proof = build_proof(pid, priv, subject, now_ms=NOW_MS)
+    r = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "parent-not-found"
+
+
+def test_chain_parent_revoked() -> None:
+    """A child of a revoked parent cannot be minted."""
+    trust = _make_trust()
+    parent_id = _issue_grant(trust, subject=_default_subject(delegate_id="parent-1"))
+    trust.revoke(parent_id)
+    pid, priv = _principal_seed()
+    subject = _default_subject(delegate_id="child-1", parent=parent_id)
+    envelope, proof = build_proof(pid, priv, subject, now_ms=NOW_MS)
+    r = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "parent-revoked"
+
+
+def test_chain_scope_widens_parent() -> None:
+    """A child cannot add a scope the parent lacked."""
+    trust = _make_trust()
+    parent_id = _issue_grant(
+        trust, subject=_default_subject(delegate_id="parent-1", scope=("trust.report",))
+    )
+    pid, priv = _principal_seed()
+    child_subject = _default_subject(
+        delegate_id="child-1", scope=("trust.report", "tool.exfiltrate"), parent=parent_id
+    )
+    envelope, proof = build_proof(pid, priv, child_subject, now_ms=NOW_MS)
+    r = trust.grant(child_subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "scope-widens-parent"
+
+
+def test_chain_ttl_widens_parent() -> None:
+    """A child cannot outlive its parent."""
+    trust = _make_trust()
+    parent_id = _issue_grant(
+        trust,
+        subject=_default_subject(delegate_id="parent-1", expires_at=NOW_S + 100),
+    )
+    pid, priv = _principal_seed()
+    child_subject = _default_subject(
+        delegate_id="child-1", parent=parent_id, expires_at=NOW_S + 1000
+    )
+    envelope, proof = build_proof(pid, priv, child_subject, now_ms=NOW_MS)
+    r = trust.grant(child_subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "ttl-widens-parent"
+
+
+def test_chain_revocable_flip_forbidden() -> None:
+    """A revocable parent cannot yield an irrevocable child."""
+    trust = _make_trust()
+    parent_id = _issue_grant(
+        trust, subject=_default_subject(delegate_id="parent-1", revocable=True)
+    )
+    pid, priv = _principal_seed()
+    child_subject = _default_subject(delegate_id="child-1", parent=parent_id, revocable=False)
+    envelope, proof = build_proof(pid, priv, child_subject, now_ms=NOW_MS)
+    r = trust.grant(child_subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "revocable-flip-forbidden"
+
+
+def test_chain_too_deep_rejected_at_mint() -> None:
+    """The MAX_HOPS-th re-delegation is minted; one deeper is refused.
+
+    Fail-closed depth cap: the production TS source bounds the cascade and
+    ancestor walks but not mint depth, which fails open past twice the
+    bound — we refuse at mint so every legal chain is fully covered.
+    """
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    parent: str | None = None
+    for i in range(MAX_HOPS + 1):  # root (depth 0) + MAX_HOPS descendants
+        subject = _default_subject(delegate_id=f"agent-{i}", parent=parent)
+        envelope, proof = build_proof(pid, priv, subject, now_ms=NOW_MS)
+        r = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+        assert r.ok, f"depth {i} should mint: {r.reason}"
+        parent = r.delegation_id
+    subject = _default_subject(delegate_id="agent-too-deep", parent=parent)
+    envelope, proof = build_proof(pid, priv, subject, now_ms=NOW_MS)
+    r = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert not r.ok and r.reason == "chain-too-deep"
+
+
+def test_policy_accessor_and_trust_principal() -> None:
+    """`policy` exposes the live policy; `trust_principal` extends the roster."""
+    trust = _make_trust()
+    assert trust.policy.required_scope == "trust.report"
+    pid2, priv2 = derive_principal(b"second-principal")
+    trust.trust_principal(pid2, _public_raw(priv2))
+    subject = _default_subject(delegate_id="agent-p2")
+    envelope, proof = build_proof(pid2, priv2, subject, now_ms=NOW_MS)
+    r = trust.grant(subject, proof, granted_by_proof_hash=envelope_hash(envelope))
+    assert r.ok
+
+
+# ---------------------------------------------------------------------------
+# 4. Revoke cascade + check semantics
+# ---------------------------------------------------------------------------
+
+
+def _build_three_level_chain(trust: DelegatedAdmissionTrust) -> tuple[str, str, str]:
+    """Root → mid → leaf; returns their delegation ids."""
+    pid, priv = _principal_seed()
+    root_sub = _default_subject(delegate_id="root", scope=("trust.report", "tool.echo"))
+    env, proof = build_proof(pid, priv, root_sub, now_ms=NOW_MS)
+    root = trust.grant(root_sub, proof, granted_by_proof_hash=envelope_hash(env))
+    assert root.ok and root.delegation_id
+    mid_sub = _default_subject(
+        delegate_id="mid", scope=("trust.report",), parent=root.delegation_id
+    )
+    env, proof = build_proof(pid, priv, mid_sub, now_ms=NOW_MS)
+    mid = trust.grant(mid_sub, proof, granted_by_proof_hash=envelope_hash(env))
+    assert mid.ok and mid.delegation_id
+    leaf_sub = _default_subject(
+        delegate_id="leaf", scope=("trust.report",), parent=mid.delegation_id
+    )
+    env, proof = build_proof(pid, priv, leaf_sub, now_ms=NOW_MS)
+    leaf = trust.grant(leaf_sub, proof, granted_by_proof_hash=envelope_hash(env))
+    assert leaf.ok and leaf.delegation_id
+    return root.delegation_id, mid.delegation_id, leaf.delegation_id
+
+
+def test_cascade_revoke_marks_descendants() -> None:
+    """Revoking mid revokes leaf but leaves root intact."""
+    trust = _make_trust()
+    root_id, mid_id, leaf_id = _build_three_level_chain(trust)
+    r = trust.revoke(mid_id)
+    assert r.ok
+    assert set(r.cascaded) == {mid_id, leaf_id}
+    assert trust.check(root_id).valid
+    assert trust.check(mid_id).revoked
+    assert trust.check(leaf_id).revoked
+
+
+def test_revoke_is_idempotent() -> None:
+    """A double revoke succeeds with an empty cascade the second time."""
+    trust = _make_trust()
+    grant_id = _issue_grant(trust)
+    first = trust.revoke(grant_id)
+    second = trust.revoke(grant_id)
+    assert first.ok and second.ok
+    assert first.cascaded == (grant_id,)
+    assert second.cascaded == ()
+
+
+def test_check_expired_grant_when_now_past_ttl() -> None:
+    """A grant whose expiry has passed is expired but not revoked."""
+    trust = _make_trust()
+    grant_id = _issue_grant(trust, subject=_default_subject(expires_at=NOW_S + 60))
+    trust.set_clock(NOW_MS + 120_000)
+    c = trust.check(grant_id)
+    assert c.expired and not c.revoked and not c.valid
+
+
+def test_ancestor_expiry_narrows_child_expiry() -> None:
+    """CRITICAL-3: a nearer ancestor's expiry overrides the child's own."""
+    trust = _make_trust()
+    pid, priv = _principal_seed()
+    # Root expires soon.
+    root_sub = _default_subject(delegate_id="root", scope=("trust.report",), expires_at=NOW_S + 60)
+    env, proof = build_proof(pid, priv, root_sub, now_ms=NOW_MS)
+    root = trust.grant(root_sub, proof, granted_by_proof_hash=envelope_hash(env))
+    assert root.ok and root.delegation_id
+    # Child requests same expiry (child cannot outlive parent, so equal is fine).
+    child_sub = _default_subject(
+        delegate_id="child",
+        scope=("trust.report",),
+        parent=root.delegation_id,
+        expires_at=NOW_S + 60,
+    )
+    env, proof = build_proof(pid, priv, child_sub, now_ms=NOW_MS)
+    child = trust.grant(child_sub, proof, granted_by_proof_hash=envelope_hash(env))
+    assert child.ok and child.delegation_id
+    # Advance the clock past root's TTL; child must now report expired,
+    # and the effective expiry surfaces the ancestor's earlier bound.
+    trust.set_clock(NOW_MS + 120_000)
+    c = trust.check(child.delegation_id)
+    assert c.expired and not c.valid
+    assert c.expires_at_effective == NOW_S + 60
+
+
+def test_cycle_safety_and_hop_bound() -> None:
+    """A pathological long chain terminates cleanly under MAX_HOPS.
+
+    We can't construct a real cycle through the grant() API (parent-not-found
+    rejects any reference to an unminted id), so this test drives directly
+    into the internal store to prove the check() ancestor walk stays bounded.
+    """
+    trust = _make_trust()
+    # Chain of length MAX_HOPS + 5 built directly into the store.
+    store = trust._grants  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    prev: str | None = None
+    ids: list[str] = []
+    for i in range(MAX_HOPS + 5):
+        gid = f"del-synthetic-{i:04d}"
+        store[gid] = store.get(gid) or _synthetic_grant(
+            gid=gid, delegate_id=f"a{i}", parent=prev, expires_at=NOW_S + 10_000
+        )
+        prev = gid
+        ids.append(gid)
+    # check() must not loop indefinitely: the deepest node reports valid
+    # because no revocation is set.
+    c = trust.check(ids[-1])
+    assert not c.revoked
+    # Force a cycle: mutate the root's parent to point to the leaf.
+    store[ids[0]] = _synthetic_grant(
+        gid=ids[0], delegate_id="a0", parent=ids[-1], expires_at=NOW_S + 10_000
+    )
+    # Must terminate — and terminate with a well-formed CheckResult. The
+    # ancestor walk is bounded by MAX_HOPS with a seen-set, so no ancestor
+    # is revoked or expired here: the leaf is still valid and the effective
+    # expiry is the untouched leaf's own expiry.
+    c2 = trust.check(ids[-1])
+    assert c2.valid is True
+    assert c2.revoked is False
+    assert c2.expired is False
+    assert c2.expires_at_effective == NOW_S + 10_000
+
+
+def _synthetic_grant(gid: str, delegate_id: str, parent: str | None, expires_at: int) -> Any:
+    """Build an internal _Grant record directly (test-only)."""
+    from nest_plugins_reference.trust.delegated_admission import (
+        _Grant,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    pid, _ = _principal_seed()
+    proof = PuhProof(
+        principal_pk=pid,
+        device_did=_FIXTURE_DEVICE_DID,
+        request_id="req",
+        bound_at_ms=NOW_MS,
+        issued_at_ms=NOW_MS,
+        signature=b"\x00" * 64,
+    )
+    return _Grant(
+        delegation_id=gid,
+        delegator_id="self",
+        delegate_id=delegate_id,
+        granted_scope=("trust.report",),
+        expires_at=expires_at,
+        parent_delegation_id=parent,
+        revocable=True,
+        granted_by_proof_hash="0" * 64,
+        proof=proof,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. report() admission end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_report_admits_grantholder_evidence() -> None:
+    """Evidence from a live grantholder scores like the score_average baseline."""
+    trust = _make_trust()
+    _issue_grant(trust, subject=_default_subject(delegate_id="honest-1"))
+    ev = Evidence(reporter=AgentId("honest-1"), subject=AgentId("victim"), kind="positive")
+    _run(trust.report(AgentId("victim"), ev))
+    rep = _run(trust.score(AgentId("victim")))
+    assert rep.sample_count == 1
+    assert rep.score == 1.0
+    assert trust.admitted_count == 1
+    v = trust.last_verdict(AgentId("honest-1"))
+    assert v is not None and v.admitted and v.reason == "admitted"
+
+
+def test_report_quarantines_sybil_without_grant() -> None:
+    """A reporter with no grant is quarantined with reason no-grant."""
+    trust = _make_trust()
+    ev = Evidence(reporter=AgentId("sybil-0"), subject=AgentId("victim"), kind="negative")
+    _run(trust.report(AgentId("victim"), ev))
+    rep = _run(trust.score(AgentId("victim")))
+    assert rep.sample_count == 0
+    assert rep.score == 0.5
+    assert trust.quarantined_count == 1
+    v = trust.last_verdict(AgentId("sybil-0"))
+    assert v is not None and not v.admitted and v.reason == "no-grant"
+
+
+def test_report_quarantines_revoked_reporter() -> None:
+    """After a grant is revoked, the reporter's evidence is quarantined."""
+    trust = _make_trust()
+    gid = _issue_grant(trust, subject=_default_subject(delegate_id="revoked-1"))
+    trust.revoke(gid)
+    ev = Evidence(reporter=AgentId("revoked-1"), subject=AgentId("victim"), kind="positive")
+    _run(trust.report(AgentId("victim"), ev))
+    assert trust.quarantined_count == 1
+    # Verdict may be either "no-grant" (index was cleared) or "revoked"
+    # depending on the delegate-index policy; the module clears the index
+    # on revoke, so we expect "no-grant" specifically.
+    v = trust.last_verdict(AgentId("revoked-1"))
+    assert v is not None and not v.admitted
+    assert v.reason in ("no-grant", "revoked")
+
+
+def test_report_quarantines_scope_mismatch() -> None:
+    """A grant lacking the required_scope is quarantined as scope-mismatch."""
+    trust = _make_trust()
+    _issue_grant(
+        trust,
+        subject=_default_subject(delegate_id="wrong-scope-1", scope=("tool.other",)),
+    )
+    ev = Evidence(reporter=AgentId("wrong-scope-1"), subject=AgentId("victim"), kind="positive")
+    _run(trust.report(AgentId("victim"), ev))
+    assert trust.quarantined_count == 1
+    v = trust.last_verdict(AgentId("wrong-scope-1"))
+    assert v is not None and v.reason == "scope-mismatch"
+
+
+def test_report_quarantines_stale_proof() -> None:
+    """A grant whose stored proof aged out by report-time is rejected."""
+    trust = _make_trust()
+    _issue_grant(trust, subject=_default_subject(delegate_id="honest-1"))
+    # Advance clock beyond puh freshness — no new proof filed.
+    trust.set_clock(NOW_MS + PUH_FRESHNESS_MS + PUH_SKEW_MS + 10_000)
+    ev = Evidence(reporter=AgentId("honest-1"), subject=AgentId("victim"), kind="positive")
+    _run(trust.report(AgentId("victim"), ev))
+    v = trust.last_verdict(AgentId("honest-1"))
+    assert v is not None and not v.admitted
+    assert v.reason in ("puh-proof-stale", "expired")  # expiry may fire first for short TTLs
+
+
+def test_report_honest_score_unaffected_by_sybil_swarm() -> None:
+    """8 honest positives + 20 sybil negatives → victim's admitted score is 1.0."""
+    trust = _make_trust()
+    honest_ids = [f"honest-{i}" for i in range(8)]
+    for hid in honest_ids:
+        _issue_grant(trust, subject=_default_subject(delegate_id=hid))
+
+    reports: list[Evidence] = []
+    for hid in honest_ids:
+        reports.append(Evidence(reporter=AgentId(hid), subject=AgentId("victim"), kind="positive"))
+    for i in range(20):
+        reports.append(
+            Evidence(
+                reporter=AgentId(f"sybil-{i}"),
+                subject=AgentId("victim"),
+                kind="negative",
+            )
+        )
+    random.Random(42).shuffle(reports)
+    for ev in reports:
+        _run(trust.report(AgentId("victim"), ev))
+
+    rep = _run(trust.score(AgentId("victim")))
+    assert rep.sample_count == 8
+    assert rep.score == 1.0
+    assert trust.quarantined_count == 20
+
+
+# ---------------------------------------------------------------------------
+# 6. Hypothesis property tests
+# ---------------------------------------------------------------------------
+
+
+_SCOPE_STRATEGY = st.lists(
+    st.sampled_from(
+        [
+            "trust.report",
+            "tool.echo",
+            "tool.summarize",
+            "tool.review",
+            "tool.compose",
+            "svc.storage",
+        ]
+    ),
+    min_size=1,
+    max_size=6,
+    unique=True,
+)
+
+
+@settings(max_examples=40, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(scope=_SCOPE_STRATEGY)
+def test_property_scope_permutation_invariant_hash(scope: list[str]) -> None:
+    """Any permutation of a scope list yields the identical envelope hash."""
+    subject_fwd = DelegationSubject(
+        delegate_id="perm-agent",
+        granted_scope=tuple(scope),
+        expires_at=1_000_000_000,
+        parent_delegation_id=None,
+        revocable=True,
+    )
+    subject_rev = DelegationSubject(
+        delegate_id="perm-agent",
+        granted_scope=tuple(reversed(scope)),
+        expires_at=1_000_000_000,
+        parent_delegation_id=None,
+        revocable=True,
+    )
+    proof = PuhProof(
+        principal_pk="pk-x",
+        device_did="dev",
+        request_id="req",
+        bound_at_ms=0,
+        issued_at_ms=0,
+    )
+    assert envelope_hash(canonical_proof_envelope(proof, subject_fwd)) == envelope_hash(
+        canonical_proof_envelope(proof, subject_rev)
+    )
+
+
+@settings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    chain_len=st.integers(min_value=2, max_value=6),
+    revoke_at=st.integers(min_value=0, max_value=5),
+)
+def test_property_no_descendant_of_revoked_is_valid(chain_len: int, revoke_at: int) -> None:
+    """After revoking any node, no descendant reports as valid."""
+    trust = _make_trust(tag="prop")
+    pid, priv = _principal_seed(tag="prop")
+    ids: list[str] = []
+    parent: str | None = None
+    for i in range(chain_len):
+        subj = _default_subject(delegate_id=f"chain-{i}", scope=("trust.report",), parent=parent)
+        env, proof = build_proof(pid, priv, subj, now_ms=NOW_MS)
+        r = trust.grant(subj, proof, granted_by_proof_hash=envelope_hash(env))
+        assert r.ok and r.delegation_id
+        ids.append(r.delegation_id)
+        parent = r.delegation_id
+
+    idx = revoke_at % chain_len
+    trust.revoke(ids[idx])
+    # Every descendant (including the revoked node itself) must be invalid.
+    for j in range(idx, chain_len):
+        c = trust.check(ids[j])
+        assert not c.valid
+    # Duplicate revoke delivery is a no-op.
+    r2 = trust.revoke(ids[idx])
+    assert r2.ok and r2.cascaded == ()
+
+
+@settings(
+    max_examples=40,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    reporter_name=st.text(
+        alphabet=st.characters(min_codepoint=32, max_codepoint=126),
+        min_size=0,
+        max_size=50,
+    ),
+    subject_name=st.text(
+        alphabet=st.characters(min_codepoint=32, max_codepoint=126),
+        min_size=0,
+        max_size=50,
+    ),
+    kind=st.text(min_size=0, max_size=30),
+    detail=st.text(min_size=0, max_size=100),
+)
+def test_property_report_never_raises_on_garbage(
+    reporter_name: str, subject_name: str, kind: str, detail: str
+) -> None:
+    """Arbitrary garbage evidence is quarantined, never raised."""
+    trust = _make_trust(tag="garbage")
+    ev = Evidence(
+        reporter=AgentId(reporter_name),
+        subject=AgentId(subject_name),
+        kind=kind,
+        detail=detail,
+    )
+    # Must not raise.
+    _run(trust.report(AgentId(subject_name), ev))
+
+
+# ---------------------------------------------------------------------------
+# 7. Byzantine parametrization — garbage grants and proofs quarantine cleanly
+# ---------------------------------------------------------------------------
+
+
+_GARBAGE_PROOFS: list[Any] = [
+    None,
+    "not-a-proof",
+    42,
+    PuhProof(
+        principal_pk="",
+        device_did="d",
+        request_id="r",
+        bound_at_ms=NOW_MS,
+        issued_at_ms=NOW_MS,
+    ),  # empty principal_pk
+    PuhProof(
+        principal_pk="p",
+        device_did="",
+        request_id="r",
+        bound_at_ms=NOW_MS,
+        issued_at_ms=NOW_MS,
+    ),  # empty device_did
+    PuhProof(
+        principal_pk="p",
+        device_did="d",
+        request_id="",
+        bound_at_ms=NOW_MS,
+        issued_at_ms=NOW_MS,
+    ),  # empty request_id
+]
+
+
+@pytest.mark.parametrize("proof", _GARBAGE_PROOFS)
+def test_garbage_proof_never_crashes_grant(proof: Any) -> None:
+    """A malformed proof yields a stable GrantResult; never an exception."""
+    trust = _make_trust()
+    subject = _default_subject()
+    r = trust.grant(subject, proof, granted_by_proof_hash="0" * 64)
+    assert not r.ok
+    assert r.reason in {"missing-proof", "invalid-proof", "puh-proof-stale", "proof-hash-mismatch"}
+
+
+def test_check_of_unknown_delegation_reports_not_found() -> None:
+    """check() on an unknown id doesn't crash and returns a stable reason."""
+    trust = _make_trust()
+    c = trust.check("del-does-not-exist")
+    assert not c.valid and c.reason == "not-found"
+
+
+def test_revoke_of_unknown_delegation_reports_not_found() -> None:
+    """revoke() on an unknown id doesn't crash and returns a stable reason."""
+    trust = _make_trust()
+    r = trust.revoke("del-does-not-exist")
+    assert not r.ok and r.reason == "not-found"
+
+
+def test_admission_verdict_is_hashable_dataclass() -> None:
+    """AdmissionVerdict is a frozen dataclass safe to store in sets/dicts."""
+    v = AdmissionVerdict(admitted=True, reason="admitted", delegation_id="del-x")
+    assert v.admitted
+    # Frozen dataclasses are hashable by default.
+    assert {v} == {v}
+
+
+# ---------------------------------------------------------------------------
+# 8. Full simulator integration, discrimination, determinism
+# ---------------------------------------------------------------------------
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "delegated_trust_market.yaml"
+_SCENARIO_SEEDS = [42, 7, 1337]
+
+
+def _run_delegated_scenario(seed: int, trust_plugin: str) -> dict[str, ValidationResult]:
+    """Run the delegated_trust_market scenario and return validator results."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH)).model_copy(update={"seed": seed})
+    config = config.model_copy(
+        update={"layers": config.layers.model_copy(update={"trust": trust_plugin})}
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"da_{trust_plugin}_{seed}.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        asyncio.run(ScenarioRunner(config, registry=PluginRegistry()).run())
+        results = validate_trace(trace_path, "delegated_admission")
+    return {r.name: r for r in results}
+
+
+def _run_delegated_bytes(seed: int) -> bytes:
+    """Run the scenario and return the raw trace bytes."""
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH)).model_copy(update={"seed": seed})
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / "da_replay.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        asyncio.run(ScenarioRunner(config, registry=PluginRegistry()).run())
+        return trace_path.read_bytes()
+
+
+@pytest.mark.parametrize("seed", _SCENARIO_SEEDS)
+def test_scenario_delegated_passes_every_validator(seed: int) -> None:
+    """With delegated_admission, all four gate validators pass at every seed."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    results = _run_delegated_scenario(seed, "delegated_admission")
+    expected = {
+        "delegated_unattested_quarantined",
+        "delegated_revocation_cascade",
+        "delegated_scope_escalation_blocked",
+        "delegated_stale_proof_rejected",
+    }
+    assert expected <= set(results), f"missing validators: {expected - set(results)}"
+    for name, res in results.items():
+        assert res.passed, f"seed={seed} {name} failed: {res.detail}"
+
+
+@pytest.mark.parametrize("seed", _SCENARIO_SEEDS)
+def test_scenario_baseline_fails_unattested_quarantined(seed: int) -> None:
+    """The discriminator: score_average admits every reporter; delegated does not.
+
+    The unattested-quarantined validator is the primary property that
+    separates the two plugins — the Sybil swarm's negatives drag the
+    victim's reputation below 0.5 under score_average and every no-grant
+    reporter appears admitted, so this validator flips PASS → FAIL. Report
+    which of the other three validators also fail on the baseline for
+    completeness (all four typically fail).
+    """
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+
+    baseline = _run_delegated_scenario(seed, "score_average")
+    assert not baseline["delegated_unattested_quarantined"].passed, (
+        f"seed={seed}: baseline should be defamed but passed: "
+        f"{baseline['delegated_unattested_quarantined'].detail}"
+    )
+    baseline_failures = sorted(name for name, r in baseline.items() if not r.passed)
+    assert "delegated_unattested_quarantined" in baseline_failures
+
+    ours = _run_delegated_scenario(seed, "delegated_admission")
+    assert ours["delegated_unattested_quarantined"].passed, (
+        f"seed={seed}: delegated plugin failed: {ours['delegated_unattested_quarantined'].detail}"
+    )
+
+
+def test_delegated_scenario_is_byte_deterministic() -> None:
+    """Two runs at the same seed produce byte-identical traces."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    assert _run_delegated_bytes(42) == _run_delegated_bytes(42)

--- a/scenarios/delegated_trust_market.yaml
+++ b/scenarios/delegated_trust_market.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Delegated-admission trust scenario: five reporter roles stress a live-grant
+# admission gate. Honest reporters hold fresh in-scope grants; a Sybil swarm
+# has no grant at all; a chain-root revocation cascades through the revoked
+# reporters mid-scenario; an escalator holds a grant whose scope excludes the
+# required scope; a stale reporter presents a proof outside the freshness
+# window. Swap `trust: delegated_admission` for `trust: score_average` and
+# every one of the four `validate_delegated_...` validators flips to FAIL.
+name: delegated_admission
+description: "32 reporters attack one victim across five failure modes; only live in-scope grants count."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 34
+  brain: state-machine
+  roles:
+    - name: honest
+      count: 8
+    - name: sybil
+      count: 20
+    - name: revoked
+      count: 2
+    - name: escalator
+      count: 1
+    - name: stale
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: delegated_admission
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: delegated_admission
+  config:
+    victim: victim
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+
+output:
+  trace: ./traces/delegated_admission.jsonl


### PR DESCRIPTION
### What this adds

A trust-layer plugin, `delegated_admission`, that gates reputation
evidence on a **live, unrevoked, scope-valid delegation grant anchored
to a human principal** — plus a Tier-1 scenario, four adversarial
validators, and a 60-test suite (Hypothesis properties, byzantine
inputs, flip test, byte-determinism).

The core rule: `report()` admits evidence into scoring only when the
reporter holds a delegation grant that (a) chains back to a trusted
principal (proof-of-human), (b) is unrevoked along its entire ancestor
chain, (c) covers the required scope, and (d) carries a fresh,
Ed25519-signed proof envelope whose SHA-256 hash matches
**byte-for-byte**. Everything else is quarantined — sybil swarms,
revoked descendants, scope escalators, and stale-proof replays never
touch the score.

Three artifacts:

- **Plugin:** `packages/nest-plugins-reference/nest_plugins_reference/trust/delegated_admission.py`
- **Scenario:** `scenarios/delegated_trust_market.yaml` (+ factory in
  `nest_core/scenarios_builtin/delegated_admission.py`)
- **Validators:** four `validate_delegated_*` functions registered
  under `VALIDATORS["delegated_admission"]`

Registered via the `nest.plugins.trust` entry point in
`pyproject.toml` **and** `_BUILTINS`.

### Why (motivation & threat model)

Every trust plugin in the reference set answers "how do I aggregate
what agents say about each other?" None answers the prior question:
**why is this agent allowed to say anything at all?** Any software
process can mint an identity and start emitting evidence; volume-based
aggregation (`score_average`) is defenseless against it — 20 sybils
outvote 8 honest reporters every time.

`delegated_admission` makes admission the primitive. Authority
originates with a *human* principal and flows down a delegation chain
that can only narrow: scope shrinks, TTL shortens, revocability can't
be discarded. Revocation cascades — kill a mid-chain grant and every
descendant dies with it (≤32 hops, cycle-safe). The human can always
pull the plug on the whole subtree.

This is not invented for the hackathon. It is a deterministic,
in-process port of the delegation-grant verifier that runs in
production on our open-source NANDA node (https://github.com/Nexartis/homeport,
`src/lib/server/delegation-grants.ts`), deployed across a live
CubiCube fleet. The port replaces every I/O seam with injected
deterministic parameters (logical clock, seeded keys) — the same move
that made #149's production port viable under the Tier-1 gate.

### Design

```
principal (human, fixture-signed Ed25519)          AdmissionPolicy
        │  PuhProof {principalPk, deviceDid,        trusted_principals
        │   requestId, boundAt, issuedAt, sig}      require_signed_puh=True
        ▼                                           puh_freshness_ms=300_000
grant(subject, proof, granted_by_proof_hash)        puh_skew_ms=30_000
  ├─ canonical envelope → SHA-256, byte-exact       required_scope
  ├─ freshness window vs injected now_ms
  ├─ Ed25519 verify over canonical bytes
  └─ chain-narrowing vs parent (scope ⊆, ttl ≤, revocable flip ban)
        │
revoke(id) ──► BFS cascade over children (≤32 hops, idempotent)
check(id)  ──► ancestor walk: revoked/expired parent kills child,
        │      expiry narrows to earliest ancestor bound
        ▼
async report(agent, evidence)
  admitted → score (same math as score_average)
  else     → quarantined with a stable machine reason
             (no-grant | revoked | scope-invalid | puh-proof-stale |
              proof-hash-mismatch | bad-signature | ...)
```

The canonical envelope is the load-bearing detail, ported byte-exactly
from the TS source (insertion-order JSON, only `scope.toolNames`
sorted/trimmed, `parentDelegationId: null` never omitted, seconds vs
milliseconds preserved) and **locked by a fixed test vector**: the test
asserts the exact canonical string and its SHA-256 hex, so any future
serialization drift fails loudly.

### Adversarial validators — the flip test

Same YAML (`scenarios/delegated_trust_market.yaml`, 34 agents:
8 honest / 20 sybil / 2 revoked / 1 scope-escalator / 1 stale-proof),
seeds 42 / 7 / 1337:

| Validator | `score_average` (baseline) | `delegated_admission` |
| --- | --- | --- |
| `delegated_unattested_quarantined` — no-grant reporters never admitted; victim score ≥ 0.5; **honest reporters MUST be admitted** (anti-degenerate guard: a quarantine-everything plugin fails) | **FAIL** — sybils admitted, victim score 0.250 | **PASS** — victim 1.000, 20 sybils quarantined |
| `delegated_revocation_cascade` — after the mid-scenario cascade (≥1 descendant), revoked reporters never admitted again | **FAIL** — no revoke surface, revoked agents keep scoring | **PASS** — cascade kills 2 descendants |
| `delegated_scope_escalation_blocked` — scope-invalid attempt must appear AND be quarantined | **FAIL** — escalator admitted | **PASS** |
| `delegated_stale_proof_rejected` — stale-proof attempt must appear AND be quarantined | **FAIL** — stale admitted | **PASS** |

Validators require the attacks to actually appear in the trace
(enforcement, not assumption).

### How to verify (runnable)

```bash
uv sync
uv run ruff check . && uv run ruff format --check . && uv run pyright
uv run pytest packages/nest-plugins-reference/tests/test_delegated_admission.py -v
# full suite (main: 1150 passed; this branch: 1210 passed — purely additive)
uv run pytest -v
# run the scenario directly
uv run nest run scenarios/delegated_trust_market.yaml
```

The test file also runs the flip half automatically:
`test_scenario_baseline_fails_unattested_quarantined` loads the same
YAML, swaps `layers.trust` to `score_average` in memory, and asserts
the discriminating validator fails.

Determinism: no wall clock, no `os.urandom`, no network, no
subprocess anywhere in the plugin or factory. All "now" values are
injected logical-clock parameters; keys derive from
`sha256(seed)[:32]`; delegation ids are content hashes.
`test_delegated_scenario_is_byte_deterministic` asserts two seed-42
runs produce byte-identical traces.

Property tests (Hypothesis): scope-permutation hash invariance; no
descendant of a revoked grant is ever valid under any revocation
order; `report()` never raises on arbitrary garbage; duplicate revoke
delivery is a no-op.

### Differentiation from existing work

- **`attested_peering` (merged #149):** peer-to-peer handshake
  attestation — proves *who a peer is and who they work for*. Ours
  gates on *what a human authorized them to do, right now*: delegation
  chains, freshness-windowed proof-of-human, cascading revocation.
  Constructor/quarantine idioms deliberately follow #149 so it slots
  into existing scenarios; credit where due.
- **`delegatable` auth + its validators (merged #138):** auth-layer
  capability tokens between software agents. Ours is a *trust-layer
  evidence gate* consuming a production credential schema with a
  human root — different layer, different question, different
  validator surface (admission/quarantine of reputation evidence, not
  token acceptance).
- **`aae_permit_gate`:** verb/resource permit checks, no principal
  anchoring, no chains, no freshness, no cascade.
- Firsts in this lane: principal-anchored admission, cascading
  revocation in trust, and a cross-stack byte-parity fixture (TS ↔
  Python canonical envelope locked by vector).

### Honest limitations

Full ledger in
`packages/nest-plugins-reference/nest_plugins_reference/trust/VERIFICATION.md`
— seven disclosed deltas, the headline three:

1. `require_signed_puh=True` is **stricter than production** (prod
   signature currently optional pending mobile signing rollout).
2. `trusted_principals` roster is an enhancement — the production
   verifier trusts a single configured key.
3. Cascading revocation composes nanda-node grant semantics with the
   trust layer; production KYM VC revocation is flat per-credential.
   The composition is the novel part and is labeled as such, never
   claimed as a 1:1 port.

Also disclosed: the biometric principal is a deterministic Tier-1
fixture (the live Yanez ceremony is out-of-band), admission is
evaluated as-of report time, our ancestor-expiry narrowing is strictly
tighter than production's (verdicts identical; reported effective
expiry more conservative), and chain depth is capped at mint time
(`chain-too-deep` at >32 ancestors) — the production source bounds its
cascade and ancestor walks but not mint depth, which fails open past
twice the bound; we close that gap and regression-test it.

### Provenance

- Production source: https://github.com/Nexartis/homeport
  `src/lib/server/delegation-grants.ts` (canonical envelope L211-231,
  cascade L645-659, ancestor walk L687-720) and
  `tests/delegation-grants.test.ts` (parity vectors L65-91). Apache-2.0.
  The delegation module is published there today; the node's full
  source is being open-sourced (code review + cleanup in progress) and
  lands in the same repo within a week of the hackathon.
- The port also **backfills six attack tests the production suite
  lacks**: signature tampering, `boundAt`/`issuedAt` ordering
  violations, scope-widens-parent, ttl-widens-parent, revocable-flip,
  parent-revoked-at-grant.
- A live deployment of the same verifier is on the NANDA Town skills
  registry ("NANDA Delegated Admission") — the SkillMD's endpoints are
  served by the production code this plugin ports.

### Files changed

```
A packages/nest-plugins-reference/nest_plugins_reference/trust/delegated_admission.py
A packages/nest-plugins-reference/nest_plugins_reference/trust/VERIFICATION.md
A packages/nest-plugins-reference/tests/test_delegated_admission.py
A packages/nest-core/nest_core/scenarios_builtin/delegated_admission.py
A scenarios/delegated_trust_market.yaml
M packages/nest-core/nest_core/plugins.py            (+1: _BUILTINS entry)
M packages/nest-core/nest_core/scenarios.py          (+6: factory branch)
M packages/nest-core/nest_core/validators.py         (+370: validators, additive)
M packages/nest-core/tests/test_validators.py        (+1: registry expected set)
M packages/nest-plugins-reference/pyproject.toml     (+1: entry point)
M docs/layers/trust.md                               (+62: plugin section)
```

### Checklist

- [x] `uv sync && ruff check && ruff format --check && pyright && pytest -v` all green locally (1210 passed)
- [x] Entry point in `pyproject.toml` (not just `_BUILTINS`)
- [x] SPDX header + `from __future__ import annotations` on every new file
- [x] `Example::` docstrings on every public symbol
- [x] Adversarial validators FAIL on the reference plugin, PASS on ours, same YAML, seeds 42/7/1337
- [x] Byte-deterministic under fixed seed
- [x] VERIFICATION.md with honest limitations
- [x] Only stdlib + `cryptography` (existing dependency)
- [x] Purely additive to shared files — zero modified/removed existing lines in validators/plugins/scenarios
- [x] https://github.com/Nexartis/homeport public and linked
