### PR TITLE
docs(registry): capability-conformance plugin note for #159

### DIFF
--- a/docs/layers/registry.md
+++ b/docs/layers/registry.md
@@ -117,6 +117,91 @@ See
 for the full FAIL/PASS matrix (validators x plugins x scenarios) and every
 honest limitation found while building this plugin.
 
+## Capability-conformance plugin: `verified_capabilities`
+
+`verified_capabilities` -- closes a gap none of the identity-focused registry
+plugins touch. `AgentCard.capabilities` is a bare, self-asserted `list[str]`;
+`ed25519_rotating` and `byzantine_gossip` verify who published a card and that
+its content wasn't forged in transit, and `agent_receipts`/`score_average`
+score an agent's reputation *overall* -- but nothing checks a specific
+capability claim against whether the agent has ever actually fulfilled it. An
+agent can register `capabilities=["sell"]` with a perfectly valid signature
+and stay discoverable via that claim forever, even if it never completes a
+single sale. This is the exact gap A2A v1.0's signed Agent Cards and NANDA's
+Verified AgentFacts layer both name and neither closes: a signature proves
+the publisher, not the capability.
+
+`verified_capabilities` wraps an inner registry and tracks
+fulfillment/defection evidence **per `(agent_id, capability)` pair**, not per
+agent:
+
+* **Bootstrap allowance.** A pair with no evidence yet is never excluded --
+  discovery cannot punish a claim nobody has tested.
+* **Per-capability exclusion.** Once a pair accumulates `defection_threshold`
+  defections (default 1, justified against this scenario's zero
+  message-drop rate), `lookup` stops returning that agent for queries naming
+  that capability. A defection on `"sell"` does not affect the same agent's
+  `"deliver"` capability -- the gate is on the claim, not the identity.
+* **Re-admission, not blacklisting.** A single `report_fulfillment` call
+  resets that pair's defection count to zero. This is a documented
+  trade-off, not an oversight: an attacker who fulfills once per
+  `defection_threshold - 1` defections evades exclusion indefinitely.
+  Closing that requires a windowed or decaying counter, out of scope here.
+
+`report_fulfillment`/`report_defection` are not part of the `Registry`
+Protocol -- callers (agents, scenario factories, tests) call them directly on
+the concrete instance, the same way `GossipRegistry` exposes `gossip_round`
+beyond the interface it implements.
+
+Source:
+[`nest_plugins_reference/registry/verified_capabilities.py`](../../packages/nest-plugins-reference/nest_plugins_reference/registry/verified_capabilities.py).
+
+### Validator
+
+[`validators/capability_validators.py`](../../packages/nest-plugins-reference/nest_plugins_reference/validators/capability_validators.py)'s
+`check_capability_conformance` asserts the one property that actually
+distinguishes a real skill from an advertised one: after enough observed
+defections, the registry must stop returning the claimant for that
+capability. Registry `lookup` calls aren't traced (`nest_core.sim.simulator`
+traces send/broadcast/deliver/receive events only), so this validator isn't a
+trace parser -- it runs directly against `ScenarioRunner.resolved_plugins["registry"]`,
+the same pattern `registry_byzantine_validators`/`gossip_validators` use for
+properties that live in plugin state rather than message content. It checks
+two things together, so a gate that blocks everyone can't pass by accident:
+no spoofer is still discoverable, and every honest seller still is.
+
+### Demo scenario
+
+[`scenarios/capability_spoofing.yaml`](../../scenarios/capability_spoofing.yaml) --
+3 honest sellers, 2 always-silent spoofers, 1 bait-and-switch seller (fulfills
+once, then goes silent), 5 buyers. Buyers discover sellers via
+`registry.lookup(Query(capabilities=["sell"]))`, send one outstanding `buy:`
+at a time, and self-schedule a `TIMEOUT:<round>` tick; a `sold:` response
+before the timeout reports a fulfillment, the timeout firing first reports a
+defection. Deterministic under seeds 42, 7, 1337, with a
+byte-identical-trace determinism test.
+
+Literal output, same scenario YAML, only `layers.registry` overridden:
+
+```
+registry='in_memory'             passed=False detail="still discoverable for 'sell': ['baitswitch-0', 'spoofer-0', 'spoofer-1']"
+registry='verified_capabilities' passed=True  detail="3 spoofer(s) excluded from 'sell', 3 honest agent(s) still discoverable"
+```
+
+```bash
+uv sync
+
+# Unit + scenario test suite:
+uv run pytest packages/nest-plugins-reference/tests/test_verified_capabilities.py \
+              packages/nest-plugins-reference/tests/test_capability_spoofing_scenario.py -v
+
+# Run the scenario directly:
+uv run nest run scenarios/capability_spoofing.yaml
+
+# The whole CI gate:
+make ci-local
+```
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md). Register under

--- a/packages/nest-plugins-reference/tests/test_negotiation_determinism.py
+++ b/packages/nest-plugins-reference/tests/test_negotiation_determinism.py
@@ -85,7 +85,9 @@ class TestDeriveSessionId:
         partner=st.text(min_size=1, max_size=16),
         seq=st.integers(min_value=0, max_value=1_000_000),
     )
-    def test_deterministic_over_arbitrary_inputs(self, initiator: str, partner: str, seq: int) -> None:
+    def test_deterministic_over_arbitrary_inputs(
+        self, initiator: str, partner: str, seq: int
+    ) -> None:
         assert derive_session_id(AgentId(initiator), AgentId(partner), seq) == derive_session_id(
             AgentId(initiator), AgentId(partner), seq
         )


### PR DESCRIPTION
## Problem

#159 (capability-conformance registry gate, merged) shipped the
`verified_capabilities` plugin, validator, and scenario without a
`docs/layers/registry.md` entry, unlike #148's `byzantine_gossip` section.
The merged commit also carried a `Co-Authored-By: Claude Sonnet 5` footer,
per reviewer feedback that should not recur in follow-up commits.

## Change

- Adds a `## Capability-conformance plugin: verified_capabilities`
  subsection to `docs/layers/registry.md`, mirroring #148's
  `byzantine_gossip` section: threat model, mechanism (bootstrap allowance,
  per-capability exclusion, re-admission), validator description, and demo
  scenario with the literal FAIL/PASS output and the exact test commands.
- No code changes; no other doc sections touched.

## Test

`make ci-local`: 1282 passed, 1 skipped, 1 deselected, all 5 checks green.

## Fit

Same documentation pattern #148 already established for a hardened registry
plugin variant, applied to `verified_capabilities`.

## Note

Includes a one-line lint fix for a pre-existing ruff failure on main
introduced by #184 (test_negotiation_determinism.py:88), isolated in its
own commit so the docs change stays clean.