### PR TITLE
[Hackathon] andrea-cola -> ed25519_recoverable: time-locked rotation + K-of-N social recovery (Layer 3 identity)

### DIFF
--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -77,6 +77,12 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("identity_rotation", identity_rotation_factory)
+    elif name == "identity_recoverable":
+        from nest_core.scenarios_builtin.identity_recoverable import (
+            identity_recoverable_factory,
+        )
+
+        register_scenario("identity_recoverable", identity_recoverable_factory)
     elif name == "attested_peering":
         from nest_core.scenarios_builtin.attested_peering import (
             attested_peering_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/identity_recoverable.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/identity_recoverable.py
@@ -1,0 +1,655 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Identity-recoverable scenario: time-locked rotation + K-of-N social recovery.
+
+This scenario exercises the two governance mechanisms unique to
+``ed25519_recoverable`` that ``ed25519_rotating`` (and ``did_key``) cannot
+demonstrate:
+
+1. **Time-locked rotations.** Honest signers rotate with a future
+   ``activates_at`` so the key window is visible in the trace; byzantine
+   signers attempt *instant* rotations (``activates_at == current_tick``) which
+   the plugin rejects — the rejection itself is emitted into the trace and
+   verified by the validator.
+
+2. **K-of-N social recovery.** One designated signer per run has its key
+   "compromised" at a configured round; K-of-N recovery attesters co-sign a
+   ``RecoveryEvent`` that force-installs a fresh key, bypassing continuity
+   entirely.  The recovered signer keeps signing under the new key;  the
+   validator confirms the recovery trace line appeared and subsequent honest
+   signatures are accepted.
+
+Trace line protocol (carried in message bodies, ``:``-delimited):
+
+* ``rotate:<agent>:<old_key_id>:<new_key_id>:<activates_at>`` — a time-locked
+  rotation announced; the old key's window closes at ``activates_at``.
+* ``activated:<agent>:<old_key_id>:<new_key_id>:<tick>`` — rotation activated
+  (clock reached ``activates_at``).
+* ``recover:<agent>:<old_key_id>:<new_key_id>:<tick>`` — social recovery
+  applied; force-installs the new key from tick.
+* ``timelock_reject:<agent>:<attempted_at>:<lock>`` — attempted instant
+  rotation rejected by time-lock.
+* ``signed:<agent>:<key_id>:<claimed_tick>:<verdict>`` — a signed heartbeat;
+  ``verdict`` is ``ok`` (honest), ``forge`` (post-rotation with stale key), or
+  ``backdate`` (new-key sig claiming old tick).
+
+Example::
+
+    agents = identity_recoverable_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId
+
+
+def _identity_of(ctx: AgentContext) -> Any:
+    return ctx.plugins.get("identity")
+
+
+def _key_id_token(sig: Any) -> str:
+    return str(getattr(sig, "key_id", None))
+
+
+def _signed_at_token(sig: Any, fallback: float) -> str:
+    value = getattr(sig, "signed_at", None)
+    return str(fallback if value is None else value)
+
+
+class HonestSigner(StateMachineAgent):
+    """Signs heartbeats, performs a time-locked rotation mid-run.
+
+    Uses ``advance()`` to tick the plugin clock, then calls ``rotate()``
+    (not ``rotate_key()``) which announces a pending rotation.  The pending
+    rotation activates automatically once ``advance()`` reaches
+    ``activates_at``.  Both the announcement and the activation are emitted
+    into the trace for the validator.
+
+    Also acts as a recovery attester for the designated victim agent: when
+    asked, signs a recovery event and broadcasts it to the auditor.
+
+    Example::
+
+        agent = HonestSigner(AgentId("signer-0"), AgentId("auditor-0"), rounds=10)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        auditor: AgentId,
+        rounds: int = 10,
+        rotate_at_round: int = 4,
+        time_lock: float = 3.0,
+        victim_id: AgentId | None = None,
+    ) -> None:
+        self._id = agent_id
+        self._auditor = auditor
+        self._rounds = rounds
+        self._rotate_at_round = rotate_at_round
+        self._time_lock = time_lock
+        self._victim_id = victim_id
+        self._round = 0
+        self._pending_activates_at: float | None = None
+
+    async def _emit_round(self, ctx: AgentContext) -> None:
+        self._round += 1
+        ident = _identity_of(ctx)
+        if ident is None:  # pragma: no cover
+            return
+
+        if hasattr(ident, "advance"):
+            ident.advance(float(ctx.time))
+
+        # Announce time-locked rotation at the designated round.
+        if self._round == self._rotate_at_round and hasattr(ident, "rotate"):
+            old_key_id = str(ident.current_key_id)
+            activates_at = float(ctx.time) + self._time_lock
+            pending = ident.rotate(b"rot:" + str(self._id).encode(), activates_at=activates_at)
+            self._pending_activates_at = activates_at
+            await ctx.send(
+                self._auditor,
+                f"rotate:{self._id}:{old_key_id}:{pending.new_key_id}:{activates_at}".encode(),
+            )
+
+        # Once the rotation has activated, emit the activation event once.
+        if (
+            self._pending_activates_at is not None
+            and float(ctx.time) >= self._pending_activates_at
+        ):
+            # The plugin auto-activates in advance(); read the now-current key.
+            new_key_id = str(ident.current_key_id)
+            await ctx.send(
+                self._auditor,
+                f"activated:{self._id}:{new_key_id}:{ctx.time}".encode(),
+            )
+            self._pending_activates_at = None
+
+        sig = ident.sign(f"heartbeat:{self._id}:{self._round}".encode())
+        await ctx.send(
+            self._auditor,
+            f"signed:{self._id}:{_key_id_token(sig)}:{_signed_at_token(sig, ctx.time)}:ok".encode(),
+        )
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Emit the first signing round.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        await self._emit_round(ctx)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Advance one round on each auditor tick, or co-sign a recovery request.
+
+        Example::
+
+            await agent.on_message(ctx, auditor, b"tick:1")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if msg.startswith("tick:") and self._round < self._rounds:
+            await self._emit_round(ctx)
+        elif msg.startswith("recover_request:") and self._victim_id is not None:
+            # Format: recover_request:<target>:<old_key_id>:<new_public_key_hex>:<recovered_at>
+            parts = msg.split(":", 5)
+            if len(parts) < 5:
+                return
+            target_str, old_key_hex, new_pub_hex, recovered_at_str = (
+                parts[1],
+                parts[2],
+                parts[3],
+                parts[4],
+            )
+            ident = _identity_of(ctx)
+            if not hasattr(ident, "sign_recovery"):
+                return
+            from nest_core.types import AgentId as Aid
+
+            from nest_plugins_reference.identity.ed25519_recoverable import KeyId
+
+            target = Aid(target_str)
+            old_key_id = KeyId(old_key_hex)
+            new_pub = bytes.fromhex(new_pub_hex)
+            recovered_at = float(recovered_at_str)
+            sig_bytes = ident.sign_recovery(target, old_key_id, new_pub, recovered_at)
+            await ctx.send(
+                self._auditor,
+                f"recovery_sig:{self._id}:{target_str}:{old_key_hex}:{new_pub_hex}:{recovered_at_str}:{sig_bytes.hex()}".encode(),
+            )
+
+
+class VictimSigner(StateMachineAgent):
+    """A signer whose key is 'compromised' mid-run and later recovered via attesters.
+
+    At ``compromise_round`` the victim broadcasts a recovery request to all
+    attesters.  Once the auditor relays back enough ``recovery_sig:`` messages
+    (≥ quorum_k), the victim assembles and applies the ``RecoveryEvent``,
+    emits a ``recover:`` trace line, and resumes signing under the new key.
+
+    Example::
+
+        agent = VictimSigner(AgentId("victim-0"), AgentId("auditor-0"), attester_ids=[...])
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        auditor: AgentId,
+        attester_ids: list[AgentId],
+        quorum_k: int = 2,
+        rounds: int = 10,
+        compromise_round: int = 5,
+        recovery_seed: bytes = b"recovery-seed",
+    ) -> None:
+        self._id = agent_id
+        self._auditor = auditor
+        self._attester_ids = attester_ids
+        self._quorum_k = quorum_k
+        self._rounds = rounds
+        self._compromise_round = compromise_round
+        self._recovery_seed = recovery_seed
+        self._round = 0
+        self._recovery_initiated = False
+        self._collected_sigs: dict[str, bytes] = {}
+        self._recovery_applied = False
+        self._new_pub: bytes | None = None
+        self._new_key_id: str | None = None
+        self._old_key_id: str | None = None
+        self._recovered_at: float | None = None
+        self._recovery_private_key: Any = None
+
+    def _prepare_recovery_key(self, ident: Any) -> tuple[bytes, str]:
+        """Derive the recovery public key deterministically; stash the private key."""
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        from nest_plugins_reference.identity.ed25519_recoverable import (
+            _derive_seed,
+            _key_id_for,
+            _public_bytes,
+        )
+
+        priv = Ed25519PrivateKey.from_private_bytes(
+            _derive_seed(self._recovery_seed, self._id, 99)
+        )
+        self._recovery_private_key = priv
+        new_pub = _public_bytes(priv.public_key())
+        new_kid = str(_key_id_for(new_pub))
+        return new_pub, new_kid
+
+    async def _emit_round(self, ctx: AgentContext) -> None:
+        self._round += 1
+        ident = _identity_of(ctx)
+        if ident is None:  # pragma: no cover
+            return
+        if hasattr(ident, "advance"):
+            ident.advance(float(ctx.time))
+
+        can_recover = hasattr(ident, "observe_recovery") and hasattr(ident, "current_key_id")
+        if self._round == self._compromise_round and not self._recovery_initiated and can_recover:
+            self._recovery_initiated = True
+            self._old_key_id = str(ident.current_key_id)
+            self._recovered_at = float(ctx.time) + 1.0
+            new_pub, new_kid = self._prepare_recovery_key(ident)
+            self._new_pub = new_pub
+            self._new_key_id = new_kid
+            # Broadcast recovery request to all attesters via auditor relay.
+            for att_id in self._attester_ids:
+                await ctx.send(
+                    att_id,
+                    f"recover_request:{self._id}:{self._old_key_id}:{new_pub.hex()}:{self._recovered_at}".encode(),
+                )
+
+        sig = ident.sign(f"heartbeat:{self._id}:{self._round}".encode())
+        await ctx.send(
+            self._auditor,
+            f"signed:{self._id}:{_key_id_token(sig)}:{_signed_at_token(sig, ctx.time)}:ok".encode(),
+        )
+
+    async def _try_apply_recovery(self, ctx: AgentContext) -> None:
+        if self._recovery_applied or len(self._collected_sigs) < self._quorum_k:
+            return
+        if self._new_pub is None or self._old_key_id is None or self._recovered_at is None:
+            return  # pragma: no cover
+
+        ident = _identity_of(ctx)
+        if not hasattr(ident, "observe_recovery"):
+            return
+
+        from nest_plugins_reference.identity.ed25519_recoverable import (
+            KeyId,
+            RecoveryEvent,
+            _key_id_for,
+        )
+
+        new_key_id = _key_id_for(self._new_pub)
+        recovery = RecoveryEvent(
+            target_agent=self._id,
+            old_key_id=KeyId(self._old_key_id),
+            new_key_id=new_key_id,
+            new_public_key=self._new_pub,
+            recovered_at=self._recovered_at,
+            attester_signatures=dict(self._collected_sigs),
+            new_epoch=1,
+        )
+        ok = ident.observe_recovery(recovery)
+        if ok:
+            self._recovery_applied = True
+            # Inject the private key into the newly installed epoch so the
+            # victim can continue signing.  observe_recovery() only stores the
+            # public key; the private key was derived locally in
+            # _prepare_recovery_key() and is safe to inject here.
+            if self._recovery_private_key is not None:
+                epochs = ident._epochs.get(self._id, [])  # noqa: SLF001
+                if epochs and epochs[-1].private_key is None:
+                    epochs[-1].private_key = self._recovery_private_key
+            await ctx.send(
+                self._auditor,
+                f"recover:{self._id}:{self._old_key_id}:{new_key_id}:{self._recovered_at}".encode(),
+            )
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Emit the first signing round.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        await self._emit_round(ctx)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Handle tick pulses and incoming recovery signatures.
+
+        Example::
+
+            await agent.on_message(ctx, sender, b"tick:2")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if msg.startswith("tick:") and self._round < self._rounds:
+            await self._emit_round(ctx)
+        elif msg.startswith("recovery_sig:"):
+            # Format: recovery_sig:<attester>:<target>:<old_key>:<new_pub_hex>:<recovered_at>:<sig_hex>
+            parts = msg.split(":", 7)
+            if len(parts) < 7:
+                return
+            attester_id_str = parts[1]
+            sig_hex = parts[6]
+            self._collected_sigs[attester_id_str] = bytes.fromhex(sig_hex)
+            await self._try_apply_recovery(ctx)
+
+
+class ByzantineSigner(StateMachineAgent):
+    """Attempts instant rotation (below time-lock) and post-rotation forgery.
+
+    Two attacks:
+
+    * At ``attack_round`` calls ``rotate()`` with ``activates_at ==
+      current_tick``, which the plugin must reject with ``ValueError``.  The
+      rejection is emitted as a ``timelock_reject:`` trace line.
+    * After performing a valid (time-locked) rotation, uses ``sign_with()``
+      to forge a signature with the rotated-out key, and also backdates a
+      new-key signature — exactly the two attacks the validator must catch.
+
+    Example::
+
+        agent = ByzantineSigner(AgentId("byz-0"), AgentId("auditor-0"), rounds=10)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        auditor: AgentId,
+        rounds: int = 10,
+        attack_round: int = 4,
+        time_lock: float = 3.0,
+    ) -> None:
+        self._id = agent_id
+        self._auditor = auditor
+        self._rounds = rounds
+        self._attack_round = attack_round
+        self._time_lock = time_lock
+        self._round = 0
+        self._old_key_id: str = ""
+        self._rotated = False
+
+    async def _emit_round(self, ctx: AgentContext) -> None:
+        self._round += 1
+        ident = _identity_of(ctx)
+        if ident is None:  # pragma: no cover
+            return
+        if hasattr(ident, "advance"):
+            ident.advance(float(ctx.time))
+
+        can_attack = hasattr(ident, "rotate") and hasattr(ident, "sign_with")
+
+        if self._round == self._attack_round and can_attack:
+            # Attack 1: attempt instant rotation (must be rejected).
+            try:
+                ident.rotate(b"instant-evil", activates_at=float(ctx.time))
+                # If we reach here the plugin did not enforce the time-lock.
+                await ctx.send(
+                    self._auditor,
+                    f"timelock_accepted:{self._id}:{ctx.time}".encode(),
+                )
+            except ValueError:
+                await ctx.send(
+                    self._auditor,
+                    f"timelock_reject:{self._id}:{ctx.time}:{self._time_lock}".encode(),
+                )
+
+            # Now perform a valid (time-locked) rotation for subsequent forgery.
+            self._old_key_id = str(ident.current_key_id)
+            activates_at = float(ctx.time) + self._time_lock
+            pending = ident.rotate(b"rot:" + str(self._id).encode(), activates_at=activates_at)
+            await ctx.send(
+                self._auditor,
+                f"rotate:{self._id}:{self._old_key_id}:{pending.new_key_id}:{activates_at}".encode(),
+            )
+            self._rotated = True
+
+        if self._rotated and float(ctx.time) >= float(self._attack_round) + self._time_lock:
+            # The rotation has activated; attempt post-rotation forgery.
+            from nest_plugins_reference.identity.ed25519_recoverable import KeyId
+
+            forged = ident.sign_with(
+                f"forged:{self._id}:{self._round}".encode(), KeyId(self._old_key_id)
+            )
+            await ctx.send(
+                self._auditor,
+                (
+                    f"signed:{self._id}:{_key_id_token(forged)}:"
+                    f"{_signed_at_token(forged, ctx.time)}:forge"
+                ).encode(),
+            )
+            # Attack 2: backdating — sign with new key, claim old tick.
+            sig = ident.sign(f"backdated:{self._id}:{self._round}".encode())
+            await ctx.send(
+                self._auditor,
+                f"signed:{self._id}:{_key_id_token(sig)}:0.0:backdate".encode(),
+            )
+            return
+
+        sig = ident.sign(f"heartbeat:{self._id}:{self._round}".encode())
+        await ctx.send(
+            self._auditor,
+            f"signed:{self._id}:{_key_id_token(sig)}:{_signed_at_token(sig, ctx.time)}:ok".encode(),
+        )
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Emit the first signing round.
+
+        Example::
+
+            await agent.on_start(ctx)
+        """
+        await self._emit_round(ctx)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Advance one round on each auditor tick.
+
+        Example::
+
+            await agent.on_message(ctx, auditor, b"tick:1")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if msg.startswith("tick:") and self._round < self._rounds:
+            await self._emit_round(ctx)
+
+
+class AuditorAgent(StateMachineAgent):
+    """Drives rounds, relays recovery signatures, records all trace events.
+
+    Example::
+
+        auditor = AuditorAgent(AgentId("auditor-0"), signers, rounds=10)
+    """
+
+    def __init__(self, agent_id: AgentId, signers: list[AgentId], rounds: int = 10) -> None:
+        self._id = agent_id
+        self._signers = signers
+        self._rounds = rounds
+        self._round = 1
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Schedule the first round pulse.
+
+        Example::
+
+            await auditor.on_start(ctx)
+        """
+        await self._schedule_next(ctx)
+
+    async def _schedule_next(self, ctx: AgentContext) -> None:
+        if self._round >= self._rounds:
+            return
+        await ctx.schedule(1.0, b"pulse:")
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Drive the next round on each self-scheduled pulse.
+
+        Also relays recovery signatures from attesters back to the victim.
+
+        Example::
+
+            await auditor.on_message(ctx, auditor, b"pulse:")
+        """
+        msg = payload.decode("utf-8", errors="replace")
+        if msg.startswith("pulse:"):
+            self._round += 1
+            for signer in self._signers:
+                await ctx.send(signer, f"tick:{self._round}".encode())
+            await self._schedule_next(ctx)
+        elif msg.startswith("recovery_sig:"):
+            # Relay recovery signatures back: the victim's id is parts[2].
+            parts = msg.split(":", 7)
+            if len(parts) >= 3:
+                from nest_core.types import AgentId as Aid
+
+                victim_id = Aid(parts[2])
+                if victim_id in self._signers:
+                    await ctx.send(victim_id, payload)
+
+
+def _provision_identities(
+    plugins: dict[str, Any],
+    victim_id: AgentId,
+    signer_ids: list[AgentId],
+    attester_ids: list[AgentId],
+    quorum_k: int,
+) -> None:
+    """Instantiate per-agent identity instances with recovery configuration.
+
+    The victim's plugin is constructed with ``recovery_attesters`` and
+    ``recovery_quorum_k`` set; all other agents get plain instances.  Attester
+    identities are cross-registered with the victim so the victim can verify
+    their recovery signatures.
+
+    Example::
+
+        _provision_identities(plugins, victim_id, signers, attesters, quorum_k=2)
+    """
+    identity_cls = plugins.get("identity")
+    if identity_cls is None or not isinstance(identity_cls, type):
+        return
+
+    import inspect
+
+    cls_params = set(inspect.signature(identity_cls.__init__).parameters)
+    supports_recovery = "recovery_attesters" in cls_params
+
+    identities: dict[AgentId, Any] = {}
+    for aid in signer_ids:
+        if aid == victim_id and supports_recovery:
+            identities[aid] = identity_cls(
+                aid,
+                seed=b"identity-recoverable:" + str(aid).encode(),
+                recovery_attesters=attester_ids,
+                recovery_quorum_k=quorum_k,
+            )
+        else:
+            identities[aid] = identity_cls(
+                aid, seed=b"identity-recoverable:" + str(aid).encode()
+            )
+
+    # Cross-register public keys so verify() works across agents.
+    for aid, ident in identities.items():
+        for peer_id, peer_ident in identities.items():
+            if peer_id != aid and hasattr(ident, "register_peer"):
+                ident.register_peer(peer_id, peer_ident.public_key)
+
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+    for aid, ident in identities.items():
+        agent_plugins.setdefault(aid, {})["identity"] = ident
+
+    plugins.pop("identity", None)
+
+
+def identity_recoverable_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create honest signers, one victim, byzantine signers, and one auditor.
+
+    Configuration keys (all optional):
+
+    * ``rounds`` (int, default 10): total rounds per agent.
+    * ``rotate_at_round`` (int, default 4): round at which honest signers rotate.
+    * ``compromise_round`` (int, default 5): round at which the victim initiates recovery.
+    * ``time_lock`` (float, default 3.0): minimum tick gap before a rotation activates.
+    * ``recovery_attesters`` (int, default 3): number of agents that act as attesters.
+    * ``recovery_quorum_k`` (int, default 2): minimum attesters required for recovery.
+
+    Example::
+
+        agents = identity_recoverable_factory(config, plugins)
+    """
+    task_config = config.task.config
+    rounds = int(task_config.get("rounds", 10))
+    rotate_at_round = int(task_config.get("rotate_at_round", 4))
+    compromise_round = int(task_config.get("compromise_round", 5))
+    time_lock = float(task_config.get("time_lock", 3.0))
+    num_attesters = int(task_config.get("recovery_attesters", 3))
+    quorum_k = int(task_config.get("recovery_quorum_k", 2))
+    byzantine_fraction = config.failures.byzantine_agents or float(
+        task_config.get("byzantine_fraction", 0.10)
+    )
+
+    total_signers = max(1, config.agents.count - 1)
+    byzantine_count = int(total_signers * byzantine_fraction)
+    honest_count = max(0, total_signers - byzantine_count - 1)  # -1 for victim
+
+    if config.agents.roles:
+        for role in config.agents.roles:
+            if role.name == "honest":
+                honest_count = role.count
+            elif role.name == "byzantine":
+                byzantine_count = role.count
+
+    auditor_id = AgentId("auditor-0")
+    victim_id = AgentId("victim-0")
+    honest_ids = [AgentId(f"signer-{i}") for i in range(honest_count)]
+    byzantine_ids = [AgentId(f"byz-{i}") for i in range(byzantine_count)]
+
+    # Pick attesters from honest signers (or wrap around if not enough).
+    attester_ids = honest_ids[:num_attesters]
+    if len(attester_ids) < quorum_k:
+        quorum_k = len(attester_ids)
+
+    all_signers: list[AgentId] = [victim_id] + honest_ids + byzantine_ids
+
+    _provision_identities(plugins, victim_id, all_signers, attester_ids, quorum_k)
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+
+    agents[victim_id] = VictimSigner(
+        victim_id,
+        auditor=auditor_id,
+        attester_ids=attester_ids,
+        quorum_k=quorum_k,
+        rounds=rounds,
+        compromise_round=compromise_round,
+    )
+
+    for aid in honest_ids:
+        agents[aid] = HonestSigner(
+            aid,
+            auditor=auditor_id,
+            rounds=rounds,
+            rotate_at_round=rotate_at_round,
+            time_lock=time_lock,
+            victim_id=victim_id,
+        )
+
+    for aid in byzantine_ids:
+        agents[aid] = ByzantineSigner(
+            aid,
+            auditor=auditor_id,
+            rounds=rounds,
+            attack_round=rotate_at_round,
+            time_lock=time_lock,
+        )
+
+    agents[auditor_id] = AuditorAgent(auditor_id, signers=all_signers, rounds=rounds)
+    return agents

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1102,6 +1102,205 @@ def validate_identity_rotation_signatures(
 
 
 # ---------------------------------------------------------------------------
+# Identity recoverable validators
+# ---------------------------------------------------------------------------
+
+
+def _build_recovery_key_windows(
+    events: list[dict[str, Any]],
+) -> dict[str, _KeyWindow]:
+    """Build key validity windows from both ``rotate:`` and ``recover:`` trace lines.
+
+    ``rotate:`` lines use a future ``activates_at`` (time-lock).
+    ``recover:`` lines take effect immediately at ``recovered_at``.
+
+    Example::
+
+        windows = _build_recovery_key_windows(events)
+    """
+    windows: dict[str, _KeyWindow] = {}
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if msg.startswith("rotate:"):
+            # rotate:<agent>:<old_key_id>:<new_key_id>:<activates_at>
+            parts = msg.split(":")
+            if len(parts) < 5:
+                continue
+            old_key_id, new_key_id = parts[2], parts[3]
+            activates_at = _parse_tick(parts[4])
+            if activates_at is None:
+                continue
+            old = windows.setdefault(old_key_id, _KeyWindow(issued_at=0.0))
+            old.rotated_out = activates_at
+            windows[new_key_id] = _KeyWindow(issued_at=activates_at)
+        elif msg.startswith("recover:"):
+            # recover:<agent>:<old_key_id>:<new_key_id>:<recovered_at>
+            parts = msg.split(":")
+            if len(parts) < 5:
+                continue
+            old_key_id, new_key_id = parts[2], parts[3]
+            recovered_at = _parse_tick(parts[4])
+            if recovered_at is None:
+                continue
+            old = windows.setdefault(old_key_id, _KeyWindow(issued_at=0.0))
+            old.rotated_out = recovered_at
+            windows[new_key_id] = _KeyWindow(issued_at=recovered_at)
+    return windows
+
+
+def validate_identity_recovery_occurred(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """At least one social recovery happened over the run.
+
+    Example::
+
+        results = validate_identity_recovery_occurred(events)
+    """
+    recoveries = sum(
+        1
+        for ev in events
+        if ev.get("kind") == "send" and _message_body(ev).startswith("recover:")
+    )
+    if recoveries == 0:
+        return [
+            ValidationResult(
+                "identity_recovery_occurred",
+                False,
+                "no social recovery events found in trace",
+            )
+        ]
+    return [
+        ValidationResult(
+            "identity_recovery_occurred",
+            True,
+            f"{recoveries} social recovery events observed",
+        )
+    ]
+
+
+def validate_identity_timelock_enforced(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """At least one ``timelock_reject:`` line is present and no ``timelock_accepted:`` line.
+
+    A ``timelock_accepted:`` line means a byzantine agent's instant-rotation was
+    accepted — the time-lock is broken.  A missing ``timelock_reject:`` line means
+    the byzantine agent never even tried or the plugin silently ate the call.
+
+    Example::
+
+        results = validate_identity_timelock_enforced(events)
+    """
+    rejections = 0
+    acceptances: list[str] = []
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if msg.startswith("timelock_reject:"):
+            rejections += 1
+        elif msg.startswith("timelock_accepted:"):
+            acceptances.append(msg)
+
+    if acceptances:
+        return [
+            ValidationResult(
+                "identity_timelock_enforced",
+                False,
+                f"instant rotation was accepted: {acceptances[0]}",
+            )
+        ]
+    if rejections == 0:
+        return [
+            ValidationResult(
+                "identity_timelock_enforced",
+                False,
+                "no timelock_reject: lines found — byzantine agent may not have attacked",
+            )
+        ]
+    return [
+        ValidationResult(
+            "identity_timelock_enforced",
+            True,
+            f"{rejections} instant-rotation attempt(s) correctly rejected",
+        )
+    ]
+
+
+def validate_identity_recoverable_signatures(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Honest signatures verify within their key windows; forged / backdated attacks are rejected.
+
+    Rebuilds key windows from ``rotate:`` and ``recover:`` trace lines (both
+    close the old key's window), then checks every ``signed:`` line.
+
+    Example::
+
+        results = validate_identity_recoverable_signatures(events)
+    """
+    windows = _build_recovery_key_windows(events)
+    honest_invalid: list[str] = []
+    attacks_accepted: list[str] = []
+    ok_count = 0
+    attack_count = 0
+
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("signed:"):
+            continue
+        parts = msg.split(":")
+        if len(parts) < 5:
+            continue
+        agent, key_id, claimed_raw, verdict = parts[1], parts[2], parts[3], parts[4]
+        observed_tick = _parse_tick(str(ev.get("ts")))
+        claimed_tick = _parse_tick(claimed_raw)
+
+        window = windows.get(key_id)
+        if window is None and key_id and key_id != "None" and verdict == "ok":
+            window = windows.setdefault(key_id, _KeyWindow(issued_at=0.0))
+
+        window_valid = (
+            window is not None
+            and observed_tick is not None
+            and claimed_tick is not None
+            and window.contains(observed_tick)
+            and window.contains(claimed_tick)
+        )
+
+        if verdict == "ok":
+            ok_count += 1
+            if not window_valid:
+                honest_invalid.append(
+                    f"{agent} honest sig key={key_id[:8] if key_id else '?'} "
+                    f"observed={observed_tick} claimed={claimed_tick} not in a valid window"
+                )
+        else:
+            attack_count += 1
+            if window_valid:
+                attacks_accepted.append(
+                    f"{agent} {verdict} sig key={key_id[:8] if key_id else '?'} "
+                    f"observed={observed_tick} claimed={claimed_tick} accepted"
+                )
+
+    problems = honest_invalid + attacks_accepted
+    if problems:
+        return [ValidationResult("identity_recoverable_signatures", False, "; ".join(problems))]
+    return [
+        ValidationResult(
+            "identity_recoverable_signatures",
+            True,
+            f"{ok_count} honest signatures valid, {attack_count} attacks rejected",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Memory convergence (CRDT) validators
 # ---------------------------------------------------------------------------
 
@@ -5329,6 +5528,11 @@ VALIDATORS: dict[str, list[Any]] = {
     "identity_rotation": [
         validate_identity_rotation_occurred,
         validate_identity_rotation_signatures,
+    ],
+    "identity_recoverable": [
+        validate_identity_recovery_occurred,
+        validate_identity_timelock_enforced,
+        validate_identity_recoverable_signatures,
     ],
     "attested_peering": [
         validate_attested_no_denied_admitted,

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -2128,6 +2128,7 @@ class TestValidatorRegistry:
             "supply_chain",
             "reputation",
             "identity_rotation",
+            "identity_recoverable",
             "attested_peering",
             "memory_concurrent_writers",
             "streaming_payments",

--- a/packages/nest-plugins-reference/nest_plugins_reference/identity/adversarial_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/identity/adversarial_validators.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportPrivateUsage=false
+"""Adversarial validators for the ``ed25519_recoverable`` identity plugin.
+
+Two governance invariants that ``ed25519_rotating`` (and ``did_key``) silently
+allow to be violated:
+
+1. **No instant rotations.** A rotation whose ``activates_at`` is less than
+   ``current_tick + time_lock`` must be rejected. ``ed25519_rotating`` accepts
+   rotations at any tick — an attacker with a briefly captured key can rotate
+   immediately. ``validate_no_instant_rotations`` exercises this by attempting
+   a rotation that violates the time-lock and asserting it fails.
+
+2. **No unilateral recoveries.** A recovery signed by fewer than K distinct,
+   declared attesters must be rejected. ``ed25519_rotating`` has no recovery
+   concept at all. ``validate_no_unilateral_recoveries`` exercises this by
+   building a recovery event with only 1 attester signature (below quorum)
+   and asserting it is rejected.
+
+Each validator is a pure function on the plugin's public API surface — it
+performs only ``rotate``/``observe_recovery``/``sign_recovery``/``advance``
+calls and never reaches into plugin internals.
+
+By construction:
+
+* against ``ed25519_recoverable`` every check **passes** (the governance
+  rules are enforced);
+* against ``ed25519_rotating`` and ``did_key`` the checks either **fail** or
+  are not applicable (no time-lock, no recovery).
+
+Example::
+
+    report = validate_no_instant_rotations(plugin)
+    assert report.passed, report.detail
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import cast
+
+
+@dataclass
+class ValidatorReport:
+    """Pass/fail report with a short human-readable explanation.
+
+    Example::
+
+        report = ValidatorReport(passed=True, detail="time-lock enforced")
+        assert report.passed, report.detail
+    """
+
+    passed: bool
+    detail: str
+    evidence: dict[str, object] = field(default_factory=lambda: dict[str, object]())
+
+
+def validate_no_instant_rotations(plugin: object) -> ValidatorReport:
+    """Assert the plugin rejects rotations that violate the time-lock.
+
+    Attempts a rotation with ``activates_at = current_tick`` (instant), which
+    must raise ``ValueError`` on ``ed25519_recoverable``. On plugins without
+    a ``rotate`` method, returns a failing report.
+
+    Example::
+
+        report = validate_no_instant_rotations(plugin)
+        assert report.passed, report.detail
+    """
+    if not hasattr(plugin, "rotate"):
+        return ValidatorReport(
+            passed=False,
+            detail="plugin has no rotate method (no time-lock support)",
+        )
+
+    if not hasattr(plugin, "advance"):
+        return ValidatorReport(
+            passed=False,
+            detail="plugin has no advance method (no time-lock support)",
+        )
+
+    plugin.advance(10.0)  # type: ignore[union-attr]
+
+    try:
+        plugin.rotate(b"instant-attack", activates_at=10.0)  # type: ignore[union-attr]
+        return ValidatorReport(
+            passed=False,
+            detail="instant rotation was accepted (no time-lock enforcement)",
+            evidence={"activates_at": 10.0, "current_tick": 10.0},
+        )
+    except ValueError:
+        return ValidatorReport(
+            passed=True,
+            detail="instant rotation rejected by time-lock",
+        )
+
+
+def validate_no_unilateral_recoveries(
+    plugin: object,
+    attester_plugins: list[object],
+) -> ValidatorReport:
+    """Assert the plugin rejects a recovery with fewer than K attester signatures.
+
+    Builds a recovery event signed by only *one* attester (below the default
+    quorum of 2) and asserts ``observe_recovery`` rejects it.
+
+    Example::
+
+        report = validate_no_unilateral_recoveries(plugin, [attester1])
+        assert report.passed, report.detail
+    """
+    if not hasattr(plugin, "observe_recovery"):
+        return ValidatorReport(
+            passed=False,
+            detail="plugin has no observe_recovery method (no recovery support)",
+        )
+
+    if not attester_plugins:
+        return ValidatorReport(
+            passed=False,
+            detail="no attester plugins provided for recovery test",
+        )
+
+    from nest_core.types import AgentId
+
+    from nest_plugins_reference.identity.ed25519_recoverable import (
+        KeyId,
+        RecoveryEvent,
+        _key_id_for,
+    )
+
+    target_agent = cast("AgentId", plugin.agent_id)  # type: ignore[union-attr]
+    old_key_id = cast("KeyId", plugin.current_key_id)  # type: ignore[union-attr]
+
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    recovery_seed = b"recovery-key-for-test"
+    import hashlib
+
+    recovery_key_material = hashlib.sha512(
+        b"ed25519-recoverable:" + recovery_seed + b":recovery:0"
+    ).digest()[:32]
+    recovery_private = Ed25519PrivateKey.from_private_bytes(recovery_key_material)
+
+    from nest_plugins_reference.identity.ed25519_recoverable import _public_bytes
+
+    new_public_key = _public_bytes(recovery_private.public_key())
+
+    recovered_at = 10.0
+    new_key_id = _key_id_for(new_public_key)
+
+    attester = attester_plugins[0]
+    attester_id = str(attester.agent_id)  # type: ignore[union-attr]
+    attester_sig = attester.sign_recovery(  # type: ignore[union-attr]
+        target_agent, old_key_id, new_public_key, recovered_at
+    )
+
+    recovery_event = RecoveryEvent(
+        target_agent=target_agent,
+        old_key_id=old_key_id,
+        new_key_id=new_key_id,
+        new_public_key=new_public_key,
+        recovered_at=recovered_at,
+        attester_signatures={attester_id: attester_sig},
+        new_epoch=1,
+    )
+
+    accepted = plugin.observe_recovery(recovery_event)  # type: ignore[union-attr]
+    if accepted:
+        return ValidatorReport(
+            passed=False,
+            detail="unilateral recovery (1 of K) was accepted",
+            evidence={"attester_count": 1, "required_k": 2},
+        )
+    return ValidatorReport(
+        passed=True,
+        detail="unilateral recovery rejected (quorum not met)",
+    )
+
+
+def validate_identity_governance(
+    plugin: object,
+    attester_plugins: list[object] | None = None,
+) -> list[ValidatorReport]:
+    """Run both governance validators and return their reports.
+
+    Example::
+
+        reports = validate_identity_governance(plugin, [att1])
+        assert all(r.passed for r in reports)
+    """
+    reports = [validate_no_instant_rotations(plugin)]
+    if attester_plugins:
+        reports.append(validate_no_unilateral_recoveries(plugin, attester_plugins))
+    return reports

--- a/packages/nest-plugins-reference/nest_plugins_reference/identity/ed25519_recoverable.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/identity/ed25519_recoverable.py
@@ -1,0 +1,738 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ed25519 identity with time-locked rotation and K-of-N social recovery.
+
+Builds on the same ``cryptography.hazmat.primitives.asymmetric.ed25519``
+(RFC 8032) foundation as :mod:`~nest_plugins_reference.identity.ed25519_rotating`,
+adding two governance features neither merged plugin has:
+
+1. **Time-locked rotations.** A rotation is only accepted if
+   ``activates_at >= now + time_lock`` (default 3 logical ticks). Even a
+   captured current key cannot lock the legitimate owner out immediately —
+   the owner sees the pending rotation and has time to counter-rotate or
+   trigger recovery.
+
+2. **K-of-N social recovery.** Each agent declares a set of recovery
+   attesters at construction (e.g. 3 peers, quorum K=2). Any K of them can
+   co-sign a :class:`RecoveryEvent` that force-installs a fresh key chosen
+   by the recovering party. This bypasses continuity entirely — the
+   compromised key gets no say. The recovery event is publicly verifiable
+   and appears in :meth:`resolve`'s metadata.
+
+Verification anchors on an externally-supplied logical tick (via
+:meth:`advance`), never on the attacker-controlled ``sig.signed_at`` — as
+the :class:`~nest_core.types.Signature` docstring already prescribes.
+
+Determinism
+-----------
+
+* Keys are derived from ``(seed, agent_id, epoch)`` via SHA-512,
+  domain-separated. No ``os.urandom``.
+* Ed25519 signatures are deterministic per RFC 8032 §5.1.6.
+* The plugin exposes only :meth:`advance` as clock input, enforced
+  monotonic. No wall-clock time is read.
+
+Example::
+
+    ident = Ed25519RecoverableIdentity(
+        AgentId("a1"), seed=b"seed",
+        recovery_attesters=[AgentId("r1"), AgentId("r2"), AgentId("r3")],
+        recovery_quorum_k=2,
+    )
+    sig = ident.sign(b"hello")
+    assert ident.verify(b"hello", sig, AgentId("a1"))
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import NewType
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from nest_core.types import AgentId, AgentIdentity, Signature
+
+ALGORITHM = "ed25519-recoverable/1"
+"""Algorithm tag stamped on every :class:`~nest_core.types.Signature`.
+
+Example::
+
+    assert sig.algorithm == ALGORITHM
+"""
+
+KeyId = NewType("KeyId", str)
+"""Stable identifier for one Ed25519 public key (``sha256`` of the raw bytes).
+
+Example::
+
+    kid = KeyId("3b1f...")
+"""
+
+_INF = float("inf")
+DEFAULT_TIME_LOCK = 3.0
+
+
+def _derive_seed(seed: bytes, agent_id: AgentId, epoch: int) -> bytes:
+    """Derive a deterministic 32-byte Ed25519 private seed via SHA-512.
+
+    Domain-separated from ``ed25519_rotating``'s SHA-256 derivation.
+
+    Example::
+
+        s = _derive_seed(b"root", AgentId("a1"), 0)
+        assert len(s) == 32
+    """
+    material = (
+        b"ed25519-recoverable:" + seed + b":" + str(agent_id).encode() + b":" + str(epoch).encode()
+    )
+    return hashlib.sha512(material).digest()[:32]
+
+
+def _key_id_for(public_key: bytes) -> KeyId:
+    """Compute the :class:`KeyId` for raw public-key bytes.
+
+    Example::
+
+        kid = _key_id_for(b"\\x00" * 32)
+    """
+    return KeyId(hashlib.sha256(public_key).hexdigest())
+
+
+def _public_bytes(key: Ed25519PublicKey) -> bytes:
+    """Raw 32-byte encoding of an Ed25519 public key.
+
+    Example::
+
+        raw = _public_bytes(private.public_key())
+        assert len(raw) == 32
+    """
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+    return key.public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+
+@dataclass
+class KeyEpoch:
+    """One key in an agent's history with its validity window ``[issued_at, superseded_at)``.
+
+    Example::
+
+        epoch = KeyEpoch(key_id=KeyId("ab.."), public_key=pk, issued_at=0.0)
+        assert epoch.is_valid_at(0.0)
+    """
+
+    key_id: KeyId
+    public_key: bytes
+    issued_at: float
+    superseded_at: float = _INF
+    epoch: int = 0
+    private_key: Ed25519PrivateKey | None = field(default=None, repr=False)
+    recovery_events: list[RecoveryEvent] = field(default_factory=lambda: list[RecoveryEvent]())
+
+    def is_valid_at(self, tick: float) -> bool:
+        """Return whether this key's window contains *tick*.
+
+        Example::
+
+            e = KeyEpoch(KeyId("x"), b"pk", issued_at=10.0, superseded_at=20.0)
+            assert e.is_valid_at(10.0) and not e.is_valid_at(20.0)
+        """
+        return self.issued_at <= tick < self.superseded_at
+
+
+@dataclass
+class PendingRotation:
+    """A rotation that has been announced but not yet activated.
+
+    Example::
+
+        pr = PendingRotation(new_key_id=KeyId("ab"), ...)
+    """
+
+    new_key_id: KeyId
+    new_public_key: bytes
+    activates_at: float
+    continuity_signature: bytes
+    new_epoch: int
+    new_private_key: Ed25519PrivateKey | None = field(default=None, repr=False)
+
+
+@dataclass
+class RecoveryEvent:
+    """Publicly verifiable evidence that K-of-N attesters restored an agent's key.
+
+    Example::
+
+        re = RecoveryEvent(target_agent=AgentId("a1"), ...)
+    """
+
+    target_agent: AgentId
+    old_key_id: KeyId
+    new_key_id: KeyId
+    new_public_key: bytes
+    recovered_at: float
+    attester_signatures: dict[str, bytes] = field(default_factory=lambda: dict[str, bytes]())
+    new_epoch: int = 0
+
+
+class Ed25519RecoverableIdentity:
+    """Per-agent Ed25519 identity with time-locked rotation and social recovery.
+
+    Implements the structural :class:`~nest_core.layers.identity.Identity`
+    protocol (``sign``/``verify``/``resolve``) and adds :meth:`rotate`,
+    :meth:`observe_rotation`, :meth:`observe_recovery`, :meth:`sign_recovery`,
+    and :meth:`advance`.
+
+    Example::
+
+        ident = Ed25519RecoverableIdentity(AgentId("a1"), seed=b"seed")
+        sig = ident.sign(b"data")
+        assert ident.verify(b"data", sig, AgentId("a1"))
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        seed: bytes = b"",
+        *,
+        recovery_attesters: list[AgentId] | None = None,
+        recovery_quorum_k: int = 2,
+        time_lock: float = DEFAULT_TIME_LOCK,
+    ) -> None:
+        self._agent_id = agent_id
+        self._seed = seed
+        self._epoch = 0
+        self._tick: float = 0.0
+        self._time_lock = time_lock
+        self._recovery_attesters = list(recovery_attesters) if recovery_attesters else []
+        self._recovery_quorum_k = recovery_quorum_k
+
+        private = Ed25519PrivateKey.from_private_bytes(_derive_seed(seed, agent_id, 0))
+        pub = _public_bytes(private.public_key())
+        epoch0 = KeyEpoch(
+            key_id=_key_id_for(pub),
+            public_key=pub,
+            issued_at=0.0,
+            epoch=0,
+            private_key=private,
+        )
+        self._epochs: dict[AgentId, list[KeyEpoch]] = {agent_id: [epoch0]}
+        self._pending: dict[AgentId, PendingRotation | None] = {}
+        self._recovery_events: list[RecoveryEvent] = []
+
+    @property
+    def agent_id(self) -> AgentId:
+        """This agent's identifier.
+
+        Example::
+
+            aid = ident.agent_id
+        """
+        return self._agent_id
+
+    @property
+    def public_key(self) -> bytes:
+        """This agent's *current* public key bytes.
+
+        Example::
+
+            pk = ident.public_key
+        """
+        return self._epochs[self._agent_id][-1].public_key
+
+    @property
+    def current_key_id(self) -> KeyId:
+        """The :class:`KeyId` of this agent's current signing key.
+
+        Example::
+
+            kid = ident.current_key_id
+        """
+        return self._epochs[self._agent_id][-1].key_id
+
+    @property
+    def current_epoch(self) -> int:
+        """The current epoch index.
+
+        Example::
+
+            e = ident.current_epoch
+        """
+        return self._epoch
+
+    @property
+    def time_lock(self) -> float:
+        """The time-lock period for rotations.
+
+        Example::
+
+            tl = ident.time_lock
+        """
+        return self._time_lock
+
+    @property
+    def recovery_attesters(self) -> list[AgentId]:
+        """The set of recovery attesters for this agent.
+
+        Example::
+
+            attesters = ident.recovery_attesters
+        """
+        return list(self._recovery_attesters)
+
+    @property
+    def recovery_quorum_k(self) -> int:
+        """The required quorum for social recovery.
+
+        Example::
+
+            k = ident.recovery_quorum_k
+        """
+        return self._recovery_quorum_k
+
+    def advance(self, tick: float) -> None:
+        """Advance the plugin's logical clock. Monotonic: ignores backward ticks.
+
+        Also activates any pending rotation whose ``activates_at`` has been reached.
+
+        Example::
+
+            ident.advance(42.0)
+        """
+        if tick <= self._tick:
+            return
+        self._tick = tick
+        self._activate_pending()
+
+    def _activate_pending(self) -> None:
+        """Activate pending rotations whose time-lock has expired."""
+        for agent_id, pending in list(self._pending.items()):
+            if pending is None:
+                continue
+            if self._tick >= pending.activates_at:
+                epochs = self._epochs.get(agent_id, [])
+                if epochs:
+                    epochs[-1].superseded_at = pending.activates_at
+                new_epoch = KeyEpoch(
+                    key_id=pending.new_key_id,
+                    public_key=pending.new_public_key,
+                    issued_at=pending.activates_at,
+                    epoch=pending.new_epoch,
+                    private_key=pending.new_private_key,
+                )
+                epochs.append(new_epoch)
+                self._pending[agent_id] = None
+
+    def register_peer(
+        self,
+        agent_id: AgentId,
+        public_key: bytes,
+        private_key: bytes | None = None,
+        *,
+        recovery_attesters: list[AgentId] | None = None,
+        recovery_quorum_k: int | None = None,
+    ) -> None:
+        """Register a peer's *current* public key for verification.
+
+        Signature-compatible with ``did_key.register_peer`` so existing callers
+        keep working. Optional keyword-only parameters configure social recovery
+        for this peer.
+
+        Example::
+
+            ident.register_peer(AgentId("a2"), peer_pk)
+        """
+        if private_key is not None:
+            msg = "register_peer accepts public keys only"
+            raise ValueError(msg)
+        record = KeyEpoch(
+            key_id=_key_id_for(public_key),
+            public_key=public_key,
+            issued_at=self._tick,
+            epoch=0,
+        )
+        self._epochs[agent_id] = [record]
+
+    def rotate(self, new_seed: bytes, *, activates_at: float | None = None) -> PendingRotation:
+        """Announce a time-locked key rotation.
+
+        The rotation activates at ``activates_at`` (defaults to
+        ``current_tick + time_lock``). Raises ``ValueError`` if the activation
+        time violates the time-lock constraint.
+
+        Example::
+
+            pending = ident.rotate(b"new-seed")
+        """
+        if activates_at is None:
+            activates_at = self._tick + self._time_lock
+        if activates_at < self._tick + self._time_lock:
+            msg = (
+                f"activates_at ({activates_at}) must be >= "
+                f"current_tick ({self._tick}) + time_lock ({self._time_lock})"
+            )
+            raise ValueError(msg)
+
+        new_epoch_idx = self._epoch + 1
+        private = Ed25519PrivateKey.from_private_bytes(
+            _derive_seed(new_seed, self._agent_id, new_epoch_idx)
+        )
+        pub = _public_bytes(private.public_key())
+
+        current_epochs = self._epochs[self._agent_id]
+        current = current_epochs[-1]
+        if current.private_key is None:
+            msg = "cannot rotate: current key has no private material"
+            raise ValueError(msg)
+
+        continuity_msg = _continuity_message(
+            self._agent_id, current.key_id, _key_id_for(pub), pub, activates_at
+        )
+        continuity_sig = current.private_key.sign(continuity_msg)
+
+        pending = PendingRotation(
+            new_key_id=_key_id_for(pub),
+            new_public_key=pub,
+            activates_at=activates_at,
+            continuity_signature=continuity_sig,
+            new_epoch=new_epoch_idx,
+            new_private_key=private,
+        )
+        self._pending[self._agent_id] = pending
+        self._seed = new_seed
+        self._epoch = new_epoch_idx
+        return pending
+
+    def observe_rotation(self, agent_id: AgentId, pending: PendingRotation) -> bool:
+        """Record a peer's pending rotation after verifying continuity.
+
+        Returns ``False`` if the continuity signature does not check out or if
+        the time-lock is violated.
+
+        Example::
+
+            ok = observer.observe_rotation(AgentId("a2"), peer_pending)
+        """
+        epochs = self._epochs.get(agent_id, [])
+        if not epochs:
+            return False
+
+        current = epochs[-1]
+        if pending.activates_at < self._tick + self._time_lock:
+            return False
+
+        continuity_msg = _continuity_message(
+            agent_id,
+            current.key_id,
+            pending.new_key_id,
+            pending.new_public_key,
+            pending.activates_at,
+        )
+        try:
+            Ed25519PublicKey.from_public_bytes(current.public_key).verify(
+                pending.continuity_signature, continuity_msg
+            )
+        except InvalidSignature:
+            return False
+
+        self._pending[agent_id] = PendingRotation(
+            new_key_id=pending.new_key_id,
+            new_public_key=pending.new_public_key,
+            activates_at=pending.activates_at,
+            continuity_signature=pending.continuity_signature,
+            new_epoch=pending.new_epoch,
+        )
+        return True
+
+    def sign_recovery(
+        self,
+        target_agent: AgentId,
+        old_key_id: KeyId,
+        new_public_key: bytes,
+        recovered_at: float,
+    ) -> bytes:
+        """Sign a recovery event for another agent.
+
+        This agent must be a declared recovery attester for *target_agent*.
+        Returns the Ed25519 signature over the canonical recovery message.
+
+        Example::
+
+            sig_bytes = attester.sign_recovery(
+                AgentId("victim"), victim_old_key, new_pk, tick
+            )
+        """
+        my_epochs = self._epochs.get(self._agent_id, [])
+        if not my_epochs or my_epochs[-1].private_key is None:
+            msg = "cannot sign recovery: no private key"
+            raise ValueError(msg)
+
+        recovery_msg = _recovery_message(
+            target_agent, old_key_id, _key_id_for(new_public_key), new_public_key, recovered_at
+        )
+        return my_epochs[-1].private_key.sign(recovery_msg)
+
+    def observe_recovery(self, recovery: RecoveryEvent) -> bool:
+        """Apply a social recovery event if the quorum is met.
+
+        Verifies that:
+        - The target agent's current key matches ``recovery.old_key_id``
+        - At least K distinct, declared attesters have signed
+        - Each attester signature is valid
+
+        On success, force-installs the new key, bypassing continuity.
+
+        Example::
+
+            ok = ident.observe_recovery(recovery_event)
+        """
+        epochs = self._epochs.get(recovery.target_agent, [])
+        if not epochs:
+            return False
+
+        current = epochs[-1]
+        if current.key_id != recovery.old_key_id:
+            return False
+
+        recovery_msg = _recovery_message(
+            recovery.target_agent,
+            recovery.old_key_id,
+            recovery.new_key_id,
+            recovery.new_public_key,
+            recovery.recovered_at,
+        )
+
+        valid_attesters: set[str] = set()
+        for attester_id_str, sig_bytes in recovery.attester_signatures.items():
+            attester_id = AgentId(attester_id_str)
+            if attester_id not in self._recovery_attesters:
+                continue
+            attester_epochs = self._epochs.get(attester_id, [])
+            if not attester_epochs:
+                continue
+            attester_key = attester_epochs[-1]
+            try:
+                Ed25519PublicKey.from_public_bytes(attester_key.public_key).verify(
+                    sig_bytes, recovery_msg
+                )
+                valid_attesters.add(attester_id_str)
+            except InvalidSignature:
+                continue
+
+        if len(valid_attesters) < self._recovery_quorum_k:
+            return False
+
+        current.superseded_at = recovery.recovered_at
+        new_epoch_record = KeyEpoch(
+            key_id=recovery.new_key_id,
+            public_key=recovery.new_public_key,
+            issued_at=recovery.recovered_at,
+            epoch=recovery.new_epoch,
+        )
+        new_epoch_record.recovery_events.append(recovery)
+        epochs.append(new_epoch_record)
+        self._recovery_events.append(recovery)
+
+        self._pending[recovery.target_agent] = None
+        return True
+
+    def sign(self, payload: bytes) -> Signature:
+        """Sign *payload* with this agent's current Ed25519 key.
+
+        Example::
+
+            sig = ident.sign(b"data")
+        """
+        record = self._epochs[self._agent_id][-1]
+        if record.private_key is None:
+            msg = "cannot sign: no private key for current record"
+            raise ValueError(msg)
+        value = record.private_key.sign(payload)
+        return Signature(
+            signer=self._agent_id,
+            value=value,
+            algorithm=ALGORITHM,
+            key_id=str(record.key_id),
+            signed_at=self._tick,
+        )
+
+    def sign_with(self, payload: bytes, key_id: KeyId) -> Signature:
+        """Sign *payload* with a specific (possibly superseded) key by id.
+
+        Exposed so adversarial agents can attempt post-rotation forgery.
+
+        Example::
+
+            forged = attacker.sign_with(b"data", stolen_key_id)
+        """
+        record = next(
+            (e for e in self._epochs[self._agent_id] if e.key_id == key_id),
+            None,
+        )
+        if record is None or record.private_key is None:
+            msg = f"no private key for {key_id!r}"
+            raise ValueError(msg)
+        value = record.private_key.sign(payload)
+        return Signature(
+            signer=self._agent_id,
+            value=value,
+            algorithm=ALGORITHM,
+            key_id=str(record.key_id),
+            signed_at=self._tick,
+        )
+
+    def verify(
+        self,
+        payload: bytes,
+        sig: Signature,
+        agent: AgentId,
+        as_of: float | None = None,
+    ) -> bool:
+        """Verify *sig* over *payload* from *agent*, optionally as-of a tick.
+
+        A signature is accepted iff **both** hold:
+
+        1. It cryptographically verifies under the key bound to ``sig.key_id``.
+        2. That key's validity window ``[issued_at, superseded_at)`` contains the
+           **as-of tick**.
+
+        The as-of tick is supplied by the *verifier* (never from ``sig.signed_at``).
+
+        Example::
+
+            ok = ident.verify(b"data", sig, AgentId("a2"), as_of=15.0)
+        """
+        if sig.signer != agent:
+            return False
+        epochs = self._epochs.get(agent)
+        if not epochs:
+            return False
+        as_of_tick = self._tick if as_of is None else as_of
+
+        record = self._select_epoch(epochs, sig.key_id, as_of_tick)
+        if record is None:
+            return False
+        if not record.is_valid_at(as_of_tick):
+            return False
+        try:
+            Ed25519PublicKey.from_public_bytes(record.public_key).verify(sig.value, payload)
+        except InvalidSignature:
+            return False
+        return True
+
+    @staticmethod
+    def _select_epoch(
+        epochs: list[KeyEpoch],
+        key_id: str | None,
+        as_of_tick: float,
+    ) -> KeyEpoch | None:
+        """Pick the key epoch a signature binds to.
+
+        If the signature names a ``key_id`` we resolve exactly that epoch.
+        Without a ``key_id`` we fall back to whichever epoch was valid at
+        the as-of tick.
+        """
+        if key_id is not None:
+            return next((e for e in epochs if str(e.key_id) == key_id), None)
+        return next((e for e in epochs if e.is_valid_at(as_of_tick)), None)
+
+    async def resolve(self, agent: AgentId) -> AgentIdentity:
+        """Resolve *agent* to its identity record.
+
+        The ``metadata`` carries key history and recovery events.
+
+        Example::
+
+            info = await ident.resolve(AgentId("a2"))
+        """
+        epochs = self._epochs.get(agent, [])
+        current_pk = epochs[-1].public_key if epochs else b""
+        history = [
+            {
+                "key_id": str(e.key_id),
+                "public_key": e.public_key.hex(),
+                "issued_at": e.issued_at,
+                "superseded_at": None if e.superseded_at == _INF else e.superseded_at,
+                "epoch": e.epoch,
+                "recovered": len(e.recovery_events) > 0,
+            }
+            for e in epochs
+        ]
+        recoveries = [
+            {
+                "old_key_id": str(r.old_key_id),
+                "new_key_id": str(r.new_key_id),
+                "recovered_at": r.recovered_at,
+                "attester_count": len(r.attester_signatures),
+            }
+            for r in self._recovery_events
+            if r.target_agent == agent
+        ]
+        return AgentIdentity(
+            agent_id=agent,
+            public_key=current_pk,
+            method="did:key",
+            metadata={
+                "algorithm": ALGORITHM,
+                "keys": history,
+                "recovery_events": recoveries,
+                "time_lock": self._time_lock,
+            },
+        )
+
+
+def _continuity_message(
+    agent_id: AgentId,
+    old_key_id: KeyId,
+    new_key_id: KeyId,
+    new_public_key: bytes,
+    activates_at: float,
+) -> bytes:
+    """Build the deterministic byte string a rotation's continuity sig covers.
+
+    Example::
+
+        msg = _continuity_message(AgentId("a1"), KeyId("old"), KeyId("new"), b"pk", 5.0)
+    """
+    return json.dumps(
+        {
+            "agent": str(agent_id),
+            "old": str(old_key_id),
+            "new": str(new_key_id),
+            "pk": new_public_key.hex(),
+            "activates_at": activates_at,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+
+
+def _recovery_message(
+    target_agent: AgentId,
+    old_key_id: KeyId,
+    new_key_id: KeyId,
+    new_public_key: bytes,
+    recovered_at: float,
+) -> bytes:
+    """Build the deterministic byte string recovery attesters sign.
+
+    Example::
+
+        msg = _recovery_message(AgentId("a1"), KeyId("old"), KeyId("new"), b"pk", 10.0)
+    """
+    return json.dumps(
+        {
+            "action": "recover",
+            "target": str(target_agent),
+            "old": str(old_key_id),
+            "new": str(new_key_id),
+            "pk": new_public_key.hex(),
+            "recovered_at": recovered_at,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("ascii")

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -49,6 +49,9 @@ byzantine_gossip = "nest_plugins_reference.registry.byzantine_gossip:ByzantineGo
 hybrid_x25519 = "nest_plugins_reference.privacy.hybrid_x25519:HybridX25519Privacy"
 trust_gated = "nest_plugins_reference.privacy.trust_gated:TrustGatedPrivacy"
 
+[project.entry-points."nest.plugins.identity"]
+ed25519_recoverable = "nest_plugins_reference.identity.ed25519_recoverable:Ed25519RecoverableIdentity"
+
 [project.entry-points."nest.plugins.datafacts"]
 cid_facts = "nest_plugins_reference.datafacts.cid_facts:CidFacts"
 

--- a/packages/nest-plugins-reference/tests/test_ed25519_recoverable.py
+++ b/packages/nest-plugins-reference/tests/test_ed25519_recoverable.py
@@ -1,0 +1,379 @@
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportPrivateUsage=false
+"""Unit tests for the ``ed25519_recoverable`` identity plugin.
+
+Covers real Ed25519 sign/verify, time-locked rotation, K-of-N social recovery,
+the nine adversarial attacks the plugin defeats, determinism, and monotonic
+clock enforcement.
+
+Example::
+
+    pytest packages/nest-plugins-reference/tests/test_ed25519_recoverable.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from nest_core.types import AgentId
+from nest_plugins_reference.identity.ed25519_recoverable import (
+    ALGORITHM,
+    DEFAULT_TIME_LOCK,
+    Ed25519RecoverableIdentity,
+    KeyId,
+    RecoveryEvent,
+    _key_id_for,
+    _public_bytes,
+)
+
+
+def _ident(
+    name: str = "a1",
+    seed: bytes = b"seed",
+    *,
+    attesters: list[str] | None = None,
+    quorum_k: int = 2,
+    time_lock: float = DEFAULT_TIME_LOCK,
+) -> Ed25519RecoverableIdentity:
+    attester_ids = [AgentId(a) for a in attesters] if attesters else []
+    return Ed25519RecoverableIdentity(
+        AgentId(name),
+        seed=seed,
+        recovery_attesters=attester_ids,
+        recovery_quorum_k=quorum_k,
+        time_lock=time_lock,
+    )
+
+
+def _attester(name: str, seed: bytes | None = None) -> Ed25519RecoverableIdentity:
+    return Ed25519RecoverableIdentity(AgentId(name), seed=seed or name.encode())
+
+
+# ── Basic sign/verify ────────────────────────────────────────────────
+
+
+class TestSignVerify:
+    def test_sign_verify_roundtrip(self) -> None:
+        ident = _ident()
+        sig = ident.sign(b"hello")
+        assert sig.algorithm == ALGORITHM
+        assert sig.key_id is not None
+        assert ident.verify(b"hello", sig, AgentId("a1"))
+
+    def test_verify_rejects_wrong_payload(self) -> None:
+        ident = _ident()
+        sig = ident.sign(b"hello")
+        assert not ident.verify(b"tampered", sig, AgentId("a1"))
+
+    def test_verify_rejects_wrong_signer(self) -> None:
+        ident = _ident()
+        sig = ident.sign(b"hello")
+        assert not ident.verify(b"hello", sig, AgentId("someone-else"))
+
+    def test_public_key_is_raw_32_bytes(self) -> None:
+        assert len(_ident().public_key) == 32
+
+    def test_private_key_never_serialised(self) -> None:
+        ident = _ident()
+        record = asyncio.run(ident.resolve(AgentId("a1")))
+        for key in record.metadata["keys"]:
+            assert "private" not in str(key).lower()
+
+
+# ── Time-locked rotation ─────────────────────────────────────────────
+
+
+class TestTimeLock:
+    def test_instant_rotation_rejected(self) -> None:
+        ident = _ident()
+        ident.advance(5.0)
+        with pytest.raises(ValueError, match="activates_at"):
+            ident.rotate(b"new", activates_at=5.0)
+
+    def test_rotation_below_time_lock_rejected(self) -> None:
+        ident = _ident()
+        ident.advance(5.0)
+        with pytest.raises(ValueError, match="activates_at"):
+            ident.rotate(b"new", activates_at=7.0)
+
+    def test_rotation_at_time_lock_accepted(self) -> None:
+        ident = _ident()
+        ident.advance(5.0)
+        pending = ident.rotate(b"new", activates_at=8.0)
+        assert pending.activates_at == 8.0
+
+    def test_rotation_activates_after_advance(self) -> None:
+        ident = _ident()
+        old_key = ident.current_key_id
+        ident.advance(5.0)
+        ident.rotate(b"new", activates_at=8.0)
+        assert ident.current_key_id == old_key
+        ident.advance(8.0)
+        assert ident.current_key_id != old_key
+
+    def test_default_activates_at_uses_time_lock(self) -> None:
+        ident = _ident(time_lock=5.0)
+        ident.advance(10.0)
+        pending = ident.rotate(b"new")
+        assert pending.activates_at == 15.0
+
+
+# ── Social recovery ──────────────────────────────────────────────────
+
+
+def _setup_recovery() -> tuple[
+    Ed25519RecoverableIdentity,
+    Ed25519RecoverableIdentity,
+    Ed25519RecoverableIdentity,
+    Ed25519RecoverableIdentity,
+]:
+    """Create a target with 3 attesters (quorum=2)."""
+    r1 = _attester("r1", b"seed-r1")
+    r2 = _attester("r2", b"seed-r2")
+    r3 = _attester("r3", b"seed-r3")
+    target = _ident("victim", b"victim-seed", attesters=["r1", "r2", "r3"], quorum_k=2)
+    target.register_peer(AgentId("r1"), r1.public_key)
+    target.register_peer(AgentId("r2"), r2.public_key)
+    target.register_peer(AgentId("r3"), r3.public_key)
+    return target, r1, r2, r3
+
+
+def _build_recovery_event(
+    target: Ed25519RecoverableIdentity,
+    attesters: list[Ed25519RecoverableIdentity],
+    new_seed: bytes = b"recovery-key",
+    recovered_at: float = 10.0,
+) -> RecoveryEvent:
+    """Build a recovery event signed by the given attesters."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+    )
+    from nest_plugins_reference.identity.ed25519_recoverable import _derive_seed
+
+    new_priv = Ed25519PrivateKey.from_private_bytes(_derive_seed(new_seed, target.agent_id, 99))
+    new_pub = _public_bytes(new_priv.public_key())
+    old_key_id = target.current_key_id
+    new_key_id = _key_id_for(new_pub)
+
+    sigs: dict[str, bytes] = {}
+    for att in attesters:
+        sig_bytes = att.sign_recovery(target.agent_id, old_key_id, new_pub, recovered_at)
+        sigs[str(att.agent_id)] = sig_bytes
+
+    return RecoveryEvent(
+        target_agent=target.agent_id,
+        old_key_id=old_key_id,
+        new_key_id=new_key_id,
+        new_public_key=new_pub,
+        recovered_at=recovered_at,
+        attester_signatures=sigs,
+        new_epoch=target.current_epoch + 1,
+    )
+
+
+class TestSocialRecovery:
+    def test_quorum_recovery_accepted(self) -> None:
+        target, r1, r2, _r3 = _setup_recovery()
+        recovery = _build_recovery_event(target, [r1, r2])
+        assert target.observe_recovery(recovery)
+
+    def test_full_quorum_recovery_accepted(self) -> None:
+        target, r1, r2, r3 = _setup_recovery()
+        recovery = _build_recovery_event(target, [r1, r2, r3])
+        assert target.observe_recovery(recovery)
+
+    def test_recovery_installs_new_key(self) -> None:
+        target, r1, r2, _r3 = _setup_recovery()
+        old_key = target.current_key_id
+        recovery = _build_recovery_event(target, [r1, r2])
+        target.observe_recovery(recovery)
+        assert target.current_key_id != old_key
+
+    def test_recovery_appears_in_resolve(self) -> None:
+        target, r1, r2, _r3 = _setup_recovery()
+        recovery = _build_recovery_event(target, [r1, r2])
+        target.observe_recovery(recovery)
+        info = asyncio.run(target.resolve(AgentId("victim")))
+        assert len(info.metadata["recovery_events"]) == 1
+        assert info.metadata["recovery_events"][0]["attester_count"] == 2
+
+
+# ── Attack classes ───────────────────────────────────────────────────
+
+
+class TestInstantRotationAttack:
+    def test_attacker_cannot_rotate_instantly(self) -> None:
+        ident = _ident()
+        ident.advance(5.0)
+        with pytest.raises(ValueError, match="activates_at"):
+            ident.rotate(b"evil-key", activates_at=5.0)
+
+
+class TestUnilateralRecovery:
+    def test_single_attester_insufficient(self) -> None:
+        target, r1, _r2, _r3 = _setup_recovery()
+        recovery = _build_recovery_event(target, [r1])
+        assert not target.observe_recovery(recovery)
+
+    def test_zero_attesters_rejected(self) -> None:
+        target, _r1, _r2, _r3 = _setup_recovery()
+        recovery = _build_recovery_event(target, [])
+        assert not target.observe_recovery(recovery)
+
+
+class TestDuplicateAttesterInflation:
+    def test_duplicate_signatures_not_counted_twice(self) -> None:
+        target, r1, _r2, _r3 = _setup_recovery()
+        recovery = _build_recovery_event(target, [r1])
+        recovery.attester_signatures[str(r1.agent_id) + "_dup"] = recovery.attester_signatures[
+            str(r1.agent_id)
+        ]
+        assert not target.observe_recovery(recovery)
+
+
+class TestForgedAttesterSignature:
+    def test_forged_attester_sig_rejected(self) -> None:
+        target, r1, r2, _r3 = _setup_recovery()
+        recovery = _build_recovery_event(target, [r1, r2])
+        real_sig = recovery.attester_signatures[str(r1.agent_id)]
+        recovery.attester_signatures[str(r1.agent_id)] = b"\x00" * len(real_sig)
+        assert not target.observe_recovery(recovery)
+
+
+class TestRecoveryStaleKey:
+    def test_recovery_must_match_current_key(self) -> None:
+        target, r1, r2, _r3 = _setup_recovery()
+        recovery = _build_recovery_event(target, [r1, r2])
+        recovery.old_key_id = KeyId("nonexistent_key_id")
+        assert not target.observe_recovery(recovery)
+
+
+class TestPostRotationForgery:
+    def test_forged_old_key_sig_rejected_after_rotation(self) -> None:
+        ident = _ident()
+        old_key = ident.current_key_id
+        ident.advance(5.0)
+        ident.rotate(b"new")
+        ident.advance(8.0)
+        ident.advance(9.0)
+        forged = ident.sign_with(b"forged-after-rotation", old_key)
+        assert not ident.verify(b"forged-after-rotation", forged, AgentId("a1"), as_of=9.0)
+
+
+class TestStaleKeyReuse:
+    def test_stale_key_rejected_after_supersession(self) -> None:
+        ident = _ident()
+        ident.advance(1.0)
+        old_sig = ident.sign(b"old")
+        ident.advance(5.0)
+        ident.rotate(b"new")
+        ident.advance(8.0)
+        assert not ident.verify(b"old", old_sig, AgentId("a1"), as_of=8.0)
+
+
+class TestForgedSignedAtBypass:
+    def test_verifier_anchors_on_own_tick(self) -> None:
+        ident = _ident()
+        ident.advance(1.0)
+        sig = ident.sign(b"data")
+        assert sig.signed_at == 1.0
+        ident.advance(5.0)
+        ident.rotate(b"new")
+        ident.advance(8.0)
+        assert not ident.verify(b"data", sig, AgentId("a1"))
+
+
+# ── Determinism ──────────────────────────────────────────────────────
+
+
+class TestDeterminism:
+    def test_same_seed_same_signature(self) -> None:
+        a = _ident(seed=b"fixed")
+        b = _ident(seed=b"fixed")
+        assert a.sign(b"msg").value == b.sign(b"msg").value
+
+    def test_same_seed_same_key_id(self) -> None:
+        a = _ident(seed=b"fixed")
+        b = _ident(seed=b"fixed")
+        assert a.current_key_id == b.current_key_id
+
+    def test_different_seed_different_key(self) -> None:
+        a = _ident(seed=b"seed-a")
+        b = _ident(seed=b"seed-b")
+        assert a.current_key_id != b.current_key_id
+
+
+# ── Monotonic clock ──────────────────────────────────────────────────
+
+
+class TestMonotonicClock:
+    def test_backward_tick_ignored(self) -> None:
+        ident = _ident()
+        ident.advance(10.0)
+        ident.advance(5.0)  # should be silently ignored
+        sig = ident.sign(b"x")
+        assert sig.signed_at == 10.0
+
+    def test_equal_tick_ignored(self) -> None:
+        ident = _ident()
+        ident.advance(10.0)
+        ident.advance(10.0)  # should be silently ignored (not advance)
+        sig = ident.sign(b"x")
+        assert sig.signed_at == 10.0
+
+
+# ── Observer rotation verification ──────────────────────────────────
+
+
+class TestObserverRotation:
+    def test_observer_verifies_rotation_continuity(self) -> None:
+        signer = _ident("signer")
+        signer.advance(5.0)
+        pending = signer.rotate(b"new")
+
+        observer = _ident("observer")
+        observer.register_peer(AgentId("signer"), signer._epochs[AgentId("signer")][0].public_key)  # noqa: SLF001
+        assert observer.observe_rotation(AgentId("signer"), pending)
+
+    def test_observer_rejects_tampered_continuity(self) -> None:
+        signer = _ident("signer")
+        signer.advance(5.0)
+        pending = signer.rotate(b"new")
+        pending.continuity_signature = b"\x00" * 64
+
+        observer = _ident("observer")
+        observer.register_peer(AgentId("signer"), signer._epochs[AgentId("signer")][0].public_key)  # noqa: SLF001
+        assert not observer.observe_rotation(AgentId("signer"), pending)
+
+
+# ── Adversarial validators ───────────────────────────────────────────
+
+
+class TestAdversarialValidators:
+    def test_validate_no_instant_rotations_passes(self) -> None:
+        from nest_plugins_reference.identity.adversarial_validators import (
+            validate_no_instant_rotations,
+        )
+
+        ident = _ident()
+        report = validate_no_instant_rotations(ident)
+        assert report.passed, report.detail
+
+    def test_validate_no_unilateral_recoveries_passes(self) -> None:
+        from nest_plugins_reference.identity.adversarial_validators import (
+            validate_no_unilateral_recoveries,
+        )
+
+        target, r1, _r2, _r3 = _setup_recovery()
+        report = validate_no_unilateral_recoveries(target, [r1])
+        assert report.passed, report.detail
+
+    def test_validate_identity_governance_all_pass(self) -> None:
+        from nest_plugins_reference.identity.adversarial_validators import (
+            validate_identity_governance,
+        )
+
+        target, r1, _r2, _r3 = _setup_recovery()
+        reports = validate_identity_governance(target, [r1])
+        assert all(r.passed for r in reports), [r.detail for r in reports]

--- a/packages/nest-plugins-reference/tests/test_ed25519_recoverable.py
+++ b/packages/nest-plugins-reference/tests/test_ed25519_recoverable.py
@@ -377,3 +377,71 @@ class TestAdversarialValidators:
         target, r1, _r2, _r3 = _setup_recovery()
         reports = validate_identity_governance(target, [r1])
         assert all(r.passed for r in reports), [r.detail for r in reports]
+
+
+# ── Discrimination: validators must FAIL against did_key / ed25519_rotating ──
+
+
+class TestAdversarialValidatorsDiscrimination:
+    """Governance validators must return FAIL for plugins that don't enforce the rules.
+
+    This is the discriminating test the PR's docstring promised but never
+    asserted: ``validate_no_instant_rotations`` and
+    ``validate_no_unilateral_recoveries`` must return ``passed=False`` against
+    ``did_key`` and ``ed25519_rotating``, which have no time-lock and no
+    recovery mechanism.
+    """
+
+    def test_validate_no_instant_rotations_fails_against_did_key(self) -> None:
+        from nest_plugins_reference.identity.adversarial_validators import (
+            validate_no_instant_rotations,
+        )
+        from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+        plugin = DidKeyIdentity(AgentId("dk-1"), seed=b"test")
+        report = validate_no_instant_rotations(plugin)
+        assert not report.passed, (
+            "validate_no_instant_rotations should FAIL against did_key "
+            f"(no rotate/advance support), got: {report.detail}"
+        )
+
+    def test_validate_no_instant_rotations_fails_against_ed25519_rotating(self) -> None:
+        from nest_plugins_reference.identity.adversarial_validators import (
+            validate_no_instant_rotations,
+        )
+        from nest_plugins_reference.identity.ed25519_rotating import Ed25519RotatingIdentity
+
+        plugin = Ed25519RotatingIdentity(AgentId("rot-1"), seed=b"test")
+        report = validate_no_instant_rotations(plugin)
+        assert not report.passed, (
+            "validate_no_instant_rotations should FAIL against ed25519_rotating "
+            f"(no time-lock enforcement), got: {report.detail}"
+        )
+
+    def test_validate_no_unilateral_recoveries_fails_against_did_key(self) -> None:
+        from nest_plugins_reference.identity.adversarial_validators import (
+            validate_no_unilateral_recoveries,
+        )
+        from nest_plugins_reference.identity.did_key import DidKeyIdentity
+
+        plugin = DidKeyIdentity(AgentId("dk-2"), seed=b"test")
+        dummy_attester = _ident("att-1")
+        report = validate_no_unilateral_recoveries(plugin, [dummy_attester])
+        assert not report.passed, (
+            "validate_no_unilateral_recoveries should FAIL against did_key "
+            f"(no observe_recovery support), got: {report.detail}"
+        )
+
+    def test_validate_no_unilateral_recoveries_fails_against_ed25519_rotating(self) -> None:
+        from nest_plugins_reference.identity.adversarial_validators import (
+            validate_no_unilateral_recoveries,
+        )
+        from nest_plugins_reference.identity.ed25519_rotating import Ed25519RotatingIdentity
+
+        plugin = Ed25519RotatingIdentity(AgentId("rot-2"), seed=b"test")
+        dummy_attester = _ident("att-2")
+        report = validate_no_unilateral_recoveries(plugin, [dummy_attester])
+        assert not report.passed, (
+            "validate_no_unilateral_recoveries should FAIL against ed25519_rotating "
+            f"(no recovery mechanism), got: {report.detail}"
+        )

--- a/scenarios/identity_recoverable.yaml
+++ b/scenarios/identity_recoverable.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# Identity recovery scenario: time-locked rotations and K-of-N social recovery.
+# A byzantine agent attempts instant-rotation (blocked by time-lock) and a
+# compromised agent gets recovered via attester quorum.
+name: identity_recoverable
+description: "10 signers with time-locked rotation and social recovery; byzantine agents attempt instant-rotation and unilateral recovery."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 11
+  brain: state-machine
+  roles:
+    - name: honest
+      count: 9
+    - name: byzantine
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: ed25519_recoverable
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: identity_rotation
+  config:
+    rounds: 6
+    rotate_at_round: 3
+    byzantine_fraction: 0.10
+    recovery_attesters: 3
+    recovery_quorum_k: 2
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+
+output:
+  trace: ./traces/identity_recoverable.jsonl

--- a/scenarios/identity_recoverable.yaml
+++ b/scenarios/identity_recoverable.yaml
@@ -1,9 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Identity recovery scenario: time-locked rotations and K-of-N social recovery.
-# A byzantine agent attempts instant-rotation (blocked by time-lock) and a
-# compromised agent gets recovered via attester quorum.
+#
+# Honest signers rotate with a future activates_at (time-lock enforced).
+# A designated victim agent initiates social recovery after being "compromised".
+# A byzantine agent attempts instant-rotation (blocked by time-lock) and
+# post-rotation forgery (rejected by as-of signature verification).
+#
+# Validators:
+#   identity_recovery_occurred   — at least one recover: trace line present
+#   identity_timelock_enforced   — instant-rotation attempt rejected, none accepted
+#   identity_recoverable_signatures — honest sigs valid in their windows; attacks rejected
 name: identity_recoverable
-description: "10 signers with time-locked rotation and social recovery; byzantine agents attempt instant-rotation and unilateral recovery."
+description: "10 signers with time-locked rotation and social recovery; byzantine agents attempt instant-rotation and post-rotation forgery."
 
 tier: 1
 seed: 42
@@ -13,7 +21,7 @@ agents:
   brain: state-machine
   roles:
     - name: honest
-      count: 9
+      count: 8
     - name: byzantine
       count: 1
 
@@ -32,13 +40,15 @@ layers:
   datafacts: datafacts_v1
 
 task:
-  type: identity_rotation
+  type: identity_recoverable
   config:
-    rounds: 6
-    rotate_at_round: 3
-    byzantine_fraction: 0.10
+    rounds: 10
+    rotate_at_round: 4
+    compromise_round: 5
+    time_lock: 3.0
     recovery_attesters: 3
     recovery_quorum_k: 2
+    byzantine_fraction: 0.10
 
 failures:
   message_drop: 0.0


### PR DESCRIPTION
## Layer / plugin

* **Layer:** identity (Layer 3)
* **Plugin:** `ed25519_recoverable` at `("identity","ed25519_recoverable")`
* **Persona:** security engineer focused on key-compromise recovery in
  production identity systems.
* **Relationship to prior work:**
  * `did_key` — the deliberately simplified default; unchanged.
  * `ed25519_rotating` (PR #25, merged) — real rotation with continuity;
    unchanged.
  * `ed25519_prerotation` (PR #71, in review) — cryptographic KERI-style
    defence against rotation hijack via pre-committed key hashes.
    **This PR is orthogonal:** where PR #71 defends key compromise
    cryptographically (attacker cannot install a successor that does not
    hash to the pre-published commitment), `ed25519_recoverable` defends
    it **operationally** via K-of-N social recovery. The two mechanisms
    address the same threat with different assumptions: KERI requires you
    to have generated a cold key at inception, social recovery requires a
    network of trusted attesters. Time-lock on rotations is additive to
    both and unique to this PR.

## What it does

Real Ed25519 signatures via `cryptography` (RFC 8032), plus two governance
features neither merged plugin has:

1. **Time-locked rotations.** A rotation is only accepted if
   `activates_at >= now + time_lock` (default 3 logical ticks). Even a
   captured current key cannot lock the legitimate owner out immediately —
   the owner sees the pending rotation and has time to counter-rotate or
   trigger recovery.
2. **K-of-N social recovery.** Each agent declares a set of recovery
   attesters at construction (e.g. 3 peers, quorum K=2). Any K of them can
   co-sign a `RecoveryEvent` that force-installs a fresh key chosen by the
   recovering party. This bypasses continuity entirely — the compromised
   key gets no say. The recovery event is publicly verifiable and appears
   in `resolve()`'s metadata.

Verification anchors on an externally-supplied logical tick (via
`.advance(tick)`), never on the attacker-controlled `sig.signed_at` — as
the `Signature` docstring in `nest_core.types` already prescribes.

## Attacks defeated

| Attack | Defeated by | Merged plugins alone |
| --- | --- | --- |
| Instant-rotation after brief key capture | time-lock rejects `activates_at < now + lock` | accepted (continuity is valid) |
| Full key compromise → attacker rotates | K-of-N recovery reinstalls owner's fresh key | no recovery path |
| Unilateral recovery (< K attesters) | quorum check | no concept |
| Duplicate-attester quorum inflation | deduplication before counting | no concept |
| Forged attester signature | Ed25519 verification under declared attester pubkey | no concept |
| Recovery targeting a stale key | recovery must match current active key | no concept |
| Unauthorised rotation | rotation signature verified under current key | rejects |
| Stale-key reuse after supersession | epoch window check | rejects |
| Forged `signed_at` bypass | verifier anchors on own tick | rejects |

## Determinism

* Keys are derived from `(seed, agent_id, epoch)` via SHA-512,
  domain-separated. No `os.urandom`.
* Ed25519 signatures are deterministic per RFC 8032 §5.1.6.
* The plugin exposes only `advance(tick)` as clock input, enforced
  monotonic. No wall-clock time is read.

## API fit

Implements exactly the three-method `nest_core.layers.identity.Identity`
Protocol (`sign` / `verify` / `resolve`) with the same `register_peer`
convention as `did_key` and `ed25519_rotating` (adding optional
keyword-only `recovery_attesters` / `recovery_quorum_k`). Additional
methods (`rotate`, `observe_rotation`, `observe_recovery`,
`sign_recovery`, `advance`) are additive.

## Files

* `packages/nest-plugins-reference/nest_plugins_reference/identity/ed25519_recoverable.py`
* `packages/nest-plugins-reference/nest_plugins_reference/identity/adversarial_validators.py`
* `packages/nest-plugins-reference/tests/test_ed25519_recoverable.py`
* `scenarios/identity_recoverable.yaml`
* `packages/nest-plugins-reference/pyproject.toml` (entry-point registration only)

## Tests

`test_ed25519_recoverable.py` — 33 tests covering happy-path, all attack
classes above, determinism, and monotonic-clock enforcement.

Adversarial validators in `adversarial_validators.py`:
`validate_no_instant_rotations`, `validate_no_unilateral_recoveries`,
`validate_identity_governance` (runs both).

## Run

```bash
uv sync
uv run pytest -v packages/nest-plugins-reference/tests/test_ed25519_recoverable.py
make ci-local
```

## Not in scope

* No cross-plugin key exchange with `ed25519_rotating` or
  `ed25519_prerotation` — using multiple identity plugins in one scenario
  would require a small adapter.
* No distributed consensus around the recovery-attester set; this PR
  ships the mechanism, not a protocol for maintaining who the attesters
  are.