### PR TITLE
payments/prepaid_credits: report REFUNDED status and burn refunded refs

### DIFF
--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/prepaid_credits.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/prepaid_credits.py
@@ -35,11 +35,15 @@ class PrepaidCredits:
         initial_balance: int = 1000,
         balances: dict[AgentId, int] | None = None,
         payments: dict[PaymentRef, Receipt] | None = None,
+        refunds: set[PaymentRef] | None = None,
     ) -> None:
         self._agent_id = agent_id
         self._balances = balances if balances is not None else {}
         self._balances.setdefault(agent_id, initial_balance)
         self._payments = payments if payments is not None else {}
+        # Pass the same set to every instance sharing a ledger (like
+        # ``balances``/``payments``) so refund status is visible to all parties.
+        self._refunds: set[PaymentRef] = refunds if refunds is not None else set()
 
     def balance(self, agent: AgentId) -> int:
         """Check an agent's balance.
@@ -92,6 +96,8 @@ class PrepaidCredits:
 
             status = await pay.verify_payment(PaymentRef("p1"))
         """
+        if ref in self._refunds:
+            return PaymentStatus.REFUNDED
         if ref in self._payments:
             return PaymentStatus.CONFIRMED
         return PaymentStatus.FAILED
@@ -107,6 +113,9 @@ class PrepaidCredits:
         if receipt is None:
             msg = f"Payment not found: {ref}"
             raise ValueError(msg)
+        if ref in self._refunds:
+            msg = f"Payment already refunded: {ref}"
+            raise ValueError(msg)
 
         payee_balance = self._balances.get(receipt.payee, 0)
         if payee_balance < receipt.amount.amount:
@@ -118,4 +127,7 @@ class PrepaidCredits:
 
         self._balances[receipt.payee] = payee_balance - receipt.amount.amount
         self._balances[receipt.payer] = self._balances.get(receipt.payer, 0) + receipt.amount.amount
-        del self._payments[ref]
+        # Keep the receipt: the ref stays burned (no silent reuse) and
+        # verify_payment reports REFUNDED instead of FAILED, matching the
+        # escrow plugin's terminal-state behavior.
+        self._refunds.add(ref)

--- a/packages/nest-plugins-reference/tests/test_plugins.py
+++ b/packages/nest-plugins-reference/tests/test_plugins.py
@@ -313,6 +313,61 @@ class TestPrepaidCredits:
         assert pay.balance(AgentId("a2")) == 0
 
     @pytest.mark.asyncio
+    async def test_verify_refunded_payment_reports_refunded(self) -> None:
+        from nest_plugins_reference.payments.prepaid_credits import PrepaidCredits
+
+        pay = PrepaidCredits(AgentId("a1"), initial_balance=1000)
+        await pay.pay(AgentId("a2"), Money(amount=100), PaymentRef("p1"))
+        await pay.refund(PaymentRef("p1"))
+
+        # A refunded payment is not the same as one that never happened.
+        assert await pay.verify_payment(PaymentRef("p1")) == PaymentStatus.REFUNDED
+
+    @pytest.mark.asyncio
+    async def test_refunded_ref_cannot_be_reused(self) -> None:
+        from nest_plugins_reference.payments.prepaid_credits import PrepaidCredits
+
+        pay = PrepaidCredits(AgentId("a1"), initial_balance=1000)
+        await pay.pay(AgentId("a2"), Money(amount=100), PaymentRef("p1"))
+        await pay.refund(PaymentRef("p1"))
+
+        # The ref stays burned after refund; replaying it must fail.
+        with pytest.raises(ValueError, match="Duplicate"):
+            await pay.pay(AgentId("a2"), Money(amount=100), PaymentRef("p1"))
+
+    @pytest.mark.asyncio
+    async def test_double_refund_rejected(self) -> None:
+        from nest_plugins_reference.payments.prepaid_credits import PrepaidCredits
+
+        pay = PrepaidCredits(AgentId("a1"), initial_balance=1000)
+        await pay.pay(AgentId("a2"), Money(amount=100), PaymentRef("p1"))
+        await pay.refund(PaymentRef("p1"))
+
+        with pytest.raises(ValueError, match="already refunded"):
+            await pay.refund(PaymentRef("p1"))
+
+    @pytest.mark.asyncio
+    async def test_shared_ledger_refund_visible_to_all_parties(self) -> None:
+        from nest_plugins_reference.payments.prepaid_credits import PrepaidCredits
+
+        balances = {AgentId("buyer"): 100, AgentId("seller"): 0}
+        payments: dict[PaymentRef, Receipt] = {}
+        refunds: set[PaymentRef] = set()
+        buyer = PrepaidCredits(
+            AgentId("buyer"), balances=balances, payments=payments, refunds=refunds
+        )
+        seller = PrepaidCredits(
+            AgentId("seller"), balances=balances, payments=payments, refunds=refunds
+        )
+
+        await buyer.pay(AgentId("seller"), Money(amount=40), PaymentRef("p1"))
+        await buyer.refund(PaymentRef("p1"))
+
+        assert buyer.balance(AgentId("buyer")) == 100
+        assert seller.balance(AgentId("seller")) == 0
+        assert await seller.verify_payment(PaymentRef("p1")) == PaymentStatus.REFUNDED
+
+    @pytest.mark.asyncio
     async def test_quote(self) -> None:
         from nest_plugins_reference.payments.prepaid_credits import PrepaidCredits
 


### PR DESCRIPTION
## Building block

Layer 7, Payments — the `prepaid_credits` reference plugin.

## Problem

`refund()` deleted the receipt from the ledger. Two real defects follow:

1. **Refunds are invisible.** `verify_payment()` on a refunded payment returns `FAILED` — indistinguishable from a payment that never happened. `PaymentStatus.REFUNDED` already exists in `nest_core.types`, and the escrow plugin already reports it as a terminal state; `prepaid_credits` was inconsistent with both.
2. **Refunded refs are replayable.** Deleting the receipt frees the `PaymentRef`, so the same ref can be paid again after a refund — silently bypassing the duplicate-reference protection that `pay()` otherwise enforces.

## Fix

- Keep the receipt in the (shareable) `payments` dict after refund, so the ref stays burned and duplicate protection keeps working across a shared ledger.
- Track refunded refs in a new `refunds: set[PaymentRef]` constructor parameter that mirrors the existing `balances`/`payments` shared-ledger pattern.
- `verify_payment()` now returns `PaymentStatus.REFUNDED` for refunded refs.
- A second `refund()` of the same ref raises `ValueError("Payment already refunded")` instead of the misleading "Payment not found".

Backwards compatible: the new parameter defaults to a fresh set, and all pre-existing tests pass unchanged.

## Tests

Four new tests in `TestPrepaidCredits`, each of which **fails on main and passes with this change** (verified by stashing the plugin change and re-running):

- `test_verify_refunded_payment_reports_refunded`
- `test_refunded_ref_cannot_be_reused`
- `test_double_refund_rejected`
- `test_shared_ledger_refund_visible_to_all_parties`

## CI

`make ci-local` passes end to end: `uv sync`, `ruff check`, `ruff format --check`, `pyright`, `pytest -v` (1154 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)