### PR TITLE
[Hackathon]  cover gossip registry partition honesty against the real simulator (problem 06)

### DIFF
--- a/packages/nest-plugins-reference/tests/test_gossip_validators_and_scenario.py
+++ b/packages/nest-plugins-reference/tests/test_gossip_validators_and_scenario.py
@@ -260,6 +260,64 @@ def test_scenario_converges_via_bridge_under_partition(seed: int) -> None:
         assert conv_report.passed, f"seed={seed} divergence: {conv_report.detail}"
 
 
+@pytest.mark.parametrize("seed", [42, 7, 1337])
+def test_scenario_honors_partition_before_bridge_relay(seed: int) -> None:
+    """End-to-end: the real Simulator's partition drops actually isolate groups.
+
+    ``test_scenario_converges_via_bridge_under_partition`` above only checks
+    the *end* state (full convergence via the bridge) — it never asserts
+    ``check_no_partition_view_leak`` against a real mid-run snapshot, so a
+    regression that let ``GossipRegistry`` leak a card straight across the
+    partition (bypassing the bridge, e.g. by consulting a cached/global view)
+    would go uncaught: ``check_no_partition_view_leak`` itself is only ever
+    exercised against hand-rolled fake networks elsewhere in this file and in
+    ``test_gossip_registry.py``, never against the real ``_should_drop``
+    partition logic in ``nest_core.sim.simulator``.
+
+    Runs the real scenario for a truncated duration (``ticks: 200``) — long
+    enough that agents have already gossiped with peers inside their own
+    partition group (empirically confirmed: by tick 200 several agents' view
+    sizes exceed 1, i.e. this is checking real propagated data, not just each
+    agent's own ``on_start`` self-registration), but short enough that no
+    card has had time to relay across the bridge yet (`duration: "ticks:
+    10000"` caps *events*, not wall-clock time, and event-to-round timing is
+    seed-dependent — empirically, seeds 42/7/1337 all still pass at tick 250
+    but seed 42 starts failing legitimately by tick 300 once the bridge has
+    relayed a card, so 200 leaves comfortable margin either side).
+    """
+    if not SCENARIO_PATH.exists():
+        pytest.skip(f"scenario not found at {SCENARIO_PATH}")
+
+    config = ScenarioConfig.from_yaml(str(SCENARIO_PATH))
+    config = config.model_copy(update={"seed": seed, "duration": "ticks: 200"})
+
+    with tempfile.TemporaryDirectory() as tmp:
+        trace_path = Path(tmp) / f"gossip_partition_{seed}.jsonl"
+        config = config.model_copy(
+            update={"output": config.output.model_copy(update={"trace": str(trace_path)})}
+        )
+        runner = ScenarioRunner(config, registry=PluginRegistry())
+        asyncio.run(runner.run())
+
+        per_agent_regs = runner.resolved_plugins.get("_gossip_registries")
+        assert per_agent_regs is not None, "scenario factory should expose _gossip_registries"
+
+        views = {aid: reg.view_snapshot() for aid, reg in per_agent_regs.items()}
+        assert any(len(v) > 1 for v in views.values()), (
+            "expected at least one agent to have gossiped with a peer by tick 200 "
+            "(all views only contain self-registration -- test would be vacuous)"
+        )
+
+        peer_a = [AgentId(f"peer_a-{i}") for i in range(10)]
+        peer_b = [AgentId(f"peer_b-{i}") for i in range(10)]
+        report = check_no_partition_view_leak(
+            views=views,
+            partition_groups=[peer_a, peer_b],
+            bridge_agents={AgentId("bridge-0")},
+        )
+        assert report.passed, f"seed={seed}: {report.detail}"
+
+
 def test_scenario_deterministic_under_replay() -> None:
     """Two runs with seed=42 produce identical per-agent snapshots."""
     if not SCENARIO_PATH.exists():


### PR DESCRIPTION
<html>
<p><strong>Title:</strong> <code>[Hackathon] ang101: cover gossip registry partition honesty against the real simulator (problem 06)</code></p>
<p><strong>Body:</strong></p>
<h2>Problem</h2>
<p><code>check_no_partition_view_leak</code> (<code>packages/nest-plugins-reference/nest_plugins_reference/validators/gossip_validators.py</code>) is the adversarial validator that should catch a <code>GossipRegistry</code> agent leaking a card straight across a network partition instead of only relaying it via a bridge. It has never actually been run against a real partition:</p>
<ul>
<li>Unit tests in this file and in <code>test_gossip_registry.py::test_partition_without_bridge_does_not_leak</code> all use a hand-rolled <code>_FakeNetwork</code>/<code>drop()</code> callable — never <code>nest_core.sim.simulator</code>'s real <code>_should_drop</code> partition logic.</li>
<li>The one test that <em>does</em> boot the real <code>Simulator</code> under a real partition (<code>test_scenario_converges_via_bridge_under_partition</code>, driving <code>scenarios/gossip_registry.yaml</code> via <code>ScenarioRunner</code>) only asserts <code>check_converged(...)</code> on the final state at end-of-run. It never calls <code>check_no_partition_view_leak</code> against a real mid-run snapshot.</li>
</ul>
<p>Net effect: a regression in <code>GossipRegistry</code> that leaked cross-group data through some other path — e.g. consulting a cached/shared view instead of only state that legitimately gossiped in — would pass the full test suite undetected.</p>
<h2>Fix</h2>
<p>Added <code>test_scenario_honors_partition_before_bridge_relay</code> (parametrized over seeds <code>42, 7, 1337</code>, matching this file's existing convention):</p>
<ol>
<li>Loads <code>scenarios/gossip_registry.yaml</code> via <code>ScenarioConfig.from_yaml</code>, overrides <code>duration</code> to <code>"ticks: 200"</code>.</li>
<li>Runs it through the real <code>ScenarioRunner</code>/<code>Simulator</code> (<code>asyncio.run(runner.run())</code>) — identical code path to the full-length test, just truncated.</li>
<li>Reads <code>runner.resolved_plugins["_gossip_registries"]</code> (the real per-agent <code>GossipRegistry</code> instances the scenario factory stashes there) and calls <code>.view_snapshot()</code> on each — the exact production method (<code>gossip.py:329</code>), not a mock.</li>
<li>Asserts at least one agent's view exceeds size 1 (proves real gossip propagated, not just each agent's own <code>on_start</code> self-registration — guards against the test being accidentally vacuous).</li>
<li>Calls <code>check_no_partition_view_leak(views=..., partition_groups=[peer_a[0..9], peer_b[0..9]], bridge_agents={AgentId("bridge-0")})</code> and asserts it passes.</li>
</ol>
<h3>Why 200 ticks specifically</h3>
<p>The scenario's partition never heals (<code>scenarios/gossip_registry.yaml</code> sets <code>network_partition.groups</code> with no <code>partition_heal_at_tick</code>), so any point before the bridge relays a card across groups is a valid "mid-partition, still honest" snapshot to check. But <code>duration: "ticks: N"</code> caps <strong>event count</strong>, not wall-clock time (<code>Simulator.run</code>'s <code>max_ticks</code> increments once per popped queue event), and <code>gossip_interval: 50</code> plus per-agent seeded RNG fanout selection makes event-to-round timing seed-dependent — so N had to be found empirically rather than derived:</p>

N | Behavior
-- | --
≤100 | Every agent's view size = 1 (only self-registration; first gossip round hasn't fired) — vacuous
200–250 | View sizes 1–4, real intra-group propagation, passes on all 3 required seeds
300 | Seed 42 starts legitimately failing — bridge has relayed a card cross-group by then
500–1000 | All seeds fail — full mesh convergence via bridge, exactly as intended by design


<p>200 was chosen for comfortable margin on both sides.</p>
<h2>Verification</h2>
<ul>
<li><strong>Mutation test</strong> (not part of the committed diff, run manually to validate the test has teeth): took a real 200-tick scenario run's output, injected <code>peer_b-0</code>'s own view entry into <code>peer_a-0</code>'s view (simulating the exact "leaked via shared cache" bug this validator exists to catch), re-ran <code>check_no_partition_view_leak</code> on the tampered data — confirmed it correctly reports <code>passed: False</code>, <code>"1 cross-partition leaks"</code>. This proves the new test's wiring (real per-agent state → validator) would actually catch a real regression, not just pass by construction.</li>
<li>Full suite: <code>1236 passed, 1 skipped</code>. 17 failures in <code>test_byzantine_gossip*</code>/<code>test_byzantine_gossip_scenario.py</code> excluded — verified pre-existing on a pristine <code>upstream/main</code> checkout (<code>("registry", "byzantine_gossip")</code> was never registered in <code>plugins.py</code>'s <code>_BUILTINS</code>), unrelated to this change.</li>
<li><code>ruff check</code> / <code>ruff format --check</code>: clean. <code>pyright</code>: 0 errors/warnings repo-wide.</li>
<li>Scope: one file, 58 lines added, test-only — no plugin, validator, or scenario-factory logic touched, per the charter's scope rule for problem 06.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>