### PR TITLE
[Hackathon] distributed-sys-engg: deterministic negotiation session ids (ADR-004 sibling fix)

### DIFF
--- a/packages/nest-plugins-reference/nest_plugins_reference/negotiation/_ids.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/negotiation/_ids.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic negotiation session identifiers.
+
+Nanda Town's core guarantee is a *byte-deterministic* JSONL trace: the same
+seed must replay to an identical trace so operators can ``diff`` two runs and
+``replay`` a failure. ADR-004 (seeded-determinism) makes that a hard rule and
+calls out unseeded RNG as a violation of it.
+
+The alternating-offers plugin previously minted a session id with
+:func:`uuid.uuid4`, which draws from ``os.urandom`` and is therefore
+**unseedable**: every run produced a fresh ``NegotiationSession`` id, so two
+runs of the *same* seed diverged on every opened negotiation and their traces
+could neither be diffed nor replayed. This is the negotiation-layer sibling of
+the coordination-layer fix (``coordination/_ids.py``).
+
+:func:`derive_session_id` replaces that with a pure function of the initiating
+agent, the partner, and a monotonic per-initiator sequence number. It is:
+
+- **deterministic** -- identical inputs always yield the identical id, so a
+  seeded run replays byte-for-byte;
+- **injective on its inputs** -- distinct ``(initiator, partner, seq)`` triples
+  map to distinct ids, because the pre-image is a length-prefixed encoding that
+  no two distinct triples can share (this rules out concatenation ambiguity
+  such as ``("ab", "c")`` vs ``("a", "bc")``);
+- **free of ambient state** -- no reliance on object identity, dict insertion
+  order, wall-clock time, or a global RNG.
+
+Example::
+
+    from nest_core.types import AgentId
+
+    sid = derive_session_id(AgentId("a1"), AgentId("a2"), 1)
+    assert sid == derive_session_id(AgentId("a1"), AgentId("a2"), 1)
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from nest_core.types import AgentId
+
+
+def derive_session_id(initiator: AgentId, partner: AgentId, seq: int) -> str:
+    """Return a deterministic, collision-resistant negotiation session id.
+
+    The id is ``"session-" + sha256(preimage)[:16]`` where ``preimage`` is a
+    length-prefixed (netstring-style) encoding of ``(initiator, partner, seq)``.
+    Length-prefixing makes the encoding injective, so distinct inputs cannot
+    alias onto the same digest through boundary ambiguity.
+
+    Args:
+        initiator: The agent opening the negotiation.
+        partner: The counterparty. Distinguishes sessions the same initiator
+            opens with different partners.
+        seq: A monotonic per-initiator counter. Distinguishes successive
+            sessions opened by the same initiator; the caller owns incrementing
+            it.
+
+    Example::
+
+        sid = derive_session_id(AgentId("a1"), AgentId("a2"), 1)
+    """
+    parts = (str(initiator), str(partner), str(seq))
+    preimage = "|".join(f"{len(p)}:{p}" for p in parts).encode("utf-8")
+    return "session-" + hashlib.sha256(preimage).hexdigest()[:16]

--- a/packages/nest-plugins-reference/nest_plugins_reference/negotiation/alternating_offers.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/negotiation/alternating_offers.py
@@ -9,8 +9,6 @@ Example::
 
 from __future__ import annotations
 
-import uuid
-
 from nest_core.types import (
     AgentId,
     Agreement,
@@ -19,6 +17,8 @@ from nest_core.types import (
     NegotiationStatus,
     Terms,
 )
+
+from ._ids import derive_session_id
 
 
 class AlternatingOffers:
@@ -34,16 +34,23 @@ class AlternatingOffers:
         self._agent_id = agent_id
         self._patience = patience
         self._sessions: dict[str, NegotiationSession] = {}
+        self._session_seq = 0
 
     async def open(self, partner: AgentId, terms: Terms) -> NegotiationSession:
         """Open a negotiation with initial terms.
+
+        The session id is derived deterministically from the initiating agent,
+        the partner, and a monotonic per-initiator sequence number, so a seeded
+        run replays byte-for-byte (ADR-004) instead of drawing a fresh ``uuid4``
+        each run. See :func:`._ids.derive_session_id`.
 
         Example::
 
             session = await neg.open(AgentId("a2"), terms)
         """
+        self._session_seq += 1
         session = NegotiationSession(
-            id=str(uuid.uuid4()),
+            id=derive_session_id(self._agent_id, partner, self._session_seq),
             initiator=self._agent_id,
             partner=partner,
             status=NegotiationStatus.OPEN,

--- a/packages/nest-plugins-reference/tests/test_negotiation_determinism.py
+++ b/packages/nest-plugins-reference/tests/test_negotiation_determinism.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Determinism regression tests for negotiation session identifiers.
+
+These tests fail against the previous ``uuid.uuid4`` implementation of
+``AlternatingOffers.open`` (which minted a fresh id every run) and pass once
+session ids are derived deterministically from ``(initiator, partner, seq)``.
+They pin ADR-004 (seeded-determinism) for the negotiation layer: the same
+logical sequence of opened negotiations must produce byte-identical ids across
+independent runs, so a seeded trace can be diffed and replayed. Sibling of
+``test_coordination_determinism`` for the coordination layer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from hypothesis import given
+from hypothesis import strategies as st
+from nest_core.types import AgentId, Money, Terms
+from nest_plugins_reference.negotiation._ids import derive_session_id
+from nest_plugins_reference.negotiation.alternating_offers import AlternatingOffers
+
+
+def _terms() -> Terms:
+    return Terms(price=Money(amount=100))
+
+
+async def _open_ids(neg: AlternatingOffers, partner: AgentId, n: int) -> list[str]:
+    """Return the session ids from opening ``n`` successive negotiations."""
+    return [(await neg.open(partner, _terms())).id for _ in range(n)]
+
+
+class TestReplayDeterminism:
+    """The same logical run must produce byte-identical session ids."""
+
+    async def test_open_replays_identically(self) -> None:
+        run1 = await _open_ids(AlternatingOffers(AgentId("a1")), AgentId("a2"), 5)
+        run2 = await _open_ids(AlternatingOffers(AgentId("a1")), AgentId("a2"), 5)
+        assert run1 == run2
+
+
+class TestUniqueness:
+    """Distinct sessions must still get distinct ids (no regression in function)."""
+
+    async def test_successive_sessions_are_distinct(self) -> None:
+        ids = await _open_ids(AlternatingOffers(AgentId("a1")), AgentId("a2"), 50)
+        assert len(set(ids)) == len(ids)
+
+    async def test_distinct_partners_are_distinct(self) -> None:
+        neg = AlternatingOffers(AgentId("a1"))
+        a = (await neg.open(AgentId("a2"), _terms())).id
+        b = (await neg.open(AgentId("a3"), _terms())).id
+        assert a != b
+
+    async def test_distinct_initiators_are_distinct(self) -> None:
+        a = (await AlternatingOffers(AgentId("x")).open(AgentId("p"), _terms())).id
+        b = (await AlternatingOffers(AgentId("y")).open(AgentId("p"), _terms())).id
+        assert a != b
+
+
+class TestDeriveSessionId:
+    """Unit properties of the id derivation itself."""
+
+    def test_is_pure(self) -> None:
+        assert derive_session_id(AgentId("a1"), AgentId("a2"), 1) == derive_session_id(
+            AgentId("a1"), AgentId("a2"), 1
+        )
+
+    def test_uses_no_ambient_state(self) -> None:
+        # Recomputing after unrelated work (which would perturb any RNG or
+        # clock-based scheme) yields the identical id.
+        first = derive_session_id(AgentId("a1"), AgentId("a2"), 7)
+        _ = [hashlib.sha256(str(i).encode()).hexdigest() for i in range(1000)]
+        assert derive_session_id(AgentId("a1"), AgentId("a2"), 7) == first
+
+    def test_encoding_is_injective(self) -> None:
+        # Length-prefixing prevents boundary-ambiguity collisions that plain
+        # concatenation would allow.
+        assert derive_session_id(AgentId("ab"), AgentId("c"), 0) != derive_session_id(
+            AgentId("a"), AgentId("bc"), 0
+        )
+
+    @given(
+        initiator=st.text(min_size=1, max_size=16),
+        partner=st.text(min_size=1, max_size=16),
+        seq=st.integers(min_value=0, max_value=1_000_000),
+    )
+    def test_deterministic_over_arbitrary_inputs(self, initiator: str, partner: str, seq: int) -> None:
+        assert derive_session_id(AgentId(initiator), AgentId(partner), seq) == derive_session_id(
+            AgentId(initiator), AgentId(partner), seq
+        )


### PR DESCRIPTION
# Deterministic negotiation session ids (ADR-004 fix for `alternating_offers`)

**Persona:** `distributed-sys-engg` — reliability/determinism focus.

Sibling to the coordination-layer round-id PR (requested by the reviewer there:
"send it scoped to the negotiation layer the same way"). Same bug, same fix,
different layer.

## Motivation

`ADR-004-seeded-determinism` requires that the same seed replay to an identical
trace, so operators can diff two runs or replay a failure. The alternating-offers
plugin breaks it: `open()` mints its `NegotiationSession` id with
`uuid.uuid4()`, which draws from `os.urandom` and is unseedable. Two runs of the
same seed produce different session ids on every opened negotiation — the
plugin's public output is not reproducible.

Stated plainly: this is a latent bug today. No shipped scenario serializes the
session id into its trace, which is why it's gone unnoticed. But `open()` is a
public API with nondeterministic output, and any negotiation scenario or
validator that starts using session ids directly would silently inherit a trace
that can't be diffed or replayed.

## The change

Add `negotiation/_ids.py::derive_session_id(initiator, partner, seq)` and use it
in `open()`. The id is:

- Deterministic: a pure function of `(initiator, partner, monotonic
  per-initiator sequence)`. A seeded run replays byte-for-byte.
- Injective on its inputs: the pre-image is a length-prefixed (netstring-style)
  encoding, so distinct triples can't alias onto one digest through boundary
  ambiguity (`("ab","c")` vs `("a","bc")`).
- Free of ambient state: no `uuid4`, no wall clock, no object identity, no
  dict-ordering dependence.

`AlternatingOffers` keeps a private `_session_seq` counter. The sim drives
`open()` in a seeded, deterministic order, so the counter, and thus the id,
reproduces. Mirrors `coordination/_ids.py` exactly.

## Tests — fail without the change, pass with it

`packages/nest-plugins-reference/tests/test_negotiation_determinism.py`:

- Replay identity: opening the same negotiation sequence twice yields
  byte-identical ids. This is the check that fails against `uuid4`.
- Uniqueness: successive sessions, distinct partners, and distinct initiators
  all still get distinct ids (no functional regression).
- Derivation properties: purity, no ambient state, injective encoding, and a
  Hypothesis property over arbitrary inputs.

## Verification

Local: `test_negotiation_determinism` 8/8 pass; the wider negotiation/market
suites (`test_pareto_negotiation`, `test_plugins`, `test_multi_attribute_market`,
`test_hotstuff_properties`) all pass unchanged (66 total), confirming no
regression. Please run `make ci-local` for the full gate.
