### PR TITLE
hackathon/daksh-orset-memory: OR-Set CRDT memory plugin — concurrent adds survive

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -50,6 +50,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("negotiation", "pareto"): f"{_REF}.negotiation.pareto:ParetoNegotiation",
     ("memory", "blackboard"): f"{_REF}.memory.blackboard:Blackboard",
     ("memory", "lww_register"): f"{_REF}.memory.lww_register:LwwRegisterMemory",
+    ("memory", "or_set"): f"{_REF}.memory.or_set:OrSetMemory",
     ("privacy", "noop"): f"{_REF}.privacy.noop:NoopPrivacy",
     ("privacy", "hybrid_x25519"): f"{_REF}.privacy.hybrid_x25519:HybridX25519Privacy",
     ("privacy", "trust_gated"): f"{_REF}.privacy.trust_gated:TrustGatedPrivacy",

--- a/packages/nest-plugins-reference/nest_plugins_reference/memory/or_set.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/memory/or_set.py
@@ -1,0 +1,409 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OR-Set CRDT memory plugin -- concurrent adds survive, nothing is lost.
+
+This module implements a **state-based observed-remove set** (OR-Set CvRDT)
+for the Nanda Town memory layer. It is the complement to the existing
+``lww_register`` plugin: where an LWW-Register resolves a concurrent-write
+race by *discarding* all but one winner, the OR-Set *keeps every
+concurrently added element*. That is the right shape for the shared-catalogue
+pain called out in the memory-CRDT problem: when fifty sellers race to claim
+entries under one key in ``scenarios/marketplace.yaml``, an LWW register
+silently drops forty-nine of them; this plugin preserves all fifty.
+
+Through the base :class:`~nest_core.layers.memory.Memory` protocol the plugin
+behaves like a multi-value register built on an OR-Set:
+
+- ``write(key, value)`` performs an *observed-remove* of every element this
+  replica has seen for ``key``, then adds ``value`` with a fresh unique tag.
+  Locally that reads back exactly like a register write.
+- ``read(key)`` returns the element payload when exactly one element is
+  live. When concurrent writes from other replicas have merged in, it
+  returns **all** live elements as a canonical, sorted JSON array -- a
+  deterministic encoding, byte-identical on every converged replica.
+
+Replicas exchange state with ``export`` / ``merge`` exactly like
+``lww_register``; the merge is a join on (adds ∪ adds, removes ∪ removes)
+and is commutative, associative, and idempotent, which yields strong
+eventual consistency: same multiset of operations, any delivery order,
+identical bytes on read.
+
+The serialized state for a single key is inspectable JSON so it stays
+grep-able inside a JSONL trace::
+
+    {"crdt": "or_set", "adds": {"agent-1:3": "<base64>"}, "removes": ["agent-0:1"]}
+
+Add-tags are ``(node_id, counter)`` pairs -- deterministic, no wall clock, no
+global RNG -- so the same seed and operation sequence always produces a
+byte-identical merged state.
+
+Example::
+
+    a = OrSetMemory("a")
+    b = OrSetMemory("b")
+    await a.write("catalogue", b"from-a")
+    await b.write("catalogue", b"from-b")
+    # Gossip both ways; order does not matter.
+    await b.merge("catalogue", a.export("catalogue"))
+    await a.merge("catalogue", b.export("catalogue"))
+    assert await a.read("catalogue") == await b.read("catalogue")
+    # Both concurrent adds survive -- unlike lww_register.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+CRDT_KIND = "or_set"
+"""Schema tag stamped into every serialized set, used to detect and validate
+CRDT state when it is read back from a trace or the wire."""
+
+
+class CrdtStateError(ValueError):
+    """Raised when a byte string is not a valid serialized OR-Set.
+
+    Subclasses :class:`ValueError` so existing ``except ValueError`` handlers
+    keep working while callers that care can catch the specific type.
+
+    Example::
+
+        try:
+            OrSet.decode(b"not json")
+        except CrdtStateError:
+            ...
+    """
+
+
+@dataclass
+class OrSet:
+    """The pure OR-Set state for a single key: tagged adds plus removed tags.
+
+    An element is *live* when at least one of its add-tags has not been
+    removed. ``adds`` maps ``"node:counter"`` tags to payload bytes;
+    ``removes`` is the set of tags whose adds have been observed-removed.
+    The join of two states is the pairwise union of both fields, which is
+    commutative, associative, and idempotent -- a genuine semilattice join.
+
+    Example::
+
+        s = OrSet()
+        s.adds["a:1"] = b"x"
+        assert s.live() == {b"x"}
+    """
+
+    adds: dict[str, bytes] = field(default_factory=dict)
+    removes: set[str] = field(default_factory=set)
+
+    def live(self) -> set[bytes]:
+        """The set of currently visible element payloads.
+
+        Example::
+
+            elements = state.live()
+        """
+        return {v for tag, v in self.adds.items() if tag not in self.removes}
+
+    def live_tags(self) -> set[str]:
+        """Tags of adds that have not been removed.
+
+        Example::
+
+            tags = state.live_tags()
+        """
+        return {tag for tag in self.adds if tag not in self.removes}
+
+    def join(self, other: OrSet) -> OrSet:
+        """Least-upper-bound merge of two OR-Set states.
+
+        Union of adds, union of removes. Commutative, associative, and
+        idempotent by construction.
+
+        Example::
+
+            merged = mine.join(theirs)
+        """
+        return OrSet(
+            adds={**self.adds, **other.adds},
+            removes=self.removes | other.removes,
+        )
+
+    def encode(self) -> bytes:
+        """Serialize to canonical, grep-able JSON bytes.
+
+        Keys are sorted at every level, so two equal states always encode to
+        identical bytes -- the property the determinism tests pin down.
+
+        Example::
+
+            raw = state.encode()
+        """
+        data = {
+            "crdt": CRDT_KIND,
+            "adds": {
+                tag: base64.b64encode(payload).decode("ascii")
+                for tag, payload in sorted(self.adds.items())
+            },
+            "removes": sorted(self.removes),
+        }
+        return json.dumps(data, sort_keys=True).encode("utf-8")
+
+    @staticmethod
+    def decode(raw: bytes) -> OrSet:
+        """Parse serialized OR-Set state, validating shape and schema tag.
+
+        Raises:
+            CrdtStateError: if ``raw`` is not valid OR-Set JSON.
+
+        Example::
+
+            state = OrSet.decode(raw)
+        """
+        try:
+            obj = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise CrdtStateError(f"not valid OR-Set JSON: {exc}") from exc
+        if not isinstance(obj, dict) or obj.get("crdt") != CRDT_KIND:
+            raise CrdtStateError("missing or wrong 'crdt' schema tag")
+        adds_raw = obj.get("adds")
+        removes_raw = obj.get("removes")
+        if not isinstance(adds_raw, dict) or not isinstance(removes_raw, list):
+            raise CrdtStateError("'adds' must be an object and 'removes' a list")
+        try:
+            adds = {
+                str(tag): base64.b64decode(cast("str", b64), validate=True)
+                for tag, b64 in adds_raw.items()
+            }
+        except (ValueError, TypeError) as exc:
+            raise CrdtStateError(f"bad base64 payload: {exc}") from exc
+        return OrSet(adds=adds, removes={str(t) for t in removes_raw})
+
+
+class OrSetMemory:
+    """An observed-remove set CRDT implementing the ``Memory`` protocol.
+
+    Each instance is an independent **replica**. Local writes observed-remove
+    the elements this replica can currently see, then add the new value under
+    a fresh ``node_id:counter`` tag; replicas exchange state with
+    :meth:`export` / :meth:`merge`. Because removes only ever name tags the
+    replica has *observed*, an add performed concurrently on another replica
+    is never covered by the remove and therefore survives the merge -- the
+    defining OR-Set guarantee, and the exact behaviour an LWW register cannot
+    provide.
+
+    The standard :class:`~nest_core.layers.memory.Memory` surface
+    (``read`` / ``write`` / ``cas`` / ``subscribe``) treats values as opaque
+    user payloads; the CRDT machinery is internal. The extra
+    :meth:`export` / :meth:`merge` / :meth:`export_all` / :meth:`merge_all`
+    methods are the replication channel and are additive -- a caller that only
+    speaks the base protocol never has to know a set lives underneath.
+
+    Example::
+
+        mem = OrSetMemory("agent-0")
+        await mem.write("catalogue", b"widget")
+        assert await mem.read("catalogue") == b"widget"
+    """
+
+    def __init__(self, node_id: str = "node") -> None:
+        """Create a replica with a stable, unique ``node_id``.
+
+        The ``node_id`` must be stable for the lifetime of the replica and
+        unique across replicas: it namespaces add-tags, which is what makes
+        every tag globally unique without wall clocks or global RNG.
+
+        Example::
+
+            mem = OrSetMemory("agent-0")
+        """
+        self._node_id = str(node_id)
+        self._store: dict[str, OrSet] = {}
+        self._counter: int = 0
+        self._subscribers: dict[str, list[asyncio.Queue[bytes]]] = {}
+
+    @property
+    def node_id(self) -> str:
+        """The stable node identifier namespacing this replica's add-tags.
+
+        Example::
+
+            assert OrSetMemory("agent-0").node_id == "agent-0"
+        """
+        return self._node_id
+
+    # -- canonical read encoding -----------------------------------------
+
+    @staticmethod
+    def _canonical(elements: set[bytes]) -> bytes | None:
+        """Deterministic byte encoding of the live element set.
+
+        One element decodes to itself (register-like reads); several encode
+        to a sorted JSON array of base64 strings, so converged replicas
+        return byte-identical reads regardless of merge order.
+
+        Example::
+
+            assert OrSetMemory._canonical({b"x"}) == b"x"
+        """
+        if not elements:
+            return None
+        if len(elements) == 1:
+            return next(iter(elements))
+        encoded = sorted(base64.b64encode(e).decode("ascii") for e in elements)
+        return json.dumps(encoded, sort_keys=True).encode("utf-8")
+
+    # -- Memory protocol -------------------------------------------------
+
+    async def read(self, key: str) -> bytes | None:
+        """Read the live value(s) for ``key`` or ``None`` if empty.
+
+        A single live element is returned as-is. Multiple concurrent
+        elements are returned as a canonical sorted JSON array so that the
+        caller sees *everything that survived*, deterministically.
+
+        Example::
+
+            val = await mem.read("catalogue")
+        """
+        state = self._store.get(key)
+        if state is None:
+            return None
+        return self._canonical(state.live())
+
+    async def write(self, key: str, value: bytes) -> None:
+        """Observed-remove current elements, then add ``value``.
+
+        Locally this reads back like a register write. Concurrently added
+        elements on *other* replicas are untouched -- their tags were not
+        observed here, so the remove cannot cover them and they survive the
+        next merge. Subscribers are notified, matching the ``blackboard``
+        contract that every local write is observable.
+
+        Example::
+
+            await mem.write("catalogue", b"widget")
+        """
+        state = self._store.setdefault(key, OrSet())
+        state.removes |= state.live_tags()
+        self._counter += 1
+        state.adds[f"{self._node_id}:{self._counter}"] = value
+        await self._notify(key)
+
+    async def cas(self, key: str, expected: bytes, new: bytes) -> bool:
+        """Compare-and-swap in terms of the set's natural merge semantics.
+
+        Succeeds when the current canonical read equals ``expected``; the
+        swap is an ordinary observed-remove write, so it composes with
+        concurrent remote adds instead of clobbering them.
+
+        Example::
+
+            ok = await mem.cas("catalogue", b"widget", b"gadget")
+        """
+        if await self.read(key) != expected:
+            return False
+        await self.write(key, new)
+        return True
+
+    async def subscribe(self, key: str) -> AsyncIterator[bytes]:
+        """Subscribe to changes of the canonical value for ``key``.
+
+        Example::
+
+            async for val in mem.subscribe("catalogue"):
+                print(val)
+        """
+        q: asyncio.Queue[bytes] = asyncio.Queue()
+        self._subscribers.setdefault(key, []).append(q)
+        try:
+            while True:
+                yield await q.get()
+        finally:
+            self._subscribers[key].remove(q)
+
+    # -- replication channel ----------------------------------------------
+
+    def export(self, key: str) -> bytes | None:
+        """Serialize this replica's full state for ``key`` for gossip.
+
+        Example::
+
+            raw = mem.export("catalogue")
+        """
+        state = self._store.get(key)
+        return state.encode() if state is not None else None
+
+    async def merge(self, key: str, raw: bytes | None) -> None:
+        """Join remote serialized state for ``key`` into this replica.
+
+        Merging is idempotent and order-independent; subscribers are only
+        notified when the canonical read value actually changes.
+
+        Raises:
+            CrdtStateError: if ``raw`` is not valid OR-Set state.
+
+        Example::
+
+            await mem.merge("catalogue", remote_state)
+        """
+        if raw is None:
+            return
+        incoming = OrSet.decode(raw)
+        current = self._store.get(key, OrSet())
+        before = self._canonical(current.live())
+        merged = current.join(incoming)
+        self._store[key] = merged
+        if self._canonical(merged.live()) != before:
+            await self._notify(key)
+
+    def export_all(self) -> dict[str, bytes]:
+        """Serialize every key's state, for whole-store gossip.
+
+        Example::
+
+            for key, raw in mem.export_all().items():
+                await peer.merge(key, raw)
+        """
+        return {key: state.encode() for key, state in self._store.items()}
+
+    async def merge_all(self, states: dict[str, bytes]) -> None:
+        """Merge a whole-store export from a peer replica.
+
+        Example::
+
+            await mem.merge_all(peer.export_all())
+        """
+        for key, raw in states.items():
+            await self.merge(key, raw)
+
+    # -- internals ---------------------------------------------------------
+
+    async def _notify(self, key: str) -> None:
+        """Push the current canonical value to subscribers of ``key``.
+
+        Example::
+
+            await mem._notify("catalogue")
+        """
+        state = self._store.get(key)
+        value = self._canonical(state.live()) if state is not None else None
+        if value is None:
+            return
+        for q in self._subscribers.get(key, []):
+            await q.put(value)
+
+
+def _protocol_check() -> None:
+    """Static guard that ``OrSetMemory`` satisfies the ``Memory`` protocol.
+
+    Example::
+
+        _protocol_check()
+    """
+    from nest_core.layers.memory import Memory
+
+    mem: Any = OrSetMemory("check")
+    assert isinstance(mem, Memory)

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -41,6 +41,7 @@ authenticated = "nest_plugins_reference.comms.authenticated:AuthenticatedComms"
 
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"
+or_set = "nest_plugins_reference.memory.or_set:OrSetMemory"
 
 [project.entry-points."nest.plugins.registry"]
 byzantine_gossip = "nest_plugins_reference.registry.byzantine_gossip:ByzantineGossipRegistry"

--- a/packages/nest-plugins-reference/tests/test_or_set.py
+++ b/packages/nest-plugins-reference/tests/test_or_set.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the OR-Set CRDT memory plugin.
+
+Covers protocol conformance, the standard read/write/cas/subscribe surface,
+the export/merge replication channel, the three CRDT algebraic laws
+(commutativity, associativity, idempotence), convergence under arbitrary
+delivery order via the adversarial validator (which must fail for
+``blackboard`` and pass for the OR-Set), the defining OR-Set property that
+concurrent adds all survive (which ``lww_register`` cannot provide),
+determinism of the canonical encoding, malformed-input handling, and
+registry wiring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+
+import pytest
+from nest_core.layers.memory import Memory
+from nest_core.plugins import PluginRegistry
+from nest_core.validators import validate_crdt_convergence
+from nest_plugins_reference.memory.blackboard import Blackboard
+from nest_plugins_reference.memory.lww_register import LwwRegisterMemory
+from nest_plugins_reference.memory.or_set import (
+    CRDT_KIND,
+    CrdtStateError,
+    OrSet,
+    OrSetMemory,
+)
+
+# ---------------------------------------------------------------------------
+# Protocol conformance and base Memory surface
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_isinstance_memory(self) -> None:
+        assert isinstance(OrSetMemory("a"), Memory)
+
+    @pytest.mark.asyncio
+    async def test_read_missing_is_none(self) -> None:
+        mem = OrSetMemory("a")
+        assert await mem.read("missing") is None
+
+    @pytest.mark.asyncio
+    async def test_write_read_roundtrip(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k", b"value")
+        assert await mem.read("k") == b"value"
+
+    @pytest.mark.asyncio
+    async def test_overwrite_keeps_latest(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k", b"old")
+        await mem.write("k", b"new")
+        assert await mem.read("k") == b"new"
+
+    @pytest.mark.asyncio
+    async def test_cas_success(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k", b"old")
+        assert await mem.cas("k", b"old", b"new") is True
+        assert await mem.read("k") == b"new"
+
+    @pytest.mark.asyncio
+    async def test_cas_failure_leaves_value(self) -> None:
+        mem = OrSetMemory("a")
+        await mem.write("k", b"current")
+        assert await mem.cas("k", b"wrong", b"new") is False
+        assert await mem.read("k") == b"current"
+
+    @pytest.mark.asyncio
+    async def test_cas_on_missing_key(self) -> None:
+        mem = OrSetMemory("a")
+        assert await mem.cas("k", b"expected", b"new") is False
+
+    @pytest.mark.asyncio
+    async def test_subscribe_sees_local_write(self) -> None:
+        mem = OrSetMemory("a")
+        agen = mem.subscribe("k")
+        task = asyncio.ensure_future(agen.__anext__())
+        await asyncio.sleep(0)
+        await mem.write("k", b"ping")
+        assert await asyncio.wait_for(task, timeout=1) == b"ping"
+        await agen.aclose()
+
+
+# ---------------------------------------------------------------------------
+# CRDT algebraic laws on the pure state
+# ---------------------------------------------------------------------------
+
+
+class TestAlgebraicLaws:
+    def _states(self) -> tuple[OrSet, OrSet, OrSet]:
+        s1 = OrSet(adds={"a:1": b"x"}, removes=set())
+        s2 = OrSet(adds={"b:1": b"y"}, removes={"a:1"})
+        s3 = OrSet(adds={"c:1": b"z", "a:1": b"x"}, removes={"b:1"})
+        return s1, s2, s3
+
+    def test_join_commutative(self) -> None:
+        s1, s2, _ = self._states()
+        assert s1.join(s2).encode() == s2.join(s1).encode()
+
+    def test_join_associative(self) -> None:
+        s1, s2, s3 = self._states()
+        left = s1.join(s2).join(s3)
+        right = s1.join(s2.join(s3))
+        assert left.encode() == right.encode()
+
+    def test_join_idempotent(self) -> None:
+        s1, _, _ = self._states()
+        assert s1.join(s1).encode() == s1.encode()
+
+    def test_observed_remove_only_covers_observed_tags(self) -> None:
+        # A remove for tag a:1 must not affect a concurrent add under b:1.
+        removed = OrSet(adds={"a:1": b"x"}, removes={"a:1"})
+        concurrent = OrSet(adds={"b:1": b"y"}, removes=set())
+        assert removed.join(concurrent).live() == {b"y"}
+
+
+# ---------------------------------------------------------------------------
+# The defining OR-Set property: concurrent adds survive
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentAddsSurvive:
+    @pytest.mark.asyncio
+    async def test_or_set_keeps_both_concurrent_writes(self) -> None:
+        a, b = OrSetMemory("a"), OrSetMemory("b")
+        await a.write("catalogue", b"from-a")
+        await b.write("catalogue", b"from-b")
+        await b.merge("catalogue", a.export("catalogue"))
+        await a.merge("catalogue", b.export("catalogue"))
+        merged = await a.read("catalogue")
+        assert merged == await b.read("catalogue")
+        assert merged is not None
+        elements = {base64.b64decode(e) for e in json.loads(merged)}
+        assert elements == {b"from-a", b"from-b"}
+
+    @pytest.mark.asyncio
+    async def test_lww_register_loses_a_concurrent_write(self) -> None:
+        # The gap this plugin closes: the LWW register converges but keeps
+        # only one of two concurrent writes, silently dropping the other.
+        a, b = LwwRegisterMemory("a"), LwwRegisterMemory("b")
+        await a.write("catalogue", b"from-a")
+        await b.write("catalogue", b"from-b")
+        await b.merge("catalogue", a.export("catalogue"))
+        await a.merge("catalogue", b.export("catalogue"))
+        winner = await a.read("catalogue")
+        assert winner == await b.read("catalogue")
+        assert winner in (b"from-a", b"from-b")  # exactly one survives
+
+    @pytest.mark.asyncio
+    async def test_local_rewrite_after_merge_replaces_all_observed(self) -> None:
+        a, b = OrSetMemory("a"), OrSetMemory("b")
+        await a.write("k", b"one")
+        await b.write("k", b"two")
+        await a.merge("k", b.export("k"))
+        await a.write("k", b"final")  # observes both, removes both, adds one
+        await b.merge("k", a.export("k"))
+        assert await a.read("k") == b"final"
+        assert await b.read("k") == b"final"
+
+
+# ---------------------------------------------------------------------------
+# Adversarial convergence validator: FAIL blackboard, PASS or_set
+# ---------------------------------------------------------------------------
+
+
+WRITES = [(0, b"alpha"), (1, b"bravo"), (2, b"charlie"), (0, b"delta")]
+ORDERS = [[0, 1, 2, 3], [3, 2, 1, 0], [1, 3, 0, 2]]
+
+
+class TestConvergenceValidator:
+    @pytest.mark.asyncio
+    async def test_blackboard_fails_convergence(self) -> None:
+        results = await validate_crdt_convergence(
+            lambda _node: Blackboard(), writes=WRITES, delivery_orders=ORDERS
+        )
+        assert not all(r.passed for r in results)
+
+    @pytest.mark.asyncio
+    async def test_or_set_passes_convergence(self) -> None:
+        results = await validate_crdt_convergence(
+            OrSetMemory, writes=WRITES, delivery_orders=ORDERS
+        )
+        assert all(r.passed for r in results), [r.detail for r in results]
+
+    @pytest.mark.asyncio
+    async def test_or_set_converges_under_duplicated_gossip(self) -> None:
+        # Idempotence end-to-end: delivering the same state twice is a no-op.
+        a, b = OrSetMemory("a"), OrSetMemory("b")
+        await a.write("k", b"x")
+        state = a.export("k")
+        await b.merge("k", state)
+        await b.merge("k", state)
+        assert await b.read("k") == await a.read("k")
+
+
+# ---------------------------------------------------------------------------
+# Determinism of the canonical encoding
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    @pytest.mark.asyncio
+    async def test_same_ops_same_bytes(self) -> None:
+        def build() -> OrSetMemory:
+            return OrSetMemory("fixed-node")
+
+        async def run(mem: OrSetMemory) -> bytes | None:
+            await mem.write("k", b"one")
+            await mem.write("k", b"two")
+            return mem.export("k")
+
+        assert await run(build()) == await run(build())
+
+    @pytest.mark.asyncio
+    async def test_merge_order_does_not_change_bytes(self) -> None:
+        a, b, c = OrSetMemory("a"), OrSetMemory("b"), OrSetMemory("c")
+        for mem, payload in ((a, b"pa"), (b, b"pb"), (c, b"pc")):
+            await mem.write("k", payload)
+        sa, sb, sc = a.export("k"), b.export("k"), c.export("k")
+
+        one = OrSetMemory("x")
+        for raw in (sa, sb, sc):
+            await one.merge("k", raw)
+        other = OrSetMemory("y")
+        for raw in (sc, sa, sb):
+            await other.merge("k", raw)
+        assert one.export("k") == other.export("k")
+        assert await one.read("k") == await other.read("k")
+
+
+# ---------------------------------------------------------------------------
+# Malformed input and registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedInput:
+    def test_decode_rejects_non_json(self) -> None:
+        with pytest.raises(CrdtStateError):
+            OrSet.decode(b"\xff\xfenope")
+
+    def test_decode_rejects_wrong_schema_tag(self) -> None:
+        raw = json.dumps({"crdt": "lww_register", "adds": {}, "removes": []}).encode()
+        with pytest.raises(CrdtStateError):
+            OrSet.decode(raw)
+
+    def test_decode_rejects_bad_shapes(self) -> None:
+        raw = json.dumps({"crdt": CRDT_KIND, "adds": [], "removes": {}}).encode()
+        with pytest.raises(CrdtStateError):
+            OrSet.decode(raw)
+
+    def test_decode_rejects_bad_base64(self) -> None:
+        raw = json.dumps(
+            {"crdt": CRDT_KIND, "adds": {"a:1": "!!not-base64!!"}, "removes": []}
+        ).encode()
+        with pytest.raises(CrdtStateError):
+            OrSet.decode(raw)
+
+    def test_crdt_state_error_is_value_error(self) -> None:
+        assert issubclass(CrdtStateError, ValueError)
+
+
+class TestRegistryWiring:
+    def test_resolves_from_plugin_registry(self) -> None:
+        cls = PluginRegistry().resolve("memory", "or_set")
+        assert cls is OrSetMemory
+
+    @pytest.mark.asyncio
+    async def test_resolved_instance_satisfies_memory(self) -> None:
+        cls = PluginRegistry().resolve("memory", "or_set")
+        mem = cls("agent-0")
+        assert isinstance(mem, Memory)
+        await mem.write("k", b"v")
+        assert await mem.read("k") == b"v"


### PR DESCRIPTION
## Problem

[[02 — Conflict-free shared memory under concurrent writers](https://claude.ai/cowork/docs/hackathon/problems/02-memory-crdt-lww.md)](docs/hackathon/problems/02-memory-crdt-lww.md)

The problem statement names two suggested plugin shapes: `lww_crdt` and
`or_set`. The LWW-Register half was shipped in an earlier PR; this PR ships
the **OR-Set** half, which covers the case the register *cannot*: an
LWW-Register resolves a concurrent-write race by discarding all but one
winner. For the shared-catalogue pain named in the problem's motivation
(fifty marketplace sellers racing to claim entries under one key), that means
forty-nine writes silently vanish. An observed-remove set keeps them all.

## What this adds

**`nest_plugins_reference/memory/or_set.py`** — a state-based OR-Set CvRDT
implementing the `Memory` protocol (`isinstance(plugin, Memory)` holds):

- `write` = observed-remove of locally-seen elements + add under a fresh
  `node_id:counter` tag; local reads behave register-like.
- Concurrent adds from other replicas are never covered by a local remove,
  so they **survive the merge** — the defining OR-Set guarantee.
- `read` returns the single live element as-is, or a canonical sorted JSON
  array when concurrent elements coexist — deterministic, byte-identical on
  every converged replica.
- `cas` is implemented in terms of the set's natural merge semantics.
- `export`/`merge`/`export_all`/`merge_all` replication channel, same shape
  as `lww_register`. Merge = union ∪ union: commutative, associative,
  idempotent.
- Deterministic by construction: tags are `(node_id, counter)` — no wall
  clock, no global RNG. Serialized state is grep-able JSON tagged
  `"crdt": "or_set"`.

**Registration** — `("memory", "or_set")` in `nest_core/plugins.py` builtins
and the `nest.plugins.memory` entry point in
`nest-plugins-reference/pyproject.toml`.

**`tests/test_or_set.py`** — 27 tests:

- Protocol conformance + full read/write/cas/subscribe surface.
- The three CRDT algebraic laws on the pure state (commutativity,
  associativity, idempotence), plus observed-remove correctness.
- **The discriminating test**: the adversarial
  `validate_crdt_convergence` validator **fails against `blackboard` and
  passes against `or_set`** under three different delivery orders.
- **The test that fails without this change**: concurrent writes on two
  replicas — `or_set` preserves both elements; the companion test pins down
  that `lww_register` keeps only one, documenting exactly the gap this
  plugin closes. Registry-wiring tests fail without the `plugins.py` line.
- Determinism: same ops → byte-identical export; merge order does not
  change bytes. Idempotence under duplicated gossip. Malformed-state
  handling via `CrdtStateError`.

## How to run

```bash
pytest packages/nest-plugins-reference/tests/test_or_set.py -v
```

Results on this branch: 27/27 pass; existing `test_lww_register.py`,
`test_plugins.py`, and `test_imports.py` all still pass (74 tests). `ruff
check` and `ruff format --check` clean on all touched files.

## Scope and limits (honest)

- State-based (CvRDT), per the problem's out-of-scope note on CmRDTs.
- Remove tombstones are kept forever; garbage collection is out of scope
  here and called out in the module docstring.
- Reuses the existing generic `validate_crdt_convergence` validator rather
  than duplicating it — it was written capability-based (export/merge) and
  works unchanged for this plugin.