### PR TITLE
[Hackathon] Redeem_Grimm: extract reusable heartbeat authenticator, make the forgery discriminator a component swap

### DIFF
--- a/packages/nest-core/nest_core/scenarios_builtin/failure_detection.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/failure_detection.py
@@ -23,12 +23,15 @@ The accuracy validator in :mod:`nest_core.validators` is tuned to separate the
 two: the baseline fails it, phi-accrual passes.
 
 **Authenticated heartbeats.**  Every heartbeat is signed with the emitter's
-identity plugin and carries its emission timestamp:
-``FDHB|<id>|<ts>|<sig-hex>``.  The observer verifies the signature against the
-claimed peer's registered public key and requires the signed timestamp to be
-strictly newer than the last accepted one from that peer (and not from the
-future), so both fabricated and replayed heartbeats are rejected.  Verification
-lives in the observing agent, not in the detector: the
+identity plugin and carries its emission timestamp: ``FDHB|<id>|<ts>|<sig-hex>``.
+The wire format and the verifiers live in the reusable
+:mod:`nest_plugins_reference.failure_detection.heartbeat_auth` component, so any
+scenario can authenticate heartbeats the same way.  The observer holds a
+:class:`~nest_plugins_reference.failure_detection.heartbeat_auth.HeartbeatAuthenticator`;
+the signed one accepts a beat only if its signature verifies against the claimed
+peer's registered key and its timestamp is fresh (strictly newer than the last
+accepted, and not from the future), so both fabricated and replayed heartbeats
+are rejected.  Authentication lives in that component, not in the detector: the
 :class:`~nest_core.layers.failure_detector.FailureDetector` contract stays a
 pure liveness oracle over *accepted* observations.
 
@@ -37,12 +40,15 @@ The forgery scenario (``scenarios/failure_detection_forgery.yaml``, task type
 keep-alive attack: while the victim is genuinely down, the forger keeps
 broadcasting heartbeats that *claim* to be the victim — both fabricated
 payloads signed with the forger's own key and byte-exact replays of captured
-genuine beats.  With ``verify_heartbeats: true`` (the default) the observer
-rejects every forgery and the outage is detected; with the trusting mode
-(``verify_heartbeats: false``, the foil) the forged liveness masks the crash
-and the ``failure_detection_no_forged_liveness`` validator fails.  This is the
-same discriminator pattern the base scenario uses against the fixed-timeout
-baseline, applied to an attack class instead of an implementation mistake.
+genuine beats.  The discriminator is a **component swap**: with ``hb_auth:
+signed`` (the default) the observer rejects every forgery and the outage is
+detected; with ``hb_auth: trusting`` (the foil, the naive believe-the-claimed-id
+baseline) the forged liveness masks the crash and the
+``failure_detection_no_forged_liveness`` validator fails.  This mirrors how the
+base scenario swaps ``phi_accrual`` for the fixed-timeout ``heartbeat`` detector,
+applied to an attack class instead of an implementation mistake.  The older
+boolean ``verify_heartbeats: true|false`` still works as an alias for ``hb_auth:
+signed|trusting``.
 
 Ground truth is not inferred — the emitters broadcast ``fd:phase`` marker events
 at start and on every reachability transition, and the observer broadcasts one
@@ -65,13 +71,19 @@ Example::
 from __future__ import annotations
 
 import json
-import math
 from typing import Any, cast
+
+from nest_plugins_reference.failure_detection.heartbeat_auth import (
+    HeartbeatAuthenticator,
+    claimed_peer,
+    heartbeat_payload,
+    make_heartbeat_authenticator,
+)
 
 from nest_core.layers.failure_detector import FailureDetector
 from nest_core.scenario import ScenarioConfig
 from nest_core.sim.agent import AgentContext, StateMachineAgent
-from nest_core.types import AgentId, Signature
+from nest_core.types import AgentId
 
 HB_TICK = b"FD_HB_TICK"
 """Payload tag for an emitter's periodic self-message that triggers a heartbeat."""
@@ -81,16 +93,6 @@ EVAL_TICK = b"FD_EVAL_TICK"
 
 FORGE_TICK = b"FD_FORGE_TICK"
 """Payload tag for the forger's periodic self-message that triggers an attack round."""
-
-_HB_PREFIX = "FDHB|"
-"""Marker prefix identifying a heartbeat broadcast."""
-
-_HB_ALGORITHM = "sim-rsa-sha256"
-"""Algorithm tag stamped on reconstructed heartbeat signatures.
-
-The reference identity plugins verify by key material and ignore this field;
-it is carried for trace forensics only.
-"""
 
 IDENTITY_SEED = b"fd-heartbeat-v1"
 """Deterministic key-derivation seed shared by every agent's identity instance."""
@@ -118,101 +120,6 @@ DEFAULT_VERIFY_HEARTBEATS = True
 
 DEFAULT_FORGERY_VICTIM = "target-0"
 """Default peer the forger impersonates in the forgery scenario."""
-
-
-def heartbeat_payload(identity: Any, agent_id: AgentId, now: float) -> bytes:
-    """Return a signed heartbeat payload ``FDHB|<id>|<ts>|<sig-hex>``.
-
-    The signature covers ``FDHB|<id>|<ts>`` exactly as serialized, so a
-    verifier can rebuild the signed bytes from the wire text without float
-    round-tripping.  When *identity* is ``None`` the unsigned prefix form is
-    emitted (usable only by a trusting observer).
-
-    Example::
-
-        payload = heartbeat_payload(identity, AgentId("peer-0"), 12.5)
-    """
-    base = f"{_HB_PREFIX}{agent_id}|{round(now, 6)}"
-    if identity is None:
-        return base.encode()
-    sig = identity.sign(base.encode())
-    return f"{base}|{sig.value.hex()}".encode()
-
-
-def claimed_peer(payload: bytes) -> AgentId | None:
-    """Return the peer id a heartbeat payload *claims*, with no authentication.
-
-    This is the trusting parse: it believes whatever id the payload names,
-    which is exactly the spoofable behavior the forgery scenario attacks.
-
-    Example::
-
-        peer = claimed_peer(b"FDHB|peer-0|12.5|abcd")
-    """
-    text = payload.decode("utf-8", "replace")
-    if not text.startswith(_HB_PREFIX):
-        return None
-    claimed = text[len(_HB_PREFIX) :].split("|", 1)[0]
-    if not claimed:
-        return None
-    return AgentId(claimed)
-
-
-def verify_heartbeat(
-    identity: Any,
-    payload: bytes,
-    last_ts: dict[AgentId, float],
-    now: float,
-) -> tuple[AgentId, float] | None:
-    """Return ``(peer, ts)`` if *payload* is an authentic, fresh heartbeat.
-
-    Rejects the payload unless every check passes:
-
-    * well-formed ``FDHB|<id>|<ts>|<sig-hex>`` wire format;
-    * the signed timestamp is not from the future and is strictly newer than
-      the last accepted heartbeat from that peer (defeats replay);
-    * the signature verifies against the *claimed* peer's registered public
-      key (defeats fabrication — a forger signing with its own key fails).
-
-    Verification does not consult transport metadata, so it holds even on a
-    transport whose sender field cannot be trusted.
-
-    Example::
-
-        accepted = verify_heartbeat(identity, payload, last_ts={}, now=12.5)
-    """
-    text = payload.decode("utf-8", "replace")
-    if not text.startswith(_HB_PREFIX):
-        return None
-    fields = text[len(_HB_PREFIX) :].split("|")
-    if len(fields) != 3:
-        return None
-    claimed, ts_text, sig_hex = fields
-    if not claimed:
-        return None
-    try:
-        ts = float(ts_text)
-        sig_bytes = bytes.fromhex(sig_hex)
-    except ValueError:
-        return None
-    # A non-finite timestamp (nan/inf) would slip the IEEE-754 comparisons
-    # below, so reject it outright.  Genuine beats always carry ``round(now, 6)``.
-    if not math.isfinite(ts):
-        return None
-    peer = AgentId(claimed)
-    # The signed ts is quantized to 6 dp, so it can round a hair above the
-    # observer's exact ``now`` on the same zero-latency tick; compare against
-    # the same quantum rather than raw ``now`` so genuine beats are not read as
-    # future-dated.  Replays are still caught by the strict freshness check.
-    if ts > round(now, 6) or ts <= last_ts.get(peer, float("-inf")):
-        return None
-    if identity is None:
-        return None
-    base = f"{_HB_PREFIX}{claimed}|{ts_text}"
-    sig = Signature(signer=peer, value=sig_bytes, algorithm=_HB_ALGORITHM)
-    if not identity.verify(base.encode(), sig, peer):
-        return None
-    return peer, ts
 
 
 def _phase_payload(peer: AgentId, reachable: bool, now: float) -> bytes:
@@ -425,14 +332,15 @@ class ByzantineForgerAgent(StateMachineAgent):
 class FailureMonitorAgent(StateMachineAgent):
     """Drive one failure detector and periodically publish suspicion verdicts.
 
-    The detector is injected as the per-agent ``failure_detector`` plugin and
-    the observer's identity (with every peer's public key registered) as the
-    ``identity`` plugin.  In the default verifying mode, a heartbeat is fed to
-    the detector only after its signature and freshness pass
-    :func:`verify_heartbeat`; in the trusting mode (``verify=False``, the forgery
-    scenario's foil) the claimed peer id is believed outright.  On each
-    evaluation self-tick the agent reports, for every watched peer, a
-    ``fd:status`` broadcast carrying the boolean verdict plus the current
+    The detector is injected as the per-agent ``failure_detector`` plugin.  Each
+    received heartbeat is handed to the injected
+    :class:`~nest_plugins_reference.failure_detection.heartbeat_auth.HeartbeatAuthenticator`,
+    which either accepts it as a genuine ``(peer, ts)`` observation or rejects
+    it; only accepted beats reach the detector.  Swapping a
+    ``SignedHeartbeatAuthenticator`` for a ``TrustingHeartbeatAuthenticator`` is
+    what turns authentication on or off, so the agent itself has no verify/trust
+    branch.  On each evaluation self-tick the agent reports, for every watched
+    peer, a ``fd:status`` broadcast carrying the boolean verdict plus the current
     ``phi`` and elapsed silence (the latter two are informational — the
     validators key off the verdict and the broadcast's own timestamp).
 
@@ -440,21 +348,21 @@ class FailureMonitorAgent(StateMachineAgent):
 
         agent = FailureMonitorAgent(
             watched=[AgentId("target-0"), AgentId("peer-0")], eval_interval=3.0,
+            authenticator=SignedHeartbeatAuthenticator(identity),
         )
     """
 
     def __init__(
         self,
         watched: list[AgentId],
+        authenticator: HeartbeatAuthenticator,
         eval_interval: float = DEFAULT_EVAL_INTERVAL,
         hb_max: float = DEFAULT_HB_MAX,
-        verify: bool = DEFAULT_VERIFY_HEARTBEATS,
     ) -> None:
         self._watched = watched
+        self._authenticator = authenticator
         self._eval_interval = eval_interval
         self._hb_max = hb_max
-        self._verify = verify
-        self._last_hb_ts: dict[AgentId, float] = {}
 
     async def on_start(self, ctx: AgentContext) -> None:
         """Broadcast the ``fd:config`` marker and arm the first evaluation tick.
@@ -463,7 +371,7 @@ class FailureMonitorAgent(StateMachineAgent):
 
             await agent.on_start(ctx)
         """
-        await ctx.broadcast(_config_payload(self._hb_max, self._verify, ctx.time))
+        await ctx.broadcast(_config_payload(self._hb_max, self._authenticator.verifies, ctx.time))
         await ctx.schedule(self._eval_interval, EVAL_TICK)
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
@@ -494,21 +402,13 @@ class FailureMonitorAgent(StateMachineAgent):
                 await ctx.broadcast(body)
             await ctx.schedule(self._eval_interval, EVAL_TICK)
             return
-        if self._verify:
-            accepted = verify_heartbeat(
-                ctx.plugins.get("identity"), payload, self._last_hb_ts, ctx.time
-            )
-            if accepted is None:
-                return
-            hb_peer, hb_ts = accepted
-            if hb_peer == ctx.agent_id:
-                return
-            self._last_hb_ts[hb_peer] = hb_ts
-            await fd.heartbeat(hb_peer, now=ctx.time)
+        accepted = self._authenticator.accept(payload, now=ctx.time)
+        if accepted is None:
             return
-        hb_peer = claimed_peer(payload)
-        if hb_peer is not None and hb_peer != ctx.agent_id:
-            await fd.heartbeat(hb_peer, now=ctx.time)
+        hb_peer, _hb_ts = accepted
+        if hb_peer == ctx.agent_id:
+            return
+        await fd.heartbeat(hb_peer, now=ctx.time)
 
 
 def failure_detection_factory(
@@ -522,10 +422,11 @@ def failure_detection_factory(
     :class:`HeartbeatEmitterAgent`, a ``forger`` role becomes a
     :class:`ByzantineForgerAgent` impersonating ``forgery_victim``, and any
     other emitter role (e.g. ``peer``) becomes a never-silent emitter.  The
-    detector kind, its parameters, and the ``verify_heartbeats`` mode come from
-    ``task.config`` so the same scenario can be re-run with the baseline or the
-    accrual detector, and with or without heartbeat authentication.  The same
-    factory serves both the ``failure_detection`` and
+    detector kind, its parameters, and the ``hb_auth`` authenticator (``signed``
+    or ``trusting``, with the boolean ``verify_heartbeats`` accepted as an alias)
+    come from ``task.config`` so the same scenario can be re-run with the baseline
+    or the accrual detector, and with or without heartbeat authentication.  The
+    same factory serves both the ``failure_detection`` and
     ``failure_detection_forgery`` task types; the difference is purely which
     roles the YAML declares.
 
@@ -552,7 +453,14 @@ def failure_detection_factory(
     silent_from = float(task_cfg.get("silent_from", DEFAULT_SILENT_FROM))
     silent_until = float(task_cfg.get("silent_until", DEFAULT_SILENT_UNTIL))
     fd_plugin = str(task_cfg.get("fd_plugin", DEFAULT_FD_PLUGIN))
+    # ``hb_auth`` selects the heartbeat authenticator as a swappable component
+    # ("signed" | "trusting").  The older boolean ``verify_heartbeats`` is kept
+    # as an alias: when ``hb_auth`` is unset it maps True -> "signed",
+    # False -> "trusting", so existing scenario configs keep working unchanged.
     verify_heartbeats = bool(task_cfg.get("verify_heartbeats", DEFAULT_VERIFY_HEARTBEATS))
+    hb_auth = str(task_cfg.get("hb_auth", "")).strip().lower()
+    if not hb_auth:
+        hb_auth = "signed" if verify_heartbeats else "trusting"
     forgery_victim = AgentId(str(task_cfg.get("forgery_victim", DEFAULT_FORGERY_VICTIM)))
     raw_fd_params = task_cfg.get("fd_params", {})
     fd_params: dict[str, Any] = (
@@ -612,9 +520,9 @@ def failure_detection_factory(
     for oid in observer_ids:
         agents[oid] = FailureMonitorAgent(
             watched=list(emitter_ids),
+            authenticator=make_heartbeat_authenticator(hb_auth, identities[oid]),
             eval_interval=eval_interval,
             hb_max=hb_max,
-            verify=verify_heartbeats,
         )
     for eid in emitter_ids:
         sfrom, suntil = emitter_silence[eid]

--- a/packages/nest-plugins-reference/nest_plugins_reference/failure_detection/heartbeat_auth.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/failure_detection/heartbeat_auth.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Authenticated heartbeat wire format and pluggable heartbeat verifiers.
+
+A liveness observer that reads heartbeats off a broadcast medium has to answer
+one question about every beat it receives: *did the peer this beat claims to be
+from actually send it?*  Trusting the id printed in the payload is the naive
+answer, and it is exactly the spoofing hole a Byzantine peer exploits to keep a
+crashed peer looking alive.  This module packages the authenticated wire format
+and two swappable verifiers so any scenario -- not just failure detection -- can
+reuse them and pick a verifier the same way it picks any other component.
+
+The wire format is ``FDHB|<id>|<ts>|<sig-hex>``: the sender id, the emission
+timestamp, and a signature over ``FDHB|<id>|<ts>``.  It is deterministic (the
+timestamp is quantized to 6 dp and the signature is reconstructed from the raw
+wire text, never a re-parsed float), so traces replay byte-for-byte.
+
+A :class:`HeartbeatAuthenticator` turns a received payload into an accepted
+``(peer, ts)`` or rejects it:
+
+* :class:`SignedHeartbeatAuthenticator` requires a valid signature by the
+  claimed peer's registered key and a strictly-increasing, non-future
+  timestamp, so fabricated and replayed beats are both rejected.
+* :class:`TrustingHeartbeatAuthenticator` believes the claimed id outright.  It
+  is the naive baseline a discriminating scenario runs as its foil.
+
+Swapping one for the other is how the failure-detection forgery scenario turns
+"does authentication matter?" into a component swap rather than a code branch,
+mirroring how it swaps ``phi_accrual`` for ``heartbeat`` to test the detector.
+
+Example::
+
+    auth = SignedHeartbeatAuthenticator(observer_identity)
+    beat = heartbeat_payload(peer_identity, AgentId("peer-0"), now=12.5)
+    accepted = auth.accept(beat, now=12.5)  # -> (AgentId("peer-0"), 12.5)
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Protocol
+
+from nest_core.types import AgentId, Signature
+
+HB_PREFIX = "FDHB|"
+"""Marker prefix identifying a heartbeat broadcast; the rest is ``<id>|<ts>|<sig>``."""
+
+HB_ALGORITHM = "sim-rsa-sha256"
+"""Algorithm tag stamped on reconstructed heartbeat signatures.
+
+The reference identity plugins verify by key material and ignore this field; it
+is carried for trace forensics only.
+"""
+
+
+def heartbeat_payload(identity: Any, agent_id: AgentId, now: float) -> bytes:
+    """Return a signed heartbeat payload ``FDHB|<id>|<ts>|<sig-hex>``.
+
+    The signature covers ``FDHB|<id>|<ts>`` exactly as serialized, so a verifier
+    can rebuild the signed bytes from the wire text without float round-tripping.
+    When *identity* is ``None`` the unsigned prefix form is emitted (usable only
+    by a trusting observer).
+
+    Example::
+
+        payload = heartbeat_payload(identity, AgentId("peer-0"), 12.5)
+    """
+    base = f"{HB_PREFIX}{agent_id}|{round(now, 6)}"
+    if identity is None:
+        return base.encode()
+    sig = identity.sign(base.encode())
+    return f"{base}|{sig.value.hex()}".encode()
+
+
+def claimed_peer(payload: bytes) -> AgentId | None:
+    """Return the peer id a heartbeat payload *claims*, with no authentication.
+
+    This is the trusting parse: it believes whatever id the payload names, which
+    is exactly the spoofable behavior the forgery scenario attacks.
+
+    Example::
+
+        peer = claimed_peer(b"FDHB|peer-0|12.5|abcd")
+    """
+    text = payload.decode("utf-8", "replace")
+    if not text.startswith(HB_PREFIX):
+        return None
+    claimed = text[len(HB_PREFIX) :].split("|", 1)[0]
+    if not claimed:
+        return None
+    return AgentId(claimed)
+
+
+class HeartbeatAuthenticator(Protocol):
+    """Decide whether a received heartbeat payload is an acceptable observation.
+
+    ``name`` identifies the verifier for selection and logging; ``verifies`` is
+    ``True`` when the verifier authenticates beats (used by callers to annotate
+    the trace).  ``accept`` returns the accepted ``(peer, ts)`` or ``None``.
+
+    Example::
+
+        auth: HeartbeatAuthenticator = SignedHeartbeatAuthenticator(identity)
+    """
+
+    name: str
+    verifies: bool
+
+    def accept(self, payload: bytes, *, now: float) -> tuple[AgentId, float] | None:
+        """Return ``(peer, ts)`` if the beat is acceptable at *now*, else ``None``.
+
+        Example::
+
+            accepted = auth.accept(payload, now=12.5)
+        """
+        ...
+
+
+class TrustingHeartbeatAuthenticator:
+    """Accept a heartbeat on the strength of its *claimed* id alone.
+
+    The naive baseline: no signature check, no freshness check.  A Byzantine
+    peer that broadcasts ``FDHB|victim|...`` is believed, so this verifier lets
+    forged liveness through -- which is the whole point of running it as the
+    foil the signed verifier is measured against.
+
+    Example::
+
+        auth = TrustingHeartbeatAuthenticator()
+        auth.accept(b"FDHB|peer-0|12.5|ab", now=12.5)  # -> (AgentId("peer-0"), 12.5)
+    """
+
+    name = "trusting"
+    verifies = False
+
+    def accept(self, payload: bytes, *, now: float) -> tuple[AgentId, float] | None:
+        """Return ``(claimed_peer, now)`` for any heartbeat-shaped payload.
+
+        Example::
+
+            accepted = auth.accept(payload, now=ctx.time)
+        """
+        peer = claimed_peer(payload)
+        if peer is None:
+            return None
+        return peer, now
+
+
+class SignedHeartbeatAuthenticator:
+    """Accept a heartbeat only if it is authentically signed and fresh.
+
+    Rejects the payload unless every check passes:
+
+    * well-formed ``FDHB|<id>|<ts>|<sig-hex>`` wire format with a finite
+      timestamp;
+    * the signed timestamp is not from the future and is strictly newer than the
+      last accepted heartbeat from that peer (defeats replay);
+    * the signature verifies against the *claimed* peer's registered public key
+      (defeats fabrication -- a forger signing with its own key fails).
+
+    The last-accepted timestamp per peer is held internally and advanced on every
+    acceptance, so the verifier owns its own replay state.  Verification never
+    consults transport metadata, so it holds even on a transport whose sender
+    field cannot be trusted.
+
+    Example::
+
+        auth = SignedHeartbeatAuthenticator(observer_identity)
+        auth.accept(genuine_beat, now=12.5)   # -> (peer, 12.5)
+        auth.accept(genuine_beat, now=99.0)   # -> None  (replayed)
+    """
+
+    name = "signed"
+    verifies = True
+
+    def __init__(self, identity: Any) -> None:
+        self._identity = identity
+        self._last_ts: dict[AgentId, float] = {}
+
+    def accept(self, payload: bytes, *, now: float) -> tuple[AgentId, float] | None:
+        """Return ``(peer, ts)`` if signature and freshness pass, else ``None``.
+
+        Example::
+
+            accepted = auth.accept(payload, now=ctx.time)
+        """
+        text = payload.decode("utf-8", "replace")
+        if not text.startswith(HB_PREFIX):
+            return None
+        fields = text[len(HB_PREFIX) :].split("|")
+        if len(fields) != 3:
+            return None
+        claimed, ts_text, sig_hex = fields
+        if not claimed:
+            return None
+        try:
+            ts = float(ts_text)
+            sig_bytes = bytes.fromhex(sig_hex)
+        except ValueError:
+            return None
+        # A non-finite timestamp (nan/inf) would slip the IEEE-754 comparisons
+        # below, so reject it outright.  Genuine beats carry ``round(now, 6)``.
+        if not math.isfinite(ts):
+            return None
+        peer = AgentId(claimed)
+        # The signed ts is quantized to 6 dp, so it can round a hair above the
+        # observer's exact ``now`` on the same zero-latency tick; compare against
+        # the same quantum rather than raw ``now`` so genuine beats are not read
+        # as future-dated.  Replays are still caught by the strict freshness check.
+        if ts > round(now, 6) or ts <= self._last_ts.get(peer, float("-inf")):
+            return None
+        if self._identity is None:
+            return None
+        base = f"{HB_PREFIX}{claimed}|{ts_text}"
+        sig = Signature(signer=peer, value=sig_bytes, algorithm=HB_ALGORITHM)
+        if not self._identity.verify(base.encode(), sig, peer):
+            return None
+        self._last_ts[peer] = ts
+        return peer, ts
+
+
+def make_heartbeat_authenticator(name: str, identity: Any) -> HeartbeatAuthenticator:
+    """Build the heartbeat authenticator named *name*.
+
+    ``"signed"`` returns a :class:`SignedHeartbeatAuthenticator` bound to
+    *identity*; ``"trusting"`` returns a :class:`TrustingHeartbeatAuthenticator`
+    (which ignores *identity*).  Any other name raises ``ValueError`` so a
+    misconfigured scenario fails fast rather than silently disabling
+    authentication.
+
+    Example::
+
+        auth = make_heartbeat_authenticator("signed", observer_identity)
+    """
+    if name == "signed":
+        return SignedHeartbeatAuthenticator(identity)
+    if name == "trusting":
+        return TrustingHeartbeatAuthenticator()
+    msg = f"unknown heartbeat authenticator {name!r} (expected 'signed' or 'trusting')"
+    raise ValueError(msg)
+
+
+# Verify both verifiers structurally satisfy the protocol at import.
+_check_signed: type[HeartbeatAuthenticator] = SignedHeartbeatAuthenticator  # noqa: F841
+_check_trusting: type[HeartbeatAuthenticator] = TrustingHeartbeatAuthenticator  # noqa: F841

--- a/packages/nest-plugins-reference/tests/test_failure_detection.py
+++ b/packages/nest-plugins-reference/tests/test_failure_detection.py
@@ -34,12 +34,7 @@ from nest_core.layers.failure_detector import FailureDetector
 from nest_core.plugins import PluginRegistry
 from nest_core.runner import ScenarioRunner
 from nest_core.scenario import ScenarioConfig
-from nest_core.scenarios_builtin.failure_detection import (
-    IDENTITY_SEED,
-    claimed_peer,
-    heartbeat_payload,
-    verify_heartbeat,
-)
+from nest_core.scenarios_builtin.failure_detection import IDENTITY_SEED
 from nest_core.types import AgentId
 from nest_core.validators import (
     ValidationResult,
@@ -47,6 +42,13 @@ from nest_core.validators import (
     validate_trace,
 )
 from nest_plugins_reference.failure_detection.heartbeat import HeartbeatFailureDetector
+from nest_plugins_reference.failure_detection.heartbeat_auth import (
+    SignedHeartbeatAuthenticator,
+    TrustingHeartbeatAuthenticator,
+    claimed_peer,
+    heartbeat_payload,
+    make_heartbeat_authenticator,
+)
 from nest_plugins_reference.failure_detection.phi_accrual import PhiAccrualFailureDetector
 from nest_plugins_reference.identity.did_key import DidKeyIdentity
 
@@ -284,51 +286,56 @@ def _fd_identities() -> dict[AgentId, Any]:
     return ids
 
 
-def test_signed_heartbeat_authentic_is_accepted() -> None:
+def test_signed_authenticator_accepts_authentic_beat() -> None:
     """A heartbeat signed by the claimed peer verifies and returns (peer, ts)."""
     ids = _fd_identities()
+    auth = SignedHeartbeatAuthenticator(ids[_OBSERVER])
     payload = heartbeat_payload(ids[_VICTIM], _VICTIM, now=10.0)
-    assert verify_heartbeat(ids[_OBSERVER], payload, last_ts={}, now=10.0) == (_VICTIM, 10.0)
+    assert auth.accept(payload, now=10.0) == (_VICTIM, 10.0)
 
 
-def test_fabricated_heartbeat_signed_with_wrong_key_is_rejected() -> None:
+def test_signed_authenticator_rejects_fabrication_with_wrong_key() -> None:
     """A heartbeat that claims the victim but is signed by the forger fails verification."""
     ids = _fd_identities()
+    auth = SignedHeartbeatAuthenticator(ids[_OBSERVER])
     forged = heartbeat_payload(ids[_FORGER], _VICTIM, now=10.0)  # claims victim, forger's key
     assert claimed_peer(forged) == _VICTIM  # the trusting parse is fooled...
-    assert (
-        verify_heartbeat(ids[_OBSERVER], forged, last_ts={}, now=10.0) is None
-    )  # ...verify is not
+    assert auth.accept(forged, now=10.0) is None  # ...the signed authenticator is not
 
 
-def test_replayed_heartbeat_is_rejected_by_freshness() -> None:
-    """A byte-exact replay of an accepted heartbeat is stale and rejected."""
+def test_signed_authenticator_rejects_replay_by_freshness() -> None:
+    """A byte-exact replay of an accepted heartbeat is stale and rejected.
+
+    The authenticator owns its per-peer last-accepted timestamp, so a second
+    accept of the same beat is rejected without any external bookkeeping.
+    """
     ids = _fd_identities()
+    auth = SignedHeartbeatAuthenticator(ids[_OBSERVER])
     payload = heartbeat_payload(ids[_VICTIM], _VICTIM, now=10.0)
-    last: dict[AgentId, float] = {}
-    assert verify_heartbeat(ids[_OBSERVER], payload, last, now=10.0) == (_VICTIM, 10.0)
-    last[_VICTIM] = 10.0
-    assert verify_heartbeat(ids[_OBSERVER], payload, last, now=25.0) is None
+    assert auth.accept(payload, now=10.0) == (_VICTIM, 10.0)
+    assert auth.accept(payload, now=25.0) is None
 
 
-def test_future_dated_heartbeat_is_rejected() -> None:
+def test_signed_authenticator_rejects_future_dated_beat() -> None:
     """A heartbeat whose signed timestamp is ahead of now is rejected."""
     ids = _fd_identities()
+    auth = SignedHeartbeatAuthenticator(ids[_OBSERVER])
     payload = heartbeat_payload(ids[_VICTIM], _VICTIM, now=50.0)
-    assert verify_heartbeat(ids[_OBSERVER], payload, last_ts={}, now=10.0) is None
+    assert auth.accept(payload, now=10.0) is None
 
 
-def test_malformed_or_unsigned_heartbeat_is_rejected() -> None:
+def test_signed_authenticator_rejects_malformed_or_unsigned() -> None:
     """Unsigned, truncated, and non-heartbeat payloads all fail verification."""
     ids = _fd_identities()
-    assert verify_heartbeat(ids[_OBSERVER], b"FDHB|target-0|10.0", last_ts={}, now=10.0) is None
-    assert verify_heartbeat(ids[_OBSERVER], b"FDHB|target-0|bad|zz", last_ts={}, now=10.0) is None
-    assert verify_heartbeat(ids[_OBSERVER], b"not-a-heartbeat", last_ts={}, now=10.0) is None
+    auth = SignedHeartbeatAuthenticator(ids[_OBSERVER])
+    assert auth.accept(b"FDHB|target-0|10.0", now=10.0) is None
+    assert auth.accept(b"FDHB|target-0|bad|zz", now=10.0) is None
+    assert auth.accept(b"not-a-heartbeat", now=10.0) is None
     assert claimed_peer(b"FDHB|target-0|10.0|ab") == _VICTIM
     assert claimed_peer(b"nope") is None
 
 
-def test_non_finite_timestamp_heartbeat_is_rejected() -> None:
+def test_signed_authenticator_rejects_non_finite_timestamp() -> None:
     """A validly-signed but non-finite (nan/inf) timestamp is rejected.
 
     ``nan`` would otherwise slip both IEEE-754 freshness comparisons.  The
@@ -336,11 +343,40 @@ def test_non_finite_timestamp_heartbeat_is_rejected() -> None:
     finiteness guard rejects it.
     """
     ids = _fd_identities()
+    auth = SignedHeartbeatAuthenticator(ids[_OBSERVER])
     for ts_text in ("nan", "inf", "-inf"):
         base = f"FDHB|{_VICTIM}|{ts_text}".encode()
         sig = ids[_VICTIM].sign(base)
         payload = base + b"|" + sig.value.hex().encode()
-        assert verify_heartbeat(ids[_OBSERVER], payload, last_ts={}, now=10_000.0) is None
+        assert auth.accept(payload, now=10_000.0) is None
+
+
+def test_trusting_authenticator_believes_claimed_id() -> None:
+    """The trusting authenticator accepts any heartbeat-shaped payload by claimed id.
+
+    It is the naive foil: a forger's fabrication claiming the victim is accepted
+    just like a genuine beat, which is exactly the spoofing the signed
+    authenticator closes.
+    """
+    ids = _fd_identities()
+    auth = TrustingHeartbeatAuthenticator()
+    forged = heartbeat_payload(ids[_FORGER], _VICTIM, now=10.0)  # forger's key, claims victim
+    assert auth.accept(forged, now=12.0) == (_VICTIM, 12.0)
+    assert auth.accept(b"not-a-heartbeat", now=12.0) is None
+    assert auth.verifies is False
+
+
+def test_make_heartbeat_authenticator_selects_and_validates() -> None:
+    """The selector returns the named component and rejects unknown names."""
+    ids = _fd_identities()
+    assert isinstance(
+        make_heartbeat_authenticator("signed", ids[_OBSERVER]), SignedHeartbeatAuthenticator
+    )
+    assert isinstance(
+        make_heartbeat_authenticator("trusting", ids[_OBSERVER]), TrustingHeartbeatAuthenticator
+    )
+    with pytest.raises(ValueError, match="unknown heartbeat authenticator"):
+        make_heartbeat_authenticator("bogus", ids[_OBSERVER])
 
 
 def _accuracy_probe_events(hb_max: float, gap: float) -> list[dict[str, Any]]:
@@ -518,3 +554,64 @@ def test_forgery_scenario_is_byte_for_byte_deterministic() -> None:
     if not FORGERY_PATH.exists():
         pytest.skip(f"scenario not found at {FORGERY_PATH}")
     assert _run_forgery_bytes(42) == _run_forgery_bytes(42)
+
+
+def _run_forgery_overrides(
+    seed: int, overrides: dict[str, Any]
+) -> tuple[bytes, dict[str, ValidationResult]]:
+    """Run the forgery scenario with task.config overrides; return (bytes, results)."""
+    config = ScenarioConfig.from_yaml(str(FORGERY_PATH))
+    task_cfg = dict(config.task.config)
+    task_cfg.update(overrides)
+    config = config.model_copy(
+        update={"seed": seed, "task": config.task.model_copy(update={"config": task_cfg})}
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"fdf_{seed}.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        asyncio.run(ScenarioRunner(config, registry=PluginRegistry()).run())
+        results = {r.name: r for r in validate_trace(trace_path, "failure_detection_forgery")}
+        return trace_path.read_bytes(), results
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_forgery_hb_auth_component_swap(seed: int) -> None:
+    """Swapping the authenticator component, not a flag, drives the discriminator.
+
+    ``hb_auth: trusting`` is fooled by the forged beats; ``hb_auth: signed``
+    rejects them.  Verification is thus a swapped component, matching how the
+    detector itself swaps ``phi_accrual`` for ``heartbeat``.
+    """
+    if not FORGERY_PATH.exists():
+        pytest.skip(f"scenario not found at {FORGERY_PATH}")
+
+    _, trusting = _run_forgery_overrides(seed, {"hb_auth": "trusting"})
+    assert not trusting["failure_detection_no_forged_liveness"].passed, trusting[
+        "failure_detection_no_forged_liveness"
+    ].detail
+
+    _, signed = _run_forgery_overrides(seed, {"hb_auth": "signed"})
+    assert signed["failure_detection_no_forged_liveness"].passed, signed[
+        "failure_detection_no_forged_liveness"
+    ].detail
+
+
+def test_hb_auth_selector_and_verify_heartbeats_alias_are_identical() -> None:
+    """The ``hb_auth`` selector and the legacy ``verify_heartbeats`` bool agree byte for byte.
+
+    ``hb_auth: signed`` must reproduce ``verify_heartbeats: true`` exactly, and
+    ``hb_auth: trusting`` must reproduce ``verify_heartbeats: false`` exactly, so
+    the alias keeps existing scenario configs working unchanged.
+    """
+    if not FORGERY_PATH.exists():
+        pytest.skip(f"scenario not found at {FORGERY_PATH}")
+
+    signed_bytes, _ = _run_forgery_overrides(42, {"hb_auth": "signed"})
+    alias_true_bytes, _ = _run_forgery_overrides(42, {"verify_heartbeats": True})
+    assert signed_bytes == alias_true_bytes
+
+    trusting_bytes, _ = _run_forgery_overrides(42, {"hb_auth": "trusting"})
+    alias_false_bytes, _ = _run_forgery_overrides(42, {"verify_heartbeats": False})
+    assert trusting_bytes == alias_false_bytes

--- a/packages/nest-plugins-reference/tests/test_negotiation_determinism.py
+++ b/packages/nest-plugins-reference/tests/test_negotiation_determinism.py
@@ -85,7 +85,9 @@ class TestDeriveSessionId:
         partner=st.text(min_size=1, max_size=16),
         seq=st.integers(min_value=0, max_value=1_000_000),
     )
-    def test_deterministic_over_arbitrary_inputs(self, initiator: str, partner: str, seq: int) -> None:
+    def test_deterministic_over_arbitrary_inputs(
+        self, initiator: str, partner: str, seq: int
+    ) -> None:
         assert derive_session_id(AgentId(initiator), AgentId(partner), seq) == derive_session_id(
             AgentId(initiator), AgentId(partner), seq
         )


### PR DESCRIPTION
## Problem

This is a direct follow-up to the review note on #152. That review approved the signed-heartbeat forgery defense but flagged two structural points: the authenticated-heartbeat logic lived inside the `failure_detection` scenario builtin rather than a reusable component, and the forgery discriminator was a `verify_heartbeats` boolean toggle rather than a swapped component like the rest of the framework uses. Both are fair. No other scenario could reuse the authentication without copy-pasting it, and the "does authentication matter?" question was answered by a config flag instead of by swapping an implementation, which is the pattern everything else here follows (a scenario picks `phi_accrual` or `heartbeat` for the detector, `signed` or `noop` for privacy, and so on).

This PR extracts the authentication into a reusable module and turns the discriminator into a component swap, with no change to observable behavior.

## What is in the diff

| Path | Purpose |
|---|---|
| `packages/nest-plugins-reference/nest_plugins_reference/failure_detection/heartbeat_auth.py` | New reusable module, co-located with the detector plugins and following the same `*_wire` pattern as `coordination/hotstuff_wire.py`. It holds the wire format (`heartbeat_payload`, `claimed_peer`, `HB_PREFIX`), a `HeartbeatAuthenticator` protocol, two verifiers, and a `make_heartbeat_authenticator` selector. |
| `packages/nest-core/nest_core/scenarios_builtin/failure_detection.py` | The scenario now imports the wire format and verifiers from the reusable module instead of defining them. `FailureMonitorAgent` holds an injected authenticator and has a single heartbeat path, so it no longer branches on a verify flag. The factory selects the authenticator by name. |
| `packages/nest-plugins-reference/tests/test_failure_detection.py` | Component unit tests for both verifiers and the selector, plus an end-to-end component-swap test and a test that the new selector and the legacy alias produce byte-identical traces. |
| `packages/nest-plugins-reference/tests/test_negotiation_determinism.py` | Wraps one pre-existing over-length line. See the note at the end. |

## The reusable component

`heartbeat_auth.py` packages three things any scenario can now reuse:

- The wire format `FDHB|<id>|<ts>|<sig-hex>`, unchanged, with the signature reconstructed from the raw wire text so traces stay deterministic.
- `SignedHeartbeatAuthenticator`: accepts a beat only if the signature verifies against the claimed peer's registered key and the timestamp is fresh (strictly newer than the last accepted, and not from the future). It owns its per-peer last-accepted timestamp internally, so the replay state is encapsulated rather than threaded through the caller.
- `TrustingHeartbeatAuthenticator`: the naive baseline that believes the claimed id. This is the real foil, the behavior a spoofable observer exhibits.

Both satisfy a small `HeartbeatAuthenticator` protocol (`accept(payload, *, now) -> (peer, ts) | None`, plus `name` and `verifies`), checked structurally at import the same way the detector plugins are.

## The discriminator is now a component swap

The observer no longer has a verify-or-trust branch. It holds one `HeartbeatAuthenticator` and feeds the detector whatever that authenticator accepts. Turning authentication on or off is selecting the component:

```yaml
task:
  config:
    hb_auth: signed     # or: trusting
```

This mirrors how the detector itself is chosen (`fd_plugin: phi_accrual | heartbeat`). The forgery scenario's `no_forged_liveness` validator fails under `hb_auth: trusting` and passes under `hb_auth: signed`, exactly as it did with the boolean.

The older `verify_heartbeats: true|false` is kept as an exact alias (`true` maps to `signed`, `false` to `trusting`), so the merged forgery scenario and any existing config keep working with no change.

## Verification

`make ci-local` passes all five gates:

```
ruff check:          All checks passed!
ruff format --check: 231 files already formatted
pyright:             0 errors, 0 warnings, 0 informations
pytest:              1288 passed, 1 skipped, 1 deselected
```

Behavior preservation is checked directly. Both scenarios produce byte-identical traces to the pre-refactor code across seeds 42, 7, and 1337 (captured before the change and compared after). The new tests add:

- `test_signed_authenticator_*` and `test_trusting_authenticator_*`: the two verifiers in isolation (authentic accept, fabrication rejected, replay rejected by owned freshness state, future and non-finite timestamps rejected, malformed input rejected, trusting believes the claimed id).
- `test_make_heartbeat_authenticator_selects_and_validates`: the selector returns the named component and raises on an unknown name.
- `test_forgery_hb_auth_component_swap`: end to end, `hb_auth: trusting` is fooled and `hb_auth: signed` is not, across all three seeds.
- `test_hb_auth_selector_and_verify_heartbeats_alias_are_identical`: the selector and the legacy boolean produce byte-identical traces, so the alias is exact.

## One unrelated note

`ci-local` on the current `main` fails `ruff check` on a 103-character line in `test_negotiation_determinism.py`, introduced by the negotiation change merged just before this branch. It is unrelated to this feature, but it blocks gate 2 for any branch cut from current `main`, so I wrapped that one line to keep `ci-local` green. Happy to drop it into a separate PR if you would rather keep this one scoped to the failure detector.
