### PR TITLE
[Hackathon] calyirex: validators must not certify corrupted ground truth (3 fixes: auction shill, voting inflation, revocation laundering)

### DIFF
--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -277,11 +277,20 @@ def validate_auction_winner_highest(
         # The invariant is about the winner's REAL bid, not the announced
         # amount. Trusting the announced amount lets an auctioneer award a low
         # bidder while announcing a figure inflated past every real bid, and the
-        # check would pass. Use the winner's own highest observed bid; fall back
-        # to the announced amount only when the winner's bid was not observed
-        # (e.g. dropped under message loss), so this never fails a valid trace.
+        # check would pass. A winner with NO observed bid cannot be the highest
+        # bidder either: bid send-events are recorded at send time and survive
+        # message loss (loss emits a separate "dropped" delivery event), so an
+        # absent winner bid means a fabricated/shill award — never fall back to
+        # the announced amount.
         winner_bids = [amount for bidder, amount in item_bids if bidder == winner]
-        effective_winner_bid = max(winner_bids) if winner_bids else winning_amount
+        if not winner_bids:
+            if item_bids:
+                violations.append(
+                    f"item {item}: winner {winner} announced {winning_amount} "
+                    f"but placed no observed bid"
+                )
+            continue
+        effective_winner_bid = max(winner_bids)
         for bidder, amount in item_bids:
             if amount > effective_winner_bid:
                 violations.append(

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -384,9 +384,22 @@ def validate_auction_all_notified(
 def validate_voting_tally(
     events: list[dict[str, Any]],
 ) -> list[ValidationResult]:
-    """The announced result matches the actual vote count."""
-    # round -> list of votes
-    votes: dict[str, list[str]] = defaultdict(list)
+    """The announced result matches the actual vote count.
+
+    Votes are tallied per unique voter (first vote wins), using the same
+    voter-identity rule as ``validate_voting_no_double_vote``: the explicit
+    voter field when present (``vote:<round>:<vote>:<voter>``), otherwise the
+    sending agent. A duplicate vote therefore cannot inflate a tally into one
+    this validator certifies — previously a voter voting twice plus a
+    coordinator announcing the inflated count passed as "correct".
+
+    Example::
+
+        vote:1:yes:voter-0 (sent twice) + result:1:passed:2/2 -> FAIL;
+        the deduplicated tally is 1/1.
+    """
+    # round -> voter -> first vote cast
+    votes: dict[str, dict[str, str]] = defaultdict(dict)
     # round -> (result_str, yes_count, total)
     results: dict[str, tuple[str, int, int]] = {}
 
@@ -396,10 +409,17 @@ def validate_voting_tally(
         msg = _message_body(ev)
         if msg.startswith("vote:"):
             parts = msg.split(":")
-            if len(parts) >= 3:
+            if len(parts) >= 4:
                 rnd = parts[1]
                 vote = parts[2]
-                votes[rnd].append(vote)
+                voter = parts[3]
+            elif len(parts) >= 3:
+                rnd = parts[1]
+                vote = parts[2]
+                voter = ev.get("agent", "")
+            else:
+                continue
+            votes[rnd].setdefault(voter, vote)
         elif msg.startswith("result:"):
             parts = msg.split(":")
             if len(parts) >= 4:
@@ -416,9 +436,9 @@ def validate_voting_tally(
 
     mismatches: list[str] = []
     for rnd, (_result_str, reported_yes, reported_total) in results.items():
-        actual_votes = votes.get(rnd, [])
-        actual_yes = sum(1 for v in actual_votes if v == "yes")
-        actual_total = len(actual_votes)
+        per_voter = votes.get(rnd, {})
+        actual_yes = sum(1 for v in per_voter.values() if v == "yes")
+        actual_total = len(per_voter)
         if actual_yes != reported_yes or actual_total != reported_total:
             mismatches.append(
                 f"round {rnd}: reported {reported_yes}/{reported_total} "

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -343,6 +343,56 @@ class TestVotingTally:
         assert results[0].passed is False
         assert "round 1" in results[0].detail
 
+    def test_fail_double_vote_cannot_inflate_tally(self) -> None:
+        # Adversarial: voter-0 votes twice and the colluding coordinator
+        # announces the inflated 2/2. The raw message count matches the
+        # announcement, but the per-voter tally is 1/1 — must FAIL.
+        events = [
+            _send("voter-0", "coordinator-0", "vote:1:yes:voter-0"),
+            _send("voter-0", "coordinator-0", "vote:1:yes:voter-0"),
+            _send("coordinator-0", "proposer-0", "result:1:passed:2/2"),
+        ]
+        results = validate_voting_tally(events)
+        assert results[0].passed is False
+        assert "actual 1/1" in results[0].detail
+
+    def test_pass_double_vote_with_deduplicated_announcement(self) -> None:
+        # An honest coordinator that deduplicates the double vote passes;
+        # the duplicate is still flagged by validate_voting_no_double_vote,
+        # which is where that failure belongs.
+        events = [
+            _send("voter-0", "coordinator-0", "vote:1:yes:voter-0"),
+            _send("voter-0", "coordinator-0", "vote:1:yes:voter-0"),
+            _send("voter-1", "coordinator-0", "vote:1:no:voter-1"),
+            _send("coordinator-0", "proposer-0", "result:1:passed:1/2"),
+        ]
+        results = validate_voting_tally(events)
+        assert results[0].passed is True
+
+    def test_first_vote_wins_for_flip_flopping_voter(self) -> None:
+        # A voter that changes its vote mid-round counts once, as its first
+        # ballot — deterministic and consistent with at-most-once voting.
+        events = [
+            _send("voter-0", "coordinator-0", "vote:1:yes:voter-0"),
+            _send("voter-0", "coordinator-0", "vote:1:no:voter-0"),
+            _send("voter-1", "coordinator-0", "vote:1:no:voter-1"),
+            _send("coordinator-0", "proposer-0", "result:1:failed:1/2"),
+        ]
+        results = validate_voting_tally(events)
+        assert results[0].passed is True
+
+    def test_three_part_votes_fall_back_to_sending_agent(self) -> None:
+        # Without an explicit voter field, identity falls back to the
+        # sending agent — the same rule validate_voting_no_double_vote uses.
+        events = [
+            _send("voter-0", "coordinator-0", "vote:1:yes"),
+            _send("voter-0", "coordinator-0", "vote:1:yes"),
+            _send("voter-1", "coordinator-0", "vote:1:no"),
+            _send("coordinator-0", "proposer-0", "result:1:passed:1/2"),
+        ]
+        results = validate_voting_tally(events)
+        assert results[0].passed is True
+
 
 class TestVotingAllCounted:
     def test_pass_all_counted(self) -> None:

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -260,6 +260,30 @@ class TestAuctionWinnerHighest:
         assert results[0].passed is False
         assert "bidder-1" in results[0].detail
 
+    def test_fail_nonbidder_winner_with_invented_amount(self) -> None:
+        # Adversarial: the auctioneer awards carol, who never placed a bid,
+        # and announces an invented 999 above every real bid. Falling back to
+        # the announced amount certified the shill award; a winner with no
+        # observed bid must be a violation.
+        events = [
+            _send("alice", "auctioneer-0", "bid:item-1:100"),
+            _send("bob", "auctioneer-0", "bid:item-1:90"),
+            _send("auctioneer-0", "carol", "won:item-1:999"),
+        ]
+        results = validate_auction_winner_highest(events)
+        assert results[0].passed is False
+        assert "no observed bid" in results[0].detail
+
+    def test_pass_no_bids_at_all_observed(self) -> None:
+        # A won: announcement with zero observed bids for the item is skipped
+        # rather than flagged: with no bids in the trace there is no ground
+        # truth to contradict the award.
+        events = [
+            _send("auctioneer-0", "carol", "won:item-1:999"),
+        ]
+        results = validate_auction_winner_highest(events)
+        assert results[0].passed is True
+
     def test_pass_no_auctions(self) -> None:
         events = [{"ts": 0.0, "agent": "auctioneer-0", "kind": "start"}]
         results = validate_auction_winner_highest(events)

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/delegation_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/delegation_validators.py
@@ -130,10 +130,16 @@ def check_no_stale_ancestor_use(audits: list[AuditEvent]) -> ValidatorReport:
 
         assert check_no_stale_ancestor_use(audits).passed
     """
+    # Earliest revoke tick governs: revocation is monotonic, so a redundant
+    # later revoke of the same tid must not raise the effective revocation
+    # time (last-write-wins previously hid verifies between the two ticks).
     revoked_at: dict[str, int] = {}
     for audit in audits:
         if audit.get("op") == "revoke":
-            revoked_at[str(audit.get("tid", ""))] = int(cast("int", audit.get("tick", 0)))
+            tid = str(audit.get("tid", ""))
+            tick = int(cast("int", audit.get("tick", 0)))
+            if tid not in revoked_at or tick < revoked_at[tid]:
+                revoked_at[tid] = tick
     violations: list[AuditEvent] = []
     for audit in audits:
         if audit.get("op") != "verify" or not audit.get("verified"):

--- a/packages/nest-plugins-reference/tests/test_delegation_validators.py
+++ b/packages/nest-plugins-reference/tests/test_delegation_validators.py
@@ -245,3 +245,23 @@ def test_end_to_end_scenario_agents_under_both_plugins() -> None:
     assert check_no_scope_escalation(good_audits).passed
     assert check_no_stale_ancestor_use(good_audits).passed
     assert check_audience_binding(good_audits).passed
+
+
+def test_duplicate_revoke_keeps_earliest_revocation_tick() -> None:
+    # Adversarial: a redundant later revoke of the same tid must not raise
+    # the effective revocation time. The verify at tick 30 sits between the
+    # genuine revoke (20) and the redundant one (50) -- it must be flagged.
+    audits: list[AuditEvent] = [
+        {"type": "delegation_audit", "op": "revoke", "tid": "aa11", "tick": 20},
+        {"type": "delegation_audit", "op": "revoke", "tid": "aa11", "tick": 50},
+        {
+            "type": "delegation_audit",
+            "op": "verify",
+            "tick": 30,
+            "presenter": "leaf-0",
+            "audience": "leaf-0",
+            "chain_tids": ["root0", "aa11"],
+            "verified": True,
+        },
+    ]
+    assert not check_no_stale_ancestor_use(audits).passed


### PR DESCRIPTION
## Theme

Three validator fixes, one defect class: **a validator that reconstructs 'ground truth' from attacker-influenceable data ends up certifying the very corruption it exists to catch.** This is the class of the celebrated merged #96 (auction validator trusting announced amounts) — I found three more instances of it and fixed each with a minimal, deterministic change plus an adversarial regression test.

## Fix 1 — `validate_auction_winner_highest`: non-bidder winner with an invented amount

The validator used the winner's real bid, but **fell back to the announced amount when the winner had no observed bid** — re-opening #96's hole for shill winners:

```
bid:item-1:100 (alice)   bid:item-1:90 (bob)   won:item-1:999 (carol, never bid)  -> PASS (before)
```

Bid `send` events are recorded at send time and survive message loss (loss is a separate `dropped` delivery event), so an absent winner bid means a fabricated award, not loss. Flag it when other bids exist; skip only when the trace holds no bids at all (no ground truth to contradict).

## Fix 2 — `validate_voting_tally`: double-vote-inflated tallies certified

Counted raw `vote:` messages, so a voter voting twice + a coordinator announcing the inflated count passed — while `validate_voting_no_double_vote` simultaneously flagged the same trace as an attack:

```
vote:1:yes:voter-0 (x2)   result:1:passed:2/2  -> PASS (before)
```

Now tallies one ballot per unique voter (first vote wins), using the exact identity rule `no_double_vote` uses, aligning all three voting validators on one semantics.

## Fix 3 — `check_no_stale_ancestor_use`: revocation-time laundering

`revoked_at` used last-write-wins, so a redundant later revoke raised the effective revocation time and hid verifies in between:

```
revoke aa11@20 (genuine)   revoke aa11@50 (redundant)   verify [root0,aa11]@30 -> PASS (before)
```

Revocation is monotonic — earliest revoke tick governs.

## Design decisions

- Auction: a winner with zero observed bids is a violation only when *other* bids exist; a bidless trace is skipped, not failed.
- Voting: first vote wins for a flip-flopping voter — deterministic and order-stable under a fixed seed. The duplicate itself remains `no_double_vote`'s failure to report.
- All fixes preserve honest traces (incl. honest-under-message-loss) and touch no public interface.

## Tests

7 new adversarial tests across `TestAuctionWinnerHighest`, `TestVotingTally`, and the delegation validator suite — each demonstrates an attack that passed before and fails now, plus honest-trace guards.

## Verification

```
make ci-local   # uv sync, ruff check, ruff format --check, pyright, pytest
# -> all 5 checks passed; 1157 passed, 1 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)