### PR TITLE
memory: add OR-Set (observed-remove set) CRDT plugin

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -45,6 +45,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("negotiation", "pareto"): f"{_REF}.negotiation.pareto:ParetoNegotiation",
     ("memory", "blackboard"): f"{_REF}.memory.blackboard:Blackboard",
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
+    ("memory", "or_set"): f"{_REF}.memory.or_set:OrSetMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
     ("privacy", "hybrid_x25519"): f"{_REF}.privacy.hybrid_x25519:HybridX25519Privacy",
     ("privacy", "trust_gated"): f"{_REF}.privacy.trust_gated:TrustGatedPrivacy",

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/or_set.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/or_set.py
@@ -1,0 +1,542 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OR-Set CRDT memory plugin -- conflict-free shared *sets*.
+
+This module implements a **state-based observed-remove set** (an OR-Set CvRDT)
+for the Nanda Town memory layer. Where the ``lww_register`` plugin models a
+single-value cell whose concurrent writers fight until one wins, an OR-Set
+models a *growing set* whose concurrent writers all survive: two replicas that
+each add a different element to the same key converge to the **union** of both
+adds, never dropping one. That makes it the right primitive whenever the value
+under a key is a collection -- a capability list, a set of subscriptions, group
+membership, a bag of observed peers -- rather than a scalar.
+
+The defining property is **add-wins under concurrency**: a remove only cancels
+the specific adds it has *observed* (each add carries a unique tag), so an add
+that is concurrent with a remove is not observed by that remove and therefore
+survives. A last-writer-wins register cannot express this; it would silently
+discard one of the two concurrent contributions.
+
+Like every CvRDT here, the merge (:meth:`OrSet.join`) is the least-upper-bound
+of two grow-only tag sets and is therefore **commutative, associative, and
+idempotent** -- the three laws that guarantee *strong eventual consistency*:
+replicas that have observed the same operations converge to byte-identical
+state regardless of delivery order, duplication, or loss.
+
+State for a single key is encoded as inspectable JSON so it stays grep-able
+inside a JSONL trace::
+
+    {"crdt": "or_set",
+     "adds": [["YQ==", "agent-2", 1]],   # [base64(element), node, counter]
+     "removes": [["agent-2", 0]]}         # [node, counter]
+
+An element is *present* iff it has at least one add-tag that is not in
+``removes``. Because tags are globally unique ``(node, counter)`` pairs, the
+union of two states is a genuine semilattice join and the present-set is a
+deterministic function of that state.
+
+The set is exposed through the standard
+:class:`~nest_core.layers.memory.Memory` surface with **set semantics**:
+``write(key, value)`` *adds* ``value`` to the set at ``key`` (it accumulates;
+use :meth:`remove` to retract), and ``read(key)`` returns the current members
+as a canonical JSON array of base64 strings. The extra
+:meth:`add` / :meth:`remove` / :meth:`elements` / :meth:`contains` methods are
+the natural set API, and :meth:`export` / :meth:`merge` (plus the ``_all``
+variants) are the replication channel, exactly mirroring ``lww_register``.
+
+Example::
+
+    a = OrSetMemory("a")
+    b = OrSetMemory("b")
+    await a.write("caps", b"read")     # concurrent adds to the same key
+    await b.write("caps", b"write")
+    await b.merge("caps", a.export("caps"))   # gossip both ways
+    await a.merge("caps", b.export("caps"))
+    assert await a.elements("caps") == [b"read", b"write"]  # both survive
+    assert await a.read("caps") == await b.read("caps")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+CRDT_KIND = "or_set"
+"""Schema tag stamped into every serialized set, used to detect and validate
+CRDT state when it is read back from a trace or the wire."""
+
+Tag = tuple[str, int]
+"""A globally unique add identifier: ``(node_id, per_replica_counter)``."""
+
+
+def _empty_adds() -> frozenset[tuple[bytes, Tag]]:
+    return frozenset()
+
+
+def _empty_removes() -> frozenset[Tag]:
+    return frozenset()
+
+
+class CrdtStateError(ValueError):
+    """Raised when a byte string is not a valid serialized OR-Set.
+
+    Subclasses :class:`ValueError` so existing ``except ValueError`` handlers
+    keep working while callers that care can catch the specific type.
+
+    Example::
+
+        try:
+            OrSet.decode(b"not json")
+        except CrdtStateError:
+            ...
+    """
+
+
+@dataclass(frozen=True)
+class OrSet:
+    """An immutable observed-remove set with add-wins merge semantics.
+
+    ``adds`` is the observed set of ``(element, tag)`` pairs; ``removes`` is the
+    set of tombstoned tags. An element is present iff it owns an add-tag that is
+    not tombstoned. Every mutating method returns a *new* ``OrSet``, so the
+    value is safe to share and its :meth:`join` is a pure semilattice join --
+    commutative, associative, and idempotent.
+
+    Example::
+
+        s = OrSet().add(b"x", ("a", 1))
+        assert s.contains(b"x")
+        assert not s.remove(b"x").contains(b"x")
+    """
+
+    adds: frozenset[tuple[bytes, Tag]] = field(default_factory=_empty_adds)
+    removes: frozenset[Tag] = field(default_factory=_empty_removes)
+
+    def add(self, element: bytes, tag: Tag) -> OrSet:
+        """Return a copy with ``element`` observed under a fresh unique ``tag``.
+
+        Example::
+
+            s = OrSet().add(b"x", ("a", 1))
+        """
+        return OrSet(self.adds | {(element, tag)}, self.removes)
+
+    def remove(self, element: bytes) -> OrSet:
+        """Return a copy with every *currently observed* tag of ``element`` tombstoned.
+
+        This is the observed-remove rule: only add-tags visible in this state
+        are cancelled, so an add of the same element that this state has not yet
+        seen (a concurrent add) is left untouched and will win the merge.
+
+        Example::
+
+            s = OrSet().add(b"x", ("a", 1)).remove(b"x")
+            assert not s.contains(b"x")
+        """
+        live = {tag for (el, tag) in self.adds if el == element and tag not in self.removes}
+        if not live:
+            return self
+        return OrSet(self.adds, self.removes | live)
+
+    def contains(self, element: bytes) -> bool:
+        """Return True if ``element`` has a non-tombstoned add-tag.
+
+        Example::
+
+            assert OrSet().add(b"x", ("a", 1)).contains(b"x")
+        """
+        return any(el == element and tag not in self.removes for (el, tag) in self.adds)
+
+    def elements(self) -> list[bytes]:
+        """Return the present members, sorted for determinism.
+
+        Example::
+
+            assert OrSet().add(b"b", ("n", 2)).add(b"a", ("n", 1)).elements() == [b"a", b"b"]
+        """
+        present = {el for (el, tag) in self.adds if tag not in self.removes}
+        return sorted(present)
+
+    def join(self, other: OrSet) -> OrSet:
+        """Least-upper-bound merge (commutative, associative, idempotent).
+
+        Example::
+
+            merged = a.join(b)
+            assert merged.join(b) == merged  # idempotent
+        """
+        return OrSet(self.adds | other.adds, self.removes | other.removes)
+
+    def is_empty(self) -> bool:
+        """Return True if the state carries no adds and no removes.
+
+        Example::
+
+            assert OrSet().is_empty()
+        """
+        return not self.adds and not self.removes
+
+    def value(self) -> bytes:
+        """Encode the *present members* as canonical JSON bytes (the read value).
+
+        The value is a sorted JSON array of base64 element strings, so it is
+        deterministic and grep-able and two convergent replicas produce
+        identical bytes.
+
+        Example::
+
+            v = OrSet().add(b"x", ("a", 1)).value()
+        """
+        members = [base64.b64encode(el).decode("ascii") for el in self.elements()]
+        return json.dumps(members).encode("utf-8")
+
+    def encode(self) -> bytes:
+        """Serialize the full CRDT state (adds and removes) to canonical JSON.
+
+        Example::
+
+            raw = OrSet().add(b"x", ("a", 1)).encode()
+        """
+        data = {
+            "crdt": CRDT_KIND,
+            "adds": sorted(
+                [base64.b64encode(el).decode("ascii"), tag[0], tag[1]] for (el, tag) in self.adds
+            ),
+            "removes": sorted([node, counter] for (node, counter) in self.removes),
+        }
+        return json.dumps(data, sort_keys=True).encode("utf-8")
+
+    @staticmethod
+    def decode(state: bytes) -> OrSet:
+        """Parse canonical JSON bytes back into an :class:`OrSet`.
+
+        Raises :class:`CrdtStateError` for anything that is not a well-formed
+        ``or_set`` state.
+
+        Example::
+
+            s = OrSet.decode(OrSet().add(b"x", ("a", 1)).encode())
+        """
+        try:
+            obj = json.loads(state)
+        except (ValueError, TypeError) as exc:
+            msg = "state is not valid JSON"
+            raise CrdtStateError(msg) from exc
+        if not isinstance(obj, dict):
+            msg = f"not an {CRDT_KIND} state: {obj!r}"
+            raise CrdtStateError(msg)
+        data = cast("dict[str, Any]", obj)
+        if data.get("crdt") != CRDT_KIND:
+            msg = f"not an {CRDT_KIND} state: {data!r}"
+            raise CrdtStateError(msg)
+        adds = _decode_adds(data.get("adds", []))
+        removes = _decode_removes(data.get("removes", []))
+        return OrSet(frozenset(adds), frozenset(removes))
+
+
+def _decode_adds(raw: object) -> set[tuple[bytes, Tag]]:
+    if not isinstance(raw, list):
+        msg = "'adds' must be a list"
+        raise CrdtStateError(msg)
+    out: set[tuple[bytes, Tag]] = set()
+    for row in cast("list[Any]", raw):
+        try:
+            payload_b64, node, counter = row
+            element = base64.b64decode(payload_b64)
+            tag: Tag = (str(node), int(counter))
+        except (ValueError, TypeError) as exc:
+            msg = f"malformed add row: {row!r}"
+            raise CrdtStateError(msg) from exc
+        out.add((element, tag))
+    return out
+
+
+def _decode_removes(raw: object) -> set[Tag]:
+    if not isinstance(raw, list):
+        msg = "'removes' must be a list"
+        raise CrdtStateError(msg)
+    out: set[Tag] = set()
+    for row in cast("list[Any]", raw):
+        try:
+            node, counter = row
+            out.add((str(node), int(counter)))
+        except (ValueError, TypeError) as exc:
+            msg = f"malformed remove row: {row!r}"
+            raise CrdtStateError(msg) from exc
+    return out
+
+
+class OrSetMemory:
+    """An OR-Set CRDT implementing the ``Memory`` protocol with set semantics.
+
+    Each instance is an independent **replica**. Local adds are tagged with this
+    replica's ``node_id`` and a monotonically increasing counter, guaranteeing
+    globally unique tags; replicas exchange state with :meth:`export` /
+    :meth:`merge` (typically gossiped over the transport layer). The merge is
+    conflict-free, so any set of replicas that have observed the same operations
+    read back identical members no matter what order those operations arrived
+    in -- and, unlike ``lww_register``, concurrent adds to one key are all
+    retained rather than reduced to a single winner.
+
+    The base :class:`~nest_core.layers.memory.Memory` surface is interpreted as
+    a set: :meth:`write` adds an element and :meth:`read` returns the members.
+    The :meth:`add` / :meth:`remove` / :meth:`elements` / :meth:`contains`
+    methods are the explicit set API, and the ``export`` / ``merge`` family is
+    the replication channel -- additive, so a caller that only speaks the base
+    protocol never has to know the values are CRDT sets.
+
+    Example::
+
+        mem = OrSetMemory("agent-0")
+        await mem.write("caps", b"read")
+        await mem.write("caps", b"write")
+        assert await mem.elements("caps") == [b"read", b"write"]
+    """
+
+    def __init__(self, node_id: str = "node") -> None:
+        """Create a replica with a stable, unique ``node_id``.
+
+        The ``node_id`` must be stable for the replica's lifetime and unique
+        across replicas, since it is the node component of every add-tag. Two
+        replicas sharing a ``node_id`` could mint colliding tags and break the
+        convergence guarantee.
+
+        Example::
+
+            mem = OrSetMemory("agent-0")
+        """
+        self._node_id = str(node_id)
+        self._store: dict[str, OrSet] = {}
+        self._clock: int = 0
+        self._subscribers: dict[str, list[asyncio.Queue[bytes]]] = {}
+
+    @property
+    def node_id(self) -> str:
+        """The stable node identifier used in every add-tag minted here.
+
+        Example::
+
+            assert OrSetMemory("agent-0").node_id == "agent-0"
+        """
+        return self._node_id
+
+    @property
+    def clock(self) -> int:
+        """The replica's current add counter.
+
+        Example::
+
+            mem = OrSetMemory("a")
+            assert mem.clock == 0
+        """
+        return self._clock
+
+    # -- Memory protocol -------------------------------------------------
+
+    async def read(self, key: str) -> bytes | None:
+        """Return the present members of ``key`` as canonical JSON, or None if unset.
+
+        The value is a sorted JSON array of base64 element strings. A key that
+        has never been touched reads as ``None``; a key whose every element was
+        removed reads as the empty array ``b"[]"`` -- distinguishing "unset"
+        from "empty".
+
+        Example::
+
+            members = await mem.read("caps")
+        """
+        current = self._store.get(key)
+        return current.value() if current is not None else None
+
+    async def write(self, key: str, value: bytes) -> None:
+        """Add ``value`` to the set at ``key`` (set semantics: writes accumulate).
+
+        This is an alias for :meth:`add`. To retract a value, use
+        :meth:`remove`; a plain write never deletes.
+
+        Example::
+
+            await mem.write("caps", b"read")
+        """
+        await self.add(key, value)
+
+    async def subscribe(self, key: str) -> AsyncIterator[bytes]:
+        """Yield the canonical member list for ``key`` each time it changes.
+
+        Example::
+
+            async for members in mem.subscribe("caps"):
+                print(members)
+        """
+        q: asyncio.Queue[bytes] = asyncio.Queue()
+        self._subscribers.setdefault(key, []).append(q)
+        try:
+            while True:
+                yield await q.get()
+        finally:
+            self._subscribers[key].remove(q)
+
+    async def cas(self, key: str, expected: bytes, new: bytes) -> bool:
+        """Conditionally add ``new`` iff the current member list equals ``expected``.
+
+        ``expected`` is compared against :meth:`read` (the canonical member
+        list). On a match this adds ``new`` as an element and returns ``True``;
+        otherwise it leaves the set untouched and returns ``False``. As with all
+        set operations, cross-replica conflicts are reconciled by the CRDT merge
+        rather than by CAS.
+
+        Example::
+
+            ok = await mem.cas("caps", b'["cmVhZA=="]', b"write")
+        """
+        current = await self.read(key)
+        if current == expected:
+            await self.add(key, new)
+            return True
+        return False
+
+    # -- Set API ---------------------------------------------------------
+
+    async def add(self, key: str, element: bytes) -> None:
+        """Observe ``element`` under a fresh unique tag and notify subscribers.
+
+        Example::
+
+            await mem.add("caps", b"read")
+        """
+        self._clock += 1
+        current = self._store.get(key, OrSet())
+        updated = current.add(element, (self._node_id, self._clock))
+        self._store[key] = updated
+        await self._notify(key, updated.value())
+
+    async def remove(self, key: str, element: bytes) -> bool:
+        """Tombstone every observed tag of ``element`` at ``key`` (observed-remove).
+
+        Returns ``True`` if the element was present and is now removed, ``False``
+        if it was already absent. A concurrent add of the same element on
+        another replica is *not* observed here and survives the merge.
+
+        Example::
+
+            removed = await mem.remove("caps", b"read")
+        """
+        current = self._store.get(key)
+        if current is None or not current.contains(element):
+            return False
+        updated = current.remove(element)
+        self._store[key] = updated
+        await self._notify(key, updated.value())
+        return True
+
+    async def elements(self, key: str) -> list[bytes]:
+        """Return the present members of ``key`` as decoded bytes, sorted.
+
+        Example::
+
+            members = await mem.elements("caps")
+        """
+        current = self._store.get(key)
+        return current.elements() if current is not None else []
+
+    async def contains(self, key: str, element: bytes) -> bool:
+        """Return True if ``element`` is a present member of ``key``.
+
+        Example::
+
+            has_read = await mem.contains("caps", b"read")
+        """
+        current = self._store.get(key)
+        return current.contains(element) if current is not None else False
+
+    # -- CRDT replication channel ---------------------------------------
+
+    def export(self, key: str) -> bytes | None:
+        """Serialize the OR-Set state for ``key`` for gossip, or None if unset.
+
+        The result is valid input to another replica's :meth:`merge`.
+
+        Example::
+
+            state = mem.export("caps")
+        """
+        current = self._store.get(key)
+        return current.encode() if current is not None else None
+
+    def export_all(self) -> bytes:
+        """Serialize this replica's full state for a full-state anti-entropy push.
+
+        Example::
+
+            snapshot = mem.export_all()
+        """
+        data = {
+            "crdt": CRDT_KIND,
+            "keys": {key: json.loads(state.encode()) for key, state in sorted(self._store.items())},
+        }
+        return json.dumps(data, sort_keys=True).encode("utf-8")
+
+    async def merge(self, key: str, state: bytes) -> bool:
+        """Merge a remote OR-Set for ``key`` into this replica.
+
+        Joins the incoming state by least-upper-bound. Returns ``True`` if the
+        present member list changed, in which case subscribers are notified.
+        Idempotent: merging the same state twice is a no-op.
+
+        Example::
+
+            changed = await mem.merge("caps", other.export("caps"))
+        """
+        incoming = OrSet.decode(state)
+        current = self._store.get(key, OrSet())
+        merged = current.join(incoming)
+        self._store[key] = merged
+        before = current.value()
+        after = merged.value()
+        if after != before:
+            await self._notify(key, after)
+            return True
+        return False
+
+    async def merge_all(self, state: bytes) -> list[str]:
+        """Merge a full-state snapshot, returning the keys whose members changed.
+
+        Example::
+
+            changed_keys = await mem.merge_all(other.export_all())
+        """
+        keys = _decode_snapshot(state)
+        changed: list[str] = []
+        for key in sorted(keys):
+            if await self.merge(key, json.dumps(keys[key], sort_keys=True).encode("utf-8")):
+                changed.append(key)
+        return changed
+
+    # -- internals -------------------------------------------------------
+
+    async def _notify(self, key: str, value: bytes) -> None:
+        for q in self._subscribers.get(key, []):
+            await q.put(value)
+
+
+def _decode_snapshot(state: bytes) -> dict[str, Any]:
+    try:
+        obj = json.loads(state)
+    except (ValueError, TypeError) as exc:
+        msg = "snapshot is not valid JSON"
+        raise CrdtStateError(msg) from exc
+    if not isinstance(obj, dict):
+        msg = f"not an {CRDT_KIND} snapshot: {obj!r}"
+        raise CrdtStateError(msg)
+    data = cast("dict[str, Any]", obj)
+    if data.get("crdt") != CRDT_KIND:
+        msg = f"not an {CRDT_KIND} snapshot: {data!r}"
+        raise CrdtStateError(msg)
+    raw = data.get("keys", {})
+    if not isinstance(raw, dict):
+        msg = "snapshot 'keys' must be an object"
+        raise CrdtStateError(msg)
+    return cast("dict[str, Any]", raw)

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -38,6 +38,7 @@ authenticated = "nest_plugins_reference.comms.authenticated:AuthenticatedComms"
 
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
+or_set = "nest_plugins_reference.memory.or_set:OrSetMemory"
 
 [project.entry-points."nest.plugins.registry"]
 byzantine_gossip = "nest_plugins_reference.registry.byzantine_gossip:ByzantineGossipRegistry"

--- a/packages/nest-plugins-reference/tests/test_or_set.py
+++ b/packages/nest-plugins-reference/tests/test_or_set.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the OR-Set CRDT memory plugin.
+
+Covers protocol conformance, the set-semantic read/write/add/remove/cas/
+subscribe surface, the export/merge replication channel, the three CRDT
+algebraic laws (commutativity, associativity, idempotence), convergence under
+arbitrary delivery order via the shared adversarial validator, the defining
+add-wins property (concurrent add survives a concurrent remove) and the
+concrete contrast with LWW-Register (which loses concurrent adds), determinism,
+malformed-input handling, and registry wiring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.layers.memory import Memory
+from nest_core.plugins import PluginRegistry
+from nest_core.validators import validate_crdt_convergence
+from nest_plugins_reference.memory.lww_register import LwwRegisterMemory
+from nest_plugins_reference.memory.or_set import (
+    CRDT_KIND,
+    CrdtStateError,
+    OrSet,
+    OrSetMemory,
+)
+
+# ---------------------------------------------------------------------------
+# Protocol conformance and base Memory surface (set semantics)
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_isinstance_memory(self) -> None:
+        assert isinstance(OrSetMemory("a"), Memory)
+
+    @pytest.mark.asyncio
+    async def test_read_missing_is_none(self) -> None:
+        mem = OrSetMemory("a")
+        assert await mem.read("missing") is None
+
+    @pytest.mark.asyncio
+    async def test_write_adds_element(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k", b"value")
+        assert await mem.elements("k") == [b"value"]
+
+    @pytest.mark.asyncio
+    async def test_writes_accumulate(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k", b"one")
+        await mem.write("k", b"two")
+        assert await mem.elements("k") == [b"one", b"two"]
+
+    @pytest.mark.asyncio
+    async def test_read_returns_canonical_member_list(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k", b"b")
+        await mem.write("k", b"a")
+        expected = json.dumps(
+            [base64.b64encode(b"a").decode(), base64.b64encode(b"b").decode()]
+        ).encode()
+        assert await mem.read("k") == expected
+
+    @pytest.mark.asyncio
+    async def test_remove_present_element(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k", b"x")
+        assert await mem.remove("k", b"x") is True
+        assert await mem.contains("k", b"x") is False
+
+    @pytest.mark.asyncio
+    async def test_remove_absent_element_returns_false(self) -> None:
+        mem = OrSetMemory("a")
+        assert await mem.remove("k", b"missing") is False
+
+    @pytest.mark.asyncio
+    async def test_removed_key_reads_empty_not_none(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k", b"x")
+        await mem.remove("k", b"x")
+        assert await mem.read("k") == b"[]"
+
+    @pytest.mark.asyncio
+    async def test_readd_after_remove_is_present(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k", b"x")
+        await mem.remove("k", b"x")
+        await mem.write("k", b"x")  # fresh tag, not tombstoned
+        assert await mem.contains("k", b"x") is True
+
+    @pytest.mark.asyncio
+    async def test_binary_payload(self) -> None:
+        mem = OrSetMemory("a")
+        blob = bytes(range(256))
+        await mem.write("k", blob)
+        assert await mem.elements("k") == [blob]
+
+    @pytest.mark.asyncio
+    async def test_cas_success_adds(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k", b"one")
+        snapshot = await mem.read("k")
+        assert snapshot is not None
+        assert await mem.cas("k", snapshot, b"two") is True
+        assert await mem.elements("k") == [b"one", b"two"]
+
+    @pytest.mark.asyncio
+    async def test_cas_failure_leaves_set(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k", b"one")
+        assert await mem.cas("k", b"wrong", b"two") is False
+        assert await mem.elements("k") == [b"one"]
+
+    @pytest.mark.asyncio
+    async def test_subscribe_receives_writes(self) -> None:
+        mem = OrSetMemory("a")
+        sub = mem.subscribe("k")
+
+        await asyncio.sleep(0)  # let the generator register its queue
+        task = asyncio.ensure_future(sub.__anext__())
+        await asyncio.sleep(0)
+        await mem.write("k", b"v")
+        received = await asyncio.wait_for(task, timeout=1)
+        assert received == await mem.read("k")
+
+
+# ---------------------------------------------------------------------------
+# Replication channel: export / merge / *_all
+# ---------------------------------------------------------------------------
+
+
+class TestReplication:
+    @pytest.mark.asyncio
+    async def test_export_none_for_missing_key(self) -> None:
+        assert OrSetMemory("a").export("missing") is None
+
+    @pytest.mark.asyncio
+    async def test_merge_is_idempotent(self) -> None:
+        a = OrSetMemory("a")
+        await a.write("k", b"x")
+        state = a.export("k")
+        assert state is not None
+        b = OrSetMemory("b")
+        assert await b.merge("k", state) is True
+        assert await b.merge("k", state) is False
+        assert await b.elements("k") == [b"x"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_adds_union(self) -> None:
+        a = OrSetMemory("a")
+        b = OrSetMemory("b")
+        await a.write("k", b"from-a")
+        await b.write("k", b"from-b")
+        a_state = a.export("k")
+        b_state = b.export("k")
+        assert a_state is not None and b_state is not None
+        await b.merge("k", a_state)
+        await a.merge("k", b_state)
+        assert await a.elements("k") == [b"from-a", b"from-b"]
+        assert await a.read("k") == await b.read("k")
+
+    @pytest.mark.asyncio
+    async def test_export_all_merge_all_roundtrip(self) -> None:
+        a = OrSetMemory("a")
+        await a.write("k1", b"v1")
+        await a.write("k2", b"v2")
+        b = OrSetMemory("b")
+        changed = await b.merge_all(a.export_all())
+        assert changed == ["k1", "k2"]
+        assert await b.elements("k1") == [b"v1"]
+        assert await b.elements("k2") == [b"v2"]
+
+
+# ---------------------------------------------------------------------------
+# The defining OR-Set property: add-wins, and the contrast with LWW
+# ---------------------------------------------------------------------------
+
+
+class TestAddWins:
+    @pytest.mark.asyncio
+    async def test_concurrent_add_survives_remove(self) -> None:
+        # a adds and removes x; b concurrently adds x. After merge, x survives
+        # because b's add-tag was never observed by a's remove.
+        a = OrSetMemory("a")
+        b = OrSetMemory("b")
+        await a.write("k", b"x")
+        await b.write("k", b"x")
+        b_state_add = b.export("k")
+        assert b_state_add is not None
+        await a.remove("k", b"x")  # only tombstones a's own tag
+        await a.merge("k", b_state_add)
+        assert await a.contains("k", b"x") is True
+
+    @pytest.mark.asyncio
+    async def test_or_set_preserves_concurrent_adds_lww_does_not(self) -> None:
+        # Same concurrent scenario on both plugins: two replicas each add a
+        # distinct value to one key, then exchange state.
+        # OR-Set: both values retained (the union).
+        oa, ob = OrSetMemory("a"), OrSetMemory("b")
+        await oa.write("k", b"alpha")
+        await ob.write("k", b"beta")
+        oa_state, ob_state = oa.export("k"), ob.export("k")
+        assert oa_state is not None and ob_state is not None
+        await oa.merge("k", ob_state)
+        await ob.merge("k", oa_state)
+        assert await oa.elements("k") == [b"alpha", b"beta"]
+
+        # LWW-Register: exactly one value survives; the other is lost.
+        la, lb = LwwRegisterMemory("a"), LwwRegisterMemory("b")
+        await la.write("k", b"alpha")
+        await lb.write("k", b"beta")
+        la_state, lb_state = la.export("k"), lb.export("k")
+        assert la_state is not None and lb_state is not None
+        await la.merge("k", lb_state)
+        await lb.merge("k", la_state)
+        survivor = await la.read("k")
+        assert survivor in (b"alpha", b"beta")
+        assert await la.read("k") == await lb.read("k")  # converged, but to one value
+
+
+# ---------------------------------------------------------------------------
+# Malformed input handling
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedState:
+    @pytest.mark.asyncio
+    async def test_merge_rejects_non_json(self) -> None:
+        with pytest.raises(CrdtStateError):
+            await OrSetMemory("a").merge("k", b"\xff\xfenot json")
+
+    @pytest.mark.asyncio
+    async def test_merge_rejects_wrong_kind(self) -> None:
+        with pytest.raises(CrdtStateError):
+            await OrSetMemory("a").merge("k", b'{"crdt": "other"}')
+
+    @pytest.mark.asyncio
+    async def test_merge_rejects_malformed_add_row(self) -> None:
+        with pytest.raises(CrdtStateError):
+            await OrSetMemory("a").merge(
+                "k", b'{"crdt": "or_set", "adds": [["bad-row"]], "removes": []}'
+            )
+
+    def test_crdt_state_error_is_value_error(self) -> None:
+        assert issubclass(CrdtStateError, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# CRDT algebraic laws (property-based) on the OrSet join
+# ---------------------------------------------------------------------------
+
+_element = st.binary(min_size=0, max_size=4)
+_node = st.text(alphabet="abcdef", min_size=1, max_size=3)
+_counter = st.integers(min_value=0, max_value=8)
+_tag = st.tuples(_node, _counter)
+_pair = st.tuples(_element, _tag)
+
+
+@st.composite
+def _or_sets(draw: st.DrawFn) -> OrSet:
+    adds = draw(st.frozensets(_pair, max_size=6))
+    # removes drawn from the tags that appear in adds, plus some free tags
+    add_tags = [tag for (_el, tag) in adds]
+    remove_pool = add_tags + draw(st.lists(_tag, max_size=3))
+    removes = draw(st.frozensets(st.sampled_from(remove_pool) if remove_pool else _tag, max_size=4))
+    return OrSet(adds, removes)
+
+
+class TestCrdtLaws:
+    @settings(max_examples=80, deadline=None)
+    @given(a=_or_sets(), b=_or_sets())
+    def test_join_is_commutative(self, a: OrSet, b: OrSet) -> None:
+        assert a.join(b).value() == b.join(a).value()
+
+    @settings(max_examples=80, deadline=None)
+    @given(a=_or_sets(), b=_or_sets(), c=_or_sets())
+    def test_join_is_associative(self, a: OrSet, b: OrSet, c: OrSet) -> None:
+        assert a.join(b).join(c) == a.join(b.join(c))
+
+    @settings(max_examples=80, deadline=None)
+    @given(a=_or_sets())
+    def test_join_is_idempotent(self, a: OrSet) -> None:
+        assert a.join(a) == a
+
+    @settings(max_examples=80, deadline=None)
+    @given(a=_or_sets())
+    def test_encode_decode_roundtrip(self, a: OrSet) -> None:
+        assert OrSet.decode(a.encode()).value() == a.value()
+
+
+# ---------------------------------------------------------------------------
+# Convergence under arbitrary delivery order (shared adversarial validator)
+# ---------------------------------------------------------------------------
+
+
+class TestConvergence:
+    @settings(max_examples=40, deadline=None)
+    @given(data=st.data())
+    @pytest.mark.asyncio
+    async def test_replicas_converge_for_any_order(self, data: st.DataObject) -> None:
+        n_writes = data.draw(st.integers(min_value=2, max_value=6))
+        replicas = data.draw(st.integers(min_value=2, max_value=5))
+        writes = [
+            (data.draw(st.integers(min_value=0, max_value=replicas - 1)), f"v{i}".encode())
+            for i in range(n_writes)
+        ]
+        orders = [data.draw(st.permutations(list(range(n_writes)))) for _ in range(replicas)]
+        results = await validate_crdt_convergence(OrSetMemory, writes, orders)
+        assert all(r.passed for r in results), results[0].detail
+
+    @pytest.mark.asyncio
+    async def test_determinism_same_ops_same_state(self) -> None:
+        async def build() -> bytes:
+            mem = OrSetMemory("a")
+            await mem.write("k", b"one")
+            await mem.merge("k", OrSet().add(b"two", ("b", 3)).encode())
+            await mem.write("k", b"three")
+            return mem.export_all()
+
+        assert await build() == await build()
+
+
+# ---------------------------------------------------------------------------
+# Adversarial validator: blackboard fails, OR-Set passes
+# ---------------------------------------------------------------------------
+
+
+class TestConvergenceValidator:
+    _writes = [(0, b"A"), (1, b"B"), (2, b"C")]
+    _orders = [[0, 1, 2], [2, 1, 0], [1, 0, 2]]
+
+    @pytest.mark.asyncio
+    async def test_or_set_passes(self) -> None:
+        results = await validate_crdt_convergence(OrSetMemory, self._writes, self._orders)
+        assert all(r.passed for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_builtin_resolves(self) -> None:
+        cls = PluginRegistry().resolve("memory", "or_set")
+        assert cls is OrSetMemory
+
+    def test_listed_for_memory_layer(self) -> None:
+        assert ("memory", "or_set") in PluginRegistry().list_plugins("memory")
+
+    def test_crdt_kind_tag(self) -> None:
+        assert CRDT_KIND == "or_set"


### PR DESCRIPTION
Adds a state-based OR-Set CvRDT to the memory layer, registered as memory/or_set. Concurrent adds to a key converge to the union (add-wins), unlike lww_register which reduces concurrent writes to a single winner. Merge is commutative, associative, and idempotent; property tests and the shared validate_crdt_convergence harness verify strong eventual consistency. Registered in both _BUILTINS and the nest.plugins.memory entry points.