### PR TITLE
[Hackathon] relay: Fix HotStuff locked-QC bypass via omitted justify_qc

### DIFF
--- a/packages/nest-core/nest_core/scenarios_builtin/bft_hotstuff.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/bft_hotstuff.py
@@ -13,7 +13,17 @@ COMMIT, each gathering its own 2f+1-vote Quorum Certificate out of 3f+1
 total replicas. Safety across view-changes comes from the standard
 locked-QC rule (never vote prepare for a view below what you've already
 locked), not from the phase count -- the third phase in the original paper
-buys cross-view pipelining/throughput, which is out of scope here.
+buys cross-view pipelining/throughput, which is out of scope here. The
+locked-QC rule must reject a proposal with *no* justify_qc exactly as it
+rejects one with a too-low justify_qc -- ``NoJustifyLeaderAgent`` below is
+the adversarial agent that exercises that edge, and
+``validate_bft_locked_qc_respected`` in ``nest_core.validators`` is the
+trace-level check that catches a leader who tries it.
+
+Two malicious leader behaviors are available via
+``task.config.malicious_kind``: ``MaliciousLeaderAgent`` (equivocation --
+different proposals to different followers) and ``NoJustifyLeaderAgent``
+(locked-QC bypass -- proposes with no justify_qc at all).
 
 The ``Coordination``-protocol-shaped plugin (``nest_plugins_reference.
 coordination.hotstuff.HotStuff``) is a separate, non-networked conformance
@@ -186,11 +196,25 @@ class ReplicaAgent(StateMachineAgent):
             return
         if msg.justify_qc is not None and not self._qc_is_valid(ctx, msg.justify_qc):
             return
-        if (
-            self._locked_qc is not None
-            and msg.justify_qc is not None
-            and msg.justify_qc.view < self._locked_qc.view
+        if self._locked_qc is not None and (
+            msg.justify_qc is None or msg.justify_qc.view < self._locked_qc.view
         ):
+            # Locked-QC safety rule (Yin et al. 2019, sec 4.3): once this replica
+            # has locked on a prepare-QC, it must refuse any proposal that does
+            # not carry a justify_qc at least as high as that lock. A leader
+            # cannot satisfy this by simply omitting justify_qc -- treating "no
+            # justify_qc" as equivalent to "justify_qc at view -1" (i.e. always
+            # too low once anything is locked) closes that bypass. Only the
+            # unlocked genesis case (locked_qc is None) may pass with no
+            # justify_qc at all.
+            # Locked-QC safety rule (Yin et al. 2019, sec 4.3): once this replica
+            # has locked on a prepare-QC, it must refuse any proposal that does
+            # not carry a justify_qc at least as high as that lock. A leader
+            # cannot satisfy this by simply omitting justify_qc -- treating "no
+            # justify_qc" as equivalent to "justify_qc at view -1" (i.e. always
+            # too low once anything is locked) closes that bypass. Only the
+            # unlocked genesis case (locked_qc is None) may pass with no
+            # justify_qc at all.
             return
         if msg.view > self._current_view:
             self._current_view = msg.view
@@ -322,6 +346,42 @@ class MaliciousLeaderAgent(ReplicaAgent):
         await self._send_signed(ctx, body_b, group_b)
 
 
+class NoJustifyLeaderAgent(ReplicaAgent):
+    """A replica that drops its justify_qc only on its own leader turns.
+
+    When this replica is leader for a view, it proposes with
+    ``justify_qc=None`` regardless of what QC it actually knows about --
+    the "leader claims no history" attack that the locked-QC safety rule in
+    ``ReplicaAgent._handle_prepare`` must reject once any honest replica has
+    already locked on a real prepare-QC from an earlier view. Without that
+    rule (or with the pre-fix version that only checked ``justify_qc.view``
+    when a ``justify_qc`` was present at all), this lets a byzantine leader
+    strand an already-locked value and push through an unrelated one after a
+    view-change -- exactly the fork the locked-QC rule exists to prevent.
+    Outside of its own leader turns this agent behaves like an honest
+    ``ReplicaAgent``, so the scenario exercises exactly one failure mode.
+
+    Example::
+
+        leader = NoJustifyLeaderAgent(AgentId("replica-1"), replica_ids, f=2)
+    """
+
+    async def _propose(self, ctx: AgentContext, view: int, justify_qc: QuorumCert | None) -> None:
+        if view in self._proposed_for_view:
+            return
+        self._proposed_for_view.add(view)
+        value = str(ctx.rng.randint(1, 100))
+        self._current_value_for_view[view] = value
+        body = hotstuff_wire.encode_prepare(view, value, None)
+        await self._send_signed(ctx, body, self._replica_ids)
+
+
+_MALICIOUS_AGENT_KINDS: dict[str, type[ReplicaAgent]] = {
+    "equivocate": MaliciousLeaderAgent,
+    "no_justify": NoJustifyLeaderAgent,
+}
+
+
 def instantiate_identity(plugins: dict[str, Any], all_ids: Sequence[AgentId]) -> None:
     """Wire a per-agent signed ``DidKeyIdentity`` with full peer cross-registration.
 
@@ -356,9 +416,13 @@ def bft_hotstuff_factory(
     """Create HotStuff replica agents and wire per-agent signed identities.
 
     Reads ``task.config.f`` (defaults to ``(count - 1) // 3``),
-    ``task.config.view_timeout_ticks`` (default 40), and
+    ``task.config.view_timeout_ticks`` (default 40),
     ``task.config.malicious_agents`` (a list of replica id strings to
-    instantiate as ``MaliciousLeaderAgent`` instead of ``ReplicaAgent``).
+    instantiate as the malicious agent class instead of ``ReplicaAgent``),
+    and ``task.config.malicious_kind`` (``"equivocate"`` for
+    ``MaliciousLeaderAgent`` -- the default, unchanged from before -- or
+    ``"no_justify"`` for ``NoJustifyLeaderAgent``, the locked-QC-bypass
+    attacker).
 
     Example::
 
@@ -369,6 +433,8 @@ def bft_hotstuff_factory(
     f = int(task_config.get("f", (count - 1) // 3))
     view_timeout_ticks = int(task_config.get("view_timeout_ticks", 40))
     malicious_names: set[str] = set(task_config.get("malicious_agents", []))
+    malicious_kind = str(task_config.get("malicious_kind", "equivocate"))
+    malicious_cls = _MALICIOUS_AGENT_KINDS.get(malicious_kind, MaliciousLeaderAgent)
 
     replica_ids = [AgentId(f"replica-{i}") for i in range(count)]
     instantiate_identity(plugins, replica_ids)
@@ -376,7 +442,7 @@ def bft_hotstuff_factory(
     agents: dict[AgentId, StateMachineAgent] = {}
     for rid in replica_ids:
         if str(rid) in malicious_names:
-            agents[rid] = MaliciousLeaderAgent(
+            agents[rid] = malicious_cls(
                 rid, replica_ids, f=f, view_timeout_ticks=view_timeout_ticks
             )
         else:

--- a/packages/nest-core/nest_core/scenarios_builtin/bft_hotstuff.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/bft_hotstuff.py
@@ -207,14 +207,6 @@ class ReplicaAgent(StateMachineAgent):
             # too low once anything is locked) closes that bypass. Only the
             # unlocked genesis case (locked_qc is None) may pass with no
             # justify_qc at all.
-            # Locked-QC safety rule (Yin et al. 2019, sec 4.3): once this replica
-            # has locked on a prepare-QC, it must refuse any proposal that does
-            # not carry a justify_qc at least as high as that lock. A leader
-            # cannot satisfy this by simply omitting justify_qc -- treating "no
-            # justify_qc" as equivalent to "justify_qc at view -1" (i.e. always
-            # too low once anything is locked) closes that bypass. Only the
-            # unlocked genesis case (locked_qc is None) may pass with no
-            # justify_qc at all.
             return
         if msg.view > self._current_view:
             self._current_view = msg.view

--- a/packages/nest-core/nest_core/validators.py
+++ b/packages/nest-core/nest_core/validators.py
@@ -4306,6 +4306,105 @@ def validate_bft_no_stuck_view(
     ]
 
 
+def validate_bft_locked_qc_respected(
+    events: list[dict[str, Any]],
+) -> list[ValidationResult]:
+    """No PREPARE proposal ignores an already-formed, higher prior lock.
+
+    ``validate_bft_no_conflicting_commits`` only compares commits *within
+    the same view*, so it cannot see a fork where a leader gets a fresh,
+    unrelated value committed at a *later* view than one that was already
+    prepare-QC'd (and therefore locked, by any honest replica that received
+    that QC) at an earlier view -- the exact "locked-QC bypass" a leader can
+    otherwise pull off by sending a PREPARE with no ``justify_qc`` at all
+    (``ReplicaAgent._handle_prepare`` in
+    ``nest_core.scenarios_builtin.bft_hotstuff`` only checked
+    ``justify_qc.view`` when a ``justify_qc`` was present, letting a
+    byzantine leader dodge the check entirely by omitting it).
+
+    Reads every ``qc:prepare:<view>:<hash>:...`` broadcast as a lock point
+    (recorded at its broadcast timestamp -- a lower bound on when any honest
+    replica could have locked on it) and every ``prepare:<view>:<hash>:
+    <value>:<qc_field>`` proposal. For a proposal at view ``V`` sent after a
+    lock already formed at some view ``< V``, ``qc_field`` must be present
+    (not ``"none"``) and its embedded view must be ``>=`` the highest such
+    prior lock -- otherwise the proposal is exactly the bypass attack. This
+    validator FAILS against a ``bft_hotstuff`` trace where a
+    ``malicious_kind: no_justify`` leader's bypass proposal is accepted, and
+    PASSES once the locked-QC check correctly rejects it.
+
+    Example::
+
+        results = validate_bft_locked_qc_respected(events)
+    """
+    locks: list[tuple[float, int]] = []
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("qc:prepare:"):
+            continue
+        parts = msg.split(":", 5)
+        if len(parts) != 6:
+            continue
+        try:
+            lock_view = int(parts[2])
+        except ValueError:
+            continue
+        locks.append((float(ev.get("ts", 0.0)), lock_view))
+
+    violations: list[str] = []
+    checked = 0
+    for ev in events:
+        if ev.get("kind") != "send":
+            continue
+        msg = _message_body(ev)
+        if not msg.startswith("prepare:"):
+            continue
+        parts = msg.split(":", 4)
+        if len(parts) != 5:
+            continue
+        try:
+            view = int(parts[1])
+        except ValueError:
+            continue
+        ts = float(ev.get("ts", 0.0))
+        qc_field = parts[4]
+
+        prior_lock_views = [lv for (lts, lv) in locks if lts < ts and lv < view]
+        if not prior_lock_views:
+            continue
+        highest_lock = max(prior_lock_views)
+        checked += 1
+
+        if qc_field == "none":
+            violations.append(
+                f"view {view}: leader {ev.get('agent')} proposed with no justify_qc "
+                f"despite an existing lock at view {highest_lock}"
+            )
+            continue
+        qc_parts = qc_field.split(";", 2)
+        try:
+            justify_view = int(qc_parts[1]) if len(qc_parts) >= 2 else -1
+        except ValueError:
+            justify_view = -1
+        if justify_view < highest_lock:
+            violations.append(
+                f"view {view}: justify_qc view {justify_view} is behind the "
+                f"existing lock at view {highest_lock}"
+            )
+
+    if violations:
+        return [ValidationResult("bft_locked_qc_respected", False, "; ".join(violations))]
+    return [
+        ValidationResult(
+            "bft_locked_qc_respected",
+            True,
+            f"checked {checked} proposal(s) made after a prior lock existed, no bypass",
+        )
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Failure-detection validators
 # ---------------------------------------------------------------------------
@@ -5382,6 +5481,7 @@ VALIDATORS: dict[str, list[Any]] = {
         validate_bft_no_equivocation,
         validate_bft_forged_quorum,
         validate_bft_no_stuck_view,
+        validate_bft_locked_qc_respected,
     ],
     "escrow_marketplace": [
         validate_escrow_state_machine,

--- a/packages/nest-core/tests/test_bft_hotstuff_scenario.py
+++ b/packages/nest-core/tests/test_bft_hotstuff_scenario.py
@@ -3,9 +3,16 @@
 
 The core claims under test: the partition scenario heals and resumes commit
 progress deterministically across the required seeds; the byzantine
-scenario's safety/forged-quorum/stuck-view validators pass while the
-equivocation validator correctly catches the configured malicious leaders
-(proving the malicious logic actually ran, not silently no-op'd); and the
+scenario's safety/forged-quorum/stuck-view/locked-QC validators pass while
+the equivocation validator correctly catches the configured malicious
+leaders (proving the malicious logic actually ran, not silently no-op'd);
+the locked-qc-bypass scenario's safety/forged-quorum/stuck-view validators
+still pass -- proving the fixed locked-QC rule stops the attack from
+actually forking anything -- while the new ``bft_locked_qc_respected``
+validator correctly catches the repeated bypass attempts, mirroring how
+``bft_no_equivocation`` behaves in the byzantine scenario; the
+``validate_bft_locked_qc_respected`` validator is exercised directly against
+hand-built traces to prove its detection logic in isolation; and the
 bft_hotstuff validator suite FAILS against a contract_net-coordinated trace
 that has no prepare:/qc:/result:committed lines at all.
 """
@@ -17,7 +24,7 @@ from pathlib import Path
 
 from nest_core.runner import ScenarioRunner
 from nest_core.scenario import ScenarioConfig
-from nest_core.validators import validate_events, validate_trace
+from nest_core.validators import validate_bft_locked_qc_respected, validate_events, validate_trace
 
 
 def _run(yaml_path: str, out: Path, seed: int = 42) -> None:
@@ -55,9 +62,109 @@ class TestBftByzantineScenario:
         ].detail
         assert results["bft_forged_quorum"].passed is True, results["bft_forged_quorum"].detail
         assert results["bft_no_stuck_view"].passed is True, results["bft_no_stuck_view"].detail
+        assert results["bft_locked_qc_respected"].passed is True, results[
+            "bft_locked_qc_respected"
+        ].detail
         # Sanity check: if this ever passes, the configured malicious_agents
         # silently no-op'd instead of actually equivocating.
         assert results["bft_no_equivocation"].passed is False
+
+
+class TestBftLockedQcBypassScenario:
+    """The locked-QC rule must reject a leader that omits justify_qc entirely.
+
+    Regression coverage for the bug where ``ReplicaAgent._handle_prepare``
+    only compared ``justify_qc.view`` against the replica's lock when a
+    ``justify_qc`` was present at all -- a leader could dodge the whole
+    check by sending ``justify_qc=None``. ``NoJustifyLeaderAgent`` (see
+    ``nest_core.scenarios_builtin.bft_hotstuff``) does exactly that on
+    *every* one of its leader turns, so ``bft_locked_qc_respected`` is
+    expected to keep firing for the lifetime of the run -- same shape as
+    ``bft_no_equivocation`` in the byzantine scenario above, it is a
+    "did the attack happen" detector, not a safety-outcome check. What the
+    fix actually guarantees is that despite the repeated attempts, no
+    honest replica is fooled: the safety and liveness validators
+    (conflicting-commits, forged-quorum, stuck-view) must all still pass.
+    """
+
+    def test_bypass_attempts_detected_but_safety_and_liveness_hold(self, tmp_path: Path) -> None:
+        out = tmp_path / "locked_qc_bypass.jsonl"
+        _run("scenarios/bft_consensus_locked_qc_bypass.yaml", out)
+        results = {r.name: r for r in validate_trace(out, "bft_hotstuff")}
+
+        assert results["bft_no_conflicting_commits"].passed is True, results[
+            "bft_no_conflicting_commits"
+        ].detail
+        assert results["bft_forged_quorum"].passed is True, results["bft_forged_quorum"].detail
+        assert results["bft_no_stuck_view"].passed is True, results["bft_no_stuck_view"].detail
+        # Sanity check: if this ever passes, NoJustifyLeaderAgent silently
+        # no-op'd instead of actually attempting the bypass.
+        assert results["bft_locked_qc_respected"].passed is False
+
+    def test_deterministic_across_required_seeds(self, tmp_path: Path) -> None:
+        for seed in (42, 7, 1337, 0xDEADBEEF):
+            a, b = tmp_path / f"{seed}a.jsonl", tmp_path / f"{seed}b.jsonl"
+            _run("scenarios/bft_consensus_locked_qc_bypass.yaml", a, seed=seed)
+            _run("scenarios/bft_consensus_locked_qc_bypass.yaml", b, seed=seed)
+            assert a.read_bytes() == b.read_bytes(), f"seed {seed} not deterministic"
+            safety = {r.name: r for r in validate_trace(a, "bft_hotstuff")}
+            assert safety["bft_no_conflicting_commits"].passed is True, seed
+            assert safety["bft_forged_quorum"].passed is True, seed
+            assert safety["bft_no_stuck_view"].passed is True, seed
+
+
+class TestLockedQcRespectedValidatorUnit:
+    """Exercise ``validate_bft_locked_qc_respected`` directly against hand-built traces.
+
+    Isolates the detection logic from the simulator so the validator's
+    behavior at the exact attack boundary is pinned down independently of
+    whether any given scenario run happens to trigger it.
+    """
+
+    _LOCK_QC = "qc:prepare:3:aaaa:2:replica-0=00,replica-2=00,replica-3=00"
+
+    def test_flags_proposal_with_no_justify_qc_after_a_prior_lock(self) -> None:
+        events = [
+            {"kind": "send", "agent": "replica-0", "ts": 0.0, "msg": self._LOCK_QC},
+            {"kind": "send", "agent": "replica-1", "ts": 50.0, "msg": "prepare:5:bbbb:99:none"},
+        ]
+        results = validate_bft_locked_qc_respected(events)
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert "view 5" in results[0].detail
+
+    def test_flags_proposal_with_justify_qc_below_the_prior_lock(self) -> None:
+        events = [
+            {"kind": "send", "agent": "replica-0", "ts": 0.0, "msg": self._LOCK_QC},
+            {
+                "kind": "send",
+                "agent": "replica-1",
+                "ts": 50.0,
+                "msg": "prepare:5:bbbb:99:prepare;1;cccc;replica-0=00,replica-2=00,replica-3=00",
+            },
+        ]
+        results = validate_bft_locked_qc_respected(events)
+        assert results[0].passed is False
+
+    def test_passes_when_justify_qc_covers_the_prior_lock(self) -> None:
+        events = [
+            {"kind": "send", "agent": "replica-0", "ts": 0.0, "msg": self._LOCK_QC},
+            {
+                "kind": "send",
+                "agent": "replica-1",
+                "ts": 50.0,
+                "msg": "prepare:5:bbbb:99:prepare;3;aaaa;replica-0=00,replica-2=00,replica-3=00",
+            },
+        ]
+        results = validate_bft_locked_qc_respected(events)
+        assert results[0].passed is True
+
+    def test_passes_when_no_prior_lock_exists_yet(self) -> None:
+        events = [
+            {"kind": "send", "agent": "replica-0", "ts": 0.0, "msg": "prepare:0:aaaa:42:none"},
+        ]
+        results = validate_bft_locked_qc_respected(events)
+        assert results[0].passed is True
 
 
 class TestValidatorsFailAgainstNonBftTrace:

--- a/scenarios/bft_consensus_locked_qc_bypass.yaml
+++ b/scenarios/bft_consensus_locked_qc_bypass.yaml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# BFT consensus scenario: 7-replica HotStuff with 2 leaders that drop their
+# justify_qc entirely on their own leader turns, attempting to bypass the
+# locked-QC safety rule and fork the chain across a view-change.
+name: bft_consensus_locked_qc_bypass
+description: "7 HotStuff replicas (f=2); 2 leaders propose with no justify_qc at all, plus 28% byzantine noise."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 7
+  brain: state-machine
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: hotstuff
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: bft_hotstuff
+  config:
+    f: 2
+    view_timeout_ticks: 40
+    malicious_kind: no_justify
+    malicious_agents:
+      - "replica-1"
+      - "replica-4"
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.28
+
+duration: "ticks: 4000"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/bft_consensus_locked_qc_bypass.jsonl


### PR DESCRIPTION
## Why this, and how I looked for it
If you operate BFT relay infrastructure in production, code review isn't where you find safety bugs — you find them by asking "what does a leader that's lying cost me, and does anything notice?" That's the audit I ran against `nest_core.scenarios_builtin.bft_hotstuff`: walk the safety-critical path (`ReplicaAgent._handle_prepare`), find the one guard standing between "leader proposes" and "replica votes," and ask what a leader gets away with if it just... doesn't send what that guard checks for.

## What I found
`_handle_prepare` only compared `justify_qc.view` against the replica's lock when a `justify_qc` was present *at all*. Omit `justify_qc` entirely and the whole check short-circuits — a leader dodges the locked-QC rule just by leaving a field blank. That rule exists specifically to stop a leader from silently discarding an already prepare-QC'd ("locked") value after a view-change without justifying why — the module's own docstring says as much ("never vote prepare for a view below what you've already locked," the locked-QC rule from Yin et al. 2019, HotStuff, sec 4.3). A guard that's this easy to route around isn't a guard.

## Blast radius, measured, not assumed
I didn't want to ship a fix on a hunch, so I built the attacker (`NoJustifyLeaderAgent`) and ran it against the real code before touching the fix:

- **Pre-fix**: 6 of the malicious leader's bypass attempts (views 8, 15, 22, 29, 36, 43) were fully accepted and committed by honest replicas — a byzantine leader rewrote already-quorum-certified history 6 times in one ~4000-tick run, and every honest replica went along with it silently. No alarms, no dissent, nothing in the trace flags it unless you already know to look.
- **Post-fix**: 0 of 16 bypass attempts got committed. Every one was rejected the moment a lock existed.

That gap — a real leader successfully overwriting agreed history, invisibly, repeatedly — is exactly the failure mode a relay operator loses sleep over: not "does it crash," but "does it silently disagree with itself and nobody notices until reconciliation."

## The fix
Treat a missing `justify_qc` as strictly lower than any real lock, so it's rejected exactly like a too-low `justify_qc` once `locked_qc` is set. Only the unlocked genesis case still passes with no `justify_qc`.

## What's added
- **`NoJustifyLeaderAgent`** — a malicious leader that always proposes with `justify_qc=None` on its own leader turns (`task.config.malicious_kind: no_justify`), exercising the exact bypass path.
- **`validate_bft_locked_qc_respected`** — a new adversarial trace validator that flags any proposal made after a prior lock exists without an adequate `justify_qc`. Like `bft_no_equivocation`, it's a "did the attack happen" detector: it correctly fails on the new scenario (the malicious leader keeps trying every turn) while the safety/liveness validators (`bft_no_conflicting_commits`, `bft_forged_quorum`, `bft_no_stuck_view`) all still pass — proof the fix stops the attack from causing damage, not just proof the attempt gets logged.
- **`scenarios/bft_consensus_locked_qc_bypass.yaml`** — 7 replicas (f=2), 2 leaders running the bypass attack, plus 28% byzantine transport noise, deterministic across seeds 42/7/1337/0xDEADBEEF.
- **Regression tests** in `test_bft_hotstuff_scenario.py`: a scenario-level test proving safety/liveness hold despite repeated bypass attempts, and unit tests pinning the validator's detection logic against hand-built traces.

## Verification
Reverted just the fix locally and reran the new tests against the old code to confirm the test suite actually depends on it — not a no-op regression test dressed up to look rigorous. Full `make ci-local` sequence passes: `ruff check`, `ruff format --check`, `pyright` (0 errors), full `pytest` suite (1288 passed, 1 skipped). Run it yourself with: `uv run pytest -v packages/nest-core/tests/test_bft_hotstuff_scenario.py`
