### PR TITLE
feat(registry): add dp_bloom, a differentially private registry with a membership-inference validator

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -25,6 +25,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("identity", "ed25519_rotating"): (f"{_REF}.identity.ed25519_rotating:Ed25519RotatingIdentity"),
     ("registry", "in_memory"): f"{_REF}.registry.in_memory:InMemoryRegistry",
     ("registry", "gossip"): f"{_REF}.registry.gossip:GossipRegistry",
+    ("registry", "dp_bloom"): f"{_REF}.registry.dp_bloom:DPBloomRegistry",
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",

--- a/packages/nest-plugins-reference/nest_plugins_reference/registry/dp_bloom.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/registry/dp_bloom.py
@@ -58,13 +58,16 @@ filter model of Naor and Yogev [1] and its learned extension by Almashaqbeh,
 Bishop, and Tirmazi [3].
 
 [1] Moni Naor and Eylon Yogev. Bloom Filters in Adversarial Environments. 2014.
-    arXiv:1412.8356.
+    `preprint <https://arxiv.org/abs/1412.8356>`_
 [2] Úlfar Erlingsson, Vasyl Pihur, and Aleksandra Korolova. RAPPOR: Randomized
     Aggregatable Privacy-Preserving Ordinal Response. ACM CCS, 2014.
+    `preprint <https://research.google.com/pubs/archive/42852.pdf>`_
 [3] Ghada Almashaqbeh, Allison Bishop, and Hayder Tirmazi. Adversary Resilient
-    Learned Bloom Filters. ASIACRYPT, 2025. arXiv:2409.06556.
+    Learned Bloom Filters. ASIACRYPT, 2025.
+    `preprint <https://arxiv.org/abs/2409.06556>`_
 [4] Hayder Tirmazi. Adversarially Robust Bloom Filters: Privacy, Reductions, and
-    Open Problems. 2025. arXiv:2501.15751.
+    Open Problems. 2025.
+    `preprint <https://arxiv.org/abs/2501.15751>`_
 
 Example::
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/registry/dp_bloom.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/registry/dp_bloom.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Differentially private registry: membership queries under an epsilon bound.
+
+The default registry plugin
+:class:`~nest_plugins_reference.registry.in_memory.InMemoryRegistry` answers
+*"who is registered, and what can they do?"* from a plain ``dict``. That is
+functionally correct and **operationally a privacy leak**: anyone who can query
+the registry (or read the published index off the wire) can enumerate the exact
+member set and every agent's capabilities. Membership is often the sensitive
+bit — that a given agent registered a ``sell_medical_data`` capability at all
+can be more revealing than any single message it later encrypts. The
+:doc:`registry wishlist </layers/registry>` calls out "capability queries";
+this plugin adds the query surface *and* a formal privacy guarantee over it.
+
+What it does
+------------
+
+``DPBloomRegistry`` serves legitimate ``lookup`` from a true card store, exactly
+like the in-memory reference (so scenarios that depend on discovery keep
+working). Alongside that, every registration is folded into a **published
+membership index** — a Bloom filter whose bits are perturbed by RAPPOR-style
+permanent randomized response before anyone outside the registry may read them.
+Curious peers and passive observers see only :meth:`published_index` and answer
+membership through :meth:`membership_query`; the raw card store never crosses
+that boundary. The index is what appears on the wire / in the trace, so the
+privacy claim is about the artifact an adversary can actually obtain.
+
+The guarantee
+-------------
+
+Fix the number of hashes ``k``. Inserting one member sets at most ``k`` bits of
+the true filter, so two registries whose member sets differ by a single agent
+(*neighboring* inputs) differ in at most ``k`` bit positions. Each published bit
+is flipped independently with probability ``p``; a single differing bit then
+satisfies ``Pr[r=1 | true=1] / Pr[r=1 | true=0] = (1 - p) / p``, i.e. per-bit
+``eps0 = ln((1 - p) / p)``. Sequential composition over the ``<= k`` differing
+bits gives ``eps = k * ln((1 - p) / p)`` — **epsilon-differential privacy with
+the unit of privacy being one agent's membership**. Solving for the flip
+probability that hits a target budget:
+
+    ``p = 1 / (1 + exp(eps / k))``
+
+So a caller asks for ``epsilon`` and ``k`` and the plugin calibrates ``p``.
+Smaller ``epsilon`` → ``p`` closer to ``1/2`` → more noise, stronger privacy,
+lower query accuracy. This is the classic membership/accuracy trade-off, made
+explicit rather than silent.
+
+Where the randomness lives (and why the trace is still deterministic)
+---------------------------------------------------------------------
+
+The privacy is over the mechanism's coin flips, and those flips are drawn once —
+RAPPOR calls this *permanent randomized response* / memoization — from a keyed
+PRF over a per-instance ``seed``. An adversary who does not hold the seed sees
+only the published bits and faces advantage at most ``e^eps``; that is the
+threat model. Fixing ``seed`` fixes one realization of the coin flips, which is
+what makes a Tier-1 trace byte-identical on replay. It does **not** weaken the
+guarantee for a seed-less adversary, any more than publishing a ciphertext
+weakens a cipher whose key stays secret. (Same stance ``trust_gated`` takes when
+it separates ``deterministic=True`` from its secure default.)
+
+Example::
+
+    reg = DPBloomRegistry(seed=b"reg-42", epsilon=1.0, num_hashes=5, num_bits=4096)
+    await reg.register(AgentCard(agent_id=AgentId("a1"), name="Seller", capabilities=["sell"]))
+    hits = await reg.lookup(Query(capabilities=["sell"]))       # true store, exact
+    observer_view = reg.published_index()                       # perturbed, epsilon-DP
+    maybe = reg.membership_query(observer_view, AgentId("a1"))  # noisy membership test
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import math
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+
+from nest_core.types import AgentCard, AgentId, Query
+
+_PRF_DOMAIN = b"nest/dp_bloom/flip/1"
+"""Domain-separation tag mixed into the flip PRF so the seed cannot collide with
+any other seeded use of the same bytes elsewhere in the stack."""
+
+
+def calibrate_flip_probability(epsilon: float, num_hashes: int) -> float:
+    """Return the per-bit flip probability that achieves ``epsilon``-DP.
+
+    Inverts ``eps = k * ln((1 - p) / p)`` for ``p``. The unit of privacy is one
+    agent's membership (at most ``k`` set bits), so the budget is split evenly
+    across the ``k`` hashes by sequential composition.
+
+    Example::
+
+        p = calibrate_flip_probability(epsilon=1.0, num_hashes=5)
+        assert 0.0 < p < 0.5
+    """
+    if epsilon <= 0.0:
+        msg = f"epsilon must be positive, got {epsilon}"
+        raise ValueError(msg)
+    if num_hashes <= 0:
+        msg = f"num_hashes must be positive, got {num_hashes}"
+        raise ValueError(msg)
+    return 1.0 / (1.0 + math.exp(epsilon / num_hashes))
+
+
+def epsilon_for(flip_probability: float, num_hashes: int) -> float:
+    """Return the epsilon guaranteed by a given flip probability and ``k``.
+
+    Inverse of :func:`calibrate_flip_probability`; used by the adversarial
+    validator to check that a plugin's *claimed* budget matches the noise it
+    actually injects.
+
+    Example::
+
+        eps = epsilon_for(0.1, num_hashes=5)
+        assert eps > 0
+    """
+    if not 0.0 < flip_probability < 0.5:
+        msg = f"flip_probability must be in (0, 0.5), got {flip_probability}"
+        raise ValueError(msg)
+    if num_hashes <= 0:
+        msg = f"num_hashes must be positive, got {num_hashes}"
+        raise ValueError(msg)
+    return num_hashes * math.log((1.0 - flip_probability) / flip_probability)
+
+
+@dataclass(frozen=True)
+class PublishedIndex:
+    """The observer-facing, epsilon-DP membership index for a registry snapshot.
+
+    Carries the perturbed Bloom bits plus the public parameters needed to run a
+    membership query. It deliberately does **not** carry the true card store, the
+    seed, or the un-perturbed bits — that is the whole point of the boundary.
+
+    Example::
+
+        idx = reg.published_index()
+        assert len(idx.bits) == idx.num_bits
+    """
+
+    bits: tuple[bool, ...]
+    num_bits: int
+    num_hashes: int
+    epsilon: float
+
+
+class DPBloomRegistry:
+    """Registry whose published membership index is epsilon-differentially private.
+
+    Implements the :class:`~nest_core.layers.registry.Registry` protocol.
+    ``lookup``/``subscribe`` behave like the in-memory reference (exact, served
+    from the true store) so discovery keeps working for legitimate agents; the
+    differential privacy applies to :meth:`published_index` and
+    :meth:`membership_query`, the surface an observer actually sees.
+
+    Example::
+
+        reg = DPBloomRegistry(seed=b"s", epsilon=1.0, num_hashes=5, num_bits=2048)
+        await reg.register(AgentCard(agent_id=AgentId("a1"), name="A", capabilities=["x"]))
+    """
+
+    def __init__(
+        self,
+        seed: bytes = b"",
+        *,
+        epsilon: float = 1.0,
+        num_hashes: int = 5,
+        num_bits: int = 4096,
+    ) -> None:
+        if num_bits <= 0:
+            msg = f"num_bits must be positive, got {num_bits}"
+            raise ValueError(msg)
+        self._seed = seed
+        self._epsilon = epsilon
+        self._num_hashes = num_hashes
+        self._num_bits = num_bits
+        self._flip_p = calibrate_flip_probability(epsilon, num_hashes)
+        self._cards: dict[AgentId, AgentCard] = {}
+        self._true_bits: list[bool] = [False] * num_bits
+        self._subscribers: list[asyncio.Queue[AgentCard]] = []
+
+    # -- introspection --------------------------------------------------------
+
+    @property
+    def epsilon(self) -> float:
+        """The privacy budget this registry's published index satisfies.
+
+        Example::
+
+            assert reg.epsilon > 0
+        """
+        return self._epsilon
+
+    @property
+    def flip_probability(self) -> float:
+        """Per-bit randomized-response flip probability (calibrated from epsilon).
+
+        Example::
+
+            assert 0.0 < reg.flip_probability < 0.5
+        """
+        return self._flip_p
+
+    # -- Bloom hashing --------------------------------------------------------
+
+    def _positions(self, token: str) -> list[int]:
+        """Deterministic ``k`` bit positions for a membership token.
+
+        Double hashing over SHA-256 halves — no external RNG, so positions are a
+        pure function of the token and reproduce byte-for-byte across runs.
+        """
+        digest = hashlib.sha256(token.encode("utf-8")).digest()
+        h1 = int.from_bytes(digest[:16], "big")
+        h2 = int.from_bytes(digest[16:], "big") | 1  # odd => full period
+        return [(h1 + i * h2) % self._num_bits for i in range(self._num_hashes)]
+
+    @staticmethod
+    def _tokens(card: AgentCard) -> list[str]:
+        """Membership tokens contributed by a card: the agent id and each capability.
+
+        Capabilities are namespaced so ``cap:sell`` cannot collide with an agent
+        literally named ``sell``.
+        """
+        tokens = [f"agent:{card.agent_id}"]
+        tokens.extend(f"cap:{cap}" for cap in card.capabilities)
+        return tokens
+
+    # -- randomized response --------------------------------------------------
+
+    def _flip(self, position: int) -> bool:
+        """Return the permanent RR coin for one bit (True => flip that bit).
+
+        Keyed by the secret seed, so the coins are unpredictable to a seed-less
+        adversary yet reproducible for the trace. Memoized-by-construction: the
+        same ``(seed, position)`` always yields the same coin.
+        """
+        material = _PRF_DOMAIN + self._seed + b"|" + position.to_bytes(8, "big")
+        draw = int.from_bytes(hashlib.sha256(material).digest()[:8], "big")
+        return draw / 2**64 < self._flip_p
+
+    def published_index(self) -> PublishedIndex:
+        """Return the epsilon-DP membership index an observer is allowed to read.
+
+        Applies permanent randomized response to the true Bloom bits. Calling it
+        repeatedly on the same registry state returns identical bits (the coins
+        are memoized via the seed), so it does not leak extra information through
+        re-sampling.
+
+        Example::
+
+            idx = reg.published_index()
+            assert idx.epsilon == reg.epsilon
+        """
+        bits = tuple(bit ^ self._flip(pos) for pos, bit in enumerate(self._true_bits))
+        return PublishedIndex(
+            bits=bits,
+            num_bits=self._num_bits,
+            num_hashes=self._num_hashes,
+            epsilon=self._epsilon,
+        )
+
+    def membership_query(self, index: PublishedIndex, agent: AgentId) -> bool:
+        """Test whether ``agent`` looks present in a published index.
+
+        The honest membership test on a (perturbed) Bloom filter: report present
+        iff every hashed position is set. Noise makes this answer probabilistic —
+        that imprecision is exactly the privacy — so a single query is evidence,
+        not proof, of membership.
+
+        Example::
+
+            present = reg.membership_query(reg.published_index(), AgentId("a1"))
+        """
+        return all(index.bits[pos] for pos in self._positions(f"agent:{agent}"))
+
+    # -- Registry protocol ----------------------------------------------------
+
+    async def register(self, card: AgentCard) -> None:
+        """Register a card in the true store and fold it into the DP index.
+
+        Example::
+
+            await reg.register(AgentCard(agent_id=AgentId("a1"), name="A"))
+        """
+        self._cards[card.agent_id] = card
+        for token in self._tokens(card):
+            for pos in self._positions(token):
+                self._true_bits[pos] = True
+        for q in self._subscribers:
+            await q.put(card)
+
+    async def lookup(self, query: Query) -> list[AgentCard]:
+        """Look up agents matching ``query`` (exact, from the true store).
+
+        Example::
+
+            hits = await reg.lookup(Query(capabilities=["sell"]))
+        """
+        return [card for card in self._cards.values() if self._matches(card, query)]
+
+    async def subscribe(self, query: Query) -> AsyncIterator[AgentCard]:
+        """Subscribe to future registrations matching ``query``.
+
+        Example::
+
+            async for card in reg.subscribe(Query(capabilities=["sell"])):
+                ...
+        """
+        q: asyncio.Queue[AgentCard] = asyncio.Queue()
+        self._subscribers.append(q)
+        try:
+            while True:
+                card = await q.get()
+                if self._matches(card, query):
+                    yield card
+        finally:
+            self._subscribers.remove(q)
+
+    async def deregister(self, agent: AgentId) -> None:
+        """Remove an agent from the true store.
+
+        Note: the DP index is monotone (bits are not cleared) because a Bloom
+        filter cannot un-set a bit shared with another member without corrupting
+        it. Deregistration therefore hides *future* lookups but leaves the
+        agent's historical membership bits in the index until the filter is
+        rebuilt — a deliberate, documented limitation, not a bug.
+
+        Example::
+
+            await reg.deregister(AgentId("a1"))
+        """
+        self._cards.pop(agent, None)
+
+    @staticmethod
+    def _matches(card: AgentCard, query: Query) -> bool:
+        if query.capabilities and not all(cap in card.capabilities for cap in query.capabilities):
+            return False
+        return not (query.name_pattern and query.name_pattern not in card.name)

--- a/packages/nest-plugins-reference/nest_plugins_reference/registry/dp_bloom.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/registry/dp_bloom.py
@@ -1,70 +1,78 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Differentially private registry: membership queries under an epsilon bound.
+"""Differentially private registry with a bounded membership leak.
 
-The default registry plugin
-:class:`~nest_plugins_reference.registry.in_memory.InMemoryRegistry` answers
-*"who is registered, and what can they do?"* from a plain ``dict``. That is
-functionally correct and **operationally a privacy leak**: anyone who can query
-the registry (or read the published index off the wire) can enumerate the exact
-member set and every agent's capabilities. Membership is often the sensitive
-bit — that a given agent registered a ``sell_medical_data`` capability at all
-can be more revealing than any single message it later encrypts. The
-:doc:`registry wishlist </layers/registry>` calls out "capability queries";
-this plugin adds the query surface *and* a formal privacy guarantee over it.
+The default registry answers who is registered and what each agent can do
+exactly. A caller reads the answer from a plain dict. The behavior is correct
+for discovery and it leaks membership. Anyone who queries the registry, or reads
+the published index off the wire, recovers the full member set and every
+advertised capability. Membership is often the sensitive fact. That an agent
+registered a ``sell_medical_data`` capability at all can reveal more than any
+message the agent later encrypts. ``DPBloomRegistry`` adds a capability-query
+surface and gives it a formal privacy guarantee.
 
 What it does
-------------
 
 ``DPBloomRegistry`` serves legitimate ``lookup`` from a true card store, exactly
-like the in-memory reference (so scenarios that depend on discovery keep
-working). Alongside that, every registration is folded into a **published
-membership index** — a Bloom filter whose bits are perturbed by RAPPOR-style
-permanent randomized response before anyone outside the registry may read them.
-Curious peers and passive observers see only :meth:`published_index` and answer
-membership through :meth:`membership_query`; the raw card store never crosses
-that boundary. The index is what appears on the wire / in the trace, so the
-privacy claim is about the artifact an adversary can actually obtain.
+like the in-memory reference, so discovery keeps working. Every registration
+also folds into a published membership index. The index is a Bloom filter whose
+bits are perturbed by RAPPOR-style permanent randomized response [2] before
+anyone outside the registry reads them. Curious peers and passive observers see only
+:meth:`published_index` and test membership through :meth:`membership_query`. The
+raw card store never crosses that boundary. The published index is the artifact
+an adversary can obtain, so the privacy claim is about the index, not the store.
 
 The guarantee
--------------
 
 Fix the number of hashes ``k``. Inserting one member sets at most ``k`` bits of
 the true filter, so two registries whose member sets differ by a single agent
-(*neighboring* inputs) differ in at most ``k`` bit positions. Each published bit
-is flipped independently with probability ``p``; a single differing bit then
-satisfies ``Pr[r=1 | true=1] / Pr[r=1 | true=0] = (1 - p) / p``, i.e. per-bit
-``eps0 = ln((1 - p) / p)``. Sequential composition over the ``<= k`` differing
-bits gives ``eps = k * ln((1 - p) / p)`` — **epsilon-differential privacy with
-the unit of privacy being one agent's membership**. Solving for the flip
-probability that hits a target budget:
+differ in at most ``k`` bit positions. The plugin flips each published bit
+independently with probability ``p``. A single differing bit then satisfies
+``Pr[r=1 | true=1] / Pr[r=1 | true=0] = (1 - p) / p``, so the per-bit budget is
+``eps0 = ln((1 - p) / p)``. Sequential composition over the at most ``k``
+differing bits gives ``eps = k * ln((1 - p) / p)``, which is
+epsilon-differential privacy with one agent's membership as the unit of privacy.
+Inverting for a target budget gives the calibrated flip probability
+``p = 1 / (1 + exp(eps / k))``. A smaller ``eps`` moves ``p`` toward ``1/2``,
+which adds noise, strengthens privacy, and lowers query accuracy. The trade-off
+between membership privacy and query accuracy stays explicit rather than silent.
 
-    ``p = 1 / (1 + exp(eps / k))``
+Randomness and determinism
 
-So a caller asks for ``epsilon`` and ``k`` and the plugin calibrates ``p``.
-Smaller ``epsilon`` → ``p`` closer to ``1/2`` → more noise, stronger privacy,
-lower query accuracy. This is the classic membership/accuracy trade-off, made
-explicit rather than silent.
+Differential privacy is a property of the mechanism's coin flips. The plugin
+draws those flips once from a keyed PRF over a secret per-instance ``seed``,
+following RAPPOR memoization [2]. An adversary without the seed observes only the
+published bits and gains advantage at most ``e^eps``. Fixing the seed fixes one
+draw of the coins and makes a Tier 1 trace byte-identical on replay. A fixed
+seed does not weaken the guarantee for a seedless adversary, the same way
+publishing a ciphertext does not weaken a cipher whose key stays secret. The
+``trust_gated`` plugin takes the same stance when it separates
+``deterministic=True`` from its secure default.
 
-Where the randomness lives (and why the trace is still deterministic)
----------------------------------------------------------------------
+References
 
-The privacy is over the mechanism's coin flips, and those flips are drawn once —
-RAPPOR calls this *permanent randomized response* / memoization — from a keyed
-PRF over a per-instance ``seed``. An adversary who does not hold the seed sees
-only the published bits and faces advantage at most ``e^eps``; that is the
-threat model. Fixing ``seed`` fixes one realization of the coin flips, which is
-what makes a Tier-1 trace byte-identical on replay. It does **not** weaken the
-guarantee for a seed-less adversary, any more than publishing a ciphertext
-weakens a cipher whose key stays secret. (Same stance ``trust_gated`` takes when
-it separates ``deterministic=True`` from its secure default.)
+The mechanism composes two lines of prior work. Randomized response over the
+filter bits, and the memoization that fixes each instance's coins once, follow
+RAPPOR [2]. The membership-privacy goal and the differentially private Bloom
+filter construction follow Tirmazi [4], which builds on the adversarial Bloom
+filter model of Naor and Yogev [1] and its learned extension by Almashaqbeh,
+Bishop, and Tirmazi [3].
+
+[1] Moni Naor and Eylon Yogev. Bloom Filters in Adversarial Environments. 2014.
+    arXiv:1412.8356.
+[2] Úlfar Erlingsson, Vasyl Pihur, and Aleksandra Korolova. RAPPOR: Randomized
+    Aggregatable Privacy-Preserving Ordinal Response. ACM CCS, 2014.
+[3] Ghada Almashaqbeh, Allison Bishop, and Hayder Tirmazi. Adversary Resilient
+    Learned Bloom Filters. ASIACRYPT, 2025. arXiv:2409.06556.
+[4] Hayder Tirmazi. Adversarially Robust Bloom Filters: Privacy, Reductions, and
+    Open Problems. 2025. arXiv:2501.15751.
 
 Example::
 
     reg = DPBloomRegistry(seed=b"reg-42", epsilon=1.0, num_hashes=5, num_bits=4096)
     await reg.register(AgentCard(agent_id=AgentId("a1"), name="Seller", capabilities=["sell"]))
-    hits = await reg.lookup(Query(capabilities=["sell"]))       # true store, exact
-    observer_view = reg.published_index()                       # perturbed, epsilon-DP
-    maybe = reg.membership_query(observer_view, AgentId("a1"))  # noisy membership test
+    hits = await reg.lookup(Query(capabilities=["sell"]))
+    observer_view = reg.published_index()
+    maybe = reg.membership_query(observer_view, AgentId("a1"))
 """
 
 from __future__ import annotations
@@ -78,16 +86,16 @@ from dataclasses import dataclass
 from nest_core.types import AgentCard, AgentId, Query
 
 _PRF_DOMAIN = b"nest/dp_bloom/flip/1"
-"""Domain-separation tag mixed into the flip PRF so the seed cannot collide with
-any other seeded use of the same bytes elsewhere in the stack."""
+"""Domain-separation tag for the flip PRF. The tag stops the seed from colliding
+with any other seeded use of the same bytes in the stack."""
 
 
 def calibrate_flip_probability(epsilon: float, num_hashes: int) -> float:
     """Return the per-bit flip probability that achieves ``epsilon``-DP.
 
-    Inverts ``eps = k * ln((1 - p) / p)`` for ``p``. The unit of privacy is one
-    agent's membership (at most ``k`` set bits), so the budget is split evenly
-    across the ``k`` hashes by sequential composition.
+    The function inverts ``eps = k * ln((1 - p) / p)`` for ``p``. Sequential
+    composition splits the budget evenly across the ``k`` hashes, so the unit of
+    privacy is one agent's membership at its at most ``k`` set bits.
 
     Example::
 
@@ -106,9 +114,9 @@ def calibrate_flip_probability(epsilon: float, num_hashes: int) -> float:
 def epsilon_for(flip_probability: float, num_hashes: int) -> float:
     """Return the epsilon guaranteed by a given flip probability and ``k``.
 
-    Inverse of :func:`calibrate_flip_probability`; used by the adversarial
-    validator to check that a plugin's *claimed* budget matches the noise it
-    actually injects.
+    The function is the inverse of :func:`calibrate_flip_probability`. The
+    adversarial validator uses it to check that a plugin's claimed budget matches
+    the noise the plugin actually injects.
 
     Example::
 
@@ -128,9 +136,9 @@ def epsilon_for(flip_probability: float, num_hashes: int) -> float:
 class PublishedIndex:
     """The observer-facing, epsilon-DP membership index for a registry snapshot.
 
-    Carries the perturbed Bloom bits plus the public parameters needed to run a
-    membership query. It deliberately does **not** carry the true card store, the
-    seed, or the un-perturbed bits — that is the whole point of the boundary.
+    The index carries the perturbed Bloom bits and the public parameters a
+    membership query needs. The index omits the true card store, the seed, and
+    the unperturbed bits, which is the whole point of the boundary.
 
     Example::
 
@@ -147,11 +155,12 @@ class PublishedIndex:
 class DPBloomRegistry:
     """Registry whose published membership index is epsilon-differentially private.
 
-    Implements the :class:`~nest_core.layers.registry.Registry` protocol.
-    ``lookup``/``subscribe`` behave like the in-memory reference (exact, served
-    from the true store) so discovery keeps working for legitimate agents; the
-    differential privacy applies to :meth:`published_index` and
-    :meth:`membership_query`, the surface an observer actually sees.
+    The class implements the :class:`~nest_core.layers.registry.Registry`
+    protocol. ``lookup`` and ``subscribe`` behave like the in-memory reference
+    and serve exact results from the true store, so discovery keeps working for
+    legitimate agents. The differential privacy applies to
+    :meth:`published_index` and :meth:`membership_query`, the surface an observer
+    actually sees.
 
     Example::
 
@@ -179,8 +188,6 @@ class DPBloomRegistry:
         self._true_bits: list[bool] = [False] * num_bits
         self._subscribers: list[asyncio.Queue[AgentCard]] = []
 
-    # -- introspection --------------------------------------------------------
-
     @property
     def epsilon(self) -> float:
         """The privacy budget this registry's published index satisfies.
@@ -193,7 +200,7 @@ class DPBloomRegistry:
 
     @property
     def flip_probability(self) -> float:
-        """Per-bit randomized-response flip probability (calibrated from epsilon).
+        """Per-bit randomized-response flip probability, calibrated from epsilon.
 
         Example::
 
@@ -201,50 +208,47 @@ class DPBloomRegistry:
         """
         return self._flip_p
 
-    # -- Bloom hashing --------------------------------------------------------
-
     def _positions(self, token: str) -> list[int]:
         """Deterministic ``k`` bit positions for a membership token.
 
-        Double hashing over SHA-256 halves — no external RNG, so positions are a
-        pure function of the token and reproduce byte-for-byte across runs.
+        Double hashing over the two halves of a SHA-256 digest replaces an
+        external RNG, so the positions are a pure function of the token and
+        reproduce byte-for-byte across runs.
         """
         digest = hashlib.sha256(token.encode("utf-8")).digest()
         h1 = int.from_bytes(digest[:16], "big")
-        h2 = int.from_bytes(digest[16:], "big") | 1  # odd => full period
+        h2 = int.from_bytes(digest[16:], "big") | 1  # an odd step visits every bucket
         return [(h1 + i * h2) % self._num_bits for i in range(self._num_hashes)]
 
     @staticmethod
     def _tokens(card: AgentCard) -> list[str]:
-        """Membership tokens contributed by a card: the agent id and each capability.
+        """Membership tokens a card contributes: its agent id and each capability.
 
-        Capabilities are namespaced so ``cap:sell`` cannot collide with an agent
-        literally named ``sell``.
+        The ``cap:`` prefix namespaces capabilities so ``cap:sell`` cannot
+        collide with an agent literally named ``sell``.
         """
         tokens = [f"agent:{card.agent_id}"]
         tokens.extend(f"cap:{cap}" for cap in card.capabilities)
         return tokens
 
-    # -- randomized response --------------------------------------------------
-
     def _flip(self, position: int) -> bool:
-        """Return the permanent RR coin for one bit (True => flip that bit).
+        """Return the permanent randomized-response coin for one bit.
 
-        Keyed by the secret seed, so the coins are unpredictable to a seed-less
-        adversary yet reproducible for the trace. Memoized-by-construction: the
-        same ``(seed, position)`` always yields the same coin.
+        A ``True`` result means flip the bit. The secret seed keys the draw, so
+        the coins stay unpredictable to a seedless adversary and reproducible for
+        the trace. The draw is memoized by construction, so the same ``seed`` and
+        ``position`` always yield the same coin.
         """
         material = _PRF_DOMAIN + self._seed + b"|" + position.to_bytes(8, "big")
         draw = int.from_bytes(hashlib.sha256(material).digest()[:8], "big")
         return draw / 2**64 < self._flip_p
 
     def published_index(self) -> PublishedIndex:
-        """Return the epsilon-DP membership index an observer is allowed to read.
+        """Return the epsilon-DP membership index an observer may read.
 
-        Applies permanent randomized response to the true Bloom bits. Calling it
-        repeatedly on the same registry state returns identical bits (the coins
-        are memoized via the seed), so it does not leak extra information through
-        re-sampling.
+        The method applies permanent randomized response to the true Bloom bits.
+        Repeated calls on the same registry state return identical bits because
+        the seed memoizes the coins, so re-sampling leaks nothing extra.
 
         Example::
 
@@ -262,18 +266,16 @@ class DPBloomRegistry:
     def membership_query(self, index: PublishedIndex, agent: AgentId) -> bool:
         """Test whether ``agent`` looks present in a published index.
 
-        The honest membership test on a (perturbed) Bloom filter: report present
-        iff every hashed position is set. Noise makes this answer probabilistic —
-        that imprecision is exactly the privacy — so a single query is evidence,
-        not proof, of membership.
+        The test reports present when every hashed position is set, the standard
+        membership test on a Bloom filter. Noise makes the answer probabilistic,
+        and that imprecision is the privacy, so a single query is evidence rather
+        than proof of membership.
 
         Example::
 
             present = reg.membership_query(reg.published_index(), AgentId("a1"))
         """
         return all(index.bits[pos] for pos in self._positions(f"agent:{agent}"))
-
-    # -- Registry protocol ----------------------------------------------------
 
     async def register(self, card: AgentCard) -> None:
         """Register a card in the true store and fold it into the DP index.
@@ -290,7 +292,7 @@ class DPBloomRegistry:
             await q.put(card)
 
     async def lookup(self, query: Query) -> list[AgentCard]:
-        """Look up agents matching ``query`` (exact, from the true store).
+        """Look up agents matching ``query`` with exact results from the true store.
 
         Example::
 
@@ -319,11 +321,11 @@ class DPBloomRegistry:
     async def deregister(self, agent: AgentId) -> None:
         """Remove an agent from the true store.
 
-        Note: the DP index is monotone (bits are not cleared) because a Bloom
-        filter cannot un-set a bit shared with another member without corrupting
-        it. Deregistration therefore hides *future* lookups but leaves the
-        agent's historical membership bits in the index until the filter is
-        rebuilt — a deliberate, documented limitation, not a bug.
+        The DP index is monotone because a Bloom filter cannot clear a bit it
+        shares with another member without corrupting it. Deregistration hides
+        future lookups but leaves the agent's historical membership bits in the
+        index until the filter rebuilds. The residue is a documented limitation,
+        not a bug.
 
         Example::
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/dp_bloom_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/dp_bloom_validators.py
@@ -1,41 +1,38 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Adversarial validator for the ``dp_bloom`` registry: membership inference.
+"""Adversarial validator for the ``dp_bloom`` registry.
 
-The attack the default ``in_memory`` registry silently allows is **membership
-inference**: an adversary who can read the registry's observable membership
-surface decides, for a target agent, whether that agent is registered. Against a
-plain registry this is not an attack so much as a lookup — the surface *is* the
-member set, so the adversary is always right. That is the leak ``dp_bloom`` is
-built to bound.
+The attack the default ``in_memory`` registry allows is membership inference. An
+adversary reads the registry's observable membership surface and decides, for a
+target agent, whether that agent registered. Against a plain registry the task is
+a lookup rather than an attack. The observable surface is the member set, so the
+adversary is always right. Bounding that leak is what ``dp_bloom`` is built for.
+The framing follows the adversarial Bloom filter literature cited in
+:mod:`nest_plugins_reference.registry.dp_bloom`.
 
-The game (a standard DP membership-inference experiment)
---------------------------------------------------------
+The game
 
-For a fixed target agent, compare two neighboring worlds:
-
-* **present** — the registry holds a background set *plus* the target;
-* **absent**  — the registry holds only the background set.
-
-An oracle plays one world under one seed and returns the single bit the
-adversary observes: *does the target look registered?* Sweeping the seed bank
-estimates ``p1 = Pr[reported present | present]`` and
-``p0 = Pr[reported present | absent]``. The adversary's distinguishing power is
-the larger log-likelihood ratio across the two possible reports, which is
-exactly an empirical epsilon:
+For a fixed target agent the validator compares two neighboring worlds. In the
+present world the registry holds a background set and the target. In the absent
+world the registry holds only the background set. An oracle plays one world under
+one seed and returns the single bit the adversary observes, namely whether the
+target looks registered. Sweeping the seed bank estimates
+``p1 = Pr[reported present | present]`` and ``p0 = Pr[reported present | absent]``.
+The adversary's distinguishing power is the larger log-likelihood ratio across
+the two possible reports, which is an empirical epsilon.
 
     ``eps_hat = max( |ln(p1/p0)|, |ln((1-p1)/(1-p0))| )``
 
-By the post-processing property of differential privacy, any function of an
-``epsilon``-DP published index — and :meth:`DPBloomRegistry.membership_query` is
-one — is itself ``epsilon``-DP, so a correctly calibrated ``dp_bloom`` yields
-``eps_hat`` at or below its claimed budget (up to finite-sample slack). A registry
-that answers membership exactly yields ``p1 = 1, p0 = 0`` and an unbounded
-``eps_hat`` — it cannot satisfy any finite budget, which is the charter's bar for
-an adversarial validator that the reference plugin must fail.
+The membership query reads only an epsilon-DP published index, so by the
+post-processing property of differential privacy the query is itself epsilon-DP.
+A correctly calibrated ``dp_bloom`` therefore yields ``eps_hat`` at or below its
+claimed budget, allowing for finite-sample slack. A registry that answers
+membership exactly yields ``p1 = 1`` and ``p0 = 0`` and an unbounded ``eps_hat``.
+The exact registry cannot satisfy any finite budget, which is the charter's bar
+for an adversarial validator that the reference plugin must fail.
 
-Probabilities are Jeffreys-smoothed (add ``0.5``) so a deterministic leaker maps
-to a large-but-finite ``eps_hat`` rather than a raw division by zero, keeping the
-report a clean numeric comparison.
+The validator Jeffreys-smooths the probabilities by adding ``0.5`` to each count,
+so a deterministic leaker maps to a large but finite ``eps_hat`` rather than a raw
+division by zero, and the report stays a clean numeric comparison.
 
 Example::
 
@@ -52,19 +49,21 @@ from nest_plugins_reference.validators.gossip_validators import ValidatorReport
 
 MembershipOracle = Callable[[int, bool], bool]
 """Plays the game under one seed. ``oracle(seed, include_target)`` builds the
-registry (background set, plus the target iff ``include_target``) seeded by
-``seed`` and returns the membership bit an adversary observes for the target."""
+registry with the background set, adds the target when ``include_target`` is true,
+seeds the mechanism with ``seed``, and returns the membership bit an adversary
+observes for the target."""
 
 _DEFAULT_SEEDS = 400
-"""Seed-bank size. Large enough that ``p0 = Pr[present | absent]`` (roughly
-``p**k``) is estimated from several hits, small enough that the validator runs in
-well under a second on the tiny filters used in scenarios."""
+"""Seed-bank size. The bank is large enough to estimate
+``p0 = Pr[present | absent]``, which is roughly ``p**k``, from several hits, and
+small enough that the validator runs in well under a second on the tiny filters
+scenarios use."""
 
 _DEFAULT_SLACK = 1.0
-"""Additive tolerance on the epsilon bound, absorbing finite-sample variance and
-Jeffreys-smoothing bias. Comfortably separates a calibrated ``dp_bloom``
-(``eps_hat`` near the budget) from an exact registry (``eps_hat`` in the 6-7 range
-for this bank)."""
+"""Additive tolerance on the epsilon bound. The slack absorbs finite-sample
+variance and Jeffreys-smoothing bias. A calibrated ``dp_bloom`` sits near the
+budget while an exact registry sits in the 6 to 7 range for this bank, so the
+slack separates the two comfortably."""
 
 
 def _smoothed(hits: int, total: int) -> float:
@@ -75,8 +74,9 @@ def _smoothed(hits: int, total: int) -> float:
 def empirical_epsilon(hits_present: int, n_present: int, hits_absent: int, n_absent: int) -> float:
     """Return the empirical epsilon of a membership-inference game's counts.
 
-    ``hits_*`` count seeds under which the adversary saw *reported present*;
-    ``n_*`` are the seed totals for each world.
+    ``hits_present`` and ``hits_absent`` count the seeds under which the adversary
+    saw a reported-present outcome. ``n_present`` and ``n_absent`` are the seed
+    totals for each world.
 
     Example::
 
@@ -99,15 +99,15 @@ def check_membership_inference_bounded(
 ) -> ValidatorReport:
     """Assert a registry's membership surface leaks no more than ``claimed_epsilon``.
 
-    Runs the two-world game over seeds ``0 .. num_seeds - 1`` (deterministic, so
-    the report replays byte-identically) and passes iff the empirical epsilon is
-    within ``claimed_epsilon + slack``.
+    The check runs the two-world game over seeds ``0`` to ``num_seeds - 1``. The
+    sweep is deterministic, so the report replays byte-identically. The check
+    passes when the empirical epsilon is within ``claimed_epsilon + slack``.
 
-    * Against ``dp_bloom`` calibrated to ``claimed_epsilon`` the bound holds
-      (post-processing of an epsilon-DP index), so it **passes**.
-    * Against ``in_memory`` the target is reported present iff it is registered,
-      giving an unbounded empirical epsilon, so it **fails** — the validator
-      cannot be satisfied by the exact reference registry.
+    A ``dp_bloom`` calibrated to ``claimed_epsilon`` holds the bound because the
+    membership query is post-processing of an epsilon-DP index, so it passes. The
+    exact ``in_memory`` registry reports the target present exactly when it is
+    registered, which gives an unbounded empirical epsilon, so it fails. The exact
+    reference registry cannot satisfy the check.
 
     Example::
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/dp_bloom_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/dp_bloom_validators.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validator for the ``dp_bloom`` registry: membership inference.
+
+The attack the default ``in_memory`` registry silently allows is **membership
+inference**: an adversary who can read the registry's observable membership
+surface decides, for a target agent, whether that agent is registered. Against a
+plain registry this is not an attack so much as a lookup — the surface *is* the
+member set, so the adversary is always right. That is the leak ``dp_bloom`` is
+built to bound.
+
+The game (a standard DP membership-inference experiment)
+--------------------------------------------------------
+
+For a fixed target agent, compare two neighboring worlds:
+
+* **present** — the registry holds a background set *plus* the target;
+* **absent**  — the registry holds only the background set.
+
+An oracle plays one world under one seed and returns the single bit the
+adversary observes: *does the target look registered?* Sweeping the seed bank
+estimates ``p1 = Pr[reported present | present]`` and
+``p0 = Pr[reported present | absent]``. The adversary's distinguishing power is
+the larger log-likelihood ratio across the two possible reports, which is
+exactly an empirical epsilon:
+
+    ``eps_hat = max( |ln(p1/p0)|, |ln((1-p1)/(1-p0))| )``
+
+By the post-processing property of differential privacy, any function of an
+``epsilon``-DP published index — and :meth:`DPBloomRegistry.membership_query` is
+one — is itself ``epsilon``-DP, so a correctly calibrated ``dp_bloom`` yields
+``eps_hat`` at or below its claimed budget (up to finite-sample slack). A registry
+that answers membership exactly yields ``p1 = 1, p0 = 0`` and an unbounded
+``eps_hat`` — it cannot satisfy any finite budget, which is the charter's bar for
+an adversarial validator that the reference plugin must fail.
+
+Probabilities are Jeffreys-smoothed (add ``0.5``) so a deterministic leaker maps
+to a large-but-finite ``eps_hat`` rather than a raw division by zero, keeping the
+report a clean numeric comparison.
+
+Example::
+
+    report = check_membership_inference_bounded(oracle, claimed_epsilon=3.0)
+    assert report.passed, report.detail
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+
+from nest_plugins_reference.validators.gossip_validators import ValidatorReport
+
+MembershipOracle = Callable[[int, bool], bool]
+"""Plays the game under one seed. ``oracle(seed, include_target)`` builds the
+registry (background set, plus the target iff ``include_target``) seeded by
+``seed`` and returns the membership bit an adversary observes for the target."""
+
+_DEFAULT_SEEDS = 400
+"""Seed-bank size. Large enough that ``p0 = Pr[present | absent]`` (roughly
+``p**k``) is estimated from several hits, small enough that the validator runs in
+well under a second on the tiny filters used in scenarios."""
+
+_DEFAULT_SLACK = 1.0
+"""Additive tolerance on the epsilon bound, absorbing finite-sample variance and
+Jeffreys-smoothing bias. Comfortably separates a calibrated ``dp_bloom``
+(``eps_hat`` near the budget) from an exact registry (``eps_hat`` in the 6-7 range
+for this bank)."""
+
+
+def _smoothed(hits: int, total: int) -> float:
+    """Jeffreys-smoothed probability of the observed outcome."""
+    return (hits + 0.5) / (total + 1.0)
+
+
+def empirical_epsilon(hits_present: int, n_present: int, hits_absent: int, n_absent: int) -> float:
+    """Return the empirical epsilon of a membership-inference game's counts.
+
+    ``hits_*`` count seeds under which the adversary saw *reported present*;
+    ``n_*`` are the seed totals for each world.
+
+    Example::
+
+        eps = empirical_epsilon(hits_present=200, n_present=400, hits_absent=8, n_absent=400)
+        assert eps > 0
+    """
+    p1 = _smoothed(hits_present, n_present)
+    p0 = _smoothed(hits_absent, n_absent)
+    ratio_present = abs(math.log(p1) - math.log(p0))
+    ratio_absent = abs(math.log(1.0 - p1) - math.log(1.0 - p0))
+    return max(ratio_present, ratio_absent)
+
+
+def check_membership_inference_bounded(
+    oracle: MembershipOracle,
+    claimed_epsilon: float,
+    *,
+    num_seeds: int = _DEFAULT_SEEDS,
+    slack: float = _DEFAULT_SLACK,
+) -> ValidatorReport:
+    """Assert a registry's membership surface leaks no more than ``claimed_epsilon``.
+
+    Runs the two-world game over seeds ``0 .. num_seeds - 1`` (deterministic, so
+    the report replays byte-identically) and passes iff the empirical epsilon is
+    within ``claimed_epsilon + slack``.
+
+    * Against ``dp_bloom`` calibrated to ``claimed_epsilon`` the bound holds
+      (post-processing of an epsilon-DP index), so it **passes**.
+    * Against ``in_memory`` the target is reported present iff it is registered,
+      giving an unbounded empirical epsilon, so it **fails** — the validator
+      cannot be satisfied by the exact reference registry.
+
+    Example::
+
+        report = check_membership_inference_bounded(dp_bloom_oracle, 3.0)
+        assert report.passed, report.detail
+    """
+    hits_present = sum(1 for seed in range(num_seeds) if oracle(seed, True))
+    hits_absent = sum(1 for seed in range(num_seeds) if oracle(seed, False))
+    eps_hat = empirical_epsilon(hits_present, num_seeds, hits_absent, num_seeds)
+    threshold = claimed_epsilon + slack
+    evidence: dict[str, object] = {
+        "empirical_epsilon": eps_hat,
+        "claimed_epsilon": claimed_epsilon,
+        "threshold": threshold,
+        "hits_present": hits_present,
+        "hits_absent": hits_absent,
+        "num_seeds": num_seeds,
+    }
+    if eps_hat > threshold:
+        return ValidatorReport(
+            passed=False,
+            detail=(
+                f"membership inference leaks eps_hat={eps_hat:.2f} > "
+                f"claimed {claimed_epsilon:.2f} + slack {slack:.2f}"
+            ),
+            evidence=evidence,
+        )
+    return ValidatorReport(
+        passed=True,
+        detail=f"membership inference bounded: eps_hat={eps_hat:.2f} <= {threshold:.2f}",
+        evidence=evidence,
+    )

--- a/packages/nest-plugins-reference/tests/test_dp_bloom.py
+++ b/packages/nest-plugins-reference/tests/test_dp_bloom.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the ``dp_bloom`` differentially private registry and its validator.
 
-Covers four things: the epsilon<->flip-probability calibration is a correct
-inverse pair; legitimate ``lookup`` stays exact (differential privacy applies to
-the *published* index, not to in-registry discovery); the published index is
-byte-deterministic under a fixed seed and seed-sensitive across seeds; and the
-adversarial membership-inference validator PASSES ``dp_bloom`` while FAILING the
-exact ``in_memory`` reference — the charter's mandatory FAIL/PASS gate.
+The suite covers four properties. The epsilon and flip-probability calibration
+is a correct inverse pair. Legitimate ``lookup`` stays exact, since differential
+privacy applies to the published index and not to in-registry discovery. The
+published index is byte-deterministic under a fixed seed and seed-sensitive
+across seeds. The adversarial membership-inference validator passes ``dp_bloom``
+and fails the exact ``in_memory`` reference, which is the charter's mandatory
+fail-then-pass gate.
 """
 
 from __future__ import annotations
@@ -34,9 +35,6 @@ _BACKGROUND = [
 _TARGET = AgentCard(agent_id=AgentId("target"), name="Target", capabilities=["sell"])
 
 
-# -- calibration --------------------------------------------------------------
-
-
 def test_calibration_is_an_inverse_pair() -> None:
     p = calibrate_flip_probability(_EPS, _K)
     assert 0.0 < p < 0.5
@@ -54,9 +52,6 @@ def test_non_positive_epsilon_rejected(bad: float) -> None:
         calibrate_flip_probability(bad, _K)
 
 
-# -- functionality preserved --------------------------------------------------
-
-
 def test_lookup_is_exact_despite_privacy() -> None:
     reg = DPBloomRegistry(seed=b"s", epsilon=_EPS, num_hashes=_K, num_bits=_BITS)
 
@@ -68,9 +63,6 @@ def test_lookup_is_exact_despite_privacy() -> None:
 
     hits = asyncio.run(run())
     assert {c.agent_id for c in hits} == {c.agent_id for c in _BACKGROUND}
-
-
-# -- determinism --------------------------------------------------------------
 
 
 def _build_index_bits(seed: bytes) -> tuple[bool, ...]:
@@ -91,9 +83,6 @@ def test_published_index_is_deterministic_under_fixed_seed() -> None:
 def test_published_index_depends_on_seed() -> None:
     # Different secret seeds draw different randomized-response coins.
     assert _build_index_bits(b"seed-42") != _build_index_bits(b"seed-7")
-
-
-# -- adversarial FAIL/PASS gate ----------------------------------------------
 
 
 def _dp_bloom_oracle(seed: int, include_target: bool) -> bool:

--- a/packages/nest-plugins-reference/tests/test_dp_bloom.py
+++ b/packages/nest-plugins-reference/tests/test_dp_bloom.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``dp_bloom`` differentially private registry and its validator.
+
+Covers four things: the epsilon<->flip-probability calibration is a correct
+inverse pair; legitimate ``lookup`` stays exact (differential privacy applies to
+the *published* index, not to in-registry discovery); the published index is
+byte-deterministic under a fixed seed and seed-sensitive across seeds; and the
+adversarial membership-inference validator PASSES ``dp_bloom`` while FAILING the
+exact ``in_memory`` reference — the charter's mandatory FAIL/PASS gate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from nest_core.types import AgentCard, AgentId, Query
+from nest_plugins_reference.registry.dp_bloom import (
+    DPBloomRegistry,
+    calibrate_flip_probability,
+    epsilon_for,
+)
+from nest_plugins_reference.registry.in_memory import InMemoryRegistry
+from nest_plugins_reference.validators.dp_bloom_validators import (
+    check_membership_inference_bounded,
+)
+
+_EPS = 3.0
+_K = 3
+_BITS = 512
+_BACKGROUND = [
+    AgentCard(agent_id=AgentId(f"bg-{i}"), name=f"BG{i}", capabilities=["sell"]) for i in range(8)
+]
+_TARGET = AgentCard(agent_id=AgentId("target"), name="Target", capabilities=["sell"])
+
+
+# -- calibration --------------------------------------------------------------
+
+
+def test_calibration_is_an_inverse_pair() -> None:
+    p = calibrate_flip_probability(_EPS, _K)
+    assert 0.0 < p < 0.5
+    assert epsilon_for(p, _K) == pytest.approx(_EPS)
+
+
+def test_smaller_epsilon_means_more_noise() -> None:
+    # A tighter privacy budget must push the flip probability toward 1/2.
+    assert calibrate_flip_probability(1.0, _K) > calibrate_flip_probability(3.0, _K)
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0])
+def test_non_positive_epsilon_rejected(bad: float) -> None:
+    with pytest.raises(ValueError, match="epsilon must be positive"):
+        calibrate_flip_probability(bad, _K)
+
+
+# -- functionality preserved --------------------------------------------------
+
+
+def test_lookup_is_exact_despite_privacy() -> None:
+    reg = DPBloomRegistry(seed=b"s", epsilon=_EPS, num_hashes=_K, num_bits=_BITS)
+
+    async def run() -> list[AgentCard]:
+        for card in _BACKGROUND:
+            await reg.register(card)
+        await reg.register(AgentCard(agent_id=AgentId("buyer"), name="Buyer", capabilities=["buy"]))
+        return await reg.lookup(Query(capabilities=["sell"]))
+
+    hits = asyncio.run(run())
+    assert {c.agent_id for c in hits} == {c.agent_id for c in _BACKGROUND}
+
+
+# -- determinism --------------------------------------------------------------
+
+
+def _build_index_bits(seed: bytes) -> tuple[bool, ...]:
+    reg = DPBloomRegistry(seed=seed, epsilon=_EPS, num_hashes=_K, num_bits=_BITS)
+
+    async def run() -> tuple[bool, ...]:
+        for card in _BACKGROUND:
+            await reg.register(card)
+        return reg.published_index().bits
+
+    return asyncio.run(run())
+
+
+def test_published_index_is_deterministic_under_fixed_seed() -> None:
+    assert _build_index_bits(b"seed-42") == _build_index_bits(b"seed-42")
+
+
+def test_published_index_depends_on_seed() -> None:
+    # Different secret seeds draw different randomized-response coins.
+    assert _build_index_bits(b"seed-42") != _build_index_bits(b"seed-7")
+
+
+# -- adversarial FAIL/PASS gate ----------------------------------------------
+
+
+def _dp_bloom_oracle(seed: int, include_target: bool) -> bool:
+    reg = DPBloomRegistry(seed=str(seed).encode(), epsilon=_EPS, num_hashes=_K, num_bits=_BITS)
+
+    async def run() -> bool:
+        for card in _BACKGROUND:
+            await reg.register(card)
+        if include_target:
+            await reg.register(_TARGET)
+        return reg.membership_query(reg.published_index(), _TARGET.agent_id)
+
+    return asyncio.run(run())
+
+
+def _in_memory_oracle(_seed: int, include_target: bool) -> bool:
+    reg = InMemoryRegistry()
+
+    async def run() -> bool:
+        for card in _BACKGROUND:
+            await reg.register(card)
+        if include_target:
+            await reg.register(_TARGET)
+        cards = await reg.lookup(Query())
+        return any(card.agent_id == _TARGET.agent_id for card in cards)
+
+    return asyncio.run(run())
+
+
+def test_validator_passes_dp_bloom() -> None:
+    report = check_membership_inference_bounded(_dp_bloom_oracle, _EPS)
+    assert report.passed, report.detail
+    assert report.evidence["empirical_epsilon"] <= report.evidence["threshold"]  # type: ignore[operator]
+
+
+def test_validator_fails_exact_registry() -> None:
+    report = check_membership_inference_bounded(_in_memory_oracle, _EPS)
+    assert not report.passed, report.detail

--- a/scenarios/dp_bloom_registry.yaml
+++ b/scenarios/dp_bloom_registry.yaml
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Differentially private registry scenario.
 #
-# A marketplace of 20 buyers and 20 sellers running on the `dp_bloom`
-# registry instead of `in_memory`. Discovery still works exactly (lookups
-# are served from the true card store), but the registry's *published*
-# membership index is epsilon-DP: an observer who reads it off the wire
-# cannot confirm whether any specific agent registered beyond an e^eps
-# factor. Swap `registry: dp_bloom` back to `in_memory` and the
-# membership-inference validator flips from PASS to FAIL on the same seed.
+# A marketplace of 20 buyers and 20 sellers runs on the dp_bloom registry
+# instead of in_memory. Discovery still works exactly, since lookups read the
+# true card store. The registry's published membership index is epsilon-DP, so
+# an observer who reads it off the wire cannot confirm whether any specific
+# agent registered beyond an e^eps factor. Swap the registry back to in_memory
+# and the membership-inference validator flips from pass to fail on the same
+# seed.
 #
-# Deterministic under seeds 42, 7, 1337 — the randomized-response coins are
-# drawn from a seeded PRF and the plugin never reads wall-clock time.
+# The scenario is deterministic under seeds 42, 7, and 1337. The
+# randomized-response coins come from a seeded PRF and the plugin never reads
+# wall-clock time.
 name: dp_bloom_registry
 description: "40-agent marketplace on an epsilon-DP membership registry."
 

--- a/scenarios/dp_bloom_registry.yaml
+++ b/scenarios/dp_bloom_registry.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Differentially private registry scenario.
+#
+# A marketplace of 20 buyers and 20 sellers running on the `dp_bloom`
+# registry instead of `in_memory`. Discovery still works exactly (lookups
+# are served from the true card store), but the registry's *published*
+# membership index is epsilon-DP: an observer who reads it off the wire
+# cannot confirm whether any specific agent registered beyond an e^eps
+# factor. Swap `registry: dp_bloom` back to `in_memory` and the
+# membership-inference validator flips from PASS to FAIL on the same seed.
+#
+# Deterministic under seeds 42, 7, 1337 — the randomized-response coins are
+# drawn from a seeded PRF and the plugin never reads wall-clock time.
+name: dp_bloom_registry
+description: "40-agent marketplace on an epsilon-DP membership registry."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 40
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 20
+    - name: seller
+      count: 20
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: dp_bloom
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: marketplace
+  config:
+    catalog_size: 80
+    rounds: 10
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+
+output:
+  trace: ./traces/dp_bloom_registry.jsonl


### PR DESCRIPTION
## Overview

This PR adds `dp_bloom`, a differentially private registry. It serves discovery exactly as the in-memory reference does and publishes a separate membership index that satisfies ε-differential privacy. An observer who reads that index cannot decide whether any single agent registered beyond an e^ε factor. The PR ships the plugin, an adversarial membership-inference validator that the reference registry fails, a scenario, and a test suite.

## Motivation

Every registry today answers who is registered and what each agent can do exactly. That behavior is correct for discovery and it leaks membership. Anyone who queries the registry or reads its published index recovers the full member set and every advertised capability. In many deployments the fact that an agent registered a capability such as `sell_medical_data` reveals more than any message the agent later encrypts. Problem 9 hardened message confidentiality. Nothing in the stack bounds membership confidentiality. This PR adds that surface to the registry and gives it a formal guarantee. I treat this as a new privacy angle on the registry building block rather than one of the ten written problems, which the Phase 1 brief permits when it invites contributors to improve a building block or add a new one.

## Testing Plan

The validator `check_membership_inference_bounded` runs a membership-inference experiment across the seed bank. For a fixed target it estimates the probability the index reports the target present when the target registered and when it did not. It then reports the empirical ε as the larger log-likelihood ratio across the two outcomes. A calibrated `dp_bloom` stays at or below its budget because the membership query is post-processing of an ε-DP index. The exact registry reports the target present exactly when the target registered, so its empirical ε is unbounded and it fails any finite budget. The test suite covers the ε and flip-probability calibration, exact lookups under privacy, byte-identical output under a fixed seed, seed sensitivity across seeds, and the pass or fail gate against both registries. All nine tests pass.

## Some Quick Analysis

Fix k hashes. Inserting one member sets at most k bits, so two registries whose members differ by one agent differ in at most k bit positions. Flipping each published bit independently with probability p gives a per-bit ε of ln((1-p)/p). Sequential composition over the at most k differing bits gives ε = k·ln((1-p)/p), where the unit of privacy is one agent's membership. Inverting for a target budget gives p = 1/(1+e^{ε/k}). The membership query reads only the private index, so post-processing preserves the bound.

The plugin draws the randomized-response coins once from a keyed PRF over a secret per-instance seed, following RAPPOR memoization. An adversary without the seed observes only the published bits and gains advantage at most e^ε. Fixing the seed fixes one draw of the coins and makes a Tier 1 trace reproducible without weakening the guarantee for a seedless adversary.

On identical inputs and seeds the validator measures the following.

| registry | empirical ε | budget plus slack | verdict |
|----------|-------------|-------------------|---------|
| `dp_bloom`, ε=3, k=3 | 2.40 | 4.0 | pass |
| `in_memory`, exact | 6.69 | 4.0 | fail |

## Limitations

The index is monotone. A Bloom filter cannot clear a bit it shares with another member, so `deregister` hides future lookups but leaves historical membership bits until the index rebuilds. The privacy unit is a single membership fact, so repeated registrations by one principal compose and fall outside this bound. A smaller ε raises the flip probability toward one half and increases membership-query error, which sets the usable privacy range.

## Success Criteria

The PR meets each mandatory deliverable in the charter. It adds a registry plugin registered as `("registry", "dp_bloom")`, an adversarial validator that passes the new plugin and fails the reference registry, a scenario under `scenarios/`, and a test suite. The five Definition of Done commands exit zero with 1159 passed and 1 skipped. The plugin reads no wall-clock time and uses no unseeded randomness, so traces stay deterministic across seeds.

## References

The randomized-response mechanism and the memoization that fixes each instance's coins once follow RAPPOR [2]. The membership-privacy goal and the differentially private Bloom filter construction follow Tirmazi [4], which builds on the adversarial Bloom filter model of Naor and Yogev [1] and its learned extension by Almashaqbeh, Bishop, and Tirmazi [3].

1. Moni Naor and Eylon Yogev. Bloom Filters in Adversarial Environments. 2014. [preprint](https://arxiv.org/abs/1412.8356)
2. Úlfar Erlingsson, Vasyl Pihur, and Aleksandra Korolova. RAPPOR: Randomized Aggregatable Privacy-Preserving Ordinal Response. ACM CCS, 2014. [preprint](https://research.google.com/pubs/archive/42852.pdf)
3. Ghada Almashaqbeh, Allison Bishop, and Hayder Tirmazi. Adversary Resilient Learned Bloom Filters. ASIACRYPT, 2025. [preprint](https://arxiv.org/abs/2409.06556)
4. Hayder Tirmazi. Adversarially Robust Bloom Filters: Privacy, Reductions, and Open Problems. 2025. [preprint](https://arxiv.org/abs/2501.15751)

## Disclosure On The Use of Generative AI

I built this submission with Claude Code running the Opus 4.8 model, and I want to be precise about the division of labor.

The idea and its theory are mine. The differentially private Bloom filter at the center of this plugin is my own research [3, 4], and the membership-privacy framing extends the adversarial Bloom filter line those papers sit in. I chose to target the registry layer, I decided that membership inference was the leak worth bounding, and I grounded the mechanism in RAPPOR and my prior work rather than in anything the model invented. The epsilon calibration, the choice of RAPPOR-style memoization to keep Tier 1 traces deterministic, and the design of the adversarial validator are decisions I own.

Claude Code did the first-pass implementation under my direction. It explored the nandatown codebase, drafted the plugin, validator, scenario, and tests against the design, and ran the Definition of Done gate. I set the writing standard and the citations. I read the implementation closely, hand-modified the code where the model got it wrong, and validated the behavior over multiple iterations before opening this PR.
