### PR TITLE
Guard SkillMD submissions against duplicate creation

### DIFF
--- a/apps/nest-dashboard/src/app/skills/actions.ts
+++ b/apps/nest-dashboard/src/app/skills/actions.ts
@@ -2,7 +2,12 @@
 
 import { revalidatePath, revalidateTag } from "next/cache";
 import { headers } from "next/headers";
-import { createSkill, SKILLS_CACHE_TAG, type SkillSourceType } from "@/lib/skills";
+import {
+  createSkill,
+  findRecentDuplicate,
+  SKILLS_CACHE_TAG,
+  type SkillSourceType,
+} from "@/lib/skills";
 import { initialSubmitState, type SubmitState } from "./form-state";
 
 function str(value: FormDataEntryValue | null): string {
@@ -112,6 +117,23 @@ export async function submitSkill(
     return {
       ...initialSubmitState,
       error: "Paste the full SkillMD text — that looks too short.",
+    };
+  }
+
+  // --- Reject a near-simultaneous duplicate of the same submission --------
+  // Catches what the client-side submit guard can't: a genuine double POST
+  // (double click before the guard sets, a browser/network retry, etc.).
+  const existingDuplicate = await findRecentDuplicate(
+    name,
+    sourceType === "content" ? null : sourceUrl,
+    sourceType === "content" ? content : null,
+  );
+  if (existingDuplicate) {
+    return {
+      ok: true,
+      error: null,
+      createdId: existingDuplicate.id,
+      createdName: existingDuplicate.name,
     };
   }
 

--- a/apps/nest-dashboard/src/app/skills/submit-form.tsx
+++ b/apps/nest-dashboard/src/app/skills/submit-form.tsx
@@ -36,6 +36,11 @@ export function SubmitForm() {
     CHECKLIST.map(() => false),
   );
   const formRef = useRef<HTMLFormElement>(null);
+  // `pending` from useActionState only flips true after React commits a
+  // render, which lags a rapid double/triple click by at least one frame —
+  // that gap is what let one click create three identical skill rows. This
+  // ref blocks re-entrant submits synchronously, before that render happens.
+  const submittingRef = useRef(false);
 
   // Clear the fields after a successful save.
   useEffect(() => {
@@ -46,8 +51,25 @@ export function SubmitForm() {
     }
   }, [state.ok]);
 
+  // Release the guard once the action has actually resolved (success or
+  // error), so a legitimate resubmit after fixing a validation error works.
+  useEffect(() => {
+    if (!pending) submittingRef.current = false;
+  }, [pending]);
+
   return (
-    <form ref={formRef} action={formAction} className="space-y-7">
+    <form
+      ref={formRef}
+      action={formAction}
+      onSubmit={(e) => {
+        if (submittingRef.current) {
+          e.preventDefault();
+          return;
+        }
+        submittingRef.current = true;
+      }}
+      className="space-y-7"
+    >
       {/* Readiness checklist */}
       <div className="rounded-2xl border border-cream-400/70 bg-cream-100/70 p-5">
         <p className={labelClass}>Before you submit — the steps</p>

--- a/apps/nest-dashboard/src/lib/skills.ts
+++ b/apps/nest-dashboard/src/lib/skills.ts
@@ -85,6 +85,33 @@ export async function getSkill(id: string): Promise<Skill | null> {
   return (rows as unknown as Skill[])[0] ?? null;
 }
 
+/**
+ * Look for an identical submission (same name + source) saved in the last
+ * few seconds. Guards against a client double-submit (e.g. a rapid double
+ * click, or a retried request) creating multiple identical rows.
+ */
+export async function findRecentDuplicate(
+  name: string,
+  sourceUrl: string | null,
+  content: string | null,
+  windowSeconds = 15,
+): Promise<Skill | null> {
+  await ensureSchema();
+  const db = sql();
+  const rows = await db`
+    select id, name, author, description, source_type, source_url,
+           content, endpoints, tags, reachable, created_at
+    from skills
+    where name = ${name}
+      and source_url is not distinct from ${sourceUrl}
+      and content is not distinct from ${content}
+      and created_at > now() - make_interval(secs => ${windowSeconds})
+    order by created_at asc
+    limit 1
+  `;
+  return (rows as unknown as Skill[])[0] ?? null;
+}
+
 export async function createSkill(input: NewSkill): Promise<Skill> {
   await ensureSchema();
   const db = sql();


### PR DESCRIPTION
## What

Fixes the duplicate-submission bug reported in #203 — one Submit click
on `/skills` created three identical rows for the same SkillMD.

## Why

`useActionState`'s `pending` boolean only flips `true` after React
commits a render, which lags a fast click by at least one frame — a
gap wide enough for multiple form submissions to fire before the
button actually disables. Ran into this firsthand re-registering the
StreamPay skill after a hosting migration (see #203).

## What changed

Two-layer fix:
- **Client** (`submit-form.tsx`): a synchronous `useRef` guard on the
  form's `onSubmit` blocks re-entrant submits immediately, without
  waiting on React's `pending` state to propagate.
- **Server** (`actions.ts` + `skills.ts`): `findRecentDuplicate()`
  rejects an identical `(name, source_url/content)` submission within
  a 15-second window in `submitSkill`, returning the existing row
  instead of inserting a new one. This is defense in depth against a
  genuine double POST (retry, slow network) that the client guard
  can't see — the same idempotency-key shape the StreamPay listing
  itself is built around.

## Verification

```bash
cd apps/nest-dashboard
npx tsc --noEmit -p .   # clean
npx eslint src/app/skills/submit-form.tsx src/app/skills/actions.ts src/lib/skills.ts
# one pre-existing, unrelated error (react-hooks/set-state-in-effect
# on the success-reset effect) — confirmed present on main before
# this change too, not introduced here
```

No `DATABASE_URL`/Neon credentials available in the environment this
was written in, so `findRecentDuplicate` couldn't be exercised against
the live DB — worth a manual double-submit test on `/skills` before
merging.

## Related

Closes the duplicate-cleanup half of #203 going forward (doesn't
retroactively remove the existing duplicate rows — that still needs a
manual DB cleanup as requested there).