### PR TITLE
fix(lint): E501 on main — wrap 103-char test signature from #184

### DIFF
--- a/packages/nest-plugins-reference/tests/test_negotiation_determinism.py
+++ b/packages/nest-plugins-reference/tests/test_negotiation_determinism.py
@@ -85,7 +85,9 @@ class TestDeriveSessionId:
         partner=st.text(min_size=1, max_size=16),
         seq=st.integers(min_value=0, max_value=1_000_000),
     )
-    def test_deterministic_over_arbitrary_inputs(self, initiator: str, partner: str, seq: int) -> None:
+    def test_deterministic_over_arbitrary_inputs(
+        self, initiator: str, partner: str, seq: int
+    ) -> None:
         assert derive_session_id(AgentId(initiator), AgentId(partner), seq) == derive_session_id(
             AgentId(initiator), AgentId(partner), seq
         )


### PR DESCRIPTION
`make ci-local` currently fails on main itself: `ruff check` reports E501 (103 > 100) at `packages/nest-plugins-reference/tests/test_negotiation_determinism.py:88`, introduced in #184. Every open hackathon branch rebased onto main inherits the red gate.

One-line wrap of the test signature, identical to `ruff format` output.

Verified: `ruff check` clean, `ruff format --check` clean, `pytest packages/nest-plugins-reference/tests/test_negotiation_determinism.py` 8/8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)