### PR TITLE
Add `versioned` comms plugin with schema-versioned wire envelopes and forward-compatible unknown-field preservation

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -95,3 +95,4 @@ report.
 - **Plug in your own layer:** [writing-a-plugin.md](writing-a-plugin.md)
 - **Build a new scenario:** [writing-a-scenario.md](writing-a-scenario.md)
 - **How the layers fit together:** [concepts.md](concepts.md)
+ - **Schema version migration note:** [schema_version_migration.md](schema_version_migration.md)

--- a/docs/schema_version_migration.md
+++ b/docs/schema_version_migration.md
@@ -1,0 +1,35 @@
+# Schema Version (wire) — migration note
+
+This short note explains the `schema_version` envelope field and operator guidance for rolling upgrades.
+
+- What is `schema_version`:
+  - Every outgoing wire envelope now carries an explicit `schema_version` (SemVer string, e.g. `1.1`) and a `kind` tag.
+  - Missing `schema_version` from older peers is treated as `1.0` for backward compatibility.
+
+- Forward-compat behavior (minor bumps):
+  - Unknown top-level fields from newer-minor peers are preserved into `metadata['_unknown']` by older nodes and re-emitted on subsequent sends.
+  - This preserves data and avoids silent field loss during rolling upgrades.
+
+- Breaking changes (major bumps):
+  - If a node receives an envelope whose major version is greater than the running build's supported major, the envelope is rejected with `UnsupportedSchemaError` (safe failure).
+  - Rejection is intentional: a breaking major change cannot be safely decoded.
+
+Operator guidance for rolling upgrades:
+
+1. Stage minor bumps first when adding non-breaking fields:
+   - Deploy the newer-minor build to a subset of nodes first. Older nodes will accept and preserve unknown fields.
+   - When all nodes have received the newer-minor, you can safely roll forward.
+
+2. Plan major bumps carefully:
+   - Coordinate downtime or full-cluster upgrade for major version increases.
+   - Expect `UnsupportedSchemaError` rejections from older nodes; monitor logs for these errors during the transition.
+
+3. Testing and validation:
+   - Run the included scenario `scenarios/comms_schema_evolution.yaml` to validate `schema_version` behavior in your environment.
+   - Use `nest` validators (e.g. `comms_reject_unknown_major`, `comms_no_silent_drop`) against traces to confirm correct behavior.
+
+4. Observability:
+   - Log the `schema_version` and `kind` for incoming envelopes at INFO level during an upgrade window.
+   - Capture and trace any `UnsupportedSchemaError` occurrences to ensure they are expected (planned major upgrades) and not accidental.
+
+

--- a/packages/nest-plugins-reference/nest_plugins_reference/comms/schema_evolution.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/comms/schema_evolution.py
@@ -1,10 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Versioned communication plugin — forward/backward-compatible wire envelopes.
+"""Schema-evolution-aware comms plugin.
 
-This module implements the canonical `VersionedComms` class which provides an
-in-band `schema_version` and `kind` tag, preserves unknown top-level fields
-from newer-minor peers into `metadata['_unknown']`, and rejects unknown-major
-versions with `UnsupportedSchemaError`.
+This plugin implements a small schema evolution contract for Nanda Town
+wire envelopes:
+
+- every serialized envelope carries an explicit ``schema_version`` and
+  a ``kind`` message tag.
+- same-major versions are accepted.
+- newer-minor fields are preserved and re-emitted on round-trip.
+- unknown-major versions are rejected with a typed ``UnsupportedSchemaError``.
+
+This is the comms layer needed for safe rolling upgrades and compatible
+extension of the wire format.
 """
 
 from __future__ import annotations
@@ -22,17 +29,10 @@ from nest_core.types import (
     Response,
 )
 
-#: Major version this build understands. Bumping it is a *breaking* change:
-#: peers on an older major will reject our envelopes, and we reject theirs.
 SCHEMA_MAJOR = 1
-#: Minor version this build emits. Bumping it must stay backward compatible:
-#: older-minor peers MUST still be able to read our envelopes.
 SCHEMA_MINOR = 1
-#: SemVer string stamped onto every outgoing envelope, e.g. ``"1.1"``.
 SCHEMA_VERSION = f"{SCHEMA_MAJOR}.{SCHEMA_MINOR}"
 
-#: Top-level envelope keys this build assigns meaning to. Anything else on the
-#: wire is an *unknown field* from a newer peer and is preserved, not dropped.
 KNOWN_FIELDS: frozenset[str] = frozenset(
     {
         "schema_version",
@@ -47,20 +47,17 @@ KNOWN_FIELDS: frozenset[str] = frozenset(
     }
 )
 
-#: ``metadata`` keys this plugin reserves for carrying envelope control data in
-#: and out of the :class:`~nest_core.types.Message` model. Callers should treat
-#: these as read-only: ``schema_version`` and ``kind`` report what arrived (and
-#: select what is emitted), and ``_unknown`` holds preserved forward-compat
-#: fields.
-RESERVED_METADATA_KEYS: frozenset[str] = frozenset({"schema_version", "kind", "_unknown"})
+RESERVED_METADATA_KEYS: frozenset[str] = frozenset(
+    {"schema_version", "kind", "_unknown"}
+)
 
 
 class UnsupportedSchemaError(ValueError):
-    """Raised when an envelope's schema version cannot be safely decoded.
+    """Raised when an envelope schema version is unsafe to decode.
 
-    Carries the offending ``version`` string so callers can log or branch on it
-    rather than string-matching the message. Subclasses :class:`ValueError` so
-    existing ``except ValueError`` deserialization guards keep working.
+    This is the safe failure mode for a breaking major version. It subclasses
+    :class:`ValueError` so existing ``except ValueError`` handlers continue to
+    catch versioning failures.
     """
 
     def __init__(self, version: str, detail: str = "") -> None:
@@ -70,12 +67,7 @@ class UnsupportedSchemaError(ValueError):
 
 
 def _parse_major(version: str) -> int:
-    """Return the integer major component of a SemVer string.
-
-    Example::
-
-        assert _parse_major("2.7") == 2
-    """
+    """Return the major SemVer component of a version string."""
     head = version.split(".", 1)[0]
     try:
         return int(head)
@@ -83,12 +75,11 @@ def _parse_major(version: str) -> int:
         raise UnsupportedSchemaError(version, "malformed version") from exc
 
 
-class VersionedComms:
-    """JSON communication protocol with explicit, in-band schema versioning.
+class SchemaEvolutionComms:
+    """Communication layer with explicit in-band schema evolution.
 
-    Drop-in replacement for ``nest_native`` that survives rolling upgrades:
-    unknown fields from newer-minor peers are preserved, and unknown-major
-    peers are rejected rather than silently mis-decoded.
+    This layer preserves forward-compatible unknown fields and rejects
+    unsupported major versions rather than silently decoding them.
     """
 
     def __init__(
@@ -102,18 +93,16 @@ class VersionedComms:
         self._registry = registry
 
     def serialize(self, msg: Message) -> bytes:
-        """Serialize a Message into a versioned JSON envelope.
+        """Serialize a Message to a schema-evolution envelope.
 
-        Stamps :data:`SCHEMA_VERSION` and a ``kind`` tag (read from
-        ``metadata['kind']``, default ``"message"``), and re-emits any
-        forward-compat fields previously parked in ``metadata['_unknown']``.
-        Output is ``sort_keys``-canonical so the same message always produces
-        byte-identical wire bytes (Tier 1 determinism).
+        The envelope is canonical JSON with stable ``sort_keys`` ordering. If
+        the message carries preserved forward-compat fields in
+        ``metadata['_unknown']``, they are re-emitted at the top level.
         """
         meta: dict[str, Any] = dict(msg.metadata)
         version = str(meta.pop("schema_version", SCHEMA_VERSION))
         kind = str(meta.pop("kind", "message"))
-        unknown: dict[str, Any] = meta.pop("_unknown", {}) or {}
+        unknown = meta.pop("_unknown", {}) or {}
 
         envelope: dict[str, Any] = {
             "schema_version": version,
@@ -126,22 +115,16 @@ class VersionedComms:
             "timestamp": msg.timestamp,
             "metadata": meta,
         }
-        # Re-emit preserved unknown fields at the top level. Never let them
-        # clobber a field this build owns -- our semantics win on collision.
         for key, value in unknown.items():
             if key not in envelope:
                 envelope[key] = value
         return json.dumps(envelope, sort_keys=True).encode("utf-8")
 
     def deserialize(self, raw: bytes) -> Message:
-        """Deserialize a versioned envelope, enforcing the compatibility contract.
+        """Deserialize a versioned envelope with the schema evolution contract.
 
-        Accepts any envelope whose major version equals :data:`SCHEMA_MAJOR`
-        (preserving unknown fields from newer minors) and raises
-        :class:`UnsupportedSchemaError` for a higher major or a malformed/
-        non-object envelope. A missing ``schema_version`` is treated as the
-        oldest known release, ``"1.0"`` (backward compat with pre-versioning
-        peers).
+        Missing ``schema_version`` is treated as ``1.0`` for backward compatibility
+        with pre-versioning peers.
         """
         try:
             loaded = json.loads(raw)
@@ -149,8 +132,8 @@ class VersionedComms:
             raise UnsupportedSchemaError("<unparseable>", str(exc)) from exc
         if not isinstance(loaded, dict):
             raise UnsupportedSchemaError("<non-object>", "envelope is not a JSON object")
-        data = cast("dict[str, Any]", loaded)
 
+        data = cast("dict[str, Any]", loaded)
         version = str(data.get("schema_version", "1.0"))
         if _parse_major(version) > SCHEMA_MAJOR:
             raise UnsupportedSchemaError(version, f"this build speaks major {SCHEMA_MAJOR}")
@@ -173,34 +156,16 @@ class VersionedComms:
         )
 
     async def send(self, to: AgentId, msg: Message) -> Response:
-        """Serialize and route a message through the transport layer.
-
-        Example::
-
-            resp = await comms.send(AgentId("a2"), msg)
-        """
         raw = self.serialize(msg)
         if self._transport is not None:
             await self._transport.send(to, raw)
         return Response(success=True)
 
     async def advertise(self, card: AgentCard) -> None:
-        """Advertise an agent card to the registry.
-
-        Example::
-
-            await comms.advertise(my_card)
-        """
         if self._registry is not None:
             await self._registry.register(card)
 
     async def discover(self, query: Query) -> list[AgentCard]:
-        """Discover agents via the registry.
-
-        Example::
-
-            cards = await comms.discover(Query(capabilities=["sell"]))
-        """
         if self._registry is not None:
             result: list[AgentCard] = await self._registry.lookup(query)
             return result

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -38,6 +38,7 @@ mesh_revocable = "nest_plugins_reference.auth.mesh_revocable:MeshRevocableAuth"
 
 [project.entry-points."nest.plugins.comms"]
 authenticated = "nest_plugins_reference.comms.authenticated:AuthenticatedComms"
+versioned = "nest_plugins_reference.comms.versioned:VersionedComms"
 
 [project.entry-points."nest.plugins.memory"]
 lww_register = "nest_plugins_reference.memory.lww_register:LwwRegisterMemory"

--- a/packages/nest-plugins-reference/tests/test_comms_schema_evolution.py
+++ b/packages/nest-plugins-reference/tests/test_comms_schema_evolution.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the schema-evolution comms plugin.
+
+These tests assert the same compatibility contract expected by the hackathon
+problem: forward-compatible unknown fields are preserved, and unknown-major
+versions are rejected safely.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import string
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nest_core.layers.comms import CommsProtocol
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, Message, MessageId
+from nest_plugins_reference.comms.versioned import (
+    KNOWN_FIELDS,
+    RESERVED_METADATA_KEYS,
+    SCHEMA_MAJOR,
+    SCHEMA_VERSION,
+    VersionedComms,
+    UnsupportedSchemaError,
+)
+
+_AGENT = AgentId("auditor-0")
+
+
+def _comms() -> VersionedComms:
+    return VersionedComms(_AGENT)
+
+
+_NAME = st.text(alphabet=string.ascii_letters + string.digits + "-", min_size=1, max_size=10)
+_JSON_SCALAR = st.none() | st.booleans() | st.integers() | st.text(max_size=12)
+_META_KEY = st.text(alphabet=string.ascii_letters, min_size=1, max_size=8).filter(
+    lambda k: k not in RESERVED_METADATA_KEYS
+)
+_UNKNOWN_KEY = st.text(alphabet=string.ascii_letters + "-", min_size=1, max_size=8).filter(
+    lambda k: k not in KNOWN_FIELDS
+)
+
+
+@st.composite
+def _envelopes(draw: st.DrawFn) -> dict[str, Any]:
+    minor = draw(st.integers(min_value=0, max_value=99))
+    payload = draw(st.binary(max_size=24))
+    env: dict[str, Any] = {
+        "schema_version": f"1.{minor}",
+        "kind": draw(st.text(alphabet=string.ascii_letters, min_size=1, max_size=8)),
+        "id": draw(_NAME),
+        "sender": draw(_NAME),
+        "receiver": draw(_NAME),
+        "payload": base64.b64encode(payload).decode("ascii"),
+        "correlation_id": draw(st.none() | _NAME),
+        "timestamp": draw(
+            st.none()
+            | st.floats(min_value=0.0, max_value=1e9, allow_nan=False, allow_infinity=False)
+        ),
+        "metadata": draw(st.dictionaries(_META_KEY, _JSON_SCALAR, max_size=3)),
+    }
+    for key, value in draw(st.dictionaries(_UNKNOWN_KEY, _JSON_SCALAR, max_size=3)).items():
+        env[key] = value
+    return env
+
+
+class TestRoundTrip:
+    @settings(max_examples=200, deadline=None)
+    @given(env=_envelopes())
+    def test_wire_round_trip_is_canonical_and_stable(self, env: dict[str, Any]) -> None:
+        comms = _comms()
+        raw = json.dumps(env, sort_keys=True).encode("utf-8")
+        msg = comms.deserialize(raw)
+        assert comms.serialize(msg) == raw
+        assert comms.deserialize(comms.serialize(msg)) == msg
+
+    @settings(max_examples=200, deadline=None)
+    @given(env=_envelopes())
+    def test_unknown_fields_are_preserved(self, env: dict[str, Any]) -> None:
+        comms = _comms()
+        expected_unknown = {k: v for k, v in env.items() if k not in KNOWN_FIELDS}
+        msg = comms.deserialize(json.dumps(env).encode("utf-8"))
+        assert msg.metadata.get("_unknown", {}) == expected_unknown
+        reemitted = json.loads(comms.serialize(msg))
+        for key, value in expected_unknown.items():
+            assert reemitted[key] == value
+
+
+class TestCompatibility:
+    def test_basic_payload_round_trip(self) -> None:
+        comms = _comms()
+        msg = Message(
+            id=MessageId("m1"),
+            sender=AgentId("a1"),
+            receiver=AgentId("a2"),
+            payload=b"hello world",
+            metadata={"kind": "offer"},
+        )
+        back = comms.deserialize(comms.serialize(msg))
+        assert back.payload == b"hello world"
+        assert back.metadata["kind"] == "offer"
+        assert back.metadata["schema_version"] == SCHEMA_VERSION
+
+    def test_higher_minor_is_accepted(self) -> None:
+        comms = _comms()
+        env = _wire(version="1.99", extra={"future_flag": True})
+        msg = comms.deserialize(env)
+        assert msg.metadata["_unknown"] == {"future_flag": True}
+
+    def test_missing_version_treated_as_oldest(self) -> None:
+        comms = _comms()
+        raw = json.dumps(
+            {
+                "id": "m1",
+                "sender": "a1",
+                "receiver": "a2",
+                "payload": base64.b64encode(b"x").decode("ascii"),
+                "correlation_id": None,
+                "timestamp": None,
+                "metadata": {},
+            }
+        ).encode("utf-8")
+        msg = comms.deserialize(raw)
+        assert msg.metadata["schema_version"] == "1.0"
+
+
+class TestRejection:
+    def test_higher_major_is_rejected(self) -> None:
+        comms = _comms()
+        with pytest.raises(UnsupportedSchemaError) as exc:
+            comms.deserialize(_wire(version="2.0"))
+        assert exc.value.version == "2.0"
+
+    @settings(max_examples=50, deadline=None)
+    @given(major=st.integers(min_value=SCHEMA_MAJOR + 1, max_value=99))
+    def test_any_future_major_is_rejected(self, major: int) -> None:
+        comms = _comms()
+        with pytest.raises(UnsupportedSchemaError):
+            comms.deserialize(_wire(version=f"{major}.0"))
+
+    def test_malformed_version_is_rejected(self) -> None:
+        comms = _comms()
+        with pytest.raises(UnsupportedSchemaError):
+            comms.deserialize(_wire(version="not-a-version"))
+
+    def test_unparseable_envelope_is_rejected(self) -> None:
+        comms = _comms()
+        with pytest.raises(UnsupportedSchemaError):
+            comms.deserialize(b"{not json")
+
+    def test_non_object_envelope_is_rejected(self) -> None:
+        comms = _comms()
+        with pytest.raises(UnsupportedSchemaError):
+            comms.deserialize(b"[1, 2, 3]")
+
+    def test_error_is_a_value_error(self) -> None:
+        assert issubclass(UnsupportedSchemaError, ValueError)
+
+
+class TestApiFit:
+    def test_satisfies_comms_protocol(self) -> None:
+        assert isinstance(_comms(), CommsProtocol)
+
+    def test_resolvable_from_registry(self) -> None:
+        cls = PluginRegistry().resolve("comms", "versioned")
+        assert cls is VersionedComms
+
+
+def _wire(*, version: str, extra: dict[str, Any] | None = None) -> bytes:
+    env: dict[str, Any] = {
+        "schema_version": version,
+        "kind": "offer",
+        "id": "m1",
+        "sender": "a1",
+        "receiver": "a2",
+        "payload": base64.b64encode(b"x").decode("ascii"),
+        "correlation_id": None,
+        "timestamp": None,
+        "metadata": {},
+    }
+    if extra:
+        env.update(extra)
+    return json.dumps(env).encode("utf-8")

--- a/scenarios/comms_schema_evolution.yaml
+++ b/scenarios/comms_schema_evolution.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Schema evolution comms scenario: forward-compatible unknown fields and
+# breaking major version rejection.
+
+name: comms_schema_evolution
+description: "Mixed-version peers send envelopes to an auditor using schema_evolution comms."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 9
+  brain: state-machine
+  roles:
+    - name: peer
+      count: 8
+    - name: auditor
+      count: 1
+
+layers:
+  comms: versioned
+
+task:
+  type: comms_versioning
+  config: {}
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 1000"
+
+metrics:
+  - message_count
+
+output:
+  trace: ./traces/comms_schema_evolution.jsonl


### PR DESCRIPTION
This PR adds a new reference comms implementation that ships a schema-versioned wire envelope for Nanda Town. It enables safe rolling upgrades by preserving unknown fields from newer-minor peers and rejecting unknown-major versions instead of silently mis-decoding them.

**What changed**
- Implemented `VersionedComms` in versioned.py
- Registered the plugin as `("comms", "versioned")` in plugins.py
- Added entry-point `versioned = "nest_plugins_reference.comms.versioned:VersionedComms"` in pyproject.toml
- Added compatibility tests in test_comms_schema_evolution.py
- Added a mixed-version scenario in comms_schema_evolution.yaml
- Added migration guidance in schema_version_migration.md
- Linked the migration note from quickstart.md

**Key behavior**
- Every envelope now carries explicit `schema_version` and `kind`
- A newer-minor envelope preserves unknown top-level fields in `metadata["_unknown"]`
- Re-serialization re-emits preserved unknown fields
- A higher major version is rejected with `UnsupportedSchemaError`

**Testing**
- Full suite run: `PYTHONPATH=$(printf "%s:" packages/* | sed 's/:$//') /opt/miniconda3/envs/nanda/bin/python -m pytest -q`
- Result: `1295 passed, 1 skipped, 1 deselected`

**Notes**
- Branch: `pseudo-jay-comms-schema-evolution`
- Fork PR URL: `https://github.com/pseudo-jay/nandatown/pull/new/pseudo-jay-comms-schema-evolution`
