### PR TITLE
build: migrate deprecated tool.uv.dev-dependencies to dependency-groups.dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,8 @@ members = [
     "packages/nest-marketplace",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "hypothesis>=6.100",
@@ -79,6 +79,8 @@ dev-dependencies = [
     # so the shim's smoke tests can import it.
     "nest-cli",
 ]
+
+[tool.uv]
 
 [tool.uv.sources]
 nest-core = { workspace = true }


### PR DESCRIPTION
uv prints a deprecation warning on every command: tool.uv.dev-dependencies
is deprecated and will be removed in a future release.

This moves the dev dependency list to the standard dependency-groups.dev
table (PEP 735). Same packages, same version pins, same comments.

uv sync now runs clean. ruff and the full test suite pass unchanged.