### PR TITLE
[Hackathon] replay-safe: comms replay-attack resistance on top of authenticated

### DIFF
--- a/docs/hackathon/submissions/comms-replay-safe/README.md
+++ b/docs/hackathon/submissions/comms-replay-safe/README.md
@@ -1,0 +1,134 @@
+# Comms replay-attack resistance (`replay_safe`)
+
+## The problem
+
+I originally picked problem **#01 — versioned message schemas**
+([`docs/hackathon/problems/01-comms-schema-versioning.md`](../../problems/01-comms-schema-versioning.md)).
+Before writing any code I checked the repo and found it was already solved
+and merged: PR #18 shipped `comms/versioned.py` (forward/backward-compatible
+envelopes), and a follow-on PR #105 shipped `comms/authenticated.py`
+(HMAC tamper-evidence against version rollback and field-stripping).
+
+Rather than re-solve a closed problem, I read both merged plugins looking
+for a real gap. `authenticated.py`'s own docstring names one it explicitly
+leaves open:
+
+> "a *verbatim* re-send of a genuine envelope still verifies."
+> "Bind a nonce/sequence into `metadata` to close that separately."
+
+A captured, byte-identical copy of an honest, correctly-tagged envelope has
+a perfectly valid HMAC tag — nothing was rewritten, so there's nothing for
+the tamper check to catch. An on-path relay (or attacker) can record one
+authentic envelope and re-send it, and `authenticated` accepts it again,
+every time. For a non-idempotent message — a payment, a vote, a state
+transition — that's a live replay/double-spend attack.
+
+## What I built
+
+- **`packages/nest-plugins-reference/nest_plugins_reference/comms/replay_safe.py`**
+  — `ReplaySafeComms`, a subclass of `AuthenticatedComms`. It inherits all
+  of `authenticated`'s version/tamper checks unchanged, and adds one thing:
+  after a tag verifies, it checks whether `(sender, id)` has already been
+  accepted. If so, it raises a typed `ReplayError` instead of decoding the
+  envelope again. No new wire field is needed — the envelope `id` is already
+  covered by the HMAC tag, so it's a free, tamper-evident nonce. The
+  "already seen" set is a bounded, per-sender LRU window
+  (`DEFAULT_REPLAY_WINDOW = 4096`) so a long-running agent's memory doesn't
+  grow without bound.
+- **Two adversarial validators** in `nest_core/validators.py`:
+  `validate_comms_replay_resistance` (every delivery of an id *after* the
+  first must be rejected) and `validate_comms_replay_honest_delivery` (the
+  *first* delivery of every id must still be accepted — so a plugin can't
+  "pass" by refusing all traffic). Both recompute ground truth from the raw
+  wire deliveries in the trace, independent of whichever plugin produced
+  the acks, so they can judge any comms plugin.
+- **`nest_core/scenarios_builtin/comms_replay.py`** + **`scenarios/comms_replay.yaml`**
+  — 8 peers each send one solo envelope (never replayed, a control) and one
+  envelope that a relay captures and re-sends verbatim a second time. An
+  auditor decodes everything with whichever comms plugin the scenario is
+  configured to use.
+- **Tests**: `packages/nest-plugins-reference/tests/test_replay_safe_comms.py`
+  (plugin unit tests — replay rejection, per-sender isolation, window
+  eviction, tamper-vs-replay ordering) and
+  `packages/nest-core/tests/test_comms_replay.py` (validator unit tests on
+  synthetic traces, plus end-to-end simulator runs).
+
+## How to run it
+
+```bash
+uv sync
+
+# Run the scenario (defaults to comms: replay_safe in the YAML)
+uv run nest run scenarios/comms_replay.yaml
+
+# Validate the resulting trace
+uv run python -c "
+from pathlib import Path
+from nest_core.validators import validate_trace
+for r in validate_trace(Path('traces/comms_replay.jsonl'), 'comms_replay'):
+    print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail)
+"
+
+# Just this feature's tests
+uv run pytest packages/nest-plugins-reference/tests/test_replay_safe_comms.py \
+              packages/nest-core/tests/test_comms_replay.py -v
+
+# Full CI sequence (what actually gates a merge)
+make ci-local
+```
+
+To see it fail on the pre-fix plugin, edit `scenarios/comms_replay.yaml` and
+swap `comms: replay_safe` for `comms: authenticated` (or `versioned`, or
+`nest_native`), then re-run the two commands above.
+
+## Before / after (actual output)
+
+**Before** — same scenario, `comms: authenticated` (the merged, pre-fix
+plugin — no replay memory):
+
+```
+FAIL comms_replay_resistance - m-0-replayed: replay delivery #2 not rejected (got accepted); m-1-replayed: replay delivery #2 not rejected (got accepted); ... (8 total)
+PASS comms_replay_honest_delivery - 16 first-time delivery(ies) correctly accepted
+```
+
+Every replayed envelope is silently accepted a second time. The tag is
+valid — it's a byte-for-byte capture — so `authenticated` has nothing to
+object to.
+
+**After** — `comms: replay_safe`:
+
+```
+PASS comms_replay_resistance - 8 replayed envelope(s) correctly rejected after first delivery
+PASS comms_replay_honest_delivery - 16 first-time delivery(ies) correctly accepted
+```
+
+Every replay is now rejected on the second delivery, and — the important
+counter-check — every legitimate first-time delivery (solo and replayed
+alike) still goes through. `replay_safe` doesn't "pass" by refusing traffic.
+
+`make ci-local`: ruff check clean, ruff format clean, pyright 0 errors,
+pytest 1177 passed / 1 skipped, deterministic under seeds 42/7/1337.
+
+## Limits — read before relying on this
+
+- **In-memory only.** The seen-id window lives in the `ReplaySafeComms`
+  instance. If an agent process restarts, it forgets everything it had
+  seen and a replay captured before the restart would go through again.
+  A real deployment would need to persist the window or derive it from a
+  durable monotonic counter, not the in-memory set this plugin uses.
+- **Bounded window, not exact.** With `DEFAULT_REPLAY_WINDOW = 4096`, only
+  the most recent 4096 ids per sender are remembered. A replay of an id
+  old enough to have been evicted would be accepted as if new. The default
+  is sized well above any single scenario's per-sender traffic in this
+  repo, but it is a real, tunable trade-off between memory and window
+  length, not a guarantee for arbitrary traffic volumes.
+- **No key exchange.** Like `authenticated`, this plugin uses a fixed
+  pre-shared `channel_secret` standing in for a real session key. It
+  doesn't model how peers agree on that secret.
+- **Doesn't detect out-of-order delivery, only exact duplicates.** This
+  plugin answers "have I already accepted this exact id from this sender,"
+  not "did these arrive in the order they were sent." Reordering without
+  duplication is out of scope.
+- **Single-process simulation.** Everything here runs inside Nanda Town's
+  deterministic in-memory simulator. I have not tested this against a real
+  network transport, clock skew, or genuinely concurrent processes.

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -21,6 +21,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("comms", "nest_native"): f"{_REF}.comms.nest_native:NestNativeComms",
     ("comms", "versioned"): f"{_REF}.comms.versioned:VersionedComms",
     ("comms", "authenticated"): f"{_REF}.comms.authenticated:AuthenticatedComms",
+    ("comms", "replay_safe"): f"{_REF}.comms.replay_safe:ReplaySafeComms",
     ("identity", "did_key"): f"{_REF}.identity.did_key:DidKeyIdentity",
     ("identity", "ed25519_rotating"): (f"{_REF}.identity.ed25519_rotating:Ed25519RotatingIdentity"),
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -117,6 +117,10 @@ def _try_load_builtin(name: str) -> None:
         from nest_core.scenarios_builtin.comms_downgrade import comms_downgrade_factory
 
         register_scenario("comms_downgrade", comms_downgrade_factory)
+    elif name == "comms_replay":
+        from nest_core.scenarios_builtin.comms_replay import comms_replay_factory
+
+        register_scenario("comms_replay", comms_replay_factory)
     elif name == "receipt_reputation":
         from nest_core.scenarios_builtin.receipt_reputation import (
             receipt_reputation_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/comms_replay.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/comms_replay.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Comms replay-attack scenario — an on-path relay re-sends a captured envelope.
+
+A swarm where every honest peer sends two envelopes to the ``auditor``: one
+that is delivered exactly once (the control), and one that a relay captures
+and re-sends verbatim a second time (the replay). Both envelopes are
+genuinely tagged by :class:`~nest_plugins_reference.comms.authenticated.AuthenticatedComms`
+-- the replay is *not* tampered in any way, it is a byte-for-byte duplicate --
+so the same scenario demonstrates both directions:
+
+* with ``comms: replay_safe`` the auditor remembers it already accepted the
+  replayed id from this sender and rejects the second delivery -> the replay
+  validator passes;
+* with ``comms: authenticated`` (or ``versioned``/``nest_native``) the auditor
+  has no replay memory and the tag on the duplicate verifies just as well as
+  the original -> it is accepted twice -> the validator fails.
+
+Two envelope shapes per peer, keyed by id suffix for readability (the
+validator does not trust the suffix -- it counts actual wire deliveries):
+
+* ``m-<i>-solo``     -- sent once, must be accepted (no false positives);
+* ``m-<i>-replayed`` -- sent twice, byte-identical; the first delivery must
+  be accepted, the second must be rejected.
+
+Example::
+
+    agents = comms_replay_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Message, MessageId
+
+
+def _honest_bytes(mid: str, sender: str, receiver: str) -> bytes:
+    """Serialize a genuine, correctly-tagged ``1.1`` envelope via the real plugin.
+
+    Built with :class:`~nest_plugins_reference.comms.authenticated.AuthenticatedComms`
+    so the bytes -- and their tag -- are exactly what an honest sender would
+    emit. Deterministic (no clock, no RNG).
+
+    Example::
+
+        raw = _honest_bytes("m-0-solo", "peer-0", "auditor-0")
+    """
+    from nest_plugins_reference.comms.authenticated import AuthenticatedComms
+
+    comms = AuthenticatedComms(AgentId(sender))
+    msg = Message(
+        id=MessageId(mid),
+        sender=AgentId(sender),
+        receiver=AgentId(receiver),
+        payload=b"v1.1-offer",
+        metadata={"schema_version": "1.1", "kind": "offer"},
+    )
+    return comms.serialize(msg)
+
+
+def _best_effort_id(raw: bytes) -> str:
+    """Pull the ``id`` from a possibly-undecodable envelope for ack labelling.
+
+    Example::
+
+        assert _best_effort_id(b'{"id": "m-0-solo"}') == "m-0-solo"
+    """
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return "unknown"
+    if isinstance(data, dict):
+        return str(cast("dict[str, Any]", data).get("id", "unknown"))
+    return "unknown"
+
+
+class ReplayPeerAgent(StateMachineAgent):
+    """Emits a solo envelope plus a second envelope a relay replays verbatim.
+
+    Example::
+
+        peer = ReplayPeerAgent(AgentId("peer-0"), index=0, auditor=AgentId("auditor-0"))
+    """
+
+    def __init__(self, agent_id: AgentId, index: int, auditor: AgentId) -> None:
+        self._id = agent_id
+        self._index = index
+        self._auditor = auditor
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Stagger emissions onto distinct ticks for real virtual time.
+
+        Example::
+
+            await peer.on_start(ctx)
+        """
+        await ctx.schedule(float(self._index + 1), b"emit")
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """On the self-timer, send the solo envelope, then the replayed one twice.
+
+        Example::
+
+            await peer.on_message(ctx, AgentId("peer-0"), b"emit")
+        """
+        if payload != b"emit":
+            return
+        me, to = str(self._id), str(self._auditor)
+
+        solo = _honest_bytes(f"m-{self._index}-solo", me, to)
+        await ctx.send(self._auditor, solo)
+
+        # The relay captures this exact envelope and re-sends it verbatim --
+        # not a re-serialization, the identical bytes -- so its tag is still
+        # perfectly valid. Only replay memory (not tamper-evidence) can catch it.
+        genuine = _honest_bytes(f"m-{self._index}-replayed", me, to)
+        await ctx.send(self._auditor, genuine)
+        await ctx.send(self._auditor, genuine)
+
+
+class ReplayAuditorAgent(StateMachineAgent):
+    """Decodes each envelope with the configured comms plugin and acks the outcome.
+
+    Ack format is ``ack:<id>:<status>`` where status is ``accepted``,
+    ``rejected_replay`` (a :class:`ReplayError` -- duplicate id from this
+    sender), ``rejected_tampered`` (a :class:`DowngradeError`), or
+    ``rejected_major`` (any other decode refusal). This is the evidence the
+    replay validator scores.
+
+    Example::
+
+        auditor = ReplayAuditorAgent(AgentId("auditor-0"), comms=ReplaySafeComms(...))
+    """
+
+    def __init__(self, agent_id: AgentId, comms: Any) -> None:
+        self._id = agent_id
+        self._comms = comms
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Decode one envelope and report the outcome back to the sender.
+
+        Example::
+
+            await auditor.on_message(ctx, AgentId("peer-0"), raw)
+        """
+        # Imported lazily so the scenario stays importable without the reference
+        # package present. ReplayError is a DowngradeError subclass, so it must
+        # be checked first or the broader except would mislabel it.
+        from nest_plugins_reference.comms.authenticated import DowngradeError
+        from nest_plugins_reference.comms.replay_safe import ReplayError
+
+        try:
+            msg = self._comms.deserialize(payload)
+        except ReplayError:
+            mid = _best_effort_id(payload)
+            await ctx.send(sender, f"ack:{mid}:rejected_replay:".encode())
+            return
+        except DowngradeError:
+            mid = _best_effort_id(payload)
+            await ctx.send(sender, f"ack:{mid}:rejected_tampered:".encode())
+            return
+        except (ValueError, KeyError):
+            mid = _best_effort_id(payload)
+            await ctx.send(sender, f"ack:{mid}:rejected_major:".encode())
+            return
+        await ctx.send(sender, f"ack:{msg.id}:accepted:".encode())
+
+
+def comms_replay_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create one auditor and a set of honest peers, one of whose messages is replayed.
+
+    The auditor decodes with ``plugins["comms"]`` so the scenario exercises
+    whichever comms plugin the YAML selected. Peer count comes from the
+    ``peer`` role (default: all agents but the auditor).
+
+    Example::
+
+        agents = comms_replay_factory(config, plugins)
+    """
+    peer_count = 0
+    if config.agents.roles:
+        for role in config.agents.roles:
+            if role.name == "peer":
+                peer_count = role.count
+    if peer_count == 0:
+        peer_count = max(2, config.agents.count - 1)
+
+    auditor_id = AgentId("auditor-0")
+    comms_cls = plugins["comms"]
+    auditor_comms = comms_cls(auditor_id)
+
+    agents: dict[AgentId, StateMachineAgent] = {
+        auditor_id: ReplayAuditorAgent(auditor_id, comms=auditor_comms),
+    }
+    for i in range(peer_count):
+        aid = AgentId(f"peer-{i}")
+        agents[aid] = ReplayPeerAgent(aid, index=i, auditor=auditor_id)
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -2764,6 +2764,158 @@ def validate_comms_authentic_delivery(
 
 
 # ---------------------------------------------------------------------------
+# Comms replay-attack validator (adversarial)
+# ---------------------------------------------------------------------------
+# Ground truth for "was this id replayed?" is the wire itself: how many times a
+# given envelope id was actually delivered to the receiver, independent of the
+# decoder under test. An id delivered more than once means an attacker (or a
+# faithfully-replaying relay) captured a genuine envelope and re-sent it. A
+# comms layer passes iff it accepts the *first* delivery of every id and
+# rejects every delivery after that. ``versioned`` and ``authenticated`` have
+# no replay memory -- a captured, byte-identical envelope re-verifies every
+# time -- so they accept the duplicate and fail; ``replay_safe`` remembers
+# accepted ids per sender and rejects the repeat.
+
+
+def _collect_comms_wire_sequence(
+    events: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Map each envelope id to *every* delivery it received, in trace order.
+
+    Unlike :func:`_collect_comms_wire` (which keeps only the last delivery per
+    id), this keeps the full sequence so a second delivery of the same id --
+    the replay itself -- is visible rather than overwritten.
+
+    Example::
+
+        deliveries = _collect_comms_wire_sequence(events)
+        assert len(deliveries["m-0-replayed"]) == 2
+    """
+    wire: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for ev in events:
+        if ev.get("kind") != "receive":
+            continue
+        env = _parse_comms_envelope(str(ev.get("msg", "")))
+        if env is None:
+            continue
+        mid = str(env.get("id"))
+        version = str(env.get("schema_version", "1.0"))
+        wire[mid].append({"version": version, "major": _comms_major(version)})
+    return wire
+
+
+def _collect_comms_ack_sequence(events: list[dict[str, Any]]) -> dict[str, list[str]]:
+    """Map each envelope id to the ordered list of ack statuses it received.
+
+    Unlike :func:`_collect_comms_acks` (last ack wins), this preserves every
+    ack in emission order so the first (genuine) delivery's outcome can be
+    checked separately from the replay's.
+
+    Example::
+
+        acks = _collect_comms_ack_sequence(events)
+        assert acks["m-0-replayed"] == ["accepted", "rejected_replay"]
+    """
+    acks: dict[str, list[str]] = defaultdict(list)
+    for ev in events:
+        if ev.get("kind") not in ("send", "broadcast"):
+            continue
+        msg = str(ev.get("msg", ""))
+        if not msg.startswith("ack:"):
+            continue
+        parts = msg.split(":", 3)
+        if len(parts) < 3:
+            continue
+        mid, status = parts[1], parts[2]
+        acks[mid].append(status)
+    return acks
+
+
+def validate_comms_replay_resistance(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Every delivery of an id after the first must be rejected as a replay.
+
+    Catches the *replay* attack: an on-path attacker (or relay) captures a
+    genuinely-tagged envelope and re-sends it verbatim. Nothing was rewritten,
+    so tamper-evidence alone (``authenticated``) still verifies it; only a
+    plugin that remembers accepted ids (``replay_safe``) can tell the second
+    delivery apart from the first.
+
+    Example::
+
+        results = validate_comms_replay_resistance(events)
+    """
+    wire = _collect_comms_wire_sequence(events)
+    acks = _collect_comms_ack_sequence(events)
+    replayed = {mid: deliveries for mid, deliveries in wire.items() if len(deliveries) > 1}
+    if not replayed:
+        return [
+            ValidationResult("comms_replay_resistance", False, "no replayed envelopes in trace")
+        ]
+    violations: list[str] = []
+    for mid, deliveries in replayed.items():
+        statuses = acks.get(mid, [])
+        if len(statuses) < len(deliveries):
+            violations.append(
+                f"{mid}: {len(deliveries)} deliveries but only {len(statuses)} ack(s)"
+            )
+            continue
+        for i, status in enumerate(statuses[1 : len(deliveries)], start=2):
+            if not status.startswith("rejected"):
+                violations.append(f"{mid}: replay delivery #{i} not rejected (got {status})")
+    if violations:
+        return [ValidationResult("comms_replay_resistance", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "comms_replay_resistance",
+            True,
+            f"{len(replayed)} replayed envelope(s) correctly rejected after first delivery",
+        )
+    ]
+
+
+def validate_comms_replay_honest_delivery(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """The first delivery of every id must still be accepted (no false positives).
+
+    The liveness counterpart to :func:`validate_comms_replay_resistance`: a
+    plugin cannot pass the replay check by refusing all traffic. Every id's
+    first delivery -- replayed later or not -- must be accepted.
+
+    Example::
+
+        results = validate_comms_replay_honest_delivery(events)
+    """
+    wire = _collect_comms_wire_sequence(events)
+    acks = _collect_comms_ack_sequence(events)
+    if not wire:
+        return [
+            ValidationResult(
+                "comms_replay_honest_delivery", False, "no delivered envelopes in trace"
+            )
+        ]
+    violations: list[str] = []
+    for mid in wire:
+        statuses = acks.get(mid, [])
+        if not statuses:
+            violations.append(f"{mid}: delivered but no ack")
+            continue
+        if statuses[0] != "accepted":
+            violations.append(f"{mid}: first delivery not accepted (got {statuses[0]})")
+    if violations:
+        return [ValidationResult("comms_replay_honest_delivery", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "comms_replay_honest_delivery",
+            True,
+            f"{len(wire)} first-time delivery(ies) correctly accepted",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Receipt-reputation (collusion-ring) validators
 # ---------------------------------------------------------------------------
 
@@ -4936,6 +5088,10 @@ VALIDATORS: dict[str, list[Any]] = {
     "comms_downgrade": [
         validate_comms_downgrade_resistance,
         validate_comms_authentic_delivery,
+    ],
+    "comms_replay": [
+        validate_comms_replay_resistance,
+        validate_comms_replay_honest_delivery,
     ],
     "marketplace": [
         validate_marketplace_no_double_sell,

--- a/packages/nest-core/tests/test_comms_replay.py
+++ b/packages/nest-core/tests/test_comms_replay.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the comms replay-attack validator and scenario.
+
+The core claim under test: ``validate_comms_replay_resistance`` FAILS against
+comms layers with no replay memory (``authenticated``, ``versioned``,
+``nest_native`` — a captured, byte-identical envelope re-verifies and is
+accepted twice) and PASSES against ``replay_safe`` (which remembers accepted
+ids per sender and refuses the second delivery) — driven both from synthetic
+traces and from a real simulator run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.types import AgentId, Message, MessageId
+from nest_core.validators import (
+    validate_comms_replay_honest_delivery,
+    validate_comms_replay_resistance,
+    validate_trace,
+)
+from nest_plugins_reference.comms.authenticated import AuthenticatedComms
+
+type Event = dict[str, Any]
+
+
+def _authentic_envelope(mid: str) -> dict[str, Any]:
+    """Return a genuine, correctly-tagged envelope as a dict."""
+    comms = AuthenticatedComms(AgentId("peer-1"))
+    raw = comms.serialize(
+        Message(
+            id=MessageId(mid),
+            sender=AgentId("peer-1"),
+            receiver=AgentId("auditor-0"),
+            payload=b"x",
+            metadata={"schema_version": "1.1", "kind": "offer"},
+        )
+    )
+    return json.loads(raw)
+
+
+def _recv(env: dict[str, Any]) -> Event:
+    return {
+        "ts": 1.0,
+        "agent": "auditor-0",
+        "kind": "receive",
+        "from": "peer-1",
+        "msg": json.dumps(env, sort_keys=True),
+    }
+
+
+def _ack(mid: str, status: str) -> Event:
+    return {
+        "ts": 2.0,
+        "agent": "auditor-0",
+        "kind": "send",
+        "to": "peer-1",
+        "msg": f"ack:{mid}:{status}:",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests (synthetic traces)
+# ---------------------------------------------------------------------------
+
+
+class TestReplayValidator:
+    def test_pass_when_replay_rejected_and_first_delivery_accepted(self) -> None:
+        env = _authentic_envelope("m-replayed")
+        events = [
+            _recv(env),
+            _ack("m-replayed", "accepted"),
+            _recv(env),  # verbatim replay
+            _ack("m-replayed", "rejected_replay"),
+        ]
+        results = validate_comms_replay_resistance(events)
+        assert results[0].passed is True
+
+    def test_fail_when_replay_accepted(self) -> None:
+        """authenticated/versioned behaviour: the duplicate is silently accepted."""
+        env = _authentic_envelope("m-replayed")
+        events = [
+            _recv(env),
+            _ack("m-replayed", "accepted"),
+            _recv(env),
+            _ack("m-replayed", "accepted"),  # no replay memory: accepted again
+        ]
+        results = validate_comms_replay_resistance(events)
+        assert results[0].passed is False
+
+    def test_fail_when_third_delivery_also_accepted(self) -> None:
+        env = _authentic_envelope("m-replayed")
+        events = [
+            _recv(env),
+            _ack("m-replayed", "accepted"),
+            _recv(env),
+            _ack("m-replayed", "rejected_replay"),
+            _recv(env),
+            _ack("m-replayed", "accepted"),  # a plugin that only catches the 2nd delivery
+        ]
+        results = validate_comms_replay_resistance(events)
+        assert results[0].passed is False
+
+    def test_no_replays_in_trace_reports_nothing_to_judge(self) -> None:
+        env = _authentic_envelope("m-solo")
+        events = [_recv(env), _ack("m-solo", "accepted")]
+        results = validate_comms_replay_resistance(events)
+        assert results[0].passed is False
+        assert "no replayed envelopes" in results[0].detail
+
+    def test_fail_when_first_delivery_rejected(self) -> None:
+        """A plugin cannot pass by rejecting everything: the first delivery must land."""
+        env = _authentic_envelope("m-solo")
+        events = [_recv(env), _ack("m-solo", "rejected_tampered")]
+        results = validate_comms_replay_honest_delivery(events)
+        assert results[0].passed is False
+
+    def test_honest_delivery_passes_for_solo_and_first_of_replayed(self) -> None:
+        solo = _authentic_envelope("m-solo")
+        replayed = _authentic_envelope("m-replayed")
+        events = [
+            _recv(solo),
+            _ack("m-solo", "accepted"),
+            _recv(replayed),
+            _ack("m-replayed", "accepted"),
+            _recv(replayed),
+            _ack("m-replayed", "rejected_replay"),
+        ]
+        results = validate_comms_replay_honest_delivery(events)
+        assert results[0].passed is True
+
+    def test_no_deliveries_reports_nothing_to_judge(self) -> None:
+        results = validate_comms_replay_honest_delivery([])
+        assert results[0].passed is False
+        assert "no delivered envelopes" in results[0].detail
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real simulator run
+# ---------------------------------------------------------------------------
+
+
+def _run(comms: str, out: Path, seed: int = 42) -> None:
+    cfg = ScenarioConfig.from_yaml("scenarios/comms_replay.yaml")
+    cfg.layers.comms = comms
+    cfg.seed = seed
+    cfg.output.trace = str(out)
+    asyncio.run(ScenarioRunner(cfg).run())
+
+
+class TestScenarioEndToEnd:
+    def test_replay_safe_passes(self, tmp_path: Path) -> None:
+        out = tmp_path / "replay_safe.jsonl"
+        _run("replay_safe", out)
+        results = validate_trace(out, "comms_replay")
+        assert results, "expected validator to run"
+        assert all(r.passed for r in results), [r.detail for r in results if not r.passed]
+
+    def test_authenticated_fails(self, tmp_path: Path) -> None:
+        """AuthenticatedComms has no replay memory -> accepts the duplicate."""
+        out = tmp_path / "authenticated.jsonl"
+        _run("authenticated", out)
+        results = validate_trace(out, "comms_replay")
+        by_name = {r.name: r.passed for r in results}
+        assert by_name["comms_replay_resistance"] is False
+        assert by_name["comms_replay_honest_delivery"] is True
+
+    def test_versioned_fails(self, tmp_path: Path) -> None:
+        out = tmp_path / "versioned.jsonl"
+        _run("versioned", out)
+        results = validate_trace(out, "comms_replay")
+        assert {r.name: r.passed for r in results}["comms_replay_resistance"] is False
+
+    def test_nest_native_fails(self, tmp_path: Path) -> None:
+        out = tmp_path / "native.jsonl"
+        _run("nest_native", out)
+        results = validate_trace(out, "comms_replay")
+        assert {r.name: r.passed for r in results}["comms_replay_resistance"] is False
+
+    def test_deterministic_across_required_seeds(self, tmp_path: Path) -> None:
+        for seed in (42, 7, 1337):
+            a, b = tmp_path / f"{seed}a.jsonl", tmp_path / f"{seed}b.jsonl"
+            _run("replay_safe", a, seed=seed)
+            _run("replay_safe", b, seed=seed)
+            assert a.read_bytes() == b.read_bytes(), f"seed {seed} not deterministic"
+            assert all(r.passed for r in validate_trace(a, "comms_replay"))

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2004,6 +2004,7 @@ class TestValidatorRegistry:
             "empic_payments",
             "comms_versioning",
             "comms_downgrade",
+            "comms_replay",
             "receipt_reputation",
             "multi_attribute_market",
             "provenance_supply_chain",

--- a/packages/nest-plugins-reference/nest_plugins_reference/comms/replay_safe.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/comms/replay_safe.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Replay-safe comms — rejects verbatim re-delivery of an already-seen envelope.
+
+:mod:`~nest_plugins_reference.comms.authenticated` closes the downgrade/tamper
+gap: an on-path adversary who *rewrites* an envelope gets caught because the
+rewrite invalidates the HMAC tag. But its own docstring flags what is still
+open: "a *verbatim* re-send of a genuine envelope still verifies." A captured,
+byte-identical copy of an honest envelope carries a perfectly valid tag — there
+is nothing to recompute-and-compare against, because nothing was tampered with.
+Replaying it a second (or third, or Nth) time is indistinguishable from an
+honest resend at the ``AuthenticatedComms`` layer, so it is silently accepted
+again. For a non-idempotent message (a payment instruction, a vote, a state
+transition) that is a live attack: capture one authentic envelope off the
+wire and replay it to double-spend, double-vote, or double-apply.
+
+This plugin closes that gap the way the docstring suggests — "bind a
+nonce/sequence into ``metadata``" — but does it with zero new wire fields: the
+envelope's own ``id`` is already inside the HMAC tag's coverage (see
+``canonical_untagged`` in ``authenticated.py``), so an attacker cannot forge a
+*new* id for a captured payload without invalidating the tag. That makes ``id``
+a free, tamper-evident nonce. All this plugin adds is receiver-side memory: a
+bounded, per-sender window of the ids it has already accepted. A second
+delivery of an id already in that window is rejected with a typed
+:class:`ReplayError` instead of being decoded again.
+
+Threat model (delta over ``authenticated``)::
+
+    in scope    replay: a verbatim re-send (or re-broadcast by a relay) of a
+                previously accepted, genuinely-tagged envelope is detected and
+                refused on the second and later deliveries.
+    out scope   everything already in scope for authenticated (rollback,
+                field-stripping, forgery without the channel secret).
+    out scope   replay across process restarts: the seen-id window is
+                in-memory only, exactly like the simulator's other per-agent
+                state. A real deployment would persist or derive the window
+                from a monotonic counter.
+
+Example::
+
+    comms = ReplaySafeComms(AgentId("a1"))
+    raw = comms.serialize(msg)
+    comms.deserialize(raw)                 # first delivery: accepted
+    comms.deserialize(raw)                 # replay: raises ReplayError
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+from nest_core.types import AgentId, Message, MessageId
+
+from nest_plugins_reference.comms.authenticated import (
+    AUTH_TAG_FIELD,
+    CHANNEL_SECRET_DEFAULT,
+    KNOWN_FIELDS,
+    SCHEMA_MAJOR,
+    SCHEMA_MINOR,
+    SCHEMA_VERSION,
+    AuthenticatedComms,
+    DowngradeError,
+)
+
+__all__ = [
+    "AUTH_TAG_FIELD",
+    "CHANNEL_SECRET_DEFAULT",
+    "DEFAULT_REPLAY_WINDOW",
+    "KNOWN_FIELDS",
+    "SCHEMA_MAJOR",
+    "SCHEMA_MINOR",
+    "SCHEMA_VERSION",
+    "ReplayError",
+    "ReplaySafeComms",
+]
+
+#: Number of distinct message ids remembered per sender before the oldest is
+#: evicted. Bounds memory on a long-running agent; sized generously above any
+#: single scenario's per-sender message count so it never evicts a live id.
+DEFAULT_REPLAY_WINDOW = 4096
+
+
+class ReplayError(DowngradeError):
+    """Raised when an envelope's ``id`` has already been accepted from this sender.
+
+    A subclass of :class:`~nest_plugins_reference.comms.authenticated.DowngradeError`
+    (hence :class:`UnsupportedSchemaError`, hence :class:`ValueError`): the
+    envelope is authentic and well-formed, but delivering it *again* is itself
+    the attack, so it is refused the same way a tampered envelope is.
+
+    Example::
+
+        try:
+            comms.deserialize(captured_raw)
+        except ReplayError as exc:
+            assert exc.reason == "replay"
+    """
+
+    def __init__(self, version: str, message_id: str, sender: str) -> None:
+        self.message_id = message_id
+        self.sender = sender
+        super().__init__(version, "replay", f"duplicate id {message_id!r} from {sender!r}")
+
+
+class ReplaySafeComms(AuthenticatedComms):
+    """``AuthenticatedComms`` plus rejection of verbatim envelope replay.
+
+    Strict superset: version negotiation, unknown-field preservation,
+    unknown-major rejection and tamper-evidence are all inherited unchanged
+    from :class:`AuthenticatedComms`. The only new behaviour is a per-sender
+    memory of accepted ids, consulted after the tag verifies.
+
+    Example::
+
+        comms = ReplaySafeComms(AgentId("a1"), require_auth=True)
+        resp = await comms.send(AgentId("a2"), msg)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        transport: object | None = None,
+        registry: object | None = None,
+        *,
+        channel_secret: bytes = CHANNEL_SECRET_DEFAULT,
+        require_auth: bool = False,
+        replay_window: int = DEFAULT_REPLAY_WINDOW,
+    ) -> None:
+        super().__init__(
+            agent_id,
+            transport,
+            registry,
+            channel_secret=channel_secret,
+            require_auth=require_auth,
+        )
+        if replay_window < 1:
+            msg = f"replay_window must be >= 1, got {replay_window}"
+            raise ValueError(msg)
+        self._replay_window = replay_window
+        # sender -> ordered set (dict-as-set) of accepted ids, oldest first.
+        self._seen: dict[AgentId, OrderedDict[MessageId, None]] = {}
+
+    def deserialize(self, raw: bytes) -> Message:
+        """Deserialize, then enforce that ``(sender, id)`` has not been seen before.
+
+        Delegates version/tamper checks to :class:`AuthenticatedComms` first —
+        a forged or downgraded envelope is rejected on those grounds before
+        replay bookkeeping ever runs, so an attacker cannot use a mangled
+        duplicate to probe the replay window. Only a genuinely-verified
+        envelope reaches the id check.
+
+        Example::
+
+            msg = comms.deserialize(raw)   # raises ReplayError on 2nd call
+        """
+        msg = super().deserialize(raw)
+        seen = self._seen.setdefault(msg.sender, OrderedDict())
+        if msg.id in seen:
+            version = str(msg.metadata.get("schema_version", SCHEMA_VERSION))
+            raise ReplayError(version, str(msg.id), str(msg.sender))
+        seen[msg.id] = None
+        if len(seen) > self._replay_window:
+            seen.popitem(last=False)
+        return msg

--- a/packages/nest-plugins-reference/tests/test_replay_safe_comms.py
+++ b/packages/nest-plugins-reference/tests/test_replay_safe_comms.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the replay-safe comms plugin: replay rejection, tamper/version parity.
+
+Persona note (protocol-security-engineer): ``AuthenticatedComms`` proves an
+envelope was not rewritten; it says nothing about whether it was *replayed*.
+The invariant under test here is narrow and specific: the first delivery of a
+given id from a given sender is accepted, and every delivery after that is
+refused with a typed :class:`ReplayError` -- even though the replayed bytes
+are byte-for-byte identical to an honest, correctly-tagged envelope and would
+sail through ``AuthenticatedComms`` unmodified.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from nest_core.layers.comms import CommsProtocol
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, Message, MessageId
+from nest_plugins_reference.comms.authenticated import DowngradeError
+from nest_plugins_reference.comms.replay_safe import (
+    DEFAULT_REPLAY_WINDOW,
+    ReplayError,
+    ReplaySafeComms,
+)
+
+_SENDER = AgentId("peer-1")
+_OTHER_SENDER = AgentId("peer-2")
+_AUDITOR = AgentId("auditor-0")
+
+
+def _comms(**kw: Any) -> ReplaySafeComms:
+    return ReplaySafeComms(_AUDITOR, **kw)
+
+
+def _msg(mid: str = "m-1", sender: AgentId = _SENDER) -> Message:
+    return Message(
+        id=MessageId(mid),
+        sender=sender,
+        receiver=_AUDITOR,
+        payload=b"hello-world",
+        metadata={"schema_version": "1.1", "kind": "offer"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protocol / registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_comms_protocol() -> None:
+    """The plugin structurally satisfies ``CommsProtocol``."""
+    assert isinstance(_comms(), CommsProtocol)
+
+
+def test_resolves_via_builtin_registry() -> None:
+    """``(comms, replay_safe)`` resolves through the built-in plugin registry."""
+    cls = PluginRegistry().resolve("comms", "replay_safe")
+    assert cls is ReplaySafeComms
+
+
+def test_is_a_strict_authenticated_comms_subclass() -> None:
+    """Drop-in claim: ``ReplaySafeComms`` inherits ``AuthenticatedComms`` wire behaviour."""
+    from nest_plugins_reference.comms.authenticated import AuthenticatedComms
+
+    assert issubclass(ReplaySafeComms, AuthenticatedComms)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip parity with AuthenticatedComms (unaffected by the new behaviour)
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_is_lossless() -> None:
+    """``deserialize(serialize(m)) == m`` for a plain message, first delivery."""
+    comms = _comms()
+    msg = _msg()
+    assert comms.deserialize(comms.serialize(msg)) == msg
+
+
+def test_serialize_is_deterministic() -> None:
+    """Identical input yields byte-identical output (Tier-1 replay of the *simulation*)."""
+    assert _comms().serialize(_msg()) == _comms().serialize(_msg())
+
+
+# ---------------------------------------------------------------------------
+# The bug this plugin exists to fix: AuthenticatedComms accepts a verbatim replay
+# ---------------------------------------------------------------------------
+
+
+def test_authenticated_comms_accepts_a_verbatim_replay() -> None:
+    """Baseline failure: without replay memory, a captured envelope re-verifies.
+
+    This is the exact gap flagged in ``authenticated.py``'s own docstring
+    ("a verbatim re-send of a genuine envelope still verifies"). Demonstrating
+    it here pins down *why* ``ReplaySafeComms`` needs to exist.
+    """
+    from nest_plugins_reference.comms.authenticated import AuthenticatedComms
+
+    comms = AuthenticatedComms(_AUDITOR)
+    raw = comms.serialize(_msg())
+    first = comms.deserialize(raw)
+    second = comms.deserialize(raw)  # captured & replayed verbatim
+    assert first == second  # accepted twice -- no error, no distinction
+
+
+# ---------------------------------------------------------------------------
+# Adversarial: the replay attack this plugin exists to catch
+# ---------------------------------------------------------------------------
+
+
+def test_second_delivery_of_same_envelope_is_rejected() -> None:
+    """A verbatim replay of an already-accepted envelope is refused."""
+    comms = _comms()
+    raw = comms.serialize(_msg())
+    comms.deserialize(raw)  # first delivery: accepted
+    with pytest.raises(ReplayError) as exc:
+        comms.deserialize(raw)  # replay: rejected
+    assert exc.value.message_id == "m-1"
+    assert exc.value.sender == str(_SENDER)
+    assert exc.value.reason == "replay"
+
+
+def test_replay_error_is_a_downgrade_error() -> None:
+    """``ReplayError`` still satisfies any ``except DowngradeError`` guard."""
+    comms = _comms()
+    raw = comms.serialize(_msg())
+    comms.deserialize(raw)
+    with pytest.raises(DowngradeError):
+        comms.deserialize(raw)
+
+
+def test_third_delivery_is_also_rejected() -> None:
+    """Replay rejection is not a one-shot toggle -- every repeat after the first fails."""
+    comms = _comms()
+    raw = comms.serialize(_msg())
+    comms.deserialize(raw)
+    for _ in range(5):
+        with pytest.raises(ReplayError):
+            comms.deserialize(raw)
+
+
+def test_tampered_replay_is_rejected_as_tamper_not_replay() -> None:
+    """A rewritten copy of a delivered id fails on the tag, not the replay check.
+
+    Tamper detection runs before replay bookkeeping: a forged envelope with a
+    stale tag must be caught as a forgery regardless of whether its id has
+    been seen before.
+    """
+    comms = _comms()
+    raw = comms.serialize(_msg())
+    comms.deserialize(raw)
+    env = json.loads(raw)
+    env["kind"] = "evil"  # covered field, stale tag no longer matches
+    forged = json.dumps(env, sort_keys=True).encode()
+    with pytest.raises(DowngradeError) as exc:
+        comms.deserialize(forged)
+    assert not isinstance(exc.value, ReplayError)
+
+
+def test_different_senders_have_independent_replay_windows() -> None:
+    """The same id from two different senders is not conflated as a replay."""
+    comms = _comms()
+    raw_a = comms.serialize(_msg(mid="m-shared", sender=_SENDER))
+    raw_b = comms.serialize(_msg(mid="m-shared", sender=_OTHER_SENDER))
+    comms.deserialize(raw_a)  # accepted: first time from peer-1
+    comms.deserialize(raw_b)  # accepted: first time from peer-2, different sender
+    with pytest.raises(ReplayError):
+        comms.deserialize(raw_a)  # now a replay from peer-1
+
+
+def test_two_distinct_ids_from_same_sender_both_accepted() -> None:
+    """Replay tracking is keyed on id, not just sender -- distinct ids don't collide."""
+    comms = _comms()
+    raw_1 = comms.serialize(_msg(mid="m-1"))
+    raw_2 = comms.serialize(_msg(mid="m-2"))
+    comms.deserialize(raw_1)
+    comms.deserialize(raw_2)  # different id, must not be treated as a replay
+
+
+def test_replay_window_evicts_oldest_id() -> None:
+    """A bounded window forgets the oldest id once it overflows."""
+    comms = _comms(replay_window=2)
+    raws = [comms.serialize(_msg(mid=f"m-{i}")) for i in range(3)]
+    comms.deserialize(raws[0])
+    comms.deserialize(raws[1])
+    comms.deserialize(raws[2])  # window: {m-1, m-2}, m-0 evicted
+    comms.deserialize(raws[0])  # m-0 no longer remembered -> treated as new, accepted
+    with pytest.raises(ReplayError):
+        comms.deserialize(raws[2])  # m-2 is still in the window
+
+
+def test_replay_window_must_be_positive() -> None:
+    """A non-positive window is a configuration error, not silently disabled tracking."""
+    with pytest.raises(ValueError, match="replay_window"):
+        ReplaySafeComms(_AUDITOR, replay_window=0)
+
+
+def test_default_replay_window_is_generous() -> None:
+    """Sanity: the shipped default comfortably covers a single scenario's traffic."""
+    assert DEFAULT_REPLAY_WINDOW >= 1000

--- a/scenarios/comms_replay.yaml
+++ b/scenarios/comms_replay.yaml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Comms replay-attack scenario: a relay re-sends a captured, genuine envelope.
+#
+# 8 honest peers each authenticate a "solo" envelope (sent once) and a second
+# envelope that a relay captures and re-sends verbatim a second time -- no
+# tampering, byte-for-byte identical, so its HMAC tag is perfectly valid. The
+# auditor decodes every delivery with the configured comms plugin.
+#
+#   * comms: replay_safe   -> remembers the accepted id, rejects the replay -> PASS
+#   * comms: authenticated -> no replay memory, accepts the duplicate       -> FAIL
+#   * comms: versioned     -> same gap, plus no tag concept at all          -> FAIL
+#
+# Verify::
+#
+#     nest run scenarios/comms_replay.yaml
+#     python -c "from pathlib import Path; from nest_core.validators import validate_trace; \
+#         [print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail) \
+#          for r in validate_trace(Path('traces/comms_replay.jsonl'), 'comms_replay')]"
+#
+# Swap `comms: replay_safe` for `comms: authenticated` to watch the same trace fail.
+name: comms_replay
+description: "8 honest peers, a relay replays one captured envelope per peer; replay_safe comms rejects the duplicate."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 9
+  brain: state-machine
+  roles:
+    - name: peer
+      count: 8
+    - name: auditor
+      count: 1
+
+layers:
+  comms: replay_safe
+
+task:
+  type: comms_replay
+  config: {}
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 1000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/comms_replay.jsonl


### PR DESCRIPTION
## Problem

I picked **#01 — versioned message schemas**
([`docs/hackathon/problems/01-comms-schema-versioning.md`](https://github.com/projnanda/nandatown/blob/main/docs/hackathon/problems/01-comms-schema-versioning.md)),
but before writing code I found it was already solved and merged: PR #18
(`comms/versioned.py`, forward/backward compat) and a follow-on PR #105
(`comms/authenticated.py`, HMAC tamper-evidence against rollback/stripping).

Reading `authenticated.py` for a real remaining gap, its own docstring names
one: *"a verbatim re-send of a genuine envelope still verifies."* A captured,
byte-identical copy of an honest, correctly-tagged envelope has a perfectly
valid HMAC tag — nothing was rewritten, so tamper-evidence has nothing to
catch. An on-path relay can record one authentic envelope and replay it
indefinitely; for a non-idempotent message (payment, vote, state transition)
that's a live attack.

## What I built

- `comms/replay_safe.py` — `ReplaySafeComms`, a subclass of
  `AuthenticatedComms`. Inherits all version/tamper checks unchanged; adds a
  bounded, per-sender memory of accepted envelope ids and raises a typed
  `ReplayError` on a repeat. No new wire field — the envelope `id` is already
  covered by the HMAC tag, so it's a free, tamper-evident nonce.
- Two adversarial validators, `comms_replay_resistance` and
  `comms_replay_honest_delivery`, that recompute ground truth from raw wire
  deliveries (independent of any plugin) — they fail against
  `authenticated`/`versioned`/`nest_native` and pass against `replay_safe`.
- `scenarios/comms_replay.yaml` + `scenarios_builtin/comms_replay.py` — 8
  peers each send a solo envelope (control) and one that a relay replays
  verbatim, plus an auditor.
- Unit tests (`test_replay_safe_comms.py`), validator + end-to-end tests
  (`test_comms_replay.py`), deterministic under seeds 42/7/1337.
- A short [submission README](docs/hackathon/submissions/comms-replay-safe/README.md)
  with the same info plus honest limits.

## How to run it

```bash
uv sync
uv run nest run scenarios/comms_replay.yaml
uv run python -c "
from pathlib import Path
from nest_core.validators import validate_trace
for r in validate_trace(Path('traces/comms_replay.jsonl'), 'comms_replay'):
    print('PASS' if r.passed else 'FAIL', r.name, '-', r.detail)
"
uv run pytest packages/nest-plugins-reference/tests/test_replay_safe_comms.py \
              packages/nest-core/tests/test_comms_replay.py -v
make ci-local
```

## Result

Same scenario, `comms: authenticated` (pre-fix, no replay memory):

```
FAIL comms_replay_resistance - m-0-replayed: replay delivery #2 not rejected (got accepted); ... (8 total)
PASS comms_replay_honest_delivery - 16 first-time delivery(ies) correctly accepted
```

`comms: replay_safe` (this PR):

```
PASS comms_replay_resistance - 8 replayed envelope(s) correctly rejected after first delivery
PASS comms_replay_honest_delivery - 16 first-time delivery(ies) correctly accepted
```

`make ci-local`: ruff check clean, ruff format clean, pyright 0 errors,
**pytest 1177 passed / 1 skipped**, deterministic under seeds 42/7/1337.

## Limits (see the submission README for the full list)

- In-memory only — the seen-id window doesn't survive a process restart.
- Bounded window (`DEFAULT_REPLAY_WINDOW = 4096` ids per sender) — a replay
  old enough to be evicted would be accepted as new.
- No key exchange (inherited from `authenticated`: a fixed pre-shared
  `channel_secret` stands in for a real session key).
- Detects exact duplicate ids, not general reordering.
- Only tested inside Nanda Town's deterministic in-memory simulator.
