### PR TITLE
Make DataFacts freshness deterministic

### DIFF
--- a/packages/nest-plugins-reference/nest_plugins_reference/datafacts/datafacts_v1.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/datafacts/datafacts_v1.py
@@ -11,6 +11,7 @@ Example::
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 
 from nest_core.types import AccessGrant, AgentId, DataFactsUrl, DatasetMetadata
 
@@ -24,7 +25,22 @@ class DataFactsV1:
         url = await df.publish(meta)
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        clock: Callable[[], float] | None = None,
+        freshness_window_seconds: float = 3600.0,
+    ) -> None:
+        """Create a deterministic-friendly DataFacts registry.
+
+        Example::
+
+            df = DataFactsV1(clock=lambda: 0.0, freshness_window_seconds=60.0)
+        """
+        if freshness_window_seconds <= 0:
+            msg = f"Freshness window must be positive: {freshness_window_seconds}"
+            raise ValueError(msg)
+        self._clock = clock if clock is not None else time.time
+        self._freshness_window_seconds = freshness_window_seconds
         self._datasets: dict[DataFactsUrl, DatasetMetadata] = {}
         self._grants: dict[DataFactsUrl, list[AccessGrant]] = {}
         self._timestamps: dict[DataFactsUrl, float] = {}
@@ -38,7 +54,7 @@ class DataFactsV1:
         """
         url = DataFactsUrl(f"df://{dataset.name}")
         self._datasets[url] = dataset
-        self._timestamps[url] = time.time()
+        self._timestamps[url] = self._clock()
         return url
 
     async def fetch(self, url: DataFactsUrl) -> DatasetMetadata:
@@ -61,6 +77,9 @@ class DataFactsV1:
 
             grant = await df.request_access(url, AgentId("a2"))
         """
+        if url not in self._datasets:
+            msg = f"Dataset not found: {url}"
+            raise KeyError(msg)
         grant = AccessGrant(url=url, grantee=requester, tier="read")
         self._grants.setdefault(url, []).append(grant)
         return grant
@@ -75,4 +94,4 @@ class DataFactsV1:
         ts = self._timestamps.get(url)
         if ts is None:
             return False
-        return (time.time() - ts) < 3600
+        return (self._clock() - ts) < self._freshness_window_seconds

--- a/packages/nest-plugins-reference/tests/test_plugins.py
+++ b/packages/nest-plugins-reference/tests/test_plugins.py
@@ -7,6 +7,7 @@ import pytest
 from nest_core.types import (
     AgentCard,
     AgentId,
+    DataFactsUrl,
     DatasetMetadata,
     Evidence,
     Message,
@@ -504,6 +505,14 @@ class TestDataFactsV1:
         assert grant.tier == "read"
 
     @pytest.mark.asyncio
+    async def test_request_access_rejects_unknown_dataset(self) -> None:
+        from nest_plugins_reference.datafacts.datafacts_v1 import DataFactsV1
+
+        df = DataFactsV1()
+        with pytest.raises(KeyError, match="Dataset not found"):
+            await df.request_access(DataFactsUrl("df://missing"), AgentId("a2"))
+
+    @pytest.mark.asyncio
     async def test_verify_freshness(self) -> None:
         from nest_plugins_reference.datafacts.datafacts_v1 import DataFactsV1
 
@@ -513,8 +522,25 @@ class TestDataFactsV1:
         assert await df.verify_freshness(url) is True
 
     @pytest.mark.asyncio
+    async def test_verify_freshness_uses_injected_clock(self) -> None:
+        from nest_plugins_reference.datafacts.datafacts_v1 import DataFactsV1
+
+        now = 100.0
+
+        def clock() -> float:
+            return now
+
+        df = DataFactsV1(clock=clock, freshness_window_seconds=10.0)
+        url = await df.publish(DatasetMetadata(name="timed", owner=AgentId("a1")))
+
+        now = 109.0
+        assert await df.verify_freshness(url) is True
+
+        now = 111.0
+        assert await df.verify_freshness(url) is False
+
+    @pytest.mark.asyncio
     async def test_fetch_missing(self) -> None:
-        from nest_core.types import DataFactsUrl
         from nest_plugins_reference.datafacts.datafacts_v1 import DataFactsV1
 
         df = DataFactsV1()


### PR DESCRIPTION
## Summary
- Add an injectable clock and configurable freshness window to the DataFacts v1 reference plugin.
- Reject access grants for unpublished DataFacts URLs instead of minting dangling grants.
- Add regression coverage for deterministic freshness and unknown-dataset access requests.

## Why
DataFacts freshness previously depended directly on wall-clock time, which makes deterministic Tier-1 tests harder to write. The plugin also granted access to URLs that were never published, leaving callers with grants that could not resolve to metadata.

## Impact
Existing callers keep the same defaults. Tests and deterministic scenarios can now pass a fixed or controlled clock, and access requests now fail fast for unknown datasets.

## Validation
- `uv run pytest packages/nest-plugins-reference/tests/test_plugins.py::TestDataFactsV1 -v`
- `make ci-local` (1152 passed, 1 skipped, 1 deselected)
