### PR TITLE
[Hackathon] trust-security-engineer: attested_peering operator delegation is not key-bound — trusted-operator impersonation

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,198 @@
+# [Hackathon] trust-security-engineer: attested_peering operator delegation is not key-bound — trusted-operator impersonation
+
+## TL;DR
+
+The attested-peering trust plugin gates reputation on a "who do you work for?"
+operator delegation. But the bytes the operator signed — `_delegation_msg` —
+covered only `operator_id | agent_id | label`, **not the delegated agent's
+public key**. A delegation was therefore a bearer token for a *string* id, not
+a *keypair*. An attacker copies a genuine operator delegation off an honest
+card, keeps the victim's `agent_id`, swaps in **its own** key, self-signs, and
+is admitted **as the victim** with a trusted operator's authority — identity
+impersonation that turns straight into reputation poisoning. The fix binds the
+agent public key into the delegation message (v2), so a delegation authorises
+exactly one keypair and is non-transferable. This PR ships the fix plus an
+adversarial validator, a scenario attack role, and RED→GREEN + property +
+unit tests.
+
+## Persona: trust-security engineer
+
+I read an operator delegation as a **capability bound to a principal's key**,
+not a label. The moment a signed grant names only `agent_id` (a string an
+attacker fully controls on its own card) and omits the key, the grant becomes
+transferable: possession of the *ciphertext* confers the *authority*. The
+attacker never breaks Ed25519, never steals a private key, never forges a
+signature — it **replays a valid one onto a different subject**. That is the
+classic key-substitution / unknown-key-share failure mode, and it is exactly
+what a delegation must not permit.
+
+## The vulnerability
+
+The plugin's own docstrings advertised the safety property it did not have:
+
+- Module docstring: *"a named operator delegated authority to **this agent** …
+  via a signed delegation embedded in its passport."* — but the signature did
+  not bind "this agent" to a key.
+- Constructor comment (injection path): *"a peer that claims a delegation it was
+  never granted produces a self-consistent card with an **invalid
+  delegation_signature**."* — false under v1: a *copied* (not forged) signature
+  verified fine, because the signed bytes never mentioned the agent's key.
+
+**Attack.** Given any honest card `H` delegated by trusted operator `Op`:
+
+1. Take `H.operator_id`, `H.operator_public_key`, `H.delegation_signature`
+   verbatim (all public, on the wire in every hail).
+2. Build a card that keeps `agent_id = "honest-0"` and `label`, but sets
+   `public_key` = the **attacker's** key.
+3. Self-sign the body with the attacker's key (valid — it is the card's key).
+4. Complete the handshake signing the live transcript with the attacker's key.
+
+Under v1: key possession passes (card key == attacker key, attacker signs the
+transcript), the self-signature is valid, the copied delegation verifies
+(`Op` did sign `delegation-v1|Op|honest-0|label`), and `Op` is on the roster.
+Verdict **ALLOW** — the attacker is admitted **as `honest-0`**, and every
+`report()` it files counts under the victim's identity.
+
+## Root cause
+
+`packages/nest-plugins-reference/nest_plugins_reference/trust/attested_peering.py`
+
+```python
+# v1 (vulnerable): signs only the id triple — transferable to ANY key
+return DELEGATION_TAG + f"|{operator_id}|{agent_id}|{label}".encode()
+```
+
+`_verify_card` recomputed the same key-free message, so a copied signature over
+a *different* card's key still verified. The delegation authorised a name, not a
+keypair.
+
+## The fix
+
+Bind the agent public key into the signed delegation (v2), and pass it at both
+call sites — `_verify_card` passes `card.public_key`, the sign path passes
+`self._pub`. Tag bumped `nest-attest-delegation-v1` → `-v2` so a v1 signature
+can never be reinterpreted as v2.
+
+```python
+DELEGATION_TAG = b"nest-attest-delegation-v2"
+
+def _delegation_msg(operator_id, agent_id, label, agent_public_key) -> bytes:
+    return (
+        DELEGATION_TAG
+        + f"|{operator_id}|{agent_id}|{label}|".encode()
+        + _b64(agent_public_key).encode()
+    )
+
+# _verify_card:
+msg = _delegation_msg(card.operator_id, card.agent_id, card.label, card.public_key)
+```
+
+Now a delegation issued for the honest key does not verify over the attacker's
+key: the copied-delegation card dies at **friend-or-foe** with
+`operator delegation signature invalid (agent not authorised)`. Verdict DENY.
+
+## Why the existing tests and validators missed it
+
+- **`test_impostor_signature_denied`** presents a stolen passport but signs the
+  transcript with its own key → it dies earlier, at **key possession**, so it
+  never exercises the delegation-binding path.
+- **`test_forged_operator_delegation_denied`** uses a *bogus* delegation
+  signature (`b"not-a-real-signature"`) → dies because the signature is invalid,
+  which says nothing about a *genuine* signature being transferable.
+- **No test copied a real, valid delegation onto a foreign key** — the exact
+  gap this PR closes.
+- **`validate_attested_no_denied_admitted`** parses verdicts via
+  `_attested_verdicts`, which **drops `peer_id`** and keys purely on the
+  transport `sender`. An attacker admitted under a *claimed* identity different
+  from its transport id is invisible to it.
+
+## Adversarial validator + scenario (what they catch)
+
+**Validator** — `validate_attested_no_identity_substitution`
+(`packages/nest-core/nest_core/validators.py`). The observer emits
+`verdict:<sender>:<peer_id>:<decision>:<foe>:<data>:<work>` where `sender` is the
+transport agent and `peer_id` is the identity the presented card *claims*.
+Invariant: **every `ALLOW` must have `peer_id == sender`** — an admitted peer
+must control the identity it claims. It FAILs on any `ALLOW` where a peer is
+admitted under a foreign claimed id (the substitution), and passes vacuously on
+baseline traces with no verdict lines. It is deliberately the complement of the
+`sender`-keyed sibling validator that cannot see this.
+
+**Scenario role** — `delegation_thief`
+(`packages/nest-core/nest_core/scenarios_builtin/attested_peering.py`,
+`scenarios/attested_peering.yaml`). Presents a card claiming `honest-0` with the
+victim's copied operator delegation but the attacker's own key, self-signed by
+the attacker. Under the fixed plugin its verdict is
+`verdict:delegation_thief-0:honest-0:DENY:0:1:1` — DENY at friend-or-foe — so
+`peer_id != sender` never coincides with `ALLOW` and the validator PASSes. Under
+the pre-fix message format it would ALLOW as `honest-0`, and the validator
+FAILs. Determinism is preserved (seeded key derivation only, no wall clock, no
+`os.urandom`).
+
+## Verify
+
+```bash
+# 1) Run the attack at the plugin API + the new validator/property tests
+uv run pytest packages/nest-plugins-reference/tests/test_attested_peering.py \
+  -k "copied_delegation or identity_substitution or validator_" -v
+
+# 2) Run the full scenario and print the thief verdict + all three validators
+uv run python -c "
+import asyncio, tempfile, json
+from pathlib import Path
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.plugins import PluginRegistry
+from nest_core.validators import validate_trace
+cfg = ScenarioConfig.from_yaml('scenarios/attested_peering.yaml')
+with tempfile.TemporaryDirectory() as t:
+    tp = Path(t)/'x.jsonl'
+    cfg = cfg.model_copy(update={'output': cfg.output.model_copy(update={'trace': str(tp)})})
+    asyncio.run(ScenarioRunner(cfg, registry=PluginRegistry()).run())
+    for line in tp.read_text().splitlines():
+        d = json.loads(line)
+        if d.get('kind')=='send' and d.get('agent')=='observer' and 'delegation_thief' in d['msg'] and d['msg'].startswith('verdict'):
+            print('THIEF:', d['msg'])
+    for r in validate_trace(tp, 'attested_peering'):
+        print(('PASS' if r.passed else 'FAIL'), r.name)
+"
+```
+
+Expected output of step 2:
+
+```
+THIEF: verdict:delegation_thief-0:honest-0:DENY:0:1:1
+PASS attested_no_denied_admitted
+PASS attested_no_identity_substitution
+PASS attested_sybil_quarantined
+```
+
+RED→GREEN evidence: with `_delegation_msg` reverted to the v1 (key-free) form,
+`test_copied_delegation_on_foreign_key_denied` and
+`test_property_copied_delegation_always_denied` both fail with
+`assert 'ALLOW' == 'DENY'` (attacker admitted as `honest-0`); with the v2 fix
+both pass.
+
+## Limitations / Scope
+
+- **Secondary hardening taken (defence in depth).** `evaluate_peer`'s
+  "who do you work for?" check previously tested only `op_id in
+  policy.trusted_operators` — membership by the **16-hex (64-bit) operator
+  fingerprint**. This PR now also asserts
+  `policy.trusted_operators[op_id] == peer_facts.operator_public_key` (full-key
+  equality), so a 64-bit fingerprint second-preimage that presented a different
+  operator key under a trusted id is rejected. Combined with the key-bound
+  delegation, the operator identity is now pinned end-to-end. Covered by
+  `test_operator_fingerprint_collision_rejected`.
+- The fix is a **breaking wire change** (v1 delegations no longer verify). That
+  is intentional: v1 delegations are exactly the transferable tokens being
+  retired. Any deployment must re-issue delegations under v2.
+- Scope is limited to the trust layer; no other layers or plugins are touched.
+  The safety validator, Sybil-quarantine validator, and byte-determinism test
+  all remain green.
+
+---
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_0137ni2yk8VAh26RD6PBWThu

--- a/packages/nest-core/nest_core/scenarios_builtin/attested_peering.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/attested_peering.py
@@ -20,6 +20,17 @@ stress the gate:
   captured from an earlier session, replayed against a fresh nonce. Verdict
   ``DENY`` at "friend or foe?" (the stale signature does not cover this
   transcript).
+* **delegation_thief** — the key-substitution attack. Presents a card that
+  keeps the honest victim's ``agent_id`` and copies its *genuine* operator
+  delegation (operator id, key, and signature), but carries the attacker's own
+  key and is self-signed by the attacker. Key possession therefore *passes*
+  (the card's key is the attacker's, and the attacker signs the live
+  transcript), but under the key-bound v2 delegation the copied signature no
+  longer covers this foreign key, so verdict is ``DENY`` at "friend or foe?"
+  (delegation invalid). Its verdict line carries ``peer_id`` = ``honest-0`` ≠
+  transport ``sender`` = ``delegation_thief-0``, which is exactly what
+  ``validate_attested_no_identity_substitution`` guards: an ``ALLOW`` there
+  would mean an attacker admitted *as the victim*.
 
 The agents resolve their trust plugin from ``ctx.plugins["trust"]`` and
 capability-gate the handshake on ``hasattr(trust, "make_hail")``. Swapping
@@ -57,6 +68,7 @@ from nest_core.types import AgentId, Evidence
 
 _OPERATOR_SEED = b"attested-peering:honest-operator"
 _SCENARIO_SEED = b"attested-peering"
+_THIEF_SEED = b"attested-peering:thief"
 
 
 def _encode(obj: dict[str, Any]) -> str:
@@ -85,7 +97,9 @@ class ReporterAgent(StateMachineAgent):
 
     ``role`` selects the attack: ``honest`` behaves correctly, ``sybil`` has no
     operator delegation, ``impostor`` presents a stolen passport, ``replayer``
-    replays a captured honest seal. When the configured trust plugin has no
+    replays a captured honest seal, and ``delegation_thief`` presents a crafted
+    card (built in ``_provision_trust``) that copies the victim's genuine
+    delegation onto the attacker's own key. When the configured trust plugin has no
     ``make_hail`` (e.g. ``score_average``) the agent skips the handshake and
     sends its evidence directly — the baseline path the discrimination
     validator catches.
@@ -272,7 +286,7 @@ def _role_counts(config: ScenarioConfig) -> dict[str, int]:
 
         counts = _role_counts(config)
     """
-    defaults = {"honest": 8, "sybil": 20, "impostor": 1, "replayer": 1}
+    defaults = {"honest": 8, "sybil": 20, "impostor": 1, "replayer": 1, "delegation_thief": 1}
     if config.agents.roles:
         for role in config.agents.roles:
             if role.name in defaults:
@@ -317,19 +331,22 @@ def _provision_trust(
     observer_id: AgentId,
     honest_ids: list[AgentId],
     reporter_ids: list[AgentId],
+    thief_ids: list[AgentId],
 ) -> None:
     """Instantiate one trust plugin per agent from the configured class.
 
     Mirrors ``identity_rotation``'s per-agent provisioning. For the
     attested-peering plugin every agent gets its own keyed instance and the
-    observer is told which operator + boot state to trust. For a baseline trust
-    plugin (e.g. ``score_average``, no ``make_hail``) only the observer gets a
-    single shared instance; reporters send evidence directly. No-op when no
-    trust plugin is configured.
+    observer is told which operator + boot state to trust. ``thief_ids`` receive
+    a *crafted* instance that claims the honest head's ``agent_id`` and copies
+    its genuine operator delegation onto the attacker's own key — the
+    key-substitution attack. For a baseline trust plugin (e.g. ``score_average``,
+    no ``make_hail``) only the observer gets a single shared instance; reporters
+    send evidence directly. No-op when no trust plugin is configured.
 
     Example::
 
-        _provision_trust(plugins, AgentId("observer"), honest, reporters)
+        _provision_trust(plugins, AgentId("observer"), honest, reporters, thieves)
     """
     from nest_plugins_reference.trust.attested_peering import PeeringPolicy
 
@@ -352,7 +369,10 @@ def _provision_trust(
         principal_name="Reputation Observer",
     )
 
+    thief_set = set(thief_ids)
     for aid in reporter_ids:
+        if aid in thief_set:
+            continue
         is_honest = aid in honest_ids
         reporter_trust = trust_cls(
             agent_id=aid,
@@ -367,6 +387,27 @@ def _provision_trust(
                 reporter_trust.operator_id, reporter_trust.operator_public_key
             )
 
+    # Key-substitution attackers: claim the honest head's identity + copied
+    # delegation, but carry the attacker's own key (self-signed by the attacker).
+    if thief_ids and honest_ids:
+        victim_card = agent_plugins.get(honest_ids[0], {}).get("trust")
+        if victim_card is not None and hasattr(victim_card, "card"):
+            stolen = victim_card.card
+            for aid in thief_ids:
+                thief_trust = trust_cls(
+                    agent_id=honest_ids[0],
+                    seed=_THIEF_SEED,
+                    operator_delegation=(
+                        stolen.operator_id,
+                        stolen.operator_public_key,
+                        stolen.delegation_signature,
+                    ),
+                    label=stolen.label,
+                    offer_env=True,
+                    principal_name=stolen.principal_name,
+                )
+                agent_plugins.setdefault(aid, {})["trust"] = thief_trust
+
     observer_trust.allow_boot_state()
     agent_plugins.setdefault(observer_id, {})["trust"] = observer_trust
     plugins.pop("trust", None)
@@ -379,9 +420,9 @@ def attested_peering_factory(
     """Create the observer, victim sink, and honest + adversarial reporters.
 
     Role counts come from ``agents.roles`` (defaults: 8 honest, 20 sybil, 1
-    impostor, 1 replayer). Honest reporters file *positive* evidence; every
-    attacker files *negative* evidence but is denied and quarantined under the
-    attested-peering plugin.
+    impostor, 1 replayer, 1 delegation_thief). Honest reporters file *positive*
+    evidence; every attacker files *negative* evidence but is denied and
+    quarantined under the attested-peering plugin.
 
     Example::
 
@@ -395,9 +436,10 @@ def attested_peering_factory(
     sybil_ids = [AgentId(f"sybil-{i}") for i in range(counts["sybil"])]
     impostor_ids = [AgentId(f"impostor-{i}") for i in range(counts["impostor"])]
     replayer_ids = [AgentId(f"replayer-{i}") for i in range(counts["replayer"])]
-    reporter_ids = honest_ids + sybil_ids + impostor_ids + replayer_ids
+    thief_ids = [AgentId(f"delegation_thief-{i}") for i in range(counts["delegation_thief"])]
+    reporter_ids = honest_ids + sybil_ids + impostor_ids + replayer_ids + thief_ids
 
-    _provision_trust(plugins, observer_id, honest_ids, reporter_ids)
+    _provision_trust(plugins, observer_id, honest_ids, reporter_ids, thief_ids)
 
     # The impostor and replayer both target the first honest identity.
     stolen_card: dict[str, Any] | None = None
@@ -428,6 +470,11 @@ def attested_peering_factory(
             stolen_card=stolen_card,
             replay_seal=replay_seal,
         )
+    for aid in thief_ids:
+        # The crafted trust instance already carries the copied delegation on the
+        # attacker's key, so the default present-card path presents that card
+        # (agent_id honest-0) while the transport sender stays delegation_thief-N.
+        agents[aid] = ReporterAgent(aid, observer_id, "delegation_thief", "negative")
 
     agents[observer_id] = ObserverAgent(observer_id, victim_id, expected=len(reporter_ids))
     agents[victim_id] = SinkAgent(victim_id)

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -4792,6 +4792,78 @@ def validate_attested_sybil_quarantined(
     ]
 
 
+def validate_attested_no_identity_substitution(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """No peer is admitted under a claimed identity it does not transport-control.
+
+    The observer's verdict line is
+    ``verdict:<sender>:<peer_id>:<decision>:<foe>:<data>:<work>`` where ``sender``
+    is the transport agent the verifier is actually talking to and ``peer_id`` is
+    the identity the *presented passport* claims. An honest peer transports its
+    own card, so ``peer_id == sender``. A key-substitution attacker copies a
+    genuine operator delegation onto a card that keeps the victim's ``agent_id``
+    but carries the *attacker's own* key; were that card admitted, the verifier
+    would count the attacker's evidence **as the victim**, poisoning an identity
+    the attacker never controlled.
+
+    Invariant: every ``ALLOW`` verdict must satisfy ``peer_id == sender``. FAIL
+    on any ``ALLOW`` whose claimed identity differs from its transport sender.
+
+    This is deliberately blind-spot-complementary to
+    :func:`validate_attested_no_denied_admitted`, which keys purely on the
+    transport ``sender`` (via :func:`_attested_verdicts`, that drops ``peer_id``)
+    and therefore cannot see an admitted identity substitution at all. A trace
+    with no verdict lines (a baseline plugin that runs no handshake) passes
+    vacuously.
+
+    Example::
+
+        results = validate_trace(Path("traces/attested_peering.jsonl"), "attested_peering")
+    """
+    lines = _attested_observer_lines(events)
+
+    substitutions: list[str] = []
+    verdict_count = 0
+    for line in lines:
+        if not line.startswith("verdict:"):
+            continue
+        parts = line.split(":")
+        if len(parts) != 7:
+            continue
+        _, sender, peer_id, decision, _foe, _data, _work = parts
+        verdict_count += 1
+        if decision == "ALLOW" and peer_id != sender:
+            substitutions.append(
+                f"{sender}: admitted while claiming identity '{peer_id}' it does not control"
+            )
+
+    if verdict_count == 0:
+        return [
+            ValidationResult(
+                "attested_no_identity_substitution",
+                True,
+                "no attested-peering verdicts in trace (baseline plugin, nothing to gate)",
+            )
+        ]
+    if substitutions:
+        return [
+            ValidationResult(
+                "attested_no_identity_substitution",
+                False,
+                "; ".join(substitutions),
+            )
+        ]
+    return [
+        ValidationResult(
+            "attested_no_identity_substitution",
+            True,
+            f"{verdict_count} verdict(s) checked; "
+            "every admitted peer controls the identity it claims",
+        )
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
@@ -4971,6 +5043,7 @@ VALIDATORS: dict[str, list[Any]] = {
     ],
     "attested_peering": [
         validate_attested_no_denied_admitted,
+        validate_attested_no_identity_substitution,
         validate_attested_sybil_quarantined,
     ],
     "memory_concurrent_writers": [

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/attested_peering.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/attested_peering.py
@@ -875,6 +875,16 @@ class AttestedPeeringTrust:
                 work_ok, work_detail = False, "no operator delegation (self-asserted principal)"
             elif op_id not in policy.trusted_operators:
                 work_ok, work_detail = False, f"operator {op_id} is not on your trusted roster"
+            elif policy.trusted_operators[op_id] != peer_facts.operator_public_key:
+                # Defence in depth: the roster is keyed by the 64-bit operator fingerprint, so
+                # match the FULL trusted public key too. Without this a fingerprint second-
+                # preimage could present a different operator key under a trusted id. Combined
+                # with the key-bound delegation, the operator identity is now pinned end-to-end.
+                work_ok, work_detail = (
+                    False,
+                    f"operator {op_id} fingerprint is on the roster but its public key "
+                    "does not match the trusted key (substituted operator / fingerprint collision)",
+                )
             else:
                 work_ok, work_detail = True, f"operator {op_id} delegated and trusted"
         else:

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/attested_peering.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/attested_peering.py
@@ -101,7 +101,7 @@ Example::
 """
 
 HANDSHAKE_TAG = b"nest-attest-handshake-v1"
-DELEGATION_TAG = b"nest-attest-delegation-v1"
+DELEGATION_TAG = b"nest-attest-delegation-v2"
 ENV_TAG = b"nest-attest-env-v1"
 
 _ENV_COMPONENTS = ("firmware", "bootloader", "kernel", "agent_code")
@@ -241,14 +241,24 @@ def _canon(obj: dict[str, Any]) -> bytes:
     return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 
-def _delegation_msg(operator_id: str, agent_id: str, label: str) -> bytes:
+def _delegation_msg(operator_id: str, agent_id: str, label: str, agent_public_key: bytes) -> bytes:
     """Canonical bytes an operator signs to delegate authority to an agent.
+
+    The agent's public key is bound into the message (v2). Without it a
+    delegation names only the string ``agent_id`` and is transferable to *any*
+    key wearing that id: an attacker can copy a genuine delegation onto a card
+    carrying its own key and be admitted as the delegated agent. Binding the key
+    makes a delegation non-transferable — it authorises exactly one keypair.
 
     Example::
 
-        msg = _delegation_msg("op", "a1", "buyer-1")
+        msg = _delegation_msg("op", "a1", "buyer-1", agent_pub)
     """
-    return DELEGATION_TAG + f"|{operator_id}|{agent_id}|{label}".encode()
+    return (
+        DELEGATION_TAG
+        + f"|{operator_id}|{agent_id}|{label}|".encode()
+        + _b64(agent_public_key).encode()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -377,7 +387,7 @@ def _verify_card(card: AgentFactsCard) -> tuple[bool, str]:
             return False, "delegation claims an operator but carries no operator key"
         if _fingerprint(card.operator_public_key) != card.operator_id:
             return False, "operator_id does not match its public key"
-        msg = _delegation_msg(card.operator_id, card.agent_id, card.label)
+        msg = _delegation_msg(card.operator_id, card.agent_id, card.label, card.public_key)
         if not _verify(card.operator_public_key, msg, card.delegation_signature):
             return False, "operator delegation signature invalid (agent not authorised)"
         return True, f"authentic passport; delegated by operator {card.operator_id}"
@@ -602,14 +612,15 @@ class AttestedPeeringTrust:
             self._operator_id = _fingerprint(self._operator_pub)
             delegation_sig = _sign(
                 op_priv,
-                _delegation_msg(self._operator_id, str(self._agent_id), card_label),
+                _delegation_msg(self._operator_id, str(self._agent_id), card_label, self._pub),
             )
         elif operator_delegation is not None:
             # Injection path: embed a delegation block issued out-of-band
-            # (``operator_id``, ``operator_public_key``, ``signature``). The card
-            # is still self-signed by *this* agent's key, so a peer that claims a
-            # delegation it was never granted produces a self-consistent card
-            # with an invalid ``delegation_signature`` — see ``_verify_card``.
+            # (``operator_id``, ``operator_public_key``, ``signature``). Because a
+            # v2 delegation is signed over *this agent's public key*, copying a
+            # genuine delegation issued for a different key onto this card yields
+            # an invalid ``delegation_signature`` — the key-substitution attack is
+            # rejected in ``_verify_card``.
             self._operator_id, self._operator_pub, delegation_sig = operator_delegation
 
         card = AgentFactsCard(

--- a/packages/nest-plugins-reference/tests/test_attested_peering.py
+++ b/packages/nest-plugins-reference/tests/test_attested_peering.py
@@ -38,7 +38,11 @@ from nest_core.plugins import PluginRegistry
 from nest_core.runner import ScenarioRunner
 from nest_core.scenario import ScenarioConfig
 from nest_core.types import AgentId, Evidence
-from nest_core.validators import ValidationResult, validate_trace
+from nest_core.validators import (
+    ValidationResult,
+    validate_attested_no_identity_substitution,
+    validate_trace,
+)
 from nest_plugins_reference.trust.attested_peering import (
     AgentFactsCard,
     AttestedPeeringTrust,
@@ -222,6 +226,51 @@ def test_forged_operator_delegation_denied() -> None:
     assert "delegation" in verdict.friend_or_foe.detail
 
 
+def test_copied_delegation_on_foreign_key_denied() -> None:
+    """The key-substitution attack: a copied delegation on a foreign key is denied.
+
+    An attacker copies the honest agent's *genuine* operator delegation
+    (operator id, operator key, and the operator's real signature) onto a card
+    that keeps the victim's ``agent_id`` ("honest-0") but carries the attacker's
+    own key, self-signed by the attacker. Key possession passes (the card's key
+    is the attacker's own and it signs the live transcript), but the v2
+    delegation is bound to the agent's public key, so the copied signature no
+    longer verifies over this foreign key. Verdict is ``DENY`` at friend-or-foe
+    and the attacker is never admitted as the victim.
+
+    This is the RED->GREEN proof: under the pre-fix v1 delegation message (which
+    signed only ``operator_id|agent_id|label``) the copied signature *would*
+    verify and this handshake would ``ALLOW`` — admitting the attacker as
+    honest-0.
+    """
+    verifier = _verifier()
+    honest = _honest()  # agent_id honest-0, delegated by _OP, golden boot
+    verifier.trust_operator(honest.operator_id, honest.operator_public_key)
+    verifier.allow_boot_state()
+
+    thief = AttestedPeeringTrust(
+        agent_id=AgentId("honest-0"),  # claim the victim's identity
+        seed=b"thief-distinct-key",  # but a different keypair
+        operator_delegation=(
+            honest.operator_id,
+            honest.operator_public_key,
+            honest.card.delegation_signature,  # the victim's real delegation, copied
+        ),
+        offer_env=True,
+    )
+    # The card claims the victim id but carries a foreign key.
+    assert thief.card.agent_id == honest.card.agent_id == "honest-0"
+    assert thief.card.public_key != honest.card.public_key
+    assert thief.card.delegation_signature == honest.card.delegation_signature
+
+    verdict = _handshake(verifier, thief, "delegation_thief-0", kind="negative")
+    assert verdict.decision == "DENY"
+    assert not verdict.friend_or_foe.ok
+    assert "delegation" in verdict.friend_or_foe.detail
+    assert not verifier.is_attested(AgentId("honest-0"))
+    assert not verifier.is_attested(AgentId("delegation_thief-0"))
+
+
 def test_tampered_boot_quote_denied_when_required() -> None:
     """A peer whose boot state is not on the allow-list fails trust-my-data."""
     verifier = _verifier(require_env_quote=True)
@@ -336,6 +385,52 @@ def test_property_honest_handshake_always_allows(agent_name: str) -> None:
     assert _handshake(verifier, honest, f"h-{agent_name}").decision == "ALLOW"
 
 
+@settings(max_examples=30, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    op_seed=st.binary(min_size=1, max_size=16),
+    victim=st.text(
+        alphabet=st.characters(min_codepoint=97, max_codepoint=122), min_size=1, max_size=8
+    ),
+    attacker_seed=st.binary(min_size=1, max_size=16),
+)
+def test_property_copied_delegation_always_denied(
+    op_seed: bytes, victim: str, attacker_seed: bytes
+) -> None:
+    """A copied-delegation card on a foreign key is always denied; the genuine
+    delegated agent is always allowed — for any operator/victim/attacker seeds.
+    """
+    victim_id = f"v-{victim}"
+    verifier = _verifier()
+    honest = AttestedPeeringTrust(
+        agent_id=AgentId(victim_id), seed=b"prop-victim", operator_seed=op_seed, offer_env=True
+    )
+    verifier.trust_operator(honest.operator_id, honest.operator_public_key)
+    verifier.allow_boot_state()
+
+    # The genuinely-delegated agent is always admitted.
+    assert _handshake(verifier, honest, victim_id).decision == "ALLOW"
+
+    thief = AttestedPeeringTrust(
+        agent_id=AgentId(victim_id),  # same claimed identity
+        seed=attacker_seed,
+        operator_delegation=(
+            honest.operator_id,
+            honest.operator_public_key,
+            honest.card.delegation_signature,
+        ),
+        offer_env=True,
+    )
+    # Only a *foreign* key exercises the substitution; identical keys are the
+    # honest case and out of scope for this property.
+    if thief.card.public_key == honest.card.public_key:
+        return
+    verdict = _handshake(verifier, thief, f"thief-{victim_id}", kind="negative")
+    assert verdict.decision == "DENY"
+    assert not verdict.friend_or_foe.ok
+    # The attacker's transport session is never admitted.
+    assert not verifier.is_attested(AgentId(f"thief-{victim_id}"))
+
+
 @settings(max_examples=40)
 @given(flip=st.integers(min_value=0, max_value=63))
 def test_property_tampered_signature_always_denied(flip: int) -> None:
@@ -388,6 +483,42 @@ def test_property_report_order_invariant(seed: int) -> None:
     rep = _run(verifier.score(AgentId("victim")))
     assert rep.sample_count == len(honest_ids)
     assert rep.score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# 2b. Adversarial validator unit tests
+# ---------------------------------------------------------------------------
+
+
+def _observer_send(msg: str) -> dict[str, Any]:
+    """A synthetic observer ``send`` event carrying one audit line."""
+    return {"kind": "send", "agent": "observer", "msg": msg}
+
+
+def test_validator_flags_admitted_identity_substitution() -> None:
+    """An ALLOW verdict whose claimed id != transport sender fails the validator."""
+    events = [_observer_send("verdict:delegation_thief-0:honest-0:ALLOW:1:1:1")]
+    results = validate_attested_no_identity_substitution(events)
+    assert len(results) == 1
+    assert not results[0].passed
+    assert "honest-0" in results[0].detail
+
+
+def test_validator_passes_when_claimed_id_matches_sender() -> None:
+    """Every ALLOW with peer_id == sender (and any DENY) passes the validator."""
+    events = [
+        _observer_send("verdict:honest-0:honest-0:ALLOW:1:1:1"),
+        _observer_send("verdict:delegation_thief-0:honest-0:DENY:0:1:1"),
+        _observer_send("verdict:sybil-3:sybil-3:DENY:1:1:0"),
+    ]
+    results = validate_attested_no_identity_substitution(events)
+    assert results[0].passed
+
+
+def test_validator_passes_vacuously_without_verdicts() -> None:
+    """A baseline trace with no verdict lines cannot violate the invariant."""
+    results = validate_attested_no_identity_substitution([])
+    assert results[0].passed
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nest-plugins-reference/tests/test_attested_peering.py
+++ b/packages/nest-plugins-reference/tests/test_attested_peering.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from hypothesis import HealthCheck, given, settings
+from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 from nest_core.layers.trust import Trust
 from nest_core.plugins import PluginRegistry
@@ -421,9 +421,9 @@ def test_property_copied_delegation_always_denied(
         offer_env=True,
     )
     # Only a *foreign* key exercises the substitution; identical keys are the
-    # honest case and out of scope for this property.
-    if thief.card.public_key == honest.card.public_key:
-        return
+    # honest case and out of scope for this property. Use ``assume`` so the skip
+    # is explicit to Hypothesis rather than a silent early pass.
+    assume(thief.card.public_key != honest.card.public_key)
     verdict = _handshake(verifier, thief, f"thief-{victim_id}", kind="negative")
     assert verdict.decision == "DENY"
     assert not verdict.friend_or_foe.ok
@@ -483,6 +483,27 @@ def test_property_report_order_invariant(seed: int) -> None:
     rep = _run(verifier.score(AgentId("victim")))
     assert rep.sample_count == len(honest_ids)
     assert rep.score == 1.0
+
+
+def test_operator_fingerprint_collision_rejected() -> None:
+    """Defence in depth: an operator key that fingerprints to a trusted id but is not the
+    trusted key (a 64-bit fingerprint second-preimage / substituted operator) is denied at
+    who-you-work-for, even though its delegation is internally consistent.
+
+    Example::
+
+        test_operator_fingerprint_collision_rejected()
+    """
+    verifier, honest = _verifier(), _honest("honest-0")
+    verifier.trust_operator(honest.operator_id, honest.operator_public_key)
+    assert _handshake(verifier, honest, "s-ok").decision == "ALLOW"
+    # Simulate a fingerprint collision: the roster maps honest's operator id to a DIFFERENT
+    # public key. The card still passes _verify_card (its op_id == fingerprint of its own
+    # operator key), but the full trusted key no longer matches.
+    verifier.trust_operator(honest.operator_id, b"\x00" * 32)
+    verdict = _handshake(verifier, honest, "s-collide")
+    assert verdict.decision == "DENY"
+    assert not verdict.who_you_work_for.ok
 
 
 # ---------------------------------------------------------------------------

--- a/scenarios/attested_peering.yaml
+++ b/scenarios/attested_peering.yaml
@@ -1,17 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # Attested-peering trust scenario: an unauthenticated Sybil swarm (plus an
-# impostor and a replayer) tries to defame one honest victim, but only peers
-# that clear the three-question attested-peering handshake can move its
-# reputation. Swap `trust: attested_peering` for `trust: score_average` and the
-# validate_attested_sybil_quarantined validator flips from PASS to FAIL.
+# impostor, a replayer, and a key-substitution delegation_thief) tries to defame
+# one honest victim, but only peers that clear the three-question
+# attested-peering handshake can move its reputation. Swap
+# `trust: attested_peering` for `trust: score_average` and the
+# validate_attested_sybil_quarantined validator flips from PASS to FAIL. The
+# delegation_thief copies the victim's genuine operator delegation onto its own
+# key; validate_attested_no_identity_substitution asserts it is never admitted
+# as the victim.
 name: attested_peering
-description: "20-node Sybil swarm + impostor + replayer defame one victim; only attested peers count."
+description: "Sybil swarm + impostor + replayer + delegation-thief defame one victim; only attested peers count."
 
 tier: 1
 seed: 42
 
 agents:
-  count: 32
+  count: 33
   brain: state-machine
   roles:
     - name: honest
@@ -21,6 +25,8 @@ agents:
     - name: impostor
       count: 1
     - name: replayer
+      count: 1
+    - name: delegation_thief
       count: 1
 
 layers:


### PR DESCRIPTION
# [Hackathon] trust-security-engineer: attested_peering operator delegation is not key-bound — trusted-operator impersonation

## TL;DR

The attested-peering trust plugin gates reputation on a "who do you work for?"
operator delegation. But the bytes the operator signed — `_delegation_msg` —
covered only `operator_id | agent_id | label`, **not the delegated agent's
public key**. A delegation was therefore a bearer token for a *string* id, not
a *keypair*. An attacker copies a genuine operator delegation off an honest
card, keeps the victim's `agent_id`, swaps in **its own** key, self-signs, and
is admitted **as the victim** with a trusted operator's authority — identity
impersonation that turns straight into reputation poisoning. The fix binds the
agent public key into the delegation message (v2), so a delegation authorises
exactly one keypair and is non-transferable. This PR ships the fix plus an
adversarial validator, a scenario attack role, and RED→GREEN + property +
unit tests.

## Persona: trust-security engineer

I read an operator delegation as a **capability bound to a principal's key**,
not a label. The moment a signed grant names only `agent_id` (a string an
attacker fully controls on its own card) and omits the key, the grant becomes
transferable: possession of the *ciphertext* confers the *authority*. The
attacker never breaks Ed25519, never steals a private key, never forges a
signature — it **replays a valid one onto a different subject**. That is the
classic key-substitution / unknown-key-share failure mode, and it is exactly
what a delegation must not permit.

## The vulnerability

The plugin's own docstrings advertised the safety property it did not have:

- Module docstring: *"a named operator delegated authority to **this agent** …
  via a signed delegation embedded in its passport."* — but the signature did
  not bind "this agent" to a key.
- Constructor comment (injection path): *"a peer that claims a delegation it was
  never granted produces a self-consistent card with an **invalid
  delegation_signature**."* — false under v1: a *copied* (not forged) signature
  verified fine, because the signed bytes never mentioned the agent's key.

**Attack.** Given any honest card `H` delegated by trusted operator `Op`:

1. Take `H.operator_id`, `H.operator_public_key`, `H.delegation_signature`
   verbatim (all public, on the wire in every hail).
2. Build a card that keeps `agent_id = "honest-0"` and `label`, but sets
   `public_key` = the **attacker's** key.
3. Self-sign the body with the attacker's key (valid — it is the card's key).
4. Complete the handshake signing the live transcript with the attacker's key.

Under v1: key possession passes (card key == attacker key, attacker signs the
transcript), the self-signature is valid, the copied delegation verifies
(`Op` did sign `delegation-v1|Op|honest-0|label`), and `Op` is on the roster.
Verdict **ALLOW** — the attacker is admitted **as `honest-0`**, and every
`report()` it files counts under the victim's identity.

## Root cause

`packages/nest-plugins-reference/nest_plugins_reference/trust/attested_peering.py`

```python
# v1 (vulnerable): signs only the id triple — transferable to ANY key
return DELEGATION_TAG + f"|{operator_id}|{agent_id}|{label}".encode()
```

`_verify_card` recomputed the same key-free message, so a copied signature over
a *different* card's key still verified. The delegation authorised a name, not a
keypair.

## The fix

Bind the agent public key into the signed delegation (v2), and pass it at both
call sites — `_verify_card` passes `card.public_key`, the sign path passes
`self._pub`. Tag bumped `nest-attest-delegation-v1` → `-v2` so a v1 signature
can never be reinterpreted as v2.

```python
DELEGATION_TAG = b"nest-attest-delegation-v2"

def _delegation_msg(operator_id, agent_id, label, agent_public_key) -> bytes:
    return (
        DELEGATION_TAG
        + f"|{operator_id}|{agent_id}|{label}|".encode()
        + _b64(agent_public_key).encode()
    )

# _verify_card:
msg = _delegation_msg(card.operator_id, card.agent_id, card.label, card.public_key)
```

Now a delegation issued for the honest key does not verify over the attacker's
key: the copied-delegation card dies at **friend-or-foe** with
`operator delegation signature invalid (agent not authorised)`. Verdict DENY.

## Why the existing tests and validators missed it

- **`test_impostor_signature_denied`** presents a stolen passport but signs the
  transcript with its own key → it dies earlier, at **key possession**, so it
  never exercises the delegation-binding path.
- **`test_forged_operator_delegation_denied`** uses a *bogus* delegation
  signature (`b"not-a-real-signature"`) → dies because the signature is invalid,
  which says nothing about a *genuine* signature being transferable.
- **No test copied a real, valid delegation onto a foreign key** — the exact
  gap this PR closes.
- **`validate_attested_no_denied_admitted`** parses verdicts via
  `_attested_verdicts`, which **drops `peer_id`** and keys purely on the
  transport `sender`. An attacker admitted under a *claimed* identity different
  from its transport id is invisible to it.

## Adversarial validator + scenario (what they catch)

**Validator** — `validate_attested_no_identity_substitution`
(`packages/nest-core/nest_core/validators.py`). The observer emits
`verdict:<sender>:<peer_id>:<decision>:<foe>:<data>:<work>` where `sender` is the
transport agent and `peer_id` is the identity the presented card *claims*.
Invariant: **every `ALLOW` must have `peer_id == sender`** — an admitted peer
must control the identity it claims. It FAILs on any `ALLOW` where a peer is
admitted under a foreign claimed id (the substitution), and passes vacuously on
baseline traces with no verdict lines. It is deliberately the complement of the
`sender`-keyed sibling validator that cannot see this.

**Scenario role** — `delegation_thief`
(`packages/nest-core/nest_core/scenarios_builtin/attested_peering.py`,
`scenarios/attested_peering.yaml`). Presents a card claiming `honest-0` with the
victim's copied operator delegation but the attacker's own key, self-signed by
the attacker. Under the fixed plugin its verdict is
`verdict:delegation_thief-0:honest-0:DENY:0:1:1` — DENY at friend-or-foe — so
`peer_id != sender` never coincides with `ALLOW` and the validator PASSes. Under
the pre-fix message format it would ALLOW as `honest-0`, and the validator
FAILs. Determinism is preserved (seeded key derivation only, no wall clock, no
`os.urandom`).

## Verify

```bash
# 1) Run the attack at the plugin API + the new validator/property tests
uv run pytest packages/nest-plugins-reference/tests/test_attested_peering.py \
  -k "copied_delegation or identity_substitution or validator_" -v

# 2) Run the full scenario and print the thief verdict + all three validators
uv run python -c "
import asyncio, tempfile, json
from pathlib import Path
from nest_core.runner import ScenarioRunner
from nest_core.scenario import ScenarioConfig
from nest_core.plugins import PluginRegistry
from nest_core.validators import validate_trace
cfg = ScenarioConfig.from_yaml('scenarios/attested_peering.yaml')
with tempfile.TemporaryDirectory() as t:
    tp = Path(t)/'x.jsonl'
    cfg = cfg.model_copy(update={'output': cfg.output.model_copy(update={'trace': str(tp)})})
    asyncio.run(ScenarioRunner(cfg, registry=PluginRegistry()).run())
    for line in tp.read_text().splitlines():
        d = json.loads(line)
        if d.get('kind')=='send' and d.get('agent')=='observer' and 'delegation_thief' in d['msg'] and d['msg'].startswith('verdict'):
            print('THIEF:', d['msg'])
    for r in validate_trace(tp, 'attested_peering'):
        print(('PASS' if r.passed else 'FAIL'), r.name)
"
```

Expected output of step 2:

```
THIEF: verdict:delegation_thief-0:honest-0:DENY:0:1:1
PASS attested_no_denied_admitted
PASS attested_no_identity_substitution
PASS attested_sybil_quarantined
```

RED→GREEN evidence: with `_delegation_msg` reverted to the v1 (key-free) form,
`test_copied_delegation_on_foreign_key_denied` and
`test_property_copied_delegation_always_denied` both fail with
`assert 'ALLOW' == 'DENY'` (attacker admitted as `honest-0`); with the v2 fix
both pass.

## Limitations / Scope

- **Secondary hardening taken (defence in depth).** `evaluate_peer`'s
  "who do you work for?" check previously tested only `op_id in
  policy.trusted_operators` — membership by the **16-hex (64-bit) operator
  fingerprint**. This PR now also asserts
  `policy.trusted_operators[op_id] == peer_facts.operator_public_key` (full-key
  equality), so a 64-bit fingerprint second-preimage that presented a different
  operator key under a trusted id is rejected. Combined with the key-bound
  delegation, the operator identity is now pinned end-to-end. Covered by
  `test_operator_fingerprint_collision_rejected`.
- The fix is a **breaking wire change** (v1 delegations no longer verify). That
  is intentional: v1 delegations are exactly the transferable tokens being
  retired. Any deployment must re-issue delegations under v2.
- Scope is limited to the trust layer; no other layers or plugins are touched.
  The safety validator, Sybil-quarantine validator, and byte-determinism test
  all remain green.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137ni2yk8VAh26RD6PBWThu
