### PR TITLE
[Hackathon] rahulsharma-sys: sealedbox — nonce-misuse-resistant hybrid privacy (Problem 09)

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -36,6 +36,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("memory", "blackboard"): f"{_REF}.memory.blackboard:Blackboard",
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
+    ("privacy", "sealedbox"): f"{_REF}.privacy.sealedbox:SealedBoxPrivacy",
     ("datafacts", "datafacts_v1"): f"{_REF}.datafacts.datafacts_v1:DataFactsV1",
 }
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/privacy/sealedbox.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/privacy/sealedbox.py
@@ -1,36 +1,98 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Real authenticated encryption for the Privacy layer (a sealed-box alternative
-to the ``noop`` passthrough).
+"""Nonce-misuse-resistant hybrid encryption for the Privacy layer.
 
-Multi-recipient sealed-box encryption: a fresh ChaCha20-Poly1305 content key per
-message, wrapped to each recipient via X25519 ECDH + HKDF-SHA256. This gives the
-Privacy layer genuine confidentiality (non-audience agents cannot read a payload
-through the API; the trace carries only ciphertext) and tamper-evidence (a
-modified ciphertext fails to decrypt rather than silently yielding altered bytes).
+``sealedbox`` is a full Problem 09 privacy plugin (hybrid encryption + selective
+disclosure + broadcast revocation), but its **load-bearing contribution** is a
+property the merged ``hybrid_x25519`` plugin openly concedes it lacks:
+**deterministic mode that is safe under key/nonce reuse.**
 
-Keys derive deterministically from ``(seed, agent_id)`` by default so simulation
-traces replay byte-for-byte, consistent with NandaTown's replay-first identity
-model. That is protocol/trace-level confidentiality, *not* secrecy against a
-holder of the shared seed. Pass ``deterministic=False`` for random per-agent keys
-(genuine secrecy against a seed-holder, at the cost of non-reproducible traces).
+Why that matters
+----------------
 
-``prove`` / ``verify_proof`` are honest stubs that raise ``NotImplementedError``
-— unlike the ``noop`` plugin's forged proof that always verifies. Zero-knowledge
-proofs are future work.
+Nanda Town's Tier-1 traces must replay byte-for-byte, so a privacy plugin that
+wants to run in a scenario derives its per-message key and nonce deterministically
+rather than from the system RNG. Every such scheme (including ``hybrid_x25519``)
+guards the derivation with a monotonic counter and states — correctly — that
+reusing a ``(key, nonce)`` pair would be catastrophic for the AEAD. But that
+counter lives in memory on the plugin instance: reconstruct the plugin (a
+restart, or two instances of one agent in a scenario) and the counter resets to
+zero, re-deriving the *same* key and nonce for a *different* plaintext. For a
+ChaCha20-Poly1305 stream that is a two-time pad — it leaks the XOR of the two
+plaintexts and destroys authentication. Problem 09 names this exact anti-pattern:
+*"Don't reuse the same nonce twice (test for it)."*
+
+What sealedbox does differently (SIV-style derivation)
+------------------------------------------------------
+
+In deterministic mode the content key, the content nonce, every ephemeral scalar
+and every wrap nonce are derived from a **synthetic value** that folds a digest
+of the *plaintext and the sorted audience* into the HKDF ``info`` (the
+synthetic-IV construction behind AES-GCM-SIV / deterministic AEAD). So a counter
+collision no longer reuses a keystream across distinct messages:
+
+* different plaintext (or audience) under the same counter  → different synthetic
+  value → different key + nonce → **no reuse** (safe);
+* identical plaintext *and* audience *and* counter          → identical envelope
+  bytes → replayable, and the only thing an observer learns is *message
+  equality* — never plaintext.
+
+That is a strictly stronger deterministic-mode guarantee than a counter-only
+scheme, and :mod:`nest_plugins_reference.validators.sealedbox_validators` ships
+an adversarial validator (``check_deterministic_reuse_safe``) that **fails**
+against a counter-only plugin and the ``noop`` passthrough and **passes** against
+this one.
+
+The rest of the Problem 09 surface
+-----------------------------------
+
+* **Hybrid encryption.** One fresh ChaCha20-Poly1305 content key per message
+  encrypts the payload once; the key is wrapped per recipient via X25519
+  ephemeral-static ECDH + HKDF-SHA256. A versioned self-describing envelope
+  binds ``(version, sender, epoch, counter, sorted recipient key-ids)`` as the
+  AEAD associated data, so redirecting an envelope or editing its header breaks
+  authentication.
+* **Selective disclosure.** :meth:`~SealedBoxPrivacy.prove` /
+  :meth:`~SealedBoxPrivacy.verify_proof` implement a salted Merkle commitment:
+  the holder reveals a subset of credential fields with authentication paths and
+  proves the rest are committed under the same issuer-anchored root without
+  revealing them.
+* **Broadcast revocation.** :meth:`~SealedBoxPrivacy.revoke` advances an epoch
+  and excludes a member from *future* wraps without touching any other member's
+  key. Revocation is future-only (see the forward-secrecy note on ``revoke``).
+* **Replay rejection.** Every envelope is remembered by digest on first decrypt
+  by a live recipient instance; a byte-identical re-presented envelope raises
+  :class:`ReplayError`. This memory is per-instance and in-process — it is not a
+  durable anti-replay log that survives reconstruction.
+
+Confidentiality scope of deterministic mode
+--------------------------------------------
+
+Deterministic mode derives **every** agent's X25519 keypair (its own and its
+peers') from the one shared scenario ``seed`` — that is what lets a trace replay
+without a key directory. The price: this is **protocol/trace-level**
+confidentiality (a non-audience agent using the plugin cannot read a payload, and
+the plaintext never appears on the wire), but it is **not** secrecy against a
+holder of the shared seed, who can re-derive any agent's private key. For genuine
+secrecy against a seed-holder, construct with ``deterministic=False`` (per-agent
+random keys resolved through an injected ``directory``), at the cost of
+reproducible traces.
 
 Example::
 
-    priv = SealedBoxPrivacy(AgentId("a1"), seed=7)
-    ct = await priv.encrypt(b"secret", [AgentId("a2")])
-    # only a2 (with the same seed) can decrypt; a3 raises NotInAudienceError
+    alice = SealedBoxPrivacy(AgentId("alice"), seed=7)
+    bob = SealedBoxPrivacy(AgentId("bob"), seed=7)
+    env = await alice.encrypt(b"sealed-bid:1700", [AgentId("bob")])
+    assert await bob.decrypt(env) == b"sealed-bid:1700"
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import struct
 from dataclasses import dataclass
+from typing import Any, cast
 
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives import hashes
@@ -43,28 +105,40 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from nest_core.types import AgentId, Proof, Statement, Witness
 
-_DOMAIN = b"nandatown/sealedbox/v1"
-_WRAP_INFO = b"nandatown/sealedbox/v1/wrap"
+_DOMAIN = b"nandatown/sealedbox/v2"
+_WRAP_INFO = b"nandatown/sealedbox/v2/wrap"
 _MAGIC = b"NTSB"
-_VERSION = 1
+_VERSION = 2
+
+PROOF_SCHEME = "sealedbox-merkle-disclosure/1"
+"""Scheme tag stamped on every selective-disclosure :class:`~nest_core.types.Proof`.
+
+Example::
+
+    assert PROOF_SCHEME.startswith("sealedbox-merkle")
+"""
 
 
 # --------------------------------------------------------------------------- #
-# Errors — decrypt never silently returns wrong bytes; every failure raises.
+# Errors — decrypt/verify never silently return wrong bytes; every failure raises.
 # --------------------------------------------------------------------------- #
-class DecryptError(Exception):
-    """Base class for all decryption failures."""
+class PrivacyError(Exception):
+    """Base class for all sealedbox privacy failures."""
 
 
-class NotInAudienceError(DecryptError):
-    """This agent is not a recipient of the sealed message."""
+class NotInAudienceError(PrivacyError):
+    """This agent is not a recipient of the sealed message (or was revoked)."""
 
 
-class TamperError(DecryptError):
-    """Ciphertext failed authentication (modified in transit)."""
+class ReplayError(PrivacyError):
+    """An already-seen ``(sender, epoch, counter)`` envelope was re-presented."""
 
 
-class MalformedEnvelopeError(DecryptError):
+class TamperError(PrivacyError):
+    """Ciphertext or bound header failed authentication (modified in transit)."""
+
+
+class MalformedEnvelopeError(PrivacyError):
     """The byte payload is not a valid sealedbox envelope."""
 
 
@@ -76,7 +150,12 @@ def _hkdf(ikm: bytes, info: bytes, length: int = 32) -> bytes:
 
 
 def seed_to_bytes(seed: int | bytes) -> bytes:
-    """Normalize a scenario seed (int or bytes) to a stable byte string."""
+    """Normalize a scenario seed (int or bytes) to a stable 32-byte string.
+
+    Example::
+
+        assert len(seed_to_bytes(7)) == 32
+    """
     if isinstance(seed, bytes):
         return hashlib.sha256(_DOMAIN + b"/seed/" + seed).digest()
     return hashlib.sha256(_DOMAIN + b"/seed/" + str(int(seed)).encode()).digest()
@@ -114,11 +193,47 @@ class _Recipient:
     wrapped: bytes
 
 
-def _serialize_envelope(nonce: bytes, recipients: list[_Recipient], ciphertext: bytes) -> bytes:
+@dataclass(frozen=True)
+class _Header:
+    """The authenticated, cleartext header of an envelope (bound as AEAD AAD)."""
+
+    sender: str
+    epoch: int
+    counter: int
+
+
+def _aad(header: _Header, key_ids: list[bytes]) -> bytes:
+    """Associated data bound to every AEAD in the envelope.
+
+    Reconstructible from the parsed envelope, so any edit to the sender, epoch,
+    counter, or recipient set flips authentication. ``key_ids`` are sorted so the
+    binding is over the *set* of recipients, order-independent.
+    """
+    sender_bytes = header.sender.encode()
+    parts = [
+        _DOMAIN,
+        b"/aad/",
+        struct.pack(">B", _VERSION),
+        struct.pack(">H", len(sender_bytes)),
+        sender_bytes,
+        struct.pack(">I", header.epoch),
+        struct.pack(">Q", header.counter),
+        struct.pack(">H", len(key_ids)),
+        b"".join(sorted(key_ids)),
+    ]
+    return b"".join(parts)
+
+
+def _serialize_envelope(
+    header: _Header, nonce: bytes, recipients: list[_Recipient], ciphertext: bytes
+) -> bytes:
     if len(nonce) != 12:
         raise ValueError("nonce must be 12 bytes")
+    sender_bytes = header.sender.encode()
     out = bytearray()
     out += struct.pack(">4sB", _MAGIC, _VERSION)
+    out += struct.pack(">H", len(sender_bytes)) + sender_bytes
+    out += struct.pack(">IQ", header.epoch, header.counter)
     out += nonce
     out += struct.pack(">H", len(recipients))
     for r in recipients:
@@ -130,13 +245,21 @@ def _serialize_envelope(nonce: bytes, recipients: list[_Recipient], ciphertext: 
     return bytes(out)
 
 
-def _parse_envelope(blob: bytes) -> tuple[bytes, list[_Recipient], bytes]:
+def _parse_envelope(blob: bytes) -> tuple[_Header, bytes, list[_Recipient], bytes]:
     try:
         if blob[:4] != _MAGIC:
             raise MalformedEnvelopeError("bad magic")
         if blob[4] != _VERSION:
             raise MalformedEnvelopeError(f"unsupported version {blob[4]}")
         off = 5
+        (sender_len,) = struct.unpack_from(">H", blob, off)
+        off += 2
+        sender_raw = blob[off : off + sender_len]
+        off += sender_len
+        if len(sender_raw) != sender_len:
+            raise MalformedEnvelopeError("truncated sender")
+        epoch, counter = struct.unpack_from(">IQ", blob, off)
+        off += 12
         nonce = blob[off : off + 12]
         off += 12
         if len(nonce) != 12:
@@ -169,59 +292,99 @@ def _parse_envelope(blob: bytes) -> tuple[bytes, list[_Recipient], bytes]:
         ciphertext = blob[off : off + ct_len]
         if len(ciphertext) != ct_len:
             raise MalformedEnvelopeError("truncated ciphertext")
-        return nonce, recipients, ciphertext
-    except (struct.error, IndexError) as exc:
+        header = _Header(sender=sender_raw.decode("utf-8"), epoch=epoch, counter=counter)
+        return header, nonce, recipients, ciphertext
+    except (struct.error, IndexError, UnicodeDecodeError) as exc:
         raise MalformedEnvelopeError(str(exc)) from exc
+
+
+def content_ciphertext(envelope: bytes) -> bytes:
+    """Return just the AEAD content ciphertext (``ct || tag``) from an envelope.
+
+    Exposed for adversarial validators that need to inspect the keystream region
+    of the trace (e.g. the two-time-pad detector) without decrypting.
+
+    Example::
+
+        body = content_ciphertext(env)  # bytes; last 16 bytes are the Poly1305 tag
+    """
+    _header, _nonce, _recipients, ciphertext = _parse_envelope(envelope)
+    return ciphertext
+
+
+# --------------------------------------------------------------------------- #
+# SIV-style synthetic derivation (the misuse-resistant heart of the plugin).
+# --------------------------------------------------------------------------- #
+def _synthetic_iv(data: bytes, key_ids: list[bytes]) -> bytes:
+    """Digest of the plaintext and sorted audience, folded into every derivation.
+
+    This is what makes deterministic mode nonce-misuse resistant: two messages
+    that differ in plaintext or audience get different synthetic values, so they
+    never share a derived ``(key, nonce)`` even under an identical counter.
+    """
+    h = hashlib.sha256()
+    h.update(_DOMAIN + b"/siv/")
+    h.update(struct.pack(">I", len(data)))
+    h.update(data)
+    h.update(struct.pack(">H", len(key_ids)))
+    for kid in sorted(key_ids):
+        h.update(kid)
+    return h.digest()
+
+
+def _derive(seed_bytes: bytes, msg_id: bytes, tag: bytes, siv: bytes, length: int) -> bytes:
+    info = _DOMAIN + b"/" + tag + b"/" + msg_id + b"/" + siv
+    return _hkdf(seed_bytes, info, length)
 
 
 # --------------------------------------------------------------------------- #
 # Seal / unseal — the actual multi-recipient authenticated encryption.
 # --------------------------------------------------------------------------- #
-def _derive(seed_bytes: bytes, sender_id: str, counter: int, tag: bytes, length: int) -> bytes:
-    info = (
-        b"nandatown/sealedbox/v1/" + tag + b"/" + sender_id.encode() + b"/" + str(counter).encode()
-    )
-    return _hkdf(seed_bytes, info, length)
-
-
 def _seal(
     data: bytes,
     audience_pubs: dict[str, bytes],
     *,
-    sender_id: str,
+    header: _Header,
     seed_bytes: bytes,
-    counter: int,
     deterministic: bool = True,
 ) -> bytes:
     """Encrypt *data* for every agent in *audience_pubs* (id -> raw X25519 pubkey).
 
-    In deterministic mode the content key, nonces, and ephemeral keys are derived
-    from ``(seed_bytes, sender_id, counter)``; ``counter`` MUST then be unique per
-    message from a given ``(seed_bytes, sender_id)`` pair (reuse would reuse the
-    content key + nonce). In random mode they come from ``os.urandom``.
+    In deterministic mode the content key, content nonce, ephemeral scalars and
+    wrap nonces are all derived SIV-style from ``(seed, msg_id, synthetic_iv)``,
+    where ``synthetic_iv`` binds the plaintext and audience — so a counter
+    collision degrades to revealing message equality rather than reusing a
+    keystream. In random mode they come from ``os.urandom``.
     """
     if not audience_pubs:
         raise ValueError("audience must not be empty")
+    key_ids = [_key_id_for_public(pub) for pub in audience_pubs.values()]
+    msg_id = f"{header.sender}:{header.epoch}:{header.counter}".encode()
+    aad = _aad(header, key_ids)
+
     if deterministic:
-        cek = _derive(seed_bytes, sender_id, counter, b"cek", 32)
-        payload_nonce = _derive(seed_bytes, sender_id, counter, b"nonce", 12)
+        siv = _synthetic_iv(data, key_ids)
+        cek = _derive(seed_bytes, msg_id, b"cek", siv, 32)
+        payload_nonce = _derive(seed_bytes, msg_id, b"nonce", siv, 12)
     else:
+        siv = b""
         cek = os.urandom(32)
         payload_nonce = os.urandom(12)
-    ciphertext = ChaCha20Poly1305(cek).encrypt(payload_nonce, data, None)
+    ciphertext = ChaCha20Poly1305(cek).encrypt(payload_nonce, data, aad)
 
     recipients: list[_Recipient] = []
     for idx, (_aid, recipient_pub_raw) in enumerate(sorted(audience_pubs.items())):
         if deterministic:
-            eph_raw = _derive(seed_bytes, sender_id, counter, b"eph/" + str(idx).encode(), 32)
+            idx_tag = str(idx).encode()
+            eph_raw = _derive(seed_bytes, msg_id, b"eph/" + idx_tag, siv, 32)
             eph = X25519PrivateKey.from_private_bytes(eph_raw)
-            wrap_nonce = _derive(seed_bytes, sender_id, counter, b"wn/" + str(idx).encode(), 12)
+            wrap_nonce = _derive(seed_bytes, msg_id, b"wn/" + idx_tag, siv, 12)
         else:
             eph = X25519PrivateKey.generate()
             wrap_nonce = os.urandom(12)
         shared = eph.exchange(_public_from_raw(recipient_pub_raw))
         wrap_key = _hkdf(shared, _WRAP_INFO, 32)
-        wrapped = ChaCha20Poly1305(wrap_key).encrypt(wrap_nonce, cek, None)
+        wrapped = ChaCha20Poly1305(wrap_key).encrypt(wrap_nonce, cek, aad)
         recipients.append(
             _Recipient(
                 key_id=_key_id_for_public(recipient_pub_raw),
@@ -230,34 +393,181 @@ def _seal(
                 wrapped=wrapped,
             )
         )
-    return _serialize_envelope(payload_nonce, recipients, ciphertext)
+    return _serialize_envelope(header, payload_nonce, recipients, ciphertext)
 
 
-def _unseal(blob: bytes, *, my_secret: X25519PrivateKey) -> bytes:
-    payload_nonce, recipients, ciphertext = _parse_envelope(blob)
+def _unseal(blob: bytes, *, my_secret: X25519PrivateKey) -> tuple[_Header, bytes]:
+    header, payload_nonce, recipients, ciphertext = _parse_envelope(blob)
     my_kid = _key_id_for_public(_public_raw(my_secret))
     entry = next((r for r in recipients if r.key_id == my_kid), None)
     if entry is None:
         raise NotInAudienceError("no recipient entry for this agent")
+    aad = _aad(header, [r.key_id for r in recipients])
     shared = my_secret.exchange(_public_from_raw(entry.eph_pub))
     wrap_key = _hkdf(shared, _WRAP_INFO, 32)
     try:
-        cek = ChaCha20Poly1305(wrap_key).decrypt(entry.wrap_nonce, entry.wrapped, None)
-        return ChaCha20Poly1305(cek).decrypt(payload_nonce, ciphertext, None)
+        cek = ChaCha20Poly1305(wrap_key).decrypt(entry.wrap_nonce, entry.wrapped, aad)
+        plaintext = ChaCha20Poly1305(cek).decrypt(payload_nonce, ciphertext, aad)
     except InvalidTag as exc:
-        raise TamperError("authentication failed — ciphertext was modified") from exc
+        raise TamperError("authentication failed — envelope was modified") from exc
+    return header, plaintext
+
+
+# --------------------------------------------------------------------------- #
+# Selective-disclosure Merkle commitment (pure functions; issuer + verifier).
+# --------------------------------------------------------------------------- #
+def _leaf(name: str, value: str, salt: bytes) -> bytes:
+    """Salted, length-prefixed leaf hash. The salt hides low-entropy values."""
+    parts = [
+        _DOMAIN + b"/leaf/",
+        struct.pack(">I", len(name)),
+        name.encode("utf-8"),
+        struct.pack(">I", len(value)),
+        value.encode("utf-8"),
+        salt,
+    ]
+    return hashlib.sha256(b"".join(parts)).digest()
+
+
+def _node(left: bytes, right: bytes) -> bytes:
+    return hashlib.sha256(_DOMAIN + b"/node/" + left + right).digest()
+
+
+def _merkle_levels(leaves: list[bytes]) -> list[list[bytes]]:
+    if not leaves:
+        return [[hashlib.sha256(_DOMAIN + b"/empty/").digest()]]
+    levels = [leaves]
+    while len(levels[-1]) > 1:
+        cur = levels[-1]
+        nxt = [_node(cur[i], cur[i + 1 if i + 1 < len(cur) else i]) for i in range(0, len(cur), 2)]
+        levels.append(nxt)
+    return levels
+
+
+def _merkle_root(leaves: list[bytes]) -> bytes:
+    return _merkle_levels(leaves)[-1][0]
+
+
+def _merkle_path(leaves: list[bytes], index: int) -> list[tuple[str, bool]]:
+    """Authentication path for ``leaves[index]`` as ``(sibling_hex, sibling_is_right)``."""
+    path: list[tuple[str, bool]] = []
+    levels = _merkle_levels(leaves)
+    idx = index
+    for level in levels[:-1]:
+        sibling_is_right = idx % 2 == 0
+        sib_idx = idx + 1 if sibling_is_right else idx - 1
+        if sib_idx >= len(level):  # odd node duplicated with itself
+            sib_idx = idx
+        path.append((level[sib_idx].hex(), sibling_is_right))
+        idx //= 2
+    return path
+
+
+def _root_from_path(leaf: bytes, path: list[tuple[str, bool]]) -> bytes:
+    acc = leaf
+    for sib_hex, sib_is_right in path:
+        sib = bytes.fromhex(sib_hex)
+        acc = _node(acc, sib) if sib_is_right else _node(sib, acc)
+    return acc
+
+
+def commit_credential(
+    fields: dict[str, str], *, salt_seed: bytes | None = None
+) -> tuple[str, dict[str, str]]:
+    """Issuer helper: commit a multi-field credential to a single Merkle root.
+
+    Returns ``(root_hex, salts)`` where ``salts`` maps each field name to a hex
+    16-byte salt; leaves are ordered by sorted field name. With ``salt_seed=None``
+    the salts come from the system RNG (hiding, unlinkable). Pass an explicit
+    ``salt_seed`` only for reproducible Tier-1 trace tests — that makes the salts
+    deterministic (and, for a public seed, re-derivable), trading hiding for
+    replayability.
+
+    Example::
+
+        root, salts = commit_credential({"age": "21", "country": "NG"})
+        assert len(root) == 64 and set(salts) == {"age", "country"}
+    """
+    names = sorted(fields)
+    salts: dict[str, str] = {}
+    leaves: list[bytes] = []
+    for name in names:
+        if salt_seed is None:
+            salt = os.urandom(16)
+        else:
+            salt = _hkdf(salt_seed, _DOMAIN + b"/salt/" + name.encode("utf-8"), length=16)
+        salts[name] = salt.hex()
+        leaves.append(_leaf(name, fields[name], salt))
+    return _merkle_root(leaves).hex(), salts
+
+
+def _split_witness(witness: Witness) -> tuple[dict[str, str], dict[str, str]]:
+    """Split a witness into ``(fields, salts)``; ``__salts__`` holds the salts JSON."""
+    raw = dict(witness.private_inputs)
+    salts_json = raw.pop("__salts__", "{}")
+    loaded: Any = json.loads(salts_json)
+    if not isinstance(loaded, dict):
+        msg = "__salts__ must be a JSON object"
+        raise ValueError(msg)
+    mapping = cast("dict[str, Any]", loaded)
+    salts: dict[str, str] = {str(k): str(v) for k, v in mapping.items()}
+    fields: dict[str, str] = {k: str(v) for k, v in raw.items()}
+    return fields, salts
+
+
+def _reveal_list(statement: Statement) -> list[str]:
+    """Parse the JSON ``reveal`` field-name list from the statement.
+
+    A JSON array of field names (not a comma-joined string) so that field names
+    may themselves contain commas without ambiguity. Falls back to treating a
+    non-JSON value as a single field name for convenience.
+    """
+    raw = statement.public_inputs.get("reveal", "[]")
+    try:
+        loaded: Any = json.loads(raw)
+    except (ValueError, TypeError):
+        return [raw] if raw else []
+    if not isinstance(loaded, list):
+        return []
+    return [str(name) for name in cast("list[Any]", loaded)]
+
+
+def _coerce_path(raw: Any) -> list[tuple[str, bool]]:
+    """Coerce a JSON-decoded path back into ``[(sibling_hex, is_right)]``."""
+    if not isinstance(raw, list):
+        msg = "path is not a list"
+        raise TypeError(msg)
+    path: list[tuple[str, bool]] = []
+    for step in cast("list[Any]", raw):
+        if not isinstance(step, list):
+            msg = "path step is not a list"
+            raise TypeError(msg)
+        pair = cast("list[Any]", step)
+        if len(pair) != 2:
+            msg = "path step is not a 2-element list"
+            raise TypeError(msg)
+        path.append((str(pair[0]), bool(pair[1])))
+    return path
 
 
 # --------------------------------------------------------------------------- #
 # The Privacy-layer plugin.
 # --------------------------------------------------------------------------- #
 class SealedBoxPrivacy:
-    """Per-agent privacy plugin doing real multi-recipient authenticated encryption.
+    """Per-agent privacy plugin: nonce-misuse-resistant hybrid encryption,
+    selective disclosure, and broadcast revocation (implements ``Privacy``).
 
-    One instance per agent. Deterministic mode (default) derives keys from
-    ``(seed, agent_id)`` for replayable traces; random mode (``deterministic=False``)
-    uses ``os.urandom`` for genuine secrecy at the cost of reproducibility, and
-    resolves peer keys from an injected ``directory`` (agent_id -> raw pubkey).
+    One instance per agent. Deterministic mode (default) derives keys SIV-style
+    from ``(seed, agent_id, plaintext, audience)`` for replayable *and*
+    reuse-safe traces; random mode (``deterministic=False``) uses ``os.urandom``
+    and resolves peer keys from an injected ``directory`` (agent_id -> raw pubkey).
+
+    Example::
+
+        a = SealedBoxPrivacy(AgentId("a"), seed=7)
+        b = SealedBoxPrivacy(AgentId("b"), seed=7)
+        env = await a.encrypt(b"hi", [AgentId("b")])
+        assert await b.decrypt(env) == b"hi"
     """
 
     def __init__(
@@ -272,6 +582,9 @@ class SealedBoxPrivacy:
         self._seed_bytes = seed_to_bytes(seed)
         self._deterministic = deterministic
         self._counter = 0
+        self._epoch = 0
+        self._revoked: dict[str, int] = {}
+        self._seen: set[bytes] = set()
         self._directory: dict[str, bytes] = {} if deterministic else dict(directory or {})
         if deterministic:
             secret = _derive_secret(self._seed_bytes, self._agent_id)
@@ -279,13 +592,20 @@ class SealedBoxPrivacy:
             secret = X25519PrivateKey.generate()
         self._secret: X25519PrivateKey = secret
 
+    # -- identity / directory -------------------------------------------------
+
     @property
     def public_key_raw(self) -> bytes:
         """This agent's raw X25519 public key (for random-mode directories)."""
         return _public_raw(self._secret)
 
+    @property
+    def epoch(self) -> int:
+        """Current revocation epoch (advances on :meth:`revoke`)."""
+        return self._epoch
+
     def register_peer(self, agent_id: AgentId, public_key_raw: bytes) -> None:
-        """Add a peer public key (random mode only)."""
+        """Add a peer public key (random mode only; deterministic mode derives it)."""
         self._directory[str(agent_id)] = public_key_raw
 
     def _public_for(self, agent_id: str) -> bytes:
@@ -296,30 +616,187 @@ class SealedBoxPrivacy:
         except KeyError as exc:
             raise KeyError(f"no public key for {agent_id!r} in directory") from exc
 
+    # -- revocation -----------------------------------------------------------
+
+    def revoke(self, agent_id: AgentId) -> int:
+        """Revoke *agent_id*: advance the epoch and exclude it from future wraps.
+
+        Returns the new epoch. **Forward-secrecy note:** revocation is
+        *future-only*. A member revoked at epoch *E* cannot read messages issued
+        at epoch ``>= E``, but any envelope it already received at an earlier
+        epoch stays decryptable by it forever — true past-traffic forward secrecy
+        would require per-epoch content re-keying with deletion of old key
+        material, which this plugin deliberately does not do (it would change the
+        broadcast cost model). We surface this rather than overclaim.
+
+        Example::
+
+            new_epoch = priv.revoke(AgentId("carol"))
+        """
+        sid = str(agent_id)
+        if sid in self._revoked:
+            return self._epoch  # already revoked: idempotent, preserves the first epoch
+        self._epoch += 1
+        self._revoked[sid] = self._epoch
+        return self._epoch
+
+    def _is_revoked(self, agent_id: str, epoch: int) -> bool:
+        revoked_at = self._revoked.get(agent_id)
+        return revoked_at is not None and epoch >= revoked_at
+
+    # -- Privacy protocol: encryption -----------------------------------------
+
     async def encrypt(self, data: bytes, audience: list[AgentId]) -> bytes:
+        """Encrypt *data* so only non-revoked members of *audience* can read it.
+
+        Recipients revoked as of the current epoch are silently excluded (that is
+        the revocation guarantee). Raises ``ValueError`` if the resulting audience
+        is empty.
+
+        Example::
+
+            env = await alice.encrypt(b"secret", [AgentId("bob")])
+        """
         if not audience:
             raise ValueError("audience must not be empty")
-        pubs = {str(aid): self._public_for(str(aid)) for aid in audience}
+        seen: set[str] = set()
+        recipients: list[str] = []
+        for aid in audience:
+            sid = str(aid)
+            if sid in seen or self._is_revoked(sid, self._epoch):
+                continue
+            seen.add(sid)
+            recipients.append(sid)
+        if not recipients:
+            raise ValueError("audience is empty after excluding revoked members")
+
+        pubs = {sid: self._public_for(sid) for sid in recipients}
+        header = _Header(sender=self._agent_id, epoch=self._epoch, counter=self._counter)
         blob = _seal(
             data,
             pubs,
-            sender_id=self._agent_id,
+            header=header,
             seed_bytes=self._seed_bytes,
-            counter=self._counter,
             deterministic=self._deterministic,
         )
         self._counter += 1
         return blob
 
     async def decrypt(self, data: bytes) -> bytes:
-        return _unseal(data, my_secret=self._secret)
+        """Decrypt an envelope addressed to this agent.
+
+        Raises :class:`NotInAudienceError` if this agent holds no wrap entry
+        (eavesdropper or stale-revocation), :class:`ReplayError` on a re-presented
+        envelope, :class:`TamperError` if authentication fails, and
+        :class:`MalformedEnvelopeError` on a structurally invalid envelope.
+
+        Example::
+
+            plaintext = await bob.decrypt(env)
+        """
+        header, plaintext = _unseal(data, my_secret=self._secret)
+        # Key replay memory on the whole envelope, NOT (sender, epoch, counter):
+        # the plugin's headline is that a reconstructed sender safely reuses a
+        # counter for a DIFFERENT message (SIV), so those distinct envelopes must
+        # not be mistaken for replays of each other. A byte-identical envelope
+        # still collides and is rejected.
+        replay_key = hashlib.sha256(data).digest()
+        if replay_key in self._seen:
+            raise ReplayError(f"replayed envelope {header.sender}:{header.epoch}:{header.counter}")
+        self._seen.add(replay_key)
+        return plaintext
+
+    # -- Privacy protocol: selective-disclosure proofs ------------------------
 
     async def prove(self, statement: Statement, witness: Witness) -> Proof:
-        raise NotImplementedError(
-            "sealedbox implements encryption only; ZK prove/verify is future work"
-        )
+        """Prove that the revealed fields belong to the committed credential.
+
+        ``statement.public_inputs`` carries ``root`` (issuer-committed Merkle
+        root, hex) and ``reveal`` (a JSON array of field names to disclose).
+        ``witness.private_inputs`` holds every field value plus a ``__salts__``
+        entry (JSON ``{name: salt_hex}``). The proof discloses only the requested
+        fields and their authentication paths; the rest stay hidden behind the
+        root. Raises ``ValueError`` if the witness does not reconstruct the
+        committed root or a requested field is unknown.
+
+        Example::
+
+            proof = await priv.prove(stmt, witness)
+        """
+        fields, salts = _split_witness(witness)
+        names = sorted(fields)
+        missing = [n for n in names if n not in salts]
+        if missing:
+            msg = f"witness missing salt(s) for field(s): {', '.join(missing)}"
+            raise ValueError(msg)
+        leaves = [_leaf(n, fields[n], bytes.fromhex(salts[n])) for n in names]
+        root = _merkle_root(leaves).hex()
+        if root != statement.public_inputs.get("root"):
+            msg = "witness does not match the committed root"
+            raise ValueError(msg)
+
+        reveal = _reveal_list(statement)
+        unknown = [name for name in reveal if name not in fields]
+        if unknown:
+            msg = f"cannot reveal unknown field(s): {', '.join(unknown)}"
+            raise ValueError(msg)
+        disclosed: dict[str, dict[str, Any]] = {}
+        for name in reveal:
+            idx = names.index(name)
+            disclosed[name] = {
+                "value": fields[name],
+                "salt": salts[name],
+                "index": idx,
+                "path": _merkle_path(leaves, idx),
+            }
+        payload = json.dumps(
+            {"root": root, "n": len(names), "disclosed": disclosed},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return Proof(statement=statement, data=payload, scheme=PROOF_SCHEME)
 
     async def verify_proof(self, statement: Statement, proof: Proof) -> bool:
-        raise NotImplementedError(
-            "sealedbox implements encryption only; ZK prove/verify is future work"
-        )
+        """Verify a selective-disclosure proof against the statement's root.
+
+        Returns ``True`` iff the scheme matches, every disclosed field's salted
+        leaf authenticates to ``statement.public_inputs['root']``, and the set of
+        disclosed fields equals the statement's ``reveal`` set. Any tampering with
+        a revealed value, salt, or path node flips a hash and returns ``False``.
+
+        Example::
+
+            ok = await priv.verify_proof(stmt, proof)
+        """
+        if proof.scheme != PROOF_SCHEME:
+            return False
+        anchored_root = statement.public_inputs.get("root")
+        try:
+            parsed: Any = json.loads(proof.data)
+        except (ValueError, TypeError):
+            return False
+        if not isinstance(parsed, dict):
+            return False
+        body = cast("dict[str, Any]", parsed)
+        if body.get("root") != anchored_root:
+            return False
+        raw_disclosed = body.get("disclosed")
+        if not isinstance(raw_disclosed, dict):
+            return False
+        disclosed = cast("dict[str, Any]", raw_disclosed)
+        if set(disclosed) != set(_reveal_list(statement)):
+            return False
+        for name, item in disclosed.items():
+            if not isinstance(item, dict):
+                return False
+            field = cast("dict[str, Any]", item)
+            try:
+                value = str(field["value"])
+                salt = bytes.fromhex(str(field["salt"]))
+                path = _coerce_path(field["path"])
+            except (KeyError, ValueError, TypeError):
+                return False
+            leaf = _leaf(name, value, salt)
+            if _root_from_path(leaf, path).hex() != anchored_root:
+                return False
+        return True

--- a/packages/nest-plugins-reference/nest_plugins_reference/privacy/sealedbox.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/privacy/sealedbox.py
@@ -1,0 +1,325 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Real authenticated encryption for the Privacy layer (a sealed-box alternative
+to the ``noop`` passthrough).
+
+Multi-recipient sealed-box encryption: a fresh ChaCha20-Poly1305 content key per
+message, wrapped to each recipient via X25519 ECDH + HKDF-SHA256. This gives the
+Privacy layer genuine confidentiality (non-audience agents cannot read a payload
+through the API; the trace carries only ciphertext) and tamper-evidence (a
+modified ciphertext fails to decrypt rather than silently yielding altered bytes).
+
+Keys derive deterministically from ``(seed, agent_id)`` by default so simulation
+traces replay byte-for-byte, consistent with NandaTown's replay-first identity
+model. That is protocol/trace-level confidentiality, *not* secrecy against a
+holder of the shared seed. Pass ``deterministic=False`` for random per-agent keys
+(genuine secrecy against a seed-holder, at the cost of non-reproducible traces).
+
+``prove`` / ``verify_proof`` are honest stubs that raise ``NotImplementedError``
+— unlike the ``noop`` plugin's forged proof that always verifies. Zero-knowledge
+proofs are future work.
+
+Example::
+
+    priv = SealedBoxPrivacy(AgentId("a1"), seed=7)
+    ct = await priv.encrypt(b"secret", [AgentId("a2")])
+    # only a2 (with the same seed) can decrypt; a3 raises NotInAudienceError
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import struct
+from dataclasses import dataclass
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+    X25519PublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from nest_core.types import AgentId, Proof, Statement, Witness
+
+_DOMAIN = b"nandatown/sealedbox/v1"
+_WRAP_INFO = b"nandatown/sealedbox/v1/wrap"
+_MAGIC = b"NTSB"
+_VERSION = 1
+
+
+# --------------------------------------------------------------------------- #
+# Errors — decrypt never silently returns wrong bytes; every failure raises.
+# --------------------------------------------------------------------------- #
+class DecryptError(Exception):
+    """Base class for all decryption failures."""
+
+
+class NotInAudienceError(DecryptError):
+    """This agent is not a recipient of the sealed message."""
+
+
+class TamperError(DecryptError):
+    """Ciphertext failed authentication (modified in transit)."""
+
+
+class MalformedEnvelopeError(DecryptError):
+    """The byte payload is not a valid sealedbox envelope."""
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic X25519 key material (separate from any signing identity).
+# --------------------------------------------------------------------------- #
+def _hkdf(ikm: bytes, info: bytes, length: int = 32) -> bytes:
+    return HKDF(algorithm=hashes.SHA256(), length=length, salt=None, info=info).derive(ikm)
+
+
+def seed_to_bytes(seed: int | bytes) -> bytes:
+    """Normalize a scenario seed (int or bytes) to a stable byte string."""
+    if isinstance(seed, bytes):
+        return hashlib.sha256(_DOMAIN + b"/seed/" + seed).digest()
+    return hashlib.sha256(_DOMAIN + b"/seed/" + str(int(seed)).encode()).digest()
+
+
+def _derive_secret(seed_bytes: bytes, agent_id: str) -> X25519PrivateKey:
+    raw = _hkdf(seed_bytes, _DOMAIN + b"/keyAgreement/" + agent_id.encode())
+    return X25519PrivateKey.from_private_bytes(raw)
+
+
+def _public_raw(secret: X25519PrivateKey) -> bytes:
+    return secret.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+
+def _public_raw_for_agent(seed_bytes: bytes, agent_id: str) -> bytes:
+    return _public_raw(_derive_secret(seed_bytes, agent_id))
+
+
+def _public_from_raw(raw: bytes) -> X25519PublicKey:
+    return X25519PublicKey.from_public_bytes(raw)
+
+
+def _key_id_for_public(public_raw_bytes: bytes) -> bytes:
+    return hashlib.sha256(_DOMAIN + b"/kid/" + public_raw_bytes).digest()[:8]
+
+
+# --------------------------------------------------------------------------- #
+# Versioned, self-describing envelope (pure (de)serialization, no crypto).
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class _Recipient:
+    key_id: bytes
+    eph_pub: bytes
+    wrap_nonce: bytes
+    wrapped: bytes
+
+
+def _serialize_envelope(nonce: bytes, recipients: list[_Recipient], ciphertext: bytes) -> bytes:
+    if len(nonce) != 12:
+        raise ValueError("nonce must be 12 bytes")
+    out = bytearray()
+    out += struct.pack(">4sB", _MAGIC, _VERSION)
+    out += nonce
+    out += struct.pack(">H", len(recipients))
+    for r in recipients:
+        if len(r.key_id) != 8 or len(r.eph_pub) != 32 or len(r.wrap_nonce) != 12:
+            raise ValueError("recipient field has wrong size")
+        out += r.key_id + r.eph_pub + r.wrap_nonce
+        out += struct.pack(">H", len(r.wrapped)) + r.wrapped
+    out += struct.pack(">I", len(ciphertext)) + ciphertext
+    return bytes(out)
+
+
+def _parse_envelope(blob: bytes) -> tuple[bytes, list[_Recipient], bytes]:
+    try:
+        if blob[:4] != _MAGIC:
+            raise MalformedEnvelopeError("bad magic")
+        if blob[4] != _VERSION:
+            raise MalformedEnvelopeError(f"unsupported version {blob[4]}")
+        off = 5
+        nonce = blob[off : off + 12]
+        off += 12
+        if len(nonce) != 12:
+            raise MalformedEnvelopeError("truncated nonce")
+        (n_recip,) = struct.unpack_from(">H", blob, off)
+        off += 2
+        recipients: list[_Recipient] = []
+        for _ in range(n_recip):
+            key_id = blob[off : off + 8]
+            off += 8
+            eph_pub = blob[off : off + 32]
+            off += 32
+            wrap_nonce = blob[off : off + 12]
+            off += 12
+            (wrap_len,) = struct.unpack_from(">H", blob, off)
+            off += 2
+            wrapped = blob[off : off + wrap_len]
+            off += wrap_len
+            sizes_ok = (
+                len(key_id) == 8
+                and len(eph_pub) == 32
+                and len(wrap_nonce) == 12
+                and len(wrapped) == wrap_len
+            )
+            if not sizes_ok:
+                raise MalformedEnvelopeError("truncated recipient")
+            recipients.append(_Recipient(key_id, eph_pub, wrap_nonce, wrapped))
+        (ct_len,) = struct.unpack_from(">I", blob, off)
+        off += 4
+        ciphertext = blob[off : off + ct_len]
+        if len(ciphertext) != ct_len:
+            raise MalformedEnvelopeError("truncated ciphertext")
+        return nonce, recipients, ciphertext
+    except (struct.error, IndexError) as exc:
+        raise MalformedEnvelopeError(str(exc)) from exc
+
+
+# --------------------------------------------------------------------------- #
+# Seal / unseal — the actual multi-recipient authenticated encryption.
+# --------------------------------------------------------------------------- #
+def _derive(seed_bytes: bytes, sender_id: str, counter: int, tag: bytes, length: int) -> bytes:
+    info = (
+        b"nandatown/sealedbox/v1/" + tag + b"/" + sender_id.encode() + b"/" + str(counter).encode()
+    )
+    return _hkdf(seed_bytes, info, length)
+
+
+def _seal(
+    data: bytes,
+    audience_pubs: dict[str, bytes],
+    *,
+    sender_id: str,
+    seed_bytes: bytes,
+    counter: int,
+    deterministic: bool = True,
+) -> bytes:
+    """Encrypt *data* for every agent in *audience_pubs* (id -> raw X25519 pubkey).
+
+    In deterministic mode the content key, nonces, and ephemeral keys are derived
+    from ``(seed_bytes, sender_id, counter)``; ``counter`` MUST then be unique per
+    message from a given ``(seed_bytes, sender_id)`` pair (reuse would reuse the
+    content key + nonce). In random mode they come from ``os.urandom``.
+    """
+    if not audience_pubs:
+        raise ValueError("audience must not be empty")
+    if deterministic:
+        cek = _derive(seed_bytes, sender_id, counter, b"cek", 32)
+        payload_nonce = _derive(seed_bytes, sender_id, counter, b"nonce", 12)
+    else:
+        cek = os.urandom(32)
+        payload_nonce = os.urandom(12)
+    ciphertext = ChaCha20Poly1305(cek).encrypt(payload_nonce, data, None)
+
+    recipients: list[_Recipient] = []
+    for idx, (_aid, recipient_pub_raw) in enumerate(sorted(audience_pubs.items())):
+        if deterministic:
+            eph_raw = _derive(seed_bytes, sender_id, counter, b"eph/" + str(idx).encode(), 32)
+            eph = X25519PrivateKey.from_private_bytes(eph_raw)
+            wrap_nonce = _derive(seed_bytes, sender_id, counter, b"wn/" + str(idx).encode(), 12)
+        else:
+            eph = X25519PrivateKey.generate()
+            wrap_nonce = os.urandom(12)
+        shared = eph.exchange(_public_from_raw(recipient_pub_raw))
+        wrap_key = _hkdf(shared, _WRAP_INFO, 32)
+        wrapped = ChaCha20Poly1305(wrap_key).encrypt(wrap_nonce, cek, None)
+        recipients.append(
+            _Recipient(
+                key_id=_key_id_for_public(recipient_pub_raw),
+                eph_pub=_public_raw(eph),
+                wrap_nonce=wrap_nonce,
+                wrapped=wrapped,
+            )
+        )
+    return _serialize_envelope(payload_nonce, recipients, ciphertext)
+
+
+def _unseal(blob: bytes, *, my_secret: X25519PrivateKey) -> bytes:
+    payload_nonce, recipients, ciphertext = _parse_envelope(blob)
+    my_kid = _key_id_for_public(_public_raw(my_secret))
+    entry = next((r for r in recipients if r.key_id == my_kid), None)
+    if entry is None:
+        raise NotInAudienceError("no recipient entry for this agent")
+    shared = my_secret.exchange(_public_from_raw(entry.eph_pub))
+    wrap_key = _hkdf(shared, _WRAP_INFO, 32)
+    try:
+        cek = ChaCha20Poly1305(wrap_key).decrypt(entry.wrap_nonce, entry.wrapped, None)
+        return ChaCha20Poly1305(cek).decrypt(payload_nonce, ciphertext, None)
+    except InvalidTag as exc:
+        raise TamperError("authentication failed — ciphertext was modified") from exc
+
+
+# --------------------------------------------------------------------------- #
+# The Privacy-layer plugin.
+# --------------------------------------------------------------------------- #
+class SealedBoxPrivacy:
+    """Per-agent privacy plugin doing real multi-recipient authenticated encryption.
+
+    One instance per agent. Deterministic mode (default) derives keys from
+    ``(seed, agent_id)`` for replayable traces; random mode (``deterministic=False``)
+    uses ``os.urandom`` for genuine secrecy at the cost of reproducibility, and
+    resolves peer keys from an injected ``directory`` (agent_id -> raw pubkey).
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        seed: int | bytes = 0,
+        *,
+        deterministic: bool = True,
+        directory: dict[str, bytes] | None = None,
+    ) -> None:
+        self._agent_id = str(agent_id)
+        self._seed_bytes = seed_to_bytes(seed)
+        self._deterministic = deterministic
+        self._counter = 0
+        self._directory: dict[str, bytes] = {} if deterministic else dict(directory or {})
+        if deterministic:
+            secret = _derive_secret(self._seed_bytes, self._agent_id)
+        else:
+            secret = X25519PrivateKey.generate()
+        self._secret: X25519PrivateKey = secret
+
+    @property
+    def public_key_raw(self) -> bytes:
+        """This agent's raw X25519 public key (for random-mode directories)."""
+        return _public_raw(self._secret)
+
+    def register_peer(self, agent_id: AgentId, public_key_raw: bytes) -> None:
+        """Add a peer public key (random mode only)."""
+        self._directory[str(agent_id)] = public_key_raw
+
+    def _public_for(self, agent_id: str) -> bytes:
+        if self._deterministic:
+            return _public_raw_for_agent(self._seed_bytes, agent_id)
+        try:
+            return self._directory[agent_id]
+        except KeyError as exc:
+            raise KeyError(f"no public key for {agent_id!r} in directory") from exc
+
+    async def encrypt(self, data: bytes, audience: list[AgentId]) -> bytes:
+        if not audience:
+            raise ValueError("audience must not be empty")
+        pubs = {str(aid): self._public_for(str(aid)) for aid in audience}
+        blob = _seal(
+            data,
+            pubs,
+            sender_id=self._agent_id,
+            seed_bytes=self._seed_bytes,
+            counter=self._counter,
+            deterministic=self._deterministic,
+        )
+        self._counter += 1
+        return blob
+
+    async def decrypt(self, data: bytes) -> bytes:
+        return _unseal(data, my_secret=self._secret)
+
+    async def prove(self, statement: Statement, witness: Witness) -> Proof:
+        raise NotImplementedError(
+            "sealedbox implements encryption only; ZK prove/verify is future work"
+        )
+
+    async def verify_proof(self, statement: Statement, proof: Proof) -> bool:
+        raise NotImplementedError(
+            "sealedbox implements encryption only; ZK prove/verify is future work"
+        )

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/sealedbox_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/sealedbox_validators.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for the ``sealedbox`` privacy plugin.
+
+The default ``noop`` privacy plugin silently allows every attack below — its
+``encrypt`` returns the plaintext unchanged, its ``decrypt`` returns its input,
+and its ``verify_proof`` is an unconditional ``True``. These validators run on
+the :class:`~nest_core.layers.privacy.Privacy` protocol surface (plus a
+byte-level trace inspector for the reuse check), so the *same* check passes
+against ``sealedbox`` and fails against ``noop``.
+
+Problem 09 requires four attacks; ``sealedbox`` adds a fifth that is the point of
+the plugin:
+
+1. **Eavesdropper** — ``check_eavesdropper_blocked``: a non-audience agent must
+   not recover the plaintext, and the plaintext must not appear verbatim on the
+   wire.
+2. **Replay** — ``check_replay_rejected``: a recipient accepts an envelope once
+   and rejects a byte-identical replay.
+3. **Field-injection** — ``check_field_injection_rejected``: an untampered
+   selective-disclosure proof verifies; one with an edited revealed field does
+   not.
+4. **Stale-revocation** — ``check_stale_revocation_blocked``: a revoked member
+   can read a pre-revocation message but not a post-revocation one.
+5. **Deterministic key/nonce reuse (novel)** — ``check_no_two_time_pad`` /
+   ``check_deterministic_reuse_safe``: reconstructing a deterministic plugin
+   (counter reset to zero) and encrypting two *different* plaintexts must not
+   produce a two-time pad. This **fails** against a counter-only scheme (the
+   deterministic mode ``hybrid_x25519`` concedes is unsafe under reuse) and
+   against ``noop``, and **passes** against ``sealedbox``'s SIV derivation. It is
+   the adversarial witness that the plugin's headline property is load-bearing.
+
+Example::
+
+    report = await check_eavesdropper_blocked(outsider, envelope, secret=b"bid:1700")
+    assert report.passed, report.detail
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, cast
+
+from nest_plugins_reference.privacy.sealedbox import content_ciphertext
+from nest_plugins_reference.validators.gossip_validators import ValidatorReport
+
+if TYPE_CHECKING:
+    from nest_core.layers.privacy import Privacy
+    from nest_core.types import AgentId, Proof, Statement
+
+
+async def _try_decrypt(privacy: Privacy, envelope: bytes) -> tuple[bool, bytes | None]:
+    """Attempt a decrypt; return ``(ok, plaintext)`` with any failure normalised.
+
+    Any exception (not-in-audience, replay, tamper, malformed) is treated as a
+    decrypt failure rather than propagating, so a validator can reason about the
+    *policy outcome* uniformly across plugins.
+    """
+    try:
+        return True, await privacy.decrypt(envelope)
+    except Exception:  # noqa: BLE001 - any failure is, for policy purposes, "blocked"
+        return False, None
+
+
+async def check_eavesdropper_blocked(
+    eavesdropper: Privacy, envelope: bytes, *, secret: bytes
+) -> ValidatorReport:
+    """Assert a non-audience agent cannot recover the plaintext from *envelope*.
+
+    Passes iff the outsider's decrypt does **not** yield ``secret`` and ``secret``
+    does not appear as a substring of the envelope bytes. Against ``noop`` the
+    envelope *is* the plaintext, so both conditions fail. The on-wire substring
+    test is a heuristic best suited to secrets of reasonable length; a 1-2 byte
+    secret can match ciphertext bytes by chance, so use a realistic secret.
+
+    Example::
+
+        report = await check_eavesdropper_blocked(carol, env, secret=b"bid:1700")
+        assert report.passed, report.detail
+    """
+    ok, recovered = await _try_decrypt(eavesdropper, envelope)
+    leaked_via_decrypt = ok and recovered == secret
+    leaked_on_wire = secret in envelope
+    if leaked_via_decrypt or leaked_on_wire:
+        return ValidatorReport(
+            passed=False,
+            detail="eavesdropper recovered plaintext"
+            if leaked_via_decrypt
+            else "plaintext appears verbatim in the envelope",
+            evidence={"via_decrypt": leaked_via_decrypt, "on_wire": leaked_on_wire},
+        )
+    return ValidatorReport(passed=True, detail="eavesdropper learned nothing")
+
+
+async def check_replay_rejected(recipient: Privacy, envelope: bytes) -> ValidatorReport:
+    """Assert a recipient accepts an envelope once and rejects a replay of it.
+
+    Passes iff the first decrypt succeeds and the second (byte-identical) decrypt
+    fails. Against ``noop`` both succeed (it has no replay memory).
+
+    Example::
+
+        report = await check_replay_rejected(bob, env)
+        assert report.passed, report.detail
+    """
+    first_ok, _ = await _try_decrypt(recipient, envelope)
+    second_ok, _ = await _try_decrypt(recipient, envelope)
+    if not first_ok:
+        return ValidatorReport(passed=False, detail="legitimate first decrypt failed")
+    if second_ok:
+        return ValidatorReport(passed=False, detail="replayed envelope was accepted twice")
+    return ValidatorReport(passed=True, detail="replay rejected on second presentation")
+
+
+async def check_field_injection_rejected(
+    verifier: Privacy, statement: Statement, good_proof: Proof, tampered_proof: Proof
+) -> ValidatorReport:
+    """Assert an untampered proof verifies and a field-tampered proof does not.
+
+    Passes iff ``verify_proof`` accepts ``good_proof`` and rejects
+    ``tampered_proof``. Against ``noop`` (``verify_proof`` always ``True``) the
+    tampered proof is wrongly accepted.
+
+    Example::
+
+        bad = corrupt_proof(good)
+        report = await check_field_injection_rejected(v, stmt, good, bad)
+        assert report.passed, report.detail
+    """
+    if not await verifier.verify_proof(statement, good_proof):
+        return ValidatorReport(passed=False, detail="honest proof failed to verify")
+    if await verifier.verify_proof(statement, tampered_proof):
+        return ValidatorReport(passed=False, detail="tampered proof was accepted")
+    return ValidatorReport(passed=True, detail="field-injected proof rejected")
+
+
+async def check_stale_revocation_blocked(
+    member: Privacy, pre_revocation: bytes, post_revocation: bytes
+) -> ValidatorReport:
+    """Assert a revoked member can read a pre- but not a post-revocation message.
+
+    Passes iff the member decrypts ``pre_revocation`` and fails to decrypt
+    ``post_revocation``. Against ``noop`` both passthrough-"decrypt" successfully.
+
+    Example::
+
+        report = await check_stale_revocation_blocked(carol, pre, post)
+        assert report.passed, report.detail
+    """
+    pre_ok, _ = await _try_decrypt(member, pre_revocation)
+    post_ok, _ = await _try_decrypt(member, post_revocation)
+    if not pre_ok:
+        return ValidatorReport(passed=False, detail="member could not read pre-revocation message")
+    if post_ok:
+        return ValidatorReport(
+            passed=False, detail="revoked member decrypted a post-revocation message"
+        )
+    return ValidatorReport(passed=True, detail="post-revocation message blocked for revoked member")
+
+
+def check_no_two_time_pad(ct_a: bytes, pt_a: bytes, ct_b: bytes, pt_b: bytes) -> ValidatorReport:
+    """Assert two ciphertexts do not share a keystream (no two-time pad).
+
+    For any stream/CTR AEAD (ChaCha20-Poly1305 included) the ciphertext body is
+    ``keystream XOR plaintext``. If two messages reuse a ``(key, nonce)`` pair
+    their keystreams cancel, so ``ct_a XOR ct_b == pt_a XOR pt_b`` over the common
+    length — a textbook two-time pad that leaks the plaintext XOR. This check
+    detects exactly that signature.
+
+    ``pt_a`` and ``pt_b`` must be **distinct** (otherwise the XOR is trivially
+    zero and the test is vacuous).
+
+    Example::
+
+        report = check_no_two_time_pad(ct1, b"aaaa", ct2, b"bbbb")
+        assert report.passed, report.detail
+    """
+    # Clamp to the shortest of all four so the zip(strict=True) below cannot raise
+    # on a malformed/short ciphertext — a mismatch is a failed check, not a crash.
+    n = min(len(pt_a), len(pt_b), len(ct_a), len(ct_b))
+    if n == 0:
+        return ValidatorReport(
+            passed=False, detail="cannot check with an empty plaintext/ciphertext"
+        )
+    if pt_a[:n] == pt_b[:n]:
+        return ValidatorReport(passed=False, detail="plaintexts must be distinct to detect reuse")
+    ct_xor = bytes(x ^ y for x, y in zip(ct_a[:n], ct_b[:n], strict=True))
+    pt_xor = bytes(x ^ y for x, y in zip(pt_a[:n], pt_b[:n], strict=True))
+    if ct_xor == pt_xor:
+        return ValidatorReport(
+            passed=False,
+            detail="two-time pad: ciphertext XOR reveals plaintext XOR (key/nonce reused)",
+            evidence={"leaked_bytes": n},
+        )
+    return ValidatorReport(passed=True, detail="no keystream reuse across reconstructed instances")
+
+
+async def check_deterministic_reuse_safe(
+    make_sender: Callable[[], Privacy],
+    *,
+    audience: list[AgentId],
+    plaintext_a: bytes,
+    plaintext_b: bytes,
+    extract: Callable[[bytes], bytes] = content_ciphertext,
+) -> ValidatorReport:
+    """Assert reconstructing a deterministic plugin does not leak a two-time pad.
+
+    Builds two **fresh** sender instances via ``make_sender`` — modelling a
+    restart or two instances of one agent, which resets any in-memory message
+    counter to zero — and encrypts two *different* plaintexts, one per instance.
+    A counter-only deterministic scheme re-derives the same ``(key, nonce)`` and
+    produces a two-time pad; ``sealedbox``'s SIV derivation binds the plaintext
+    into the key/nonce, so the keystreams differ.
+
+    ``extract`` pulls the content ciphertext out of an envelope (default: the
+    ``sealedbox`` parser). For a passthrough plugin, pass ``lambda env: env``.
+
+    Passes against ``sealedbox``; fails against ``noop`` and any counter-only
+    deterministic plugin.
+
+    Example::
+
+        report = await check_deterministic_reuse_safe(
+            lambda: SealedBoxPrivacy(AgentId("s"), seed=7),
+            audience=[AgentId("r")], plaintext_a=b"AAAA", plaintext_b=b"BBBB",
+        )
+        assert report.passed, report.detail
+    """
+    env_a = await make_sender().encrypt(plaintext_a, audience)
+    env_b = await make_sender().encrypt(plaintext_b, audience)
+    try:
+        ct_a = extract(env_a)
+        ct_b = extract(env_b)
+    except Exception as exc:  # noqa: BLE001 - a malformed extract is a failed check
+        return ValidatorReport(passed=False, detail=f"could not extract ciphertext: {exc}")
+    return check_no_two_time_pad(ct_a, plaintext_a, ct_b, plaintext_b)
+
+
+def corrupt_proof(proof: Proof, *, field: str | None = None) -> Proof:
+    """Return a copy of *proof* with one revealed field's value flipped.
+
+    Drives :func:`check_field_injection_rejected`. If *field* is ``None`` the
+    first disclosed field (sorted) is corrupted. On a proof body without a
+    ``disclosed`` map it returns the proof unchanged (the validator then simply
+    observes no tamper effect).
+
+    Example::
+
+        bad = corrupt_proof(good_proof)
+    """
+    try:
+        loaded: Any = json.loads(proof.data)
+    except (ValueError, TypeError):
+        return proof
+    if not isinstance(loaded, dict):
+        return proof
+    body = cast("dict[str, Any]", loaded)
+    raw_disclosed = body.get("disclosed")
+    if not isinstance(raw_disclosed, dict):
+        return proof
+    disclosed = cast("dict[str, Any]", raw_disclosed)
+    if not disclosed:
+        return proof
+    target = field if field is not None else sorted(disclosed)[0]
+    raw_entry = disclosed.get(target)
+    if not isinstance(raw_entry, dict):
+        return proof
+    entry = cast("dict[str, Any]", raw_entry)
+    if "value" not in entry:
+        return proof
+    entry["value"] = str(entry["value"]) + "!tampered"
+    payload = json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return proof.model_copy(update={"data": payload})

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -38,6 +38,7 @@ lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
 
 [project.entry-points."nest.plugins.privacy"]
 hybrid_x25519 = "nest_plugins_reference.privacy.hybrid_x25519:HybridX25519Privacy"
+sealedbox = "nest_plugins_reference.privacy.sealedbox:SealedBoxPrivacy"
 
 [project.entry-points."nest.plugins.datafacts"]
 cid_facts = "nest_plugins_reference.datafacts.cid_facts:CidFacts"

--- a/packages/nest-plugins-reference/tests/test_sealedbox.py
+++ b/packages/nest-plugins-reference/tests/test_sealedbox.py
@@ -1,17 +1,51 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the sealedbox privacy plugin (real authenticated encryption)."""
+"""Tests for the ``sealedbox`` privacy plugin.
+
+Covers the full Problem 09 surface (hybrid encryption, selective disclosure,
+broadcast revocation, the four required adversarial attacks) plus the plugin's
+headline property — nonce-misuse-resistant deterministic derivation — including a
+live demonstration that the reuse validator FAILS against the ``noop`` passthrough
+and against the merged ``hybrid_x25519`` deterministic mode, and PASSES against
+``sealedbox``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
 
 import pytest
 from nest_core.plugins import PluginRegistry
-from nest_core.types import AgentId, Proof, Statement, Witness
+from nest_core.types import AgentId, Statement, Witness
+from nest_plugins_reference.privacy.hybrid_x25519 import HybridX25519Privacy
+from nest_plugins_reference.privacy.noop import NoopPrivacy
 from nest_plugins_reference.privacy.sealedbox import (
     MalformedEnvelopeError,
     NotInAudienceError,
+    ReplayError,
     SealedBoxPrivacy,
     TamperError,
+    commit_credential,
+    content_ciphertext,
+)
+from nest_plugins_reference.validators.sealedbox_validators import (
+    check_deterministic_reuse_safe,
+    check_eavesdropper_blocked,
+    check_field_injection_rejected,
+    check_no_two_time_pad,
+    check_replay_rejected,
+    check_stale_revocation_blocked,
+    corrupt_proof,
 )
 
+# Distinct, equal-length plaintexts for two-time-pad detection.
+_PT_A = b"attack-at-dawn!!"
+_PT_B = b"retreat-at-dusk!"
 
+
+# --------------------------------------------------------------------------- #
+# Hybrid encryption round-trips
+# --------------------------------------------------------------------------- #
 async def test_encrypt_decrypt_round_trip() -> None:
     src = SealedBoxPrivacy(AgentId("src"), seed=7)
     dest = SealedBoxPrivacy(AgentId("dest"), seed=7)
@@ -31,11 +65,30 @@ async def test_multi_recipient_and_outsider() -> None:
         await outsider.decrypt(blob)
 
 
+async def test_plaintext_never_on_the_wire() -> None:
+    src = SealedBoxPrivacy(AgentId("src"), seed=7)
+    blob = await src.encrypt(b"top-secret-bid-1700", [AgentId("dest")])
+    assert b"top-secret-bid-1700" not in blob
+
+
 async def test_tampered_ciphertext_raises() -> None:
     src = SealedBoxPrivacy(AgentId("src"), seed=7)
     dest = SealedBoxPrivacy(AgentId("dest"), seed=7)
     blob = bytearray(await src.encrypt(b"secret", [AgentId("dest")]))
     blob[-1] ^= 0x01  # corrupt the AEAD tag/ciphertext
+    with pytest.raises(TamperError):
+        await dest.decrypt(bytes(blob))
+
+
+async def test_tampered_header_breaks_authentication() -> None:
+    """The header (sender/epoch/counter) is bound as AAD, so editing it fails."""
+    sender = "src"
+    src = SealedBoxPrivacy(AgentId(sender), seed=7)
+    dest = SealedBoxPrivacy(AgentId("dest"), seed=7)
+    blob = bytearray(await src.encrypt(b"secret", [AgentId("dest")]))
+    # Layout: magic(4) ver(1) sender_len(2) sender(len) epoch(4) counter(8) ...
+    epoch_off = 5 + 2 + len(sender)
+    blob[epoch_off] ^= 0x01  # flip a byte of the bound epoch -> AAD mismatch
     with pytest.raises(TamperError):
         await dest.decrypt(bytes(blob))
 
@@ -46,21 +99,86 @@ async def test_malformed_envelope_raises() -> None:
         await dest.decrypt(b"not an envelope")
 
 
-async def test_prove_and_verify_are_honest_stubs() -> None:
-    priv = SealedBoxPrivacy(AgentId("src"), seed=7)
-    with pytest.raises(NotImplementedError):
-        await priv.prove(Statement(predicate="x"), Witness())
-    proof = Proof(statement=Statement(predicate="x"), data=b"", scheme="sealedbox")
-    with pytest.raises(NotImplementedError):
-        await priv.verify_proof(Statement(predicate="x"), proof)
+async def test_replay_rejected() -> None:
+    src = SealedBoxPrivacy(AgentId("src"), seed=7)
+    dest = SealedBoxPrivacy(AgentId("dest"), seed=7)
+    env = await src.encrypt(b"once", [AgentId("dest")])
+    assert await dest.decrypt(env) == b"once"
+    with pytest.raises(ReplayError):
+        await dest.decrypt(env)
 
 
+# --------------------------------------------------------------------------- #
+# Determinism AND nonce-misuse resistance (the headline property)
+# --------------------------------------------------------------------------- #
 async def test_deterministic_mode_is_replayable() -> None:
     a = SealedBoxPrivacy(AgentId("src"), seed=7)
     b = SealedBoxPrivacy(AgentId("src"), seed=7)
     blob_a = await a.encrypt(b"same", [AgentId("dest")])
     blob_b = await b.encrypt(b"same", [AgentId("dest")])
-    assert blob_a == blob_b  # same seed + sender + counter => identical bytes (replayable)
+    assert blob_a == blob_b  # same seed+sender+counter+plaintext+audience => identical bytes
+
+
+async def test_counter_reuse_is_not_a_two_time_pad() -> None:
+    """Two reconstructed senders (counter reset) encrypting DIFFERENT plaintexts
+    must not share a keystream — the property counter-only schemes lack."""
+    a = SealedBoxPrivacy(AgentId("src"), seed=7)
+    b = SealedBoxPrivacy(AgentId("src"), seed=7)
+    env_a = await a.encrypt(_PT_A, [AgentId("dest")])  # counter 0
+    env_b = await b.encrypt(_PT_B, [AgentId("dest")])  # counter 0 again (fresh instance)
+    report = check_no_two_time_pad(
+        content_ciphertext(env_a), _PT_A, content_ciphertext(env_b), _PT_B
+    )
+    assert report.passed, report.detail
+
+
+async def test_reuse_validator_passes_against_sealedbox() -> None:
+    report = await check_deterministic_reuse_safe(
+        lambda: SealedBoxPrivacy(AgentId("src"), seed=7),
+        audience=[AgentId("dest")],
+        plaintext_a=_PT_A,
+        plaintext_b=_PT_B,
+    )
+    assert report.passed, report.detail
+
+
+async def test_reuse_validator_fails_against_noop() -> None:
+    """noop leaks the plaintext directly, so the ciphertext XOR is the plaintext XOR."""
+    report = await check_deterministic_reuse_safe(
+        NoopPrivacy,
+        audience=[AgentId("dest")],
+        plaintext_a=_PT_A,
+        plaintext_b=_PT_B,
+        extract=lambda env: env,  # noop envelope IS the plaintext
+    )
+    assert not report.passed
+    assert "two-time pad" in report.detail
+
+
+async def test_reuse_validator_fails_against_hybrid_deterministic() -> None:
+    """The novel differentiator, proven live: the merged hybrid plugin's
+    deterministic mode reuses (key, nonce) when reconstructed, and the validator
+    catches it. sealedbox is the fix."""
+    recipient_pub = HybridX25519Privacy(AgentId("r"), seed=b"r", deterministic=True).public_key
+
+    def make_hybrid_sender() -> HybridX25519Privacy:
+        s = HybridX25519Privacy(AgentId("sender"), seed=b"s", deterministic=True)
+        s.register_peer(AgentId("r"), recipient_pub)
+        return s
+
+    def extract_hybrid_ct(env: bytes) -> bytes:
+        obj = json.loads(env)
+        return base64.b64decode(obj["ct"])  # ct||tag; first len(pt) bytes = keystream^pt
+
+    report = await check_deterministic_reuse_safe(
+        make_hybrid_sender,
+        audience=[AgentId("r")],
+        plaintext_a=_PT_A,
+        plaintext_b=_PT_B,
+        extract=extract_hybrid_ct,
+    )
+    assert not report.passed
+    assert "two-time pad" in report.detail
 
 
 async def test_random_mode_is_secret_but_round_trips() -> None:
@@ -73,6 +191,151 @@ async def test_random_mode_is_secret_but_round_trips() -> None:
     assert await dest.decrypt(blob1) == b"hush"
 
 
+# --------------------------------------------------------------------------- #
+# Selective disclosure (salted Merkle commitment)
+# --------------------------------------------------------------------------- #
+def _credential() -> tuple[Statement, Witness]:
+    fields = {"name": "Ada", "age": "37", "country": "GB", "clearance": "secret"}
+    root, salts = commit_credential(fields, salt_seed=b"issuer-seed")
+    statement = Statement(
+        predicate="credential",
+        public_inputs={"root": root, "reveal": json.dumps(["age", "country"])},
+    )
+    witness = Witness(private_inputs={**fields, "__salts__": json.dumps(salts, sort_keys=True)})
+    return statement, witness
+
+
+async def test_selective_disclosure_reveals_only_requested_fields() -> None:
+    priv = SealedBoxPrivacy(AgentId("holder"), seed=7)
+    statement, witness = _credential()
+    proof = await priv.prove(statement, witness)
+    assert await priv.verify_proof(statement, proof)
+    body = json.loads(proof.data)
+    assert set(body["disclosed"]) == {"age", "country"}
+    # An undisclosed field's value must not leak anywhere in the proof bytes.
+    assert b"secret" not in proof.data
+    assert b"Ada" not in proof.data
+
+
+async def test_field_injection_fails_verification() -> None:
+    priv = SealedBoxPrivacy(AgentId("holder"), seed=7)
+    statement, witness = _credential()
+    proof = await priv.prove(statement, witness)
+    tampered = corrupt_proof(proof)
+    assert not await priv.verify_proof(statement, tampered)
+
+
+async def test_wrong_root_fails_verification() -> None:
+    priv = SealedBoxPrivacy(AgentId("holder"), seed=7)
+    statement, witness = _credential()
+    proof = await priv.prove(statement, witness)
+    forged = Statement(
+        predicate="credential",
+        public_inputs={"root": "00" * 32, "reveal": json.dumps(["age", "country"])},
+    )
+    assert not await priv.verify_proof(forged, proof)
+
+
+async def test_inconsistent_witness_raises() -> None:
+    priv = SealedBoxPrivacy(AgentId("holder"), seed=7)
+    statement, _ = _credential()
+    bad_witness = Witness(private_inputs={"age": "37", "__salts__": "{}"})
+    with pytest.raises(ValueError, match="salt"):
+        await priv.prove(statement, bad_witness)
+
+
+# --------------------------------------------------------------------------- #
+# Broadcast revocation
+# --------------------------------------------------------------------------- #
+async def test_revocation_blocks_future_but_not_past() -> None:
+    sender = SealedBoxPrivacy(AgentId("sender"), seed=7)
+    pre = await sender.encrypt(b"pre-revocation", [AgentId("carol"), AgentId("dave")])
+    new_epoch = sender.revoke(AgentId("carol"))
+    assert new_epoch == 1
+    post = await sender.encrypt(b"post-revocation", [AgentId("carol"), AgentId("dave")])
+
+    carol = SealedBoxPrivacy(AgentId("carol"), seed=7)
+    assert await carol.decrypt(pre) == b"pre-revocation"  # past message still readable
+    with pytest.raises(NotInAudienceError):
+        await carol.decrypt(post)  # excluded from the post-revocation wrap set
+
+    dave = SealedBoxPrivacy(AgentId("dave"), seed=7)
+    assert await dave.decrypt(post) == b"post-revocation"  # non-revoked member unaffected
+
+
+async def test_rerevoke_is_idempotent() -> None:
+    sender = SealedBoxPrivacy(AgentId("sender"), seed=7)
+    first = sender.revoke(AgentId("carol"))
+    second = sender.revoke(AgentId("carol"))
+    assert first == second == 1  # re-revoking does not advance the epoch again
+
+
+# --------------------------------------------------------------------------- #
+# Reconstruction is safe end-to-end: distinct messages at a reused counter are
+# not mistaken for replays of each other (the replay guard keys on the envelope).
+# --------------------------------------------------------------------------- #
+async def test_reconstructed_sender_distinct_messages_are_not_false_replays() -> None:
+    dest = SealedBoxPrivacy(AgentId("dest"), seed=7)
+    env_a = await SealedBoxPrivacy(AgentId("src"), seed=7).encrypt(_PT_A, [AgentId("dest")])
+    env_b = await SealedBoxPrivacy(AgentId("src"), seed=7).encrypt(_PT_B, [AgentId("dest")])
+    assert env_a != env_b  # same (sender, epoch, counter) but distinct plaintext -> distinct bytes
+    assert await dest.decrypt(env_a) == _PT_A
+    assert await dest.decrypt(env_b) == _PT_B  # NOT rejected as a replay
+
+
+async def test_reveal_field_name_containing_comma() -> None:
+    priv = SealedBoxPrivacy(AgentId("holder"), seed=7)
+    fields = {"a,b": "x", "c": "y"}
+    root, salts = commit_credential(fields, salt_seed=b"s")
+    statement = Statement(
+        predicate="cred", public_inputs={"root": root, "reveal": json.dumps(["a,b"])}
+    )
+    witness = Witness(private_inputs={**fields, "__salts__": json.dumps(salts, sort_keys=True)})
+    proof = await priv.prove(statement, witness)
+    assert await priv.verify_proof(statement, proof)
+    assert set(json.loads(proof.data)["disclosed"]) == {"a,b"}
+
+
+# --------------------------------------------------------------------------- #
+# The Problem-09 adversarial validators pass against sealedbox
+# --------------------------------------------------------------------------- #
+async def test_validators_pass_against_sealedbox() -> None:
+    src = SealedBoxPrivacy(AgentId("src"), seed=7)
+    secret = b"sealed-bid-1700"
+    env = await src.encrypt(secret, [AgentId("dest")])
+
+    eavesdropper = SealedBoxPrivacy(AgentId("eve"), seed=7)
+    r1 = await check_eavesdropper_blocked(eavesdropper, env, secret=secret)
+    assert r1.passed, r1.detail
+
+    r2 = await check_replay_rejected(SealedBoxPrivacy(AgentId("dest"), seed=7), env)
+    assert r2.passed, r2.detail
+
+    holder = SealedBoxPrivacy(AgentId("holder"), seed=7)
+    statement, witness = _credential()
+    good = await holder.prove(statement, witness)
+    r3 = await check_field_injection_rejected(holder, statement, good, corrupt_proof(good))
+    assert r3.passed, r3.detail
+
+    sender = SealedBoxPrivacy(AgentId("sender"), seed=7)
+    pre = await sender.encrypt(b"pre", [AgentId("carol"), AgentId("dave")])
+    sender.revoke(AgentId("carol"))
+    post = await sender.encrypt(b"post", [AgentId("carol"), AgentId("dave")])
+    r4 = await check_stale_revocation_blocked(SealedBoxPrivacy(AgentId("carol"), seed=7), pre, post)
+    assert r4.passed, r4.detail
+
+
+async def test_eavesdropper_validator_fails_against_noop() -> None:
+    noop = NoopPrivacy()
+    secret = b"sealed-bid-1700"
+    env = await noop.encrypt(secret, [AgentId("dest")])
+    report = await check_eavesdropper_blocked(noop, env, secret=secret)
+    assert not report.passed
+
+
+# --------------------------------------------------------------------------- #
+# Registry discovery (built-in map + entry point)
+# --------------------------------------------------------------------------- #
 def test_registered_in_plugin_registry() -> None:
     reg = PluginRegistry()
     assert reg.resolve("privacy", "sealedbox") is SealedBoxPrivacy

--- a/packages/nest-plugins-reference/tests/test_sealedbox.py
+++ b/packages/nest-plugins-reference/tests/test_sealedbox.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the sealedbox privacy plugin (real authenticated encryption)."""
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, Proof, Statement, Witness
+from nest_plugins_reference.privacy.sealedbox import (
+    MalformedEnvelopeError,
+    NotInAudienceError,
+    SealedBoxPrivacy,
+    TamperError,
+)
+
+
+async def test_encrypt_decrypt_round_trip() -> None:
+    src = SealedBoxPrivacy(AgentId("src"), seed=7)
+    dest = SealedBoxPrivacy(AgentId("dest"), seed=7)
+    blob = await src.encrypt(b"the eagle lands at dawn", [AgentId("dest")])
+    assert blob != b"the eagle lands at dawn"  # actually encrypted, not passthrough
+    assert await dest.decrypt(blob) == b"the eagle lands at dawn"
+
+
+async def test_multi_recipient_and_outsider() -> None:
+    src = SealedBoxPrivacy(AgentId("src"), seed=7)
+    blob = await src.encrypt(b"hello team", [AgentId("a"), AgentId("b")])
+    for name in ("a", "b"):
+        member = SealedBoxPrivacy(AgentId(name), seed=7)
+        assert await member.decrypt(blob) == b"hello team"
+    outsider = SealedBoxPrivacy(AgentId("eve"), seed=7)
+    with pytest.raises(NotInAudienceError):
+        await outsider.decrypt(blob)
+
+
+async def test_tampered_ciphertext_raises() -> None:
+    src = SealedBoxPrivacy(AgentId("src"), seed=7)
+    dest = SealedBoxPrivacy(AgentId("dest"), seed=7)
+    blob = bytearray(await src.encrypt(b"secret", [AgentId("dest")]))
+    blob[-1] ^= 0x01  # corrupt the AEAD tag/ciphertext
+    with pytest.raises(TamperError):
+        await dest.decrypt(bytes(blob))
+
+
+async def test_malformed_envelope_raises() -> None:
+    dest = SealedBoxPrivacy(AgentId("dest"), seed=7)
+    with pytest.raises(MalformedEnvelopeError):
+        await dest.decrypt(b"not an envelope")
+
+
+async def test_prove_and_verify_are_honest_stubs() -> None:
+    priv = SealedBoxPrivacy(AgentId("src"), seed=7)
+    with pytest.raises(NotImplementedError):
+        await priv.prove(Statement(predicate="x"), Witness())
+    proof = Proof(statement=Statement(predicate="x"), data=b"", scheme="sealedbox")
+    with pytest.raises(NotImplementedError):
+        await priv.verify_proof(Statement(predicate="x"), proof)
+
+
+async def test_deterministic_mode_is_replayable() -> None:
+    a = SealedBoxPrivacy(AgentId("src"), seed=7)
+    b = SealedBoxPrivacy(AgentId("src"), seed=7)
+    blob_a = await a.encrypt(b"same", [AgentId("dest")])
+    blob_b = await b.encrypt(b"same", [AgentId("dest")])
+    assert blob_a == blob_b  # same seed + sender + counter => identical bytes (replayable)
+
+
+async def test_random_mode_is_secret_but_round_trips() -> None:
+    src = SealedBoxPrivacy(AgentId("src"), deterministic=False)
+    dest = SealedBoxPrivacy(AgentId("dest"), deterministic=False)
+    src.register_peer(AgentId("dest"), dest.public_key_raw)
+    blob1 = await src.encrypt(b"hush", [AgentId("dest")])
+    blob2 = await src.encrypt(b"hush", [AgentId("dest")])
+    assert blob1 != blob2  # randomized: not seed-derivable, not reproducible
+    assert await dest.decrypt(blob1) == b"hush"
+
+
+def test_registered_in_plugin_registry() -> None:
+    reg = PluginRegistry()
+    assert reg.resolve("privacy", "sealedbox") is SealedBoxPrivacy
+    assert ("privacy", "sealedbox") in reg.list_plugins("privacy")

--- a/packages/nest-plugins-reference/tests/test_sealedbox_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_sealedbox_scenario.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Full-simulator integration for the ``sealedbox`` privacy layer.
+
+Boots ``scenarios/sealed_bid_sealedbox.yaml`` through the real
+:class:`~nest_core.runner.ScenarioRunner` to prove the plugin resolves and
+integrates into an end-to-end run without breaking the simulator, and that the
+run stays byte-deterministic under replay (Tier-1). NOTE: the Tier-1 auction
+task routes payloads through the transport, not the privacy layer, so this run
+does not itself seal bids on the wire — the encryption/disclosure/revocation
+mechanics and the adversarial validators are exercised directly in
+``test_sealedbox.py``. Here we verify the plugin is discoverable and
+simulator-safe.
+
+Example::
+
+    pytest packages/nest-plugins-reference/tests/test_sealedbox_scenario.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_plugins_reference.privacy.sealedbox import SealedBoxPrivacy
+
+SCENARIO_PATH = Path(__file__).resolve().parents[3] / "scenarios" / "sealed_bid_sealedbox.yaml"
+
+
+def test_privacy_layer_resolves_to_sealedbox_plugin() -> None:
+    """The registry discovers ``sealedbox`` via the built-in map / entry point."""
+    cls = PluginRegistry().resolve("privacy", "sealedbox")
+    assert cls is SealedBoxPrivacy
+
+
+@pytest.mark.parametrize("seed", [42, 7])
+def test_scenario_boots_and_runs(seed: int) -> None:
+    """The scenario wiring the sealedbox privacy layer runs to completion."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    assert config.layers.privacy == "sealedbox"
+    config = config.model_copy(update={"seed": seed})
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"sealed_{seed}.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        result = asyncio.run(runner.run())
+        assert result.exists()
+        assert result.stat().st_size > 0
+
+
+def test_scenario_is_deterministic_under_replay() -> None:
+    """Two seed-42 runs produce byte-identical traces (Tier-1 reproducibility)."""
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+
+    def run_once() -> bytes:
+        config = ScenarioConfig.from_yaml(str(SCENARIO_PATH)).model_copy(update={"seed": 42})
+        with tempfile.TemporaryDirectory() as tmp:
+            trace_path = Path(tmp) / "sealed_replay.jsonl"
+            config = config.model_copy(
+                update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+            )
+            runner = ScenarioRunner(config, registry=PluginRegistry())
+            result = asyncio.run(runner.run())
+            return result.read_bytes()
+
+    assert run_once() == run_once()

--- a/scenarios/sealed_bid_sealedbox.yaml
+++ b/scenarios/sealed_bid_sealedbox.yaml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Sealed-bid auction that RESOLVES the `sealedbox` privacy layer.
+#
+# Identical to the `auction` scenario except the privacy layer is `sealedbox`
+# instead of `noop`. IMPORTANT — what this run does and does not prove: the
+# Tier-1 auction task routes payloads through the transport, not the privacy
+# layer, so bids appear in cleartext in the trace here, exactly as in the `noop`
+# variant (and exactly as in the sibling `sealed_bid_with_privacy.yaml`, which
+# wires `hybrid_x25519`). What this file demonstrates end-to-end is that the
+# `sealedbox` plugin is discoverable, resolves to `SealedBoxPrivacy`, and that
+# the run is byte-deterministic under replay (Tier-1 reproducibility); see
+# `tests/test_sealedbox_scenario.py`.
+#
+# The actual sealed-bid crypto — hybrid X25519 + ChaCha20-Poly1305, SIV-style
+# deterministic derivation, plaintext-never-on-the-wire, nonce-misuse resistance
+# across a reconstructed instance, selective disclosure, and revocation — is
+# exercised directly in `tests/test_sealedbox.py`, not in this simulator run.
+# This file is the `sealedbox` variant and does not modify the hybrid one.
+name: sealed_bid_sealedbox
+description: "1 auctioneer and 7 bidders; resolves the sealedbox privacy layer (crypto exercised in tests/test_sealedbox.py)."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 8
+  brain: state-machine
+  roles:
+    - name: auctioneer
+      count: 1
+    - name: bidder
+      count: 7
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: sealedbox
+  datafacts: datafacts_v1
+
+task:
+  type: auction
+  config:
+    rounds: 3
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 10000"
+
+metrics:
+  - success_rate
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/sealed_bid_sealedbox.jsonl


### PR DESCRIPTION
## Summary

Reworked **`sealedbox`** privacy plugin (Problem 09). This supersedes #36, which
GitHub auto-closed when its branch was renamed to match the charter's
`hackathon/<handle>-<theme>` pattern (`rahul` → `rahulsharma-sys`); same author,
same work, all review feedback addressed.

The default `noop` privacy plugin is a passthrough. `sealedbox` provides a full
Problem 09 solution — hybrid X25519 + ChaCha20-Poly1305 encryption, salted-Merkle
selective disclosure, and epoch-based broadcast revocation — with one
**load-bearing differentiator** vs the merged `hybrid_x25519`: deterministic mode
is **nonce-misuse resistant (SIV-style)**.

### Why the differentiator matters

Tier-1 traces must replay byte-for-byte, so a privacy plugin derives per-message
keys/nonces deterministically. Every such scheme guards the derivation with a
monotonic counter and concedes that a `(key, nonce)` collision would be
catastrophic. But that counter lives in memory: reconstruct the plugin (restart,
or two instances of one agent) and it resets to zero, re-deriving the same key
and nonce for a different plaintext — a two-time pad. `hybrid_x25519`'s own
docstring states its deterministic mode is safe *"only because the counter never
repeats."*

`sealedbox` folds a digest of `(plaintext, sorted audience)` into the HKDF `info`
for the content key, content nonce, ephemeral scalars, and wrap nonces (the
synthetic-IV construction behind AES-GCM-SIV). A counter collision then degrades
to revealing *message equality* instead of a two-time pad. This is proven live:
the adversarial validator `check_deterministic_reuse_safe` **fails** against
`noop` and against `hybrid_x25519`'s reconstructed deterministic mode, and
**passes** against `sealedbox`.

### Problem 09 surface

- **Hybrid encryption**: fresh ChaCha20-Poly1305 content key per message, wrapped
  per recipient via X25519 ephemeral-static ECDH + HKDF-SHA256. The envelope
  header (version/sender/epoch/counter/sorted recipient key-ids) is bound as AEAD
  associated data, so redirection or header edits break authentication.
- **Selective disclosure**: salted-Merkle `prove`/`verify_proof` (a `reveal` JSON
  array selects fields to disclose; the rest stay hidden behind the issuer root).
- **Broadcast revocation**: `revoke` advances an epoch and excludes a member from
  future wraps; forward secrecy is explicitly future-only (documented).
- **Replay rejection**: keyed on the envelope digest, so a reconstructed sender's
  distinct messages are not mistaken for replays of each other.
- **Adversarial validators** (`validators/sealedbox_validators.py`): the four
  Problem 09 attacks (eavesdropper, replay, field-injection, stale-revocation) —
  each fails against `noop` and passes against `sealedbox` — plus the novel
  two-time-pad detector.
- **Scenario** `scenarios/sealed_bid_sealedbox.yaml` (the canonical
  `sealed_bid_with_privacy.yaml` filename is owned by the merged `hybrid_x25519`
  PR, so this ships the parallel variant and does not modify it). Its prose is
  explicit that the Tier-1 auction task does not route payloads through the
  privacy layer, so the crypto is exercised in `tests/test_sealedbox.py`, not on
  the wire.

Registered in both `_BUILTINS` and the `nest.plugins.privacy` entry point.

### Honesty notes

Deterministic mode is protocol/trace-level confidentiality, **not** secrecy
against a holder of the shared seed (who can re-derive any agent's key);
`deterministic=False` gives per-agent random keys for genuine secrecy at the cost
of reproducibility. This is stated in the docstrings.

## Test Plan

`make ci-local` passes — ruff, ruff format --check, pyright (strict), pytest
(**764 passed, 1 skipped**). 30 sealedbox tests cover encryption round-trips,
multi-recipient, tamper + header-binding, malformed envelopes, replay,
determinism, the nonce-misuse-resistance property (incl. a live comparison that
the validator catches `hybrid_x25519` deterministic mode failing), random mode,
selective disclosure (reveal/verify, field-injection, wrong-root, inconsistent
witness, comma-in-field-name), revocation (future-only, idempotent re-revoke),
the four Problem 09 validators against `sealedbox` and `noop`, and registry
discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
