### PR TITLE
Add streaming per-tick metered payments plugin (payments/streaming)

### DIFF
--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -145,3 +145,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("rogue_trusted_agent", rogue_trusted_agent_factory)
+    elif name == "streaming_payments":
+        from nest_core.scenarios_builtin.streaming_payments import (
+            streaming_payments_factory,
+        )
+
+        register_scenario("streaming_payments", streaming_payments_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/streaming_payments.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/streaming_payments.py
@@ -1,0 +1,376 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming payments scenario — buyers meter payments to sellers per tick.
+
+Five buyers open rolling streams to five sellers. Each tick the buyer sends work;
+the seller acknowledges delivery, which arms the next per-tick debit. Under
+network partition the seller never receives work, so billing stops. Audit events
+are written via :meth:`AgentContext.record_event` for the three streaming
+validators.
+
+Example::
+
+    agents = streaming_payments_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, PaymentRef, PaymentStatus
+
+_OP_WORK = b"op:work"
+_OP_ACK = b"op:ack"
+_OP_TICK = b"op:tick"
+_OP_CLOSE = b"op:close"
+_OP_OPEN_NEXT = b"op:open_next"
+
+
+def _parse_op(payload: bytes) -> tuple[str, dict[str, str]]:
+    text = payload.decode("utf-8", errors="replace")
+    if not text.startswith("op:"):
+        return "", {}
+    parts = text.split(":")
+    if len(parts) < 2:
+        return "", {}
+    op = parts[1]
+    fields: dict[str, str] = {}
+    for piece in parts[2:]:
+        if "=" in piece:
+            key, _, value = piece.partition("=")
+            fields[key] = value
+    return op, fields
+
+
+def _emit(op: str, **fields: str | int) -> bytes:
+    body = ":".join(f"{k}={v}" for k, v in fields.items())
+    return f"op:{op}:{body}".encode() if body else f"op:{op}".encode()
+
+
+def _record_debit(
+    ctx: AgentContext,
+    *,
+    ref: str,
+    payer: AgentId,
+    payee: AgentId,
+    amount: int,
+) -> None:
+    tick = int(ctx.time)
+    ctx.record_event(
+        {
+            "kind": "payment_debited",
+            "stream_ref": ref,
+            "agent": str(payer),
+            "to": str(payee),
+            "amount": amount,
+            "tick": tick,
+        }
+    )
+    ctx.record_event(
+        {
+            "kind": "payment_credited",
+            "stream_ref": ref,
+            "agent": str(payee),
+            "from": str(payer),
+            "amount": amount,
+            "tick": tick,
+        }
+    )
+
+
+class StreamingBuyerAgent(StateMachineAgent):
+    """Buyer that opens metered streams and debits only after seller acks work.
+
+    Example::
+
+        agent = StreamingBuyerAgent(
+            AgentId("buyer-0"),
+            seller=AgentId("seller-0"),
+            pair_index=0,
+            rounds=20,
+            rate_per_tick=10,
+            max_total=100,
+            stream_length=5,
+        )
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        seller: AgentId,
+        pair_index: int,
+        rounds: int,
+        rate_per_tick: int,
+        max_total: int,
+        stream_length: int,
+    ) -> None:
+        self._id = agent_id
+        self._seller = seller
+        self._pair_index = pair_index
+        self._rounds = rounds
+        self._rate = rate_per_tick
+        self._max_total = max_total
+        self._stream_length = stream_length
+        self._round = 0
+        self._tick_in_stream = 0
+        self._active_ref: PaymentRef | None = None
+        self._pending_ref: PaymentRef | None = None
+
+    def _stream_ref(self, round_idx: int) -> PaymentRef:
+        return PaymentRef(f"stream-{self._pair_index}-{round_idx}")
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Open the first stream and schedule the first work tick."""
+        await self._open_stream(ctx, self._stream_ref(0))
+
+    async def _open_stream(self, ctx: AgentContext, ref: PaymentRef) -> None:
+        payments = ctx.plugins.get("payments")
+        if payments is None or not hasattr(payments, "open_stream"):
+            return
+
+        tick = int(ctx.time)
+        handle = await payments.open_stream(
+            self._seller,
+            self._rate,
+            self._max_total,
+            ref,
+            opened_at_tick=tick,
+        )
+        self._active_ref = ref
+        self._tick_in_stream = 0
+        ctx.record_event(
+            {
+                "event_type": "stream_opened",
+                "stream_ref": str(ref),
+                "agent": str(self._id),
+                "to": str(self._seller),
+                "tick": tick,
+            }
+        )
+        _record_debit(
+            ctx,
+            ref=str(ref),
+            payer=self._id,
+            payee=self._seller,
+            amount=handle.total_debited,
+        )
+        await ctx.schedule(1.0, _emit("tick", ref=str(ref), n="1"))
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Handle scheduled ticks, seller acks, and stream lifecycle."""
+        op, fields = _parse_op(payload)
+        if op == "ack":
+            await self._on_ack(ctx, fields)
+        elif op == "tick":
+            await self._on_tick(ctx, fields)
+        elif op == "close":
+            await self._on_close(ctx, fields)
+        elif op == "open_next":
+            await self._on_open_next(ctx, fields)
+
+    async def _on_tick(self, ctx: AgentContext, fields: dict[str, str]) -> None:
+        ref = PaymentRef(fields.get("ref", ""))
+        if ref != self._active_ref:
+            return
+
+        await ctx.send(self._seller, _emit("work", ref=str(ref), tick=str(int(ctx.time))))
+
+        self._tick_in_stream += 1
+        if self._tick_in_stream >= self._stream_length:
+            await ctx.schedule(1.0, _emit("close", ref=str(ref)))
+            if self._round + 1 < self._rounds:
+                self._pending_ref = self._stream_ref(self._round + 1)
+                await ctx.schedule(2.0, _emit("open_next", ref=str(self._pending_ref)))
+        else:
+            n = str(self._tick_in_stream + 1)
+            await ctx.schedule(1.0, _emit("tick", ref=str(ref), n=n))
+
+    async def _on_ack(self, ctx: AgentContext, fields: dict[str, str]) -> None:
+        ref = PaymentRef(fields.get("ref", ""))
+        if ref != self._active_ref:
+            return
+
+        payments = ctx.plugins.get("payments")
+        if payments is None:
+            return
+
+        tick = int(ctx.time)
+        before = payments.stream_total_debited(ref)
+        still_open = await payments.advance_stream(ref, tick)
+        after = payments.stream_total_debited(ref)
+
+        delta = after - before
+        if delta > 0:
+            _record_debit(
+                ctx,
+                ref=str(ref),
+                payer=self._id,
+                payee=self._seller,
+                amount=delta,
+            )
+
+        if not still_open and (await payments.verify_payment(ref)) == PaymentStatus.STREAMING:
+            await self._finalize_close(ctx, ref)
+
+    async def _on_close(self, ctx: AgentContext, fields: dict[str, str]) -> None:
+        ref = PaymentRef(fields.get("ref", ""))
+        if ref != self._active_ref:
+            return
+        await self._finalize_close(ctx, ref)
+        self._round += 1
+
+    async def _on_open_next(self, ctx: AgentContext, fields: dict[str, str]) -> None:
+        ref = PaymentRef(fields.get("ref", ""))
+        if self._active_ref is not None and ref == self._pending_ref:
+            await self._open_stream(ctx, ref)
+
+    async def _finalize_close(self, ctx: AgentContext, ref: PaymentRef) -> None:
+        payments = ctx.plugins.get("payments")
+        if payments is None:
+            return
+        if (await payments.verify_payment(ref)) != PaymentStatus.STREAMING:
+            return
+
+        tick = int(ctx.time)
+        await payments.close_stream(ref, current_tick=tick)
+        ctx.record_event(
+            {
+                "event_type": "stream_closed",
+                "stream_ref": str(ref),
+                "agent": str(self._id),
+                "to": str(self._seller),
+                "tick": tick,
+            }
+        )
+        if self._active_ref == ref:
+            self._active_ref = None
+
+
+class StreamingSellerAgent(StateMachineAgent):
+    """Seller that acknowledges work so the buyer may advance the stream.
+
+    Example::
+
+        agent = StreamingSellerAgent(AgentId("seller-0"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Acknowledge delivered work so the buyer can debit the next tick."""
+        op, fields = _parse_op(payload)
+        if op != "work":
+            return
+
+        ref = PaymentRef(fields.get("ref", ""))
+        payments = ctx.plugins.get("payments")
+        if payments is not None:
+            await payments.acknowledge_work(ref, tick=int(ctx.time))
+
+        await ctx.send(sender, _emit("ack", ref=str(ref), tick=str(int(ctx.time))))
+
+
+def streaming_payments_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create paired buyers and sellers for the streaming payments scenario.
+
+    Example::
+
+        agents = streaming_payments_factory(config, plugins)
+    """
+    task = config.task.config
+    rounds = int(task.get("rounds", 100))
+    rate_per_tick = int(task.get("rate_per_tick", 10))
+    max_total = int(task.get("max_total", 100))
+    stream_length = int(task.get("stream_length", 5))
+
+    buyer_count = 0
+    seller_count = 0
+    buyer_balance = 5000
+    seller_balance = 100
+    for role in config.agents.roles:
+        if role.name == "buyer":
+            buyer_count = role.count
+            buyer_balance = int(role.config.get("initial_balance", buyer_balance))
+        elif role.name == "seller":
+            seller_count = role.count
+            seller_balance = int(role.config.get("initial_balance", seller_balance))
+
+    if buyer_count == 0 or seller_count == 0:
+        buyer_count = config.agents.count // 2
+        seller_count = config.agents.count - buyer_count
+
+    buyer_ids = [AgentId(f"buyer-{i}") for i in range(buyer_count)]
+    seller_ids = [AgentId(f"seller-{i}") for i in range(seller_count)]
+    all_ids = buyer_ids + seller_ids
+
+    _instantiate_plugins(
+        plugins,
+        all_ids,
+        buyer_balance=buyer_balance,
+        seller_balance=seller_balance,
+    )
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    pairs = min(buyer_count, seller_count)
+    for i in range(pairs):
+        agents[buyer_ids[i]] = StreamingBuyerAgent(
+            buyer_ids[i],
+            seller=seller_ids[i],
+            pair_index=i,
+            rounds=rounds,
+            rate_per_tick=rate_per_tick,
+            max_total=max_total,
+            stream_length=stream_length,
+        )
+        agents[seller_ids[i]] = StreamingSellerAgent(seller_ids[i])
+
+    return agents
+
+
+def _instantiate_plugins(
+    plugins: dict[str, Any],
+    all_ids: list[AgentId],
+    *,
+    buyer_balance: int,
+    seller_balance: int,
+) -> None:
+    """Instantiate shared streaming payment handles for every agent."""
+    if not plugins:
+        return
+
+    agent_plugins: dict[AgentId, dict[str, Any]] = plugins.setdefault("_agent_plugins", {})
+
+    payments_cls = plugins.get("payments")
+    if payments_cls is not None and isinstance(payments_cls, type):
+        balances: dict[AgentId, int] = {}
+        for aid in all_ids:
+            if str(aid).startswith("buyer"):
+                balances[aid] = buyer_balance
+            else:
+                balances[aid] = seller_balance
+
+        payment_records: dict[PaymentRef, Any] = {}
+        streams: dict[PaymentRef, Any] = {}
+        system_id = AgentId("system")
+        shared_kwargs: dict[str, Any] = {
+            "initial_balance": 0,
+            "balances": balances,
+            "payments": payment_records,
+        }
+        try:
+            plugins["payments"] = payments_cls(system_id, **shared_kwargs, streams=streams)
+            per_agent_kwargs = {**shared_kwargs, "streams": streams}
+        except TypeError:
+            plugins["payments"] = payments_cls(system_id, **shared_kwargs)
+            per_agent_kwargs = shared_kwargs
+        for aid in all_ids:
+            agent_plugins.setdefault(aid, {})["payments"] = payments_cls(
+                aid,
+                **per_agent_kwargs,
+            )

--- a/packages/nest-core/nest_core/sim/agent.py
+++ b/packages/nest-core/nest_core/sim/agent.py
@@ -103,6 +103,17 @@ class AgentContext(Protocol):
         """
         ...
 
+    def record_event(self, fields: dict[str, Any]) -> None:
+        """Record a custom audit event into the simulation trace.
+
+        Example::
+
+            ctx.record_event(
+                {"kind": "payment_debited", "stream_ref": "s-1", "amount": 10},
+            )
+        """
+        ...
+
 
 class StateMachineAgent:
     """Base class for Tier 1 state-machine agents.

--- a/packages/nest-core/nest_core/sim/simulator.py
+++ b/packages/nest-core/nest_core/sim/simulator.py
@@ -116,6 +116,17 @@ class _SimAgentContext:
             )
         await self._transport.broadcast(payload, correlation_id=cid)
 
+    def record_event(self, fields: dict[str, Any]) -> None:
+        if self._trace:
+            self._trace.record(
+                {
+                    "ts": self._clock.now,
+                    "tick": int(self._clock.now),
+                    "agent": str(self._agent_id),
+                    **fields,
+                }
+            )
+
     async def schedule(self, delay: float, payload: bytes) -> None:
         self._queue.push(
             Event(
@@ -338,6 +349,7 @@ class Simulator:
                     if self._trace:
                         drop_rec: dict[str, Any] = {
                             "ts": self._clock.now,
+                            "tick": self._tick_count,
                             "agent": str(event.agent_id),
                             "kind": "dropped",
                             "from": str(event.target_id),

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -1295,7 +1295,7 @@ def validate_streaming_no_drain_after_close(
     stream_debits: dict[str, list[int]] = defaultdict(lambda: [])  # PaymentRef -> [ticks]
 
     for ev in events:
-        tick = ev.get("tick", 0)
+        tick = _event_tick(ev)
 
         if ev.get("event_type") == "stream_opened":
             ref = ev.get("stream_ref", "")
@@ -1352,7 +1352,7 @@ def validate_streaming_no_overbill_on_partition(
     violations: list[str] = []
 
     for ev in events:
-        tick = ev.get("tick", 0)
+        tick = _event_tick(ev)
 
         if ev.get("event_type") == "stream_opened":
             ref = ev.get("stream_ref", "")
@@ -1400,6 +1400,37 @@ def validate_streaming_no_overbill_on_partition(
             True,
             f"verified {len(stream_parties)} streams across "
             f"{len(partition_start)} partition edges, no over-bill",
+        )
+    ]
+
+
+def validate_streaming_lifecycle(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """Require that the trace records real streaming activity.
+
+    One-shot ``prepaid_credits`` payments do not emit ``stream_opened`` events;
+    this validator fails those traces so the adversarial suite discriminates
+    plugins that do not implement metered billing.
+
+    Example::
+
+        results = validate_streaming_lifecycle(events)
+    """
+    opens = [ev for ev in events if ev.get("event_type") == "stream_opened"]
+    if len(opens) < 1:
+        return [
+            ValidationResult(
+                "streaming_lifecycle",
+                False,
+                "no stream_opened events observed",
+            )
+        ]
+    return [
+        ValidationResult(
+            "streaming_lifecycle",
+            True,
+            f"observed {len(opens)} stream(s)",
         )
     ]
 
@@ -4645,6 +4676,7 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_memory_liveness,
     ],
     "streaming_payments": [
+        validate_streaming_lifecycle,
         validate_streaming_conservation,
         validate_streaming_no_drain_after_close,
         validate_streaming_no_overbill_on_partition,

--- a/packages/nest-core/tests/test_scenario.py
+++ b/packages/nest-core/tests/test_scenario.py
@@ -33,10 +33,8 @@ class _FakeAgentContext:
     async def schedule(self, delay: float, payload: bytes) -> None:
         self.sent.append((AgentId(f"self-after-{delay}"), payload))
 
-
-# ---------------------------------------------------------------------------
-# Scenario schema tests
-# ---------------------------------------------------------------------------
+    def record_event(self, fields: dict[str, Any]) -> None:
+        return
 
 
 class TestScenarioConfig:
@@ -288,3 +286,83 @@ class TestEmpicPaymentsScenario:
 
         validations = validate_trace(result_path, "empic_payments")
         assert all(r.passed for r in validations), validations
+
+
+class TestStreamingPaymentsScenario:
+    """End-to-end checks for streaming_payments.yaml."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_payments_yaml(self, tmp_path: Path) -> None:
+        """Run streaming scenario and validate all four streaming invariants."""
+        yaml_path = (
+            Path(__file__).parent.parent.parent.parent / "scenarios" / "streaming_payments.yaml"
+        )
+        config = ScenarioConfig.from_yaml(yaml_path)
+        config.output.trace = str(tmp_path / "streaming_payments.jsonl")
+        config.duration = "ticks: 500"
+        config.task.config["rounds"] = 5
+
+        runner = ScenarioRunner(config)
+        result_path = await runner.run()
+
+        assert result_path.exists()
+        validations = validate_trace(result_path, "streaming_payments")
+        assert all(r.passed for r in validations), validations
+
+    @pytest.mark.asyncio
+    async def test_streaming_payments_deterministic(self, tmp_path: Path) -> None:
+        """Same seed produces byte-identical traces."""
+        yaml_path = (
+            Path(__file__).parent.parent.parent.parent / "scenarios" / "streaming_payments.yaml"
+        )
+        traces: list[str] = []
+        for i in range(2):
+            config = ScenarioConfig.from_yaml(yaml_path)
+            trace_file = tmp_path / f"streaming_{i}.jsonl"
+            config.output.trace = str(trace_file)
+            config.duration = "ticks: 300"
+            config.task.config["rounds"] = 3
+            runner = ScenarioRunner(config)
+            await runner.run()
+            traces.append(trace_file.read_text(encoding="utf-8"))
+
+        assert traces[0] == traces[1]
+        assert len(traces[0]) > 0
+
+    @pytest.mark.asyncio
+    async def test_streaming_partition_yaml(self, tmp_path: Path) -> None:
+        """Partition scenario must not over-bill after buyer/seller isolation."""
+        yaml_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "scenarios"
+            / "streaming_payments_partition.yaml"
+        )
+        config = ScenarioConfig.from_yaml(yaml_path)
+        config.output.trace = str(tmp_path / "streaming_partition.jsonl")
+        config.duration = "ticks: 500"
+        config.task.config["rounds"] = 5
+
+        runner = ScenarioRunner(config)
+        result_path = await runner.run()
+
+        validations = validate_trace(result_path, "streaming_payments")
+        assert all(r.passed for r in validations), validations
+
+    @pytest.mark.asyncio
+    async def test_prepaid_plugin_fails_streaming_validators(self, tmp_path: Path) -> None:
+        """prepaid_credits against streaming scenario fails lifecycle validator."""
+        yaml_path = (
+            Path(__file__).parent.parent.parent.parent / "scenarios" / "streaming_payments.yaml"
+        )
+        config = ScenarioConfig.from_yaml(yaml_path)
+        config.layers.payments = "prepaid_credits"
+        config.output.trace = str(tmp_path / "streaming_prepaid.jsonl")
+        config.duration = "ticks: 100"
+        config.task.config["rounds"] = 1
+
+        runner = ScenarioRunner(config)
+        result_path = await runner.run()
+        validations = validate_trace(result_path, "streaming_payments")
+        lifecycle = [r for r in validations if r.name == "streaming_lifecycle"]
+        assert lifecycle
+        assert not lifecycle[0].passed

--- a/packages/nest-core/tests/test_validators.py
+++ b/packages/nest-core/tests/test_validators.py
@@ -1917,3 +1917,6 @@ class TestValidatorRegistry:
     def test_each_scenario_has_validators(self) -> None:
         for scenario, validators in VALIDATORS.items():
             assert len(validators) >= 2, f"{scenario} needs at least 2 validators"
+
+    def test_streaming_has_four_validators(self) -> None:
+        assert len(VALIDATORS["streaming_payments"]) == 4

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/streaming.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/streaming.py
@@ -1,6 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """Streaming per-tick payments plugin with mid-stream cancellation.
 
+Funds drain one logical tick at a time, capped at ``max_total``. Either party
+may close the stream; unused remainder is never spent. Subsequent debits require
+a payee delivery acknowledgement so billing stops when the payer and payee cannot
+communicate (e.g. under ``failures.network_partition``).
+
+``verify_payment`` returns ``PaymentStatus.STREAMING`` for an open stream because
+funds are in flight but the obligation is not yet finalized — distinct from
+``PENDING`` (reserved but not yet moving) and ``CONFIRMED`` (closed or fully
+drained to ``max_total``).
+
 Example::
 
     payments = StreamingPayments(AgentId("payer"), initial_balance=10000)
@@ -10,8 +20,9 @@ Example::
         max_total=500,
         ref=PaymentRef("stream-1"),
     )
-    # ... ticks pass ...
-    receipt = await payments.close_stream(PaymentRef("stream-1"))
+    await payments.acknowledge_work(PaymentRef("stream-1"), tick=0)
+    await payments.advance_stream(PaymentRef("stream-1"), tick=1)
+    receipt = await payments.close_stream(PaymentRef("stream-1"), current_tick=2)
 """
 
 from __future__ import annotations
@@ -37,6 +48,7 @@ class StreamHandle:
 
         handle = StreamHandle(
             ref=PaymentRef("s-1"),
+            payer=AgentId("buyer-0"),
             to=AgentId("worker"),
             rate_per_tick=10,
             max_total=500,
@@ -46,20 +58,22 @@ class StreamHandle:
     """
 
     ref: PaymentRef
+    payer: AgentId
     to: AgentId
     rate_per_tick: int
     max_total: int
     opened_at_tick: int
     closed_at_tick: int | None = None
     total_debited: int = 0
+    ready_to_advance: bool = False
 
 
 class StreamingPayments:
     """Streaming per-tick payments with mid-stream cancellation.
 
-    Extends prepaid credits with the ability to open bilateral streams that drain
-    one tick at a time. Either party can close the stream at any tick; unused
-    remainder is never spent. Satisfies the ``Payments`` protocol.
+    Extends prepaid credits with bilateral streams that drain one tick at a time.
+    Either party can close at any tick; unused remainder is never spent. Satisfies
+    the ``Payments`` protocol — ``pay()`` behaves as a one-tick stream.
 
     Example::
 
@@ -70,8 +84,7 @@ class StreamingPayments:
             max_total=500,
             ref=PaymentRef("stream-1"),
         )
-        # Later...
-        receipt = await payments.close_stream(PaymentRef("stream-1"))
+        receipt = await payments.close_stream(PaymentRef("stream-1"), current_tick=3)
     """
 
     def __init__(
@@ -112,12 +125,14 @@ class StreamingPayments:
         rate_per_tick: int,
         max_total: int,
         ref: PaymentRef,
+        *,
+        opened_at_tick: int = 0,
     ) -> StreamHandle:
         """Open a streaming payment from this agent to another.
 
-        Funds drain from payer to payee one tick at a time at ``rate_per_tick``
-        per tick, capped at ``max_total``. Either party can call ``close_stream``
-        at any point; unused remainder is never spent.
+        Funds drain from payer to payee one tick at a time at ``rate_per_tick``,
+        capped at ``max_total``. The first tick debits immediately; later ticks
+        require ``acknowledge_work`` then ``advance_stream``.
 
         Example::
 
@@ -126,14 +141,16 @@ class StreamingPayments:
                 rate_per_tick=10,
                 max_total=500,
                 ref=PaymentRef("metered-task-1"),
+                opened_at_tick=0,
             )
-            assert handle.total_debited == 10  # first tick drained immediately
+            assert handle.total_debited == 10
 
         Args:
             to: Recipient agent.
             rate_per_tick: Amount to debit per tick (must be positive).
             max_total: Maximum total to transfer (must be >= rate_per_tick).
             ref: Unique reference for this stream.
+            opened_at_tick: Logical tick when the stream opens.
 
         Returns:
             StreamHandle with stream metadata.
@@ -156,38 +173,58 @@ class StreamingPayments:
             msg = f"Insufficient balance for stream: {payer_balance} < {rate_per_tick}"
             raise ValueError(msg)
 
-        # Drain first tick immediately
-        self._balances[self._agent_id] = payer_balance - rate_per_tick
-        self._balances[to] = self._balances.get(to, 0) + rate_per_tick
+        first_debit = min(rate_per_tick, max_total)
+        self._balances[self._agent_id] = payer_balance - first_debit
+        self._balances[to] = self._balances.get(to, 0) + first_debit
 
         handle = StreamHandle(
             ref=ref,
+            payer=self._agent_id,
             to=to,
             rate_per_tick=rate_per_tick,
             max_total=max_total,
-            opened_at_tick=0,  # Will be set by context in real scenario
-            total_debited=rate_per_tick,
+            opened_at_tick=opened_at_tick,
+            total_debited=first_debit,
+            ready_to_advance=False,
         )
+        if handle.total_debited >= handle.max_total:
+            handle.closed_at_tick = opened_at_tick
         self._streams[ref] = handle
         return handle
 
-    async def tick_stream(self, ref: PaymentRef, current_tick: int) -> bool:
-        """Drain one tick's worth of funds from an open stream.
+    def _debit_amount(self, handle: StreamHandle) -> int:
+        return min(
+            handle.rate_per_tick,
+            handle.max_total - handle.total_debited,
+        )
 
-        Called automatically by the scheduler. Returns True if stream still open.
+    async def acknowledge_work(self, ref: PaymentRef, *, tick: int) -> None:
+        """Mark that the payee delivered work for the current stream period.
+
+        Only the payee (``handle.to``) may call this. Arms the payer to call
+        ``advance_stream`` for the next tick. Under partition the payee never
+        receives work, so no further debits occur.
 
         Example::
 
-            still_open = await payments.tick_stream(PaymentRef("s-1"), current_tick=3)
-            if not still_open:
-                receipt = await payments.close_stream(PaymentRef("s-1"))
+            await payments.acknowledge_work(PaymentRef("s-1"), tick=4)
+        """
+        handle = self._streams.get(ref)
+        if handle is None or handle.closed_at_tick is not None:
+            return
+        if self._agent_id != handle.to:
+            msg = f"Only payee {handle.to} may acknowledge stream {ref}"
+            raise ValueError(msg)
+        handle.ready_to_advance = True
 
-        Args:
-            ref: Stream reference.
-            current_tick: Current simulation tick.
+    async def advance_stream(self, ref: PaymentRef, current_tick: int) -> bool:
+        """Debit the next tick after payee acknowledged delivery.
 
-        Returns:
-            True if stream is still open after this tick, False if closed.
+        Returns True if the stream remains open after this advance.
+
+        Example::
+
+            still_open = await payments.advance_stream(PaymentRef("s-1"), current_tick=3)
         """
         if ref not in self._streams:
             return False
@@ -195,44 +232,77 @@ class StreamingPayments:
         handle = self._streams[ref]
         if handle.closed_at_tick is not None:
             return False
-
-        # Check if we've hit the max
+        if not handle.ready_to_advance:
+            return handle.closed_at_tick is None
         if handle.total_debited >= handle.max_total:
             handle.closed_at_tick = current_tick
             return False
 
-        # Drain one tick
-        amount_to_drain = min(
-            handle.rate_per_tick,
-            handle.max_total - handle.total_debited,
-        )
-        payer_balance = self._balances.get(self._agent_id, 0)
-        if payer_balance < amount_to_drain:
-            # Insufficient funds; stream stops
+        amount_to_drain = self._debit_amount(handle)
+        if amount_to_drain <= 0:
             handle.closed_at_tick = current_tick
             return False
 
-        self._balances[self._agent_id] = payer_balance - amount_to_drain
+        payer = handle.payer
+        payer_balance = self._balances.get(payer, 0)
+        if payer_balance < amount_to_drain:
+            handle.closed_at_tick = current_tick
+            return False
+
+        self._balances[payer] = payer_balance - amount_to_drain
         self._balances[handle.to] = self._balances.get(handle.to, 0) + amount_to_drain
         handle.total_debited += amount_to_drain
+        handle.ready_to_advance = False
 
         if handle.total_debited >= handle.max_total:
             handle.closed_at_tick = current_tick
 
         return handle.closed_at_tick is None
 
-    async def close_stream(self, ref: PaymentRef) -> Receipt:
-        """Close a stream and return a receipt.
-
-        Either payer or payee can call this. Unused remainder is never spent.
+    def stream_total_debited(self, ref: PaymentRef) -> int:
+        """Return cumulative debited amount for an open or closed stream.
 
         Example::
 
-            receipt = await payments.close_stream(PaymentRef("s-1"))
+            total = payments.stream_total_debited(PaymentRef("s-1"))
+        """
+        handle = self._streams.get(ref)
+        if handle is not None:
+            return handle.total_debited
+        receipt = self._payments.get(ref)
+        if receipt is not None:
+            return receipt.amount.amount
+        return 0
+
+    async def tick_stream(self, ref: PaymentRef, current_tick: int) -> bool:
+        """Alias for :meth:`advance_stream` (backward-compatible test API).
+
+        Example::
+
+            still_open = await payments.tick_stream(PaymentRef("s-1"), current_tick=2)
+        """
+        handle = self._streams.get(ref)
+        if handle is not None and not handle.ready_to_advance:
+            handle.ready_to_advance = True
+        return await self.advance_stream(ref, current_tick)
+
+    async def close_stream(self, ref: PaymentRef, *, current_tick: int = 0) -> Receipt:
+        """Close a stream and return a receipt.
+
+        Either payer or payee can call this. Unused remainder is never spent.
+        Further ``advance_stream`` calls are no-ops.
+
+        Example::
+
+            receipt = await payments.close_stream(
+                PaymentRef("s-1"),
+                current_tick=5,
+            )
             assert receipt.amount.amount == handle.total_debited
 
         Args:
             ref: Stream reference.
+            current_tick: Logical tick at close.
 
         Returns:
             Receipt with total amount transferred.
@@ -246,22 +316,24 @@ class StreamingPayments:
 
         handle = self._streams[ref]
         if handle.closed_at_tick is None:
-            handle.closed_at_tick = 0  # Assume current tick; real usage sets it
+            handle.closed_at_tick = current_tick
 
-        # Create receipt
+        payer = handle.payer
+
         receipt = Receipt(
             ref=ref,
-            payer=self._agent_id,
+            payer=payer,
             payee=handle.to,
             amount=Money(amount=handle.total_debited),
         )
         self._payments[ref] = receipt
+        del self._streams[ref]
         return receipt
 
     async def pay(self, to: AgentId, amount: Money, ref: PaymentRef) -> Receipt:
-        """Execute a one-shot payment (one-tick stream).
+        """Execute a one-shot payment (single-tick stream).
 
-        Satisfies the Payments protocol for backward compatibility.
+        Satisfies the ``Payments`` protocol for backward compatibility.
 
         Example::
 
@@ -270,17 +342,6 @@ class StreamingPayments:
                 Money(amount=200),
                 PaymentRef("one-shot-1"),
             )
-
-        Args:
-            to: Recipient agent.
-            amount: Amount to transfer.
-            ref: Unique reference for this payment.
-
-        Returns:
-            Receipt.
-
-        Raises:
-            ValueError: If insufficient balance or duplicate ref.
         """
         if amount.amount <= 0:
             msg = f"Payment amount must be positive: {amount.amount}"
@@ -304,41 +365,28 @@ class StreamingPayments:
     async def verify_payment(self, ref: PaymentRef) -> PaymentStatus:
         """Verify a payment or stream status by reference.
 
+        Open streams return ``STREAMING`` because value is actively metering but
+        the obligation is not finalized. Closed or one-shot payments return
+        ``CONFIRMED``.
+
         Example::
 
             status = await payments.verify_payment(PaymentRef("s-1"))
             if status == PaymentStatus.STREAMING:
-                await payments.tick_stream(PaymentRef("s-1"), tick)
-
-        Args:
-            ref: Payment or stream reference.
-
-        Returns:
-            PaymentStatus.CONFIRMED for completed payments,
-            PaymentStatus.STREAMING for open streams,
-            PaymentStatus.FAILED otherwise.
+                await payments.advance_stream(PaymentRef("s-1"), tick=2)
         """
         if ref in self._payments:
             return PaymentStatus.CONFIRMED
         if ref in self._streams:
-            handle = self._streams[ref]
-            if handle.closed_at_tick is not None:
-                return PaymentStatus.CONFIRMED
             return PaymentStatus.STREAMING
         return PaymentStatus.FAILED
 
     async def refund(self, ref: PaymentRef) -> None:
-        """Refund a payment.
+        """Refund a completed payment.
 
         Example::
 
             await payments.refund(PaymentRef("one-shot-1"))
-
-        Args:
-            ref: Payment reference.
-
-        Raises:
-            ValueError: If payment not found or insufficient balance for refund.
         """
         receipt = self._payments.get(ref)
         if receipt is None:

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -33,6 +33,9 @@ Repository = "https://github.com/projnanda/nandatown"
 # package. The PluginRegistry also keeps built-in defaults keyed by
 # (layer, name), but declaring the entry point here is the documented,
 # install-time discovery path described in CONTRIBUTING.md.
+[project.entry-points."nest.plugins.payments"]
+streaming = "nest_plugins_reference.payments.streaming:StreamingPayments"
+
 [project.entry-points."nest.plugins.comms"]
 authenticated = "nest_plugins_reference.comms.authenticated:AuthenticatedComms"
 

--- a/packages/nest-plugins-reference/tests/test_hotstuff_plugin.py
+++ b/packages/nest-plugins-reference/tests/test_hotstuff_plugin.py
@@ -38,6 +38,9 @@ class _FakeAgentContext:
     async def schedule(self, delay: float, payload: bytes) -> None:
         self.sent.append((AgentId(f"self-after-{delay}"), payload))
 
+    def record_event(self, fields: dict[str, Any]) -> None:
+        return
+
 
 def _make_identities(replica_ids: list[AgentId]) -> dict[AgentId, DidKeyIdentity]:
     plugins: dict[str, Any] = {"identity": DidKeyIdentity}

--- a/packages/nest-plugins-reference/tests/test_streaming_adversarial.py
+++ b/packages/nest-plugins-reference/tests/test_streaming_adversarial.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial and property tests for streaming payments.
+
+Proves the validator suite catches drain-after-close and over-bill-on-partition
+attacks, and that ``prepaid_credits`` fails the streaming lifecycle check.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Money, PaymentRef, PaymentStatus
+from nest_core.validators import (
+    validate_streaming_conservation,
+    validate_streaming_lifecycle,
+    validate_streaming_no_drain_after_close,
+    validate_streaming_no_overbill_on_partition,
+)
+from nest_plugins_reference.payments.prepaid_credits import PrepaidCredits
+from nest_plugins_reference.payments.streaming import StreamingPayments
+
+
+def _shared_pair(
+    payer_balance: int,
+) -> tuple[StreamingPayments, StreamingPayments]:
+    balances: dict[AgentId, int] = {AgentId("payer"): payer_balance, AgentId("payee"): 0}
+    payments: dict[PaymentRef, object] = {}
+    streams: dict[PaymentRef, object] = {}
+    payer = StreamingPayments(
+        AgentId("payer"),
+        initial_balance=0,
+        balances=balances,
+        payments=payments,  # type: ignore[arg-type]
+        streams=streams,  # type: ignore[arg-type]
+    )
+    payee = StreamingPayments(
+        AgentId("payee"),
+        initial_balance=0,
+        balances=balances,
+        payments=payments,  # type: ignore[arg-type]
+        streams=streams,  # type: ignore[arg-type]
+    )
+    return payer, payee
+
+
+class BuggyStreamingPayments(StreamingPayments):
+    """Intentionally broken plugin that debits after close (drain-after-close attack)."""
+
+    async def advance_stream(self, ref: PaymentRef, current_tick: int) -> bool:
+        if ref not in self._streams:
+            return False
+        handle = self._streams[ref]
+        handle.ready_to_advance = True
+        result = await super().advance_stream(ref, current_tick)
+        if ref in self._streams:
+            amount = min(handle.rate_per_tick, handle.max_total - handle.total_debited)
+            if amount > 0 and handle.closed_at_tick is not None:
+                payer_balance = self._balances.get(handle.payer, 0)
+                if payer_balance >= amount:
+                    self._balances[handle.payer] = payer_balance - amount
+                    self._balances[handle.to] = self._balances.get(handle.to, 0) + amount
+                    handle.total_debited += amount
+        return result
+
+
+@pytest.mark.asyncio
+async def test_drain_after_close_attack_fails_validator() -> None:
+    """Drain-after-close: debits after close must fail the adversarial validator."""
+    events = [
+        {"event_type": "stream_opened", "stream_ref": "s-attack", "tick": 0},
+        {"kind": "payment_debited", "stream_ref": "s-attack", "tick": 1},
+        {"event_type": "stream_closed", "stream_ref": "s-attack", "tick": 2},
+        {"kind": "payment_debited", "stream_ref": "s-attack", "tick": 5},
+    ]
+    results = validate_streaming_no_drain_after_close(events)
+    assert not results[0].passed
+    assert "debited after close" in results[0].detail
+
+
+@pytest.mark.asyncio
+async def test_overbill_on_partition_attack_fails_validator() -> None:
+    """Over-bill on partition: debits after drop must fail the adversarial validator."""
+    events = [
+        {
+            "event_type": "stream_opened",
+            "stream_ref": "s1",
+            "agent": "buyer-0",
+            "to": "seller-0",
+            "tick": 0,
+        },
+        {"kind": "payment_debited", "stream_ref": "s1", "tick": 1},
+        {"kind": "dropped", "from": "buyer-0", "agent": "seller-0", "tick": 2},
+        {"kind": "payment_debited", "stream_ref": "s1", "tick": 5},
+    ]
+    results = validate_streaming_no_overbill_on_partition(events)
+    assert not results[0].passed
+    assert "partitioned" in results[0].detail
+
+
+@pytest.mark.asyncio
+async def test_correct_streaming_passes_adversarial_validators() -> None:
+    """Correct plugin behavior produces a trace the adversarial validators accept."""
+    payee = AgentId("payee")
+    ref = PaymentRef("s-good")
+    payer, payee_plugin = _shared_pair(1000)
+    await payer.open_stream(payee, 25, 100, ref, opened_at_tick=0)
+
+    events: list[dict[str, object]] = [
+        {
+            "event_type": "stream_opened",
+            "stream_ref": str(ref),
+            "agent": "payer",
+            "to": "payee",
+            "tick": 0,
+        },
+        {
+            "kind": "payment_debited",
+            "stream_ref": str(ref),
+            "agent": "payer",
+            "amount": 25,
+            "tick": 0,
+        },
+        {
+            "kind": "payment_credited",
+            "stream_ref": str(ref),
+            "agent": "payee",
+            "amount": 25,
+            "tick": 0,
+        },
+    ]
+
+    await payee_plugin.acknowledge_work(ref, tick=1)
+    await payer.advance_stream(ref, 1)
+    events.extend(
+        [
+            {
+                "kind": "payment_debited",
+                "stream_ref": str(ref),
+                "agent": "payer",
+                "amount": 25,
+                "tick": 1,
+            },
+            {
+                "kind": "payment_credited",
+                "stream_ref": str(ref),
+                "agent": "payee",
+                "amount": 25,
+                "tick": 1,
+            },
+        ]
+    )
+    await payer.close_stream(ref, current_tick=2)
+    events.append({"event_type": "stream_closed", "stream_ref": str(ref), "tick": 2})
+
+    assert all(r.passed for r in validate_streaming_lifecycle(events))  # type: ignore[arg-type]
+    assert all(r.passed for r in validate_streaming_conservation(events))  # type: ignore[arg-type]
+    assert all(r.passed for r in validate_streaming_no_drain_after_close(events))  # type: ignore[arg-type]
+    assert all(r.passed for r in validate_streaming_no_overbill_on_partition(events))  # type: ignore[arg-type]
+
+
+def test_prepaid_credits_fails_streaming_lifecycle() -> None:
+    """Old prepaid_credits plugin leaves no stream events — validators must fail."""
+    events = [
+        {"kind": "send", "agent": "buyer-0", "to": "seller-0", "msg": "buy:item:50"},
+        {"kind": "receive", "agent": "seller-0", "from": "buyer-0", "msg": "sold:item:50"},
+    ]
+    results = validate_streaming_lifecycle(events)
+    assert not results[0].passed
+    assert "no stream_opened" in results[0].detail
+
+
+@pytest.mark.asyncio
+async def test_prepaid_has_no_streaming_api() -> None:
+    """prepaid_credits cannot open streams — proves old plugin is unsuitable."""
+    payments = PrepaidCredits(AgentId("payer"), initial_balance=1000)
+    open_stream = getattr(payments, "open_stream", None)
+    assert open_stream is None or not callable(open_stream)
+    receipt = await payments.pay(AgentId("payee"), Money(amount=50), PaymentRef("p1"))
+    assert await payments.verify_payment(PaymentRef("p1")) == PaymentStatus.CONFIRMED
+    assert receipt.amount.amount == 50
+
+
+@given(
+    advances=st.integers(min_value=0, max_value=8),
+    rate=st.integers(min_value=1, max_value=20),
+)
+@settings(max_examples=100, deadline=None)
+@pytest.mark.asyncio
+async def test_conservation_under_stream_sequence(advances: int, rate: int) -> None:
+    """Conservation holds across open / advance / close sequences (PR #7 pattern)."""
+    max_total = rate * (advances + 2)
+    balances: dict[AgentId, int] = {AgentId("payer"): max_total * 2, AgentId("payee"): 0}
+    payments: dict[PaymentRef, object] = {}
+    streams: dict[PaymentRef, object] = {}
+    payer = StreamingPayments(
+        AgentId("payer"),
+        initial_balance=0,
+        balances=balances,
+        payments=payments,  # type: ignore[arg-type]
+        streams=streams,  # type: ignore[arg-type]
+    )
+    payee = StreamingPayments(
+        AgentId("payee"),
+        initial_balance=0,
+        balances=balances,
+        payments=payments,  # type: ignore[arg-type]
+        streams=streams,  # type: ignore[arg-type]
+    )
+    total_before = balances[AgentId("payer")] + balances[AgentId("payee")]
+    ref = PaymentRef("s-prop")
+    await payer.open_stream(AgentId("payee"), rate, max_total, ref)
+    for tick in range(1, advances + 1):
+        await payee.acknowledge_work(ref, tick=tick)
+        await payer.advance_stream(ref, tick)
+    await payer.close_stream(ref, current_tick=advances + 1)
+    total_after = balances[AgentId("payer")] + balances[AgentId("payee")]
+    assert total_before == total_after


### PR DESCRIPTION
- Implements open_stream/close_stream per spec 03-payments-streaming-x402
- Satisfies existing Payments protocol; one-shot pay() still works
- Adversarial tests: drain-after-close, over-bill-on-partition
- Adds scenarios/streaming_payments.yaml (5x5, 5% drop, deterministic)