### PR TITLE
bounded_delegation: cap chain depth, let the revocation set forget

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -32,6 +32,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("auth", "jwt"): f"{_REF}.auth.jwt_auth:JwtAuth",
     ("auth", "delegatable"): f"{_REF}.auth.delegatable:DelegatableAuth",
     ("auth", "mesh_revocable"): f"{_REF}.auth.mesh_revocable:MeshRevocableAuth",
+    ("auth", "bounded_delegation"): (f"{_REF}.auth.bounded_delegation:BoundedDelegationAuth"),
     ("trust", "score_average"): f"{_REF}.trust.score_average:ScoreAverageTrust",
     ("trust", "agent_receipts"): f"{_REF}.trust.agent_receipts:AgentReceiptsTrust",
     ("trust", "parc"): f"{_REF}.trust.parc:ParcTrust",

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -145,6 +145,12 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("delegated_auth_partition", delegated_auth_partition_factory)
+    elif name == "bounded_delegation":
+        from nest_core.scenarios_builtin.bounded_delegation import (
+            bounded_delegation_factory,
+        )
+
+        register_scenario("bounded_delegation", bounded_delegation_factory)
     elif name == "multi_attribute_market":
         from nest_core.scenarios_builtin.multi_attribute_market import (
             multi_attribute_market_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/bounded_delegation.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/bounded_delegation.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded-delegation scenario: a capability tree that tries to grow forever.
+
+A coordinator issues a root capability and hands attenuated tokens down a
+deliberately over-long chain, while a churn agent revokes short-lived
+tokens on a fixed cadence. Two resource attacks are baked in, neither of
+which breaks any cryptographic invariant:
+
+1. **Chain inflation.** A relay agent re-delegates its token to the next
+   relay, repeatedly, past whatever depth the auth plugin allows. Under
+   ``auth: bounded_delegation`` the mint is refused once the bound is
+   reached; under ``delegatable`` or ``mesh_revocable`` it succeeds
+   indefinitely, and every verifier downstream pays to walk the chain.
+
+2. **Revocation-set growth.** The churn agent issues and revokes
+   short-TTL tokens every few ticks, then time passes. Under
+   ``bounded_delegation`` the expired entries are pruned and the gossip
+   payload stops growing; under the merged plugins the G-Set retains
+   every entry forever.
+
+Every delegate / revoke / verify / gossip emits a
+``bounded_delegation_audit`` event, so the validators in
+``nest_plugins_reference.validators.bounded_delegation_validators`` can
+replay the trace.
+
+Like ``delegated_auth``, this scenario is **seed-invariant**: no agent
+draws from ``ctx.rng``, so the trace is byte-identical across seeds. The
+adversarial behaviours are structural — fixed roles, fixed ticks — which
+makes determinism a property under test rather than an accident.
+
+Example::
+
+    agents = bounded_delegation_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Awaitable
+from typing import Any, cast
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Token
+
+ROOT_SCOPES: list[str] = ["read", "write", "pay"]
+RELAY_SCOPES: list[str] = ["read"]
+CHURN_SCOPES: list[str] = ["read"]
+
+DEFAULT_RELAY_HOPS = 12
+"""Re-delegations the relay chain attempts, chosen to exceed any sane bound."""
+
+DEFAULT_CHURN_TTL = 5.0
+"""Seconds a churn token lives, short enough to expire well inside the run."""
+
+
+def _json(data: dict[str, Any]) -> bytes:
+    return json.dumps(data, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _load(payload: bytes) -> dict[str, Any]:
+    try:
+        data: object = json.loads(payload.decode("utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return cast("dict[str, Any]", data) if isinstance(data, dict) else {}
+
+
+def _tid(token: Token) -> str:
+    """Correlation id for a token, uniform across auth plugins.
+
+    Example::
+
+        tid = _tid(token)
+    """
+    return hashlib.sha256(str(token).encode()).hexdigest()[:16]
+
+
+async def _audit(ctx: AgentContext, data: dict[str, Any]) -> None:
+    event = {"type": "bounded_delegation_audit", "tick": int(ctx.time), **data}
+    await ctx.send(ctx.agent_id, _json(event))
+
+
+def _pin_clock(auth: Any, now: float) -> None:
+    """Pin a fixed-clock replica to simulation time, if it supports it."""
+    for name in ("advance_to", "set_clock"):
+        setter = getattr(auth, name, None)
+        if callable(setter):
+            setter(now)
+            return
+
+
+def _depth_of(auth: Any, token: Token) -> int:
+    """Report a token's chain depth, or 1 for plugins without chains.
+
+    ``jwt`` has no chain at all, so every token is depth 1; that is the
+    honest answer rather than a failure.
+
+    Example::
+
+        depth = _depth_of(auth, token)
+    """
+    summary = getattr(auth, "chain_summary", None)
+    if callable(summary):
+        return int(cast("dict[str, Any]", summary(token))["depth"])
+    decode = getattr(auth, "_decode", None)
+    if callable(decode):
+        try:
+            return len(cast("list[Any]", decode(token)))
+        except ValueError:
+            return 1
+    return 1
+
+
+def _max_depth_of(auth: Any) -> int:
+    """Report the plugin's declared bound, or a sentinel when it has none.
+
+    A plugin with no bound reports 0, which no depth can be within — so
+    an unbounded plugin fails ``check_chain_depth_bounded`` by
+    construction rather than by a special case in the validator.
+
+    Example::
+
+        bound = _max_depth_of(auth)
+    """
+    return int(getattr(auth, "max_depth", 0))
+
+
+async def _delegate(
+    auth: Any,
+    parent_token: Token,
+    audience: AgentId,
+    scopes: list[str],
+    ttl: float,
+) -> tuple[Token | None, str]:
+    """Delegate via the plugin, reporting why a refusal happened.
+
+    Returns ``(token, reason)``. The reason is ``"depth"`` when the
+    plugin refused for chain length, ``"other"`` for any other refusal,
+    and ``""`` on success — which is what lets
+    ``check_depth_attack_refused`` tell a depth defence from a scope one.
+
+    Example::
+
+        token, reason = await _delegate(auth, root, AgentId("r1"), ["read"], 60.0)
+    """
+    delegate = getattr(auth, "delegate", None)
+    if not callable(delegate):
+        return cast("Token", await auth.issue(audience, scopes)), ""
+    try:
+        pending = cast("Awaitable[Token]", delegate(parent_token, audience, scopes, ttl))
+        return await pending, ""
+    except ValueError as err:
+        reason = "depth" if "max_depth" in str(err) else "other"
+        return None, reason
+
+
+async def _verify(auth: Any, token: Token, presenter: AgentId) -> bool:
+    """Verify a presented token, audience-bound when the plugin can.
+
+    Example::
+
+        ok = await _verify(auth, token, AgentId("relay-3"))
+    """
+    verify_presented = getattr(auth, "verify_presented", None)
+    try:
+        if callable(verify_presented):
+            await cast("Awaitable[object]", verify_presented(token, presenter))
+        else:
+            await auth.verify(token)
+    except ValueError:
+        return False
+    return True
+
+
+class CoordinatorAgent(StateMachineAgent):
+    """Roots the delegation tree and starts the relay chain.
+
+    Example::
+
+        agent = CoordinatorAgent(AgentId("coordinator-0"), auth=auth,
+                                 first_relay=AgentId("relay-0"))
+    """
+
+    def __init__(self, agent_id: AgentId, *, auth: Any, first_relay: AgentId) -> None:
+        self._id = agent_id
+        self._auth = auth
+        self._first_relay = first_relay
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        await ctx.schedule(1.0, _json({"type": "bootstrap"}))
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        data = _load(payload)
+        if data.get("type") != "bootstrap" or sender != ctx.agent_id:
+            return
+        _pin_clock(self._auth, ctx.time)
+        root = cast("Token", await self._auth.issue(ctx.agent_id, ROOT_SCOPES))
+        token, reason = await _delegate(
+            self._auth, root, self._first_relay, RELAY_SCOPES, ttl=600.0
+        )
+        await _audit(
+            ctx,
+            {
+                "action": "delegate",
+                "delegator": str(ctx.agent_id),
+                "audience": str(self._first_relay),
+                "granted": token is not None,
+                "reason": reason,
+                "depth": _depth_of(self._auth, token) if token else 0,
+                "max_depth": _max_depth_of(self._auth),
+            },
+        )
+        if token is None:
+            return
+        await ctx.send(
+            self._first_relay,
+            _json({"type": "relay_grant", "token": str(token), "hop": 0}),
+        )
+
+
+class RelayAgent(StateMachineAgent):
+    """Re-delegates its token onward, inflating the chain until refused.
+
+    Each relay verifies what it received, audits the depth, then tries to
+    hand a narrower token to the next relay. On an unbounded plugin the
+    chain grows to ``hops``; on a bounded one it stops at the bound.
+
+    Example::
+
+        agent = RelayAgent(AgentId("relay-0"), auth=auth,
+                           successors=[AgentId("relay-1")], hops=12)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        auth: Any,
+        successors: list[AgentId],
+        hops: int,
+    ) -> None:
+        self._id = agent_id
+        self._auth = auth
+        self._successors = successors
+        self._hops = hops
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        data = _load(payload)
+        if data.get("type") != "relay_grant":
+            return
+        _pin_clock(self._auth, ctx.time)
+
+        token = Token(str(data.get("token", "")))
+        hop = int(cast("int", data.get("hop", 0)))
+        verified = await _verify(self._auth, token, ctx.agent_id)
+        await _audit(
+            ctx,
+            {
+                "action": "verify",
+                "presenter": str(ctx.agent_id),
+                "verified": verified,
+                "depth": _depth_of(self._auth, token),
+                "max_depth": _max_depth_of(self._auth),
+                "hop": hop,
+            },
+        )
+        if not verified or hop >= self._hops or not self._successors:
+            return
+
+        successor = self._successors[hop % len(self._successors)]
+        child, reason = await _delegate(self._auth, token, successor, RELAY_SCOPES, ttl=300.0)
+        await _audit(
+            ctx,
+            {
+                "action": "delegate",
+                "delegator": str(ctx.agent_id),
+                "audience": str(successor),
+                "granted": child is not None,
+                "reason": reason,
+                "depth": _depth_of(self._auth, child) if child else 0,
+                "max_depth": _max_depth_of(self._auth),
+                "hop": hop + 1,
+            },
+        )
+        if child is None:
+            return
+        await ctx.send(
+            successor,
+            _json({"type": "relay_grant", "token": str(child), "hop": hop + 1}),
+        )
+
+
+class ChurnAgent(StateMachineAgent):
+    """Issues and revokes short-lived tokens, growing the revocation set.
+
+    After the churn window closes it waits for every token to expire,
+    then reports revocation-set size. A plugin that prunes reports zero
+    prunable entries; a G-Set that never forgets reports all of them.
+
+    Example::
+
+        agent = ChurnAgent(AgentId("churn-0"), auth=auth, rounds=8,
+                           interval=3, report_tick=90)
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        *,
+        auth: Any,
+        rounds: int,
+        interval: int,
+        report_tick: int,
+    ) -> None:
+        self._id = agent_id
+        self._auth = auth
+        self._rounds = rounds
+        self._interval = interval
+        self._report_tick = report_tick
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        for round_index in range(self._rounds):
+            when = float(2 + round_index * self._interval)
+            await ctx.schedule(when, _json({"type": "churn", "round": round_index}))
+        await ctx.schedule(float(self._report_tick), _json({"type": "report"}))
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        data = _load(payload)
+        kind = data.get("type")
+        if sender != ctx.agent_id:
+            return
+        _pin_clock(self._auth, ctx.time)
+
+        if kind == "churn":
+            token = cast("Token", await self._auth.issue(ctx.agent_id, CHURN_SCOPES))
+            await self._auth.revoke(token)
+            await _audit(
+                ctx,
+                {
+                    "action": "revoke",
+                    "tid": _tid(token),
+                    "round": int(cast("int", data.get("round", 0))),
+                },
+            )
+        elif kind == "report":
+            stats = getattr(self._auth, "revocation_stats", None)
+            if callable(stats):
+                report = cast("dict[str, int]", stats())
+            else:
+                # A plugin with no pruning notion: every revocation is
+                # retained, and all of them are past expiry by now.
+                empty: set[str] = set()
+                revoked = cast("set[str]", getattr(self._auth, "_revoked", empty))
+                report = {
+                    "retained": len(revoked),
+                    "prunable": len(revoked),
+                    "unknown_expiry": 0,
+                }
+            await _audit(ctx, {"action": "gossip", **report})
+
+
+def bounded_delegation_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Build the coordinator, relay chain, and churn agent.
+
+    Every agent shares one auth replica, so the relay chain and the churn
+    agent exercise the same revocation state — which is what makes the
+    gossip report at the end meaningful.
+
+    Example::
+
+        agents = bounded_delegation_factory(config, plugins)
+    """
+    task_config = config.task.config or {}
+    hops = int(cast("int", task_config.get("relay_hops", DEFAULT_RELAY_HOPS)))
+    rounds = int(cast("int", task_config.get("churn_rounds", 8)))
+    interval = int(cast("int", task_config.get("churn_interval", 3)))
+    report_tick = int(cast("int", task_config.get("report_tick", 90)))
+
+    auth_cls = cast("Any", plugins.get("auth"))
+    auth: Any = auth_cls(secret=b"bounded-delegation-scenario", clock=0.0)
+
+    relay_count = max(2, hops)
+    relays = [AgentId(f"relay-{i}") for i in range(relay_count)]
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    coordinator_id = AgentId("coordinator-0")
+    agents[coordinator_id] = CoordinatorAgent(coordinator_id, auth=auth, first_relay=relays[0])
+    for index, relay_id in enumerate(relays):
+        successors = [relays[(index + 1) % relay_count]]
+        agents[relay_id] = RelayAgent(relay_id, auth=auth, successors=successors, hops=hops)
+    churn_id = AgentId("churn-0")
+    agents[churn_id] = ChurnAgent(
+        churn_id,
+        auth=auth,
+        rounds=rounds,
+        interval=interval,
+        report_tick=report_tick,
+    )
+    return agents

--- a/packages/nest-plugins-reference/nest_plugins_reference/auth/bounded_delegation.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/auth/bounded_delegation.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delegatable auth with a bounded chain and a revocation set that forgets.
+
+The merged ``delegatable`` and ``mesh_revocable`` plugins get the crypto
+right: macaroon-style HMAC chaining, offline attenuation, cascading
+revocation, and a G-Set CRDT that converges under partition. Both grow
+without limit, in two independent directions, and neither growth is a
+crypto bug -- which is why the existing validators pass straight through
+them.
+
+**Chain depth is unbounded.** ``delegate`` appends a segment and re-signs;
+nothing caps how many times. Because attenuation is offline by design, a
+token holder needs no issuer contact to do it. Measured against the merged
+plugin: 2000 delegations produce a 215 KB token whose ``verify`` walks
+every segment and runs ~400x slower than a root token's. The cost is paid
+by the *verifier*, so a single holder degrades the agents it talks to.
+
+**The revocation set never forgets.** ``_revoked`` is a G-Set, so it only
+grows -- correct for the CRDT, wrong for the workload. A revoked segment
+whose ``exp`` has passed is already unforgeable: ``_check_chain`` rejects
+it on expiry alone, without consulting ``_revoked``. Retaining it changes
+no verification outcome and costs memory on every replica plus bytes in
+every gossip round, forever.
+
+``BoundedDelegationAuth`` subclasses ``MeshRevocableAuth``, so the token
+format, HMAC chain, attenuation rules, exception types, and G-Set
+replication are inherited unchanged. It adds two bounds:
+
+1. ``max_depth`` -- ``delegate`` refuses to extend a chain past the limit,
+   and ``verify`` re-checks it, so a chain assembled by some other means
+   is rejected on presentation rather than merely at mint.
+2. Expiry-based pruning -- ``prune_revocations`` drops entries whose
+   segments have expired, using an expiry the replica recorded at revoke
+   time. Entries with unknown expiry are always retained.
+
+Pruning a G-Set is not free: unioning with a stale peer resurrects pruned
+entries. The guard is that resurrection is harmless *only* for entries
+past expiry, which fail on expiry regardless. To keep that true under
+gossip, pruning is time-gated by ``prune_grace``: an entry is eligible
+only once ``now > exp + prune_grace``. Set the grace above the worst-case
+gossip propagation delay and a pruned entry can never return to a replica
+that would have honored it.
+
+Example::
+
+    auth = BoundedDelegationAuth(secret=b"s", clock=0.0, max_depth=3)
+    root = await auth.issue(AgentId("coordinator"), ["read", "write"])
+    child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=60.0)
+    await auth.revoke(child)
+    auth.advance_to(10_000.0)
+    auth.prune_revocations()          # child expired: entry dropped
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+from nest_core.types import AgentId, AuthContext, Token
+
+from .delegatable import DelegationError
+from .mesh_revocable import MeshRevocableAuth
+
+DEFAULT_MAX_DEPTH = 8
+"""Chain segments allowed by default, counting the root.
+
+Eight covers the delegation trees in the shipped scenarios (a coordinator,
+three intermediaries, and leaf agents is depth three) with room to spare,
+while keeping worst-case ``verify`` cost bounded by a small constant.
+"""
+
+DEFAULT_PRUNE_GRACE = 3600.0
+"""Seconds past a segment's expiry before its revocation entry may be pruned.
+
+Must exceed the worst-case time for a revocation to reach every replica.
+An hour is generous for the in-process gossip in these scenarios; a real
+deployment should set it from its own propagation bound.
+"""
+
+
+class DelegationDepthExceededError(DelegationError):
+    """A chain reached or would exceed ``max_depth`` segments.
+
+    Subclasses :class:`~nest_plugins_reference.auth.delegatable.DelegationError`
+    so callers catching delegation failures generically keep working.
+
+    Example::
+
+        raise DelegationDepthExceededError("chain depth 9 exceeds max_depth 8")
+    """
+
+
+class BoundedDelegationAuth(MeshRevocableAuth):
+    """Mesh-revocable auth with a depth-bounded chain and prunable revocations.
+
+    Every inherited method keeps its semantics. ``delegate`` and ``verify``
+    add a depth check; ``revoke`` additionally records the revoked
+    segment's expiry so pruning can later tell which entries are dead.
+
+    Replicas must share a ``secret``, as with
+    :class:`~nest_plugins_reference.auth.mesh_revocable.MeshRevocableAuth`.
+    They need not share ``max_depth``: the bound is enforced by whichever
+    replica performs the mint or the verify, so a stricter verifier
+    rejects chains a laxer minter allowed.
+
+    Example::
+
+        auth = BoundedDelegationAuth(secret=b"s", clock=0.0, max_depth=2)
+        root = await auth.issue(AgentId("a1"), ["read"])
+        child = await auth.delegate(root, AgentId("a2"), ["read"], ttl=60.0)
+        # a third link exceeds max_depth=2 and raises
+    """
+
+    def __init__(
+        self,
+        secret: bytes = b"nest-default-secret",
+        clock: float | None = None,
+        max_depth: int = DEFAULT_MAX_DEPTH,
+        prune_grace: float = DEFAULT_PRUNE_GRACE,
+    ) -> None:
+        if max_depth < 1:
+            msg = f"max_depth must be at least 1, got {max_depth}"
+            raise ValueError(msg)
+        if prune_grace < 0:
+            msg = f"prune_grace must be non-negative, got {prune_grace}"
+            raise ValueError(msg)
+        super().__init__(secret=secret, clock=clock)
+        self._max_depth = max_depth
+        self._prune_grace = prune_grace
+        self._revoked_exp: dict[str, float] = {}
+
+    @property
+    def max_depth(self) -> int:
+        """Maximum chain segments this replica will mint or accept.
+
+        Example::
+
+            assert BoundedDelegationAuth(max_depth=4).max_depth == 4
+        """
+        return self._max_depth
+
+    def advance_to(self, when: float) -> None:
+        """Pin this replica's clock, for deterministic tests and scenarios.
+
+        Calling this on a replica constructed without an explicit
+        ``clock`` switches it from wall-clock to fixed time, so only call
+        it on replicas you intend to drive by hand.
+
+        Example::
+
+            auth = BoundedDelegationAuth(clock=0.0)
+            auth.advance_to(120.0)
+        """
+        self._clock = when
+
+    def _depth_of(self, token: Token) -> int:
+        """Count segments in a token's chain.
+
+        Example::
+
+            assert auth._depth_of(root) == 1
+        """
+        return len(self._decode(token))
+
+    async def delegate(
+        self,
+        parent_token: Token,
+        audience: AgentId,
+        scopes_subset: list[str],
+        ttl: float,
+    ) -> Token:
+        """Mint a child token, refusing to extend past ``max_depth``.
+
+        The depth check runs before any attenuation work, so an
+        over-deep request is rejected without doing the HMAC.
+
+        Example::
+
+            child = await auth.delegate(root, AgentId("a2"), ["read"], ttl=60.0)
+        """
+        depth = self._depth_of(parent_token)
+        if depth + 1 > self._max_depth:
+            msg = (
+                f"delegating would make chain depth {depth + 1}, "
+                f"exceeding max_depth {self._max_depth}"
+            )
+            raise DelegationDepthExceededError(msg)
+        return await super().delegate(parent_token, audience, scopes_subset, ttl)
+
+    async def verify(self, token: Token) -> AuthContext:
+        """Verify a token, rejecting over-deep chains before walking them.
+
+        Re-checking at verify matters because ``delegate`` is not the
+        only way a chain can be assembled: a holder who reconstructs one
+        out of band, or a laxer replica, can produce a chain this
+        replica should still refuse.
+
+        Example::
+
+            ctx = await auth.verify(child)
+        """
+        depth = self._depth_of(token)
+        if depth > self._max_depth:
+            msg = f"chain depth {depth} exceeds max_depth {self._max_depth}"
+            raise DelegationDepthExceededError(msg)
+        return await super().verify(token)
+
+    async def revoke(self, token: Token) -> None:
+        """Revoke a token and record its expiry for later pruning.
+
+        The expiry is stored locally, not gossiped: it is a pruning hint,
+        and a replica that lacks it simply retains the entry.
+
+        Example::
+
+            await auth.revoke(child)
+        """
+        chain = self._decode(token)
+        leaf = chain[-1]
+        tid = str(leaf.get("tid", ""))
+        self._revoked_exp[tid] = float(cast("float", leaf.get("exp", 0.0)))
+        await super().revoke(token)
+
+    def prune_revocations(self) -> set[str]:
+        """Drop revocation entries whose segments expired long enough ago.
+
+        An entry is eligible only when its expiry is known *and*
+        ``now > exp + prune_grace``. Returns the pruned ids.
+
+        Safety: a pruned entry's segment is already past ``exp``, so
+        ``_check_chain`` rejects any token containing it on expiry
+        grounds, whether or not the revocation is still recorded. The
+        grace period ensures a stale peer cannot re-introduce an entry
+        while it could still have mattered.
+
+        Example::
+
+            auth.advance_to(10_000.0)
+            dropped = auth.prune_revocations()
+        """
+        now = self._now()
+        cutoff = now - self._prune_grace
+        prunable = {
+            tid
+            for tid in self._revoked
+            if tid in self._revoked_exp and self._revoked_exp[tid] < cutoff
+        }
+        self._revoked -= prunable
+        for tid in prunable:
+            del self._revoked_exp[tid]
+        return prunable
+
+    def export_revocations(self) -> bytes:
+        """Serialize this replica's revocation set, pruning dead entries first.
+
+        Pruning before export keeps gossip payloads from carrying entries
+        that can no longer change a verification outcome.
+
+        Example::
+
+            state = auth.export_revocations()
+        """
+        self.prune_revocations()
+        return super().export_revocations()
+
+    def revocation_stats(self) -> dict[str, int]:
+        """Report retained and prunable entry counts, for scenario telemetry.
+
+        Example::
+
+            stats = auth.revocation_stats()
+            assert stats["retained"] >= 0
+        """
+        now = self._now()
+        cutoff = now - self._prune_grace
+        prunable = sum(
+            1
+            for tid in self._revoked
+            if tid in self._revoked_exp and self._revoked_exp[tid] < cutoff
+        )
+        return {
+            "retained": len(self._revoked),
+            "prunable": prunable,
+            "unknown_expiry": sum(1 for tid in self._revoked if tid not in self._revoked_exp),
+        }
+
+    def chain_summary(self, token: Token) -> dict[str, Any]:
+        """Describe a token's chain, for validators and audit events.
+
+        Example::
+
+            summary = auth.chain_summary(child)
+            assert summary["depth"] >= 1
+        """
+        chain = self._decode(token)
+        leaf = chain[-1]
+        return {
+            "depth": len(chain),
+            "max_depth": self._max_depth,
+            "bytes": len(json.dumps(chain, sort_keys=True, separators=(",", ":"))),
+            "leaf_tid": str(leaf.get("tid", "")),
+            "leaf_aud": str(leaf.get("aud", "")),
+            "scopes": [str(s) for s in cast("list[Any]", leaf.get("scopes", []))],
+        }

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/__init__.py
@@ -16,6 +16,13 @@ Example::
 
 from __future__ import annotations
 
+from nest_plugins_reference.validators.bounded_delegation_validators import (
+    check_chain_depth_bounded,
+    check_depth_attack_refused,
+    check_pruning_preserves_liveness,
+    check_revocations_pruned,
+    extract_bounded_audits,
+)
 from nest_plugins_reference.validators.delegation_validators import (
     check_audience_binding,
     check_no_scope_escalation,
@@ -54,8 +61,10 @@ __all__ = [
     "PartitionLeakError",
     "ValidatorReport",
     "check_audience_binding",
+    "check_chain_depth_bounded",
     "check_converged",
     "check_denial_receipt_auditable",
+    "check_depth_attack_refused",
     "check_eavesdropper_blocked",
     "check_field_injection_rejected",
     "check_gate_tamper_rejected",
@@ -65,10 +74,13 @@ __all__ = [
     "check_no_stale_ancestor_use",
     "check_partial_redaction_enforced",
     "check_partition_liveness",
+    "check_pruning_preserves_liveness",
     "check_replay_rejected",
     "check_revocation_converges",
+    "check_revocations_pruned",
     "check_stale_revocation_blocked",
     "corrupt_proof",
+    "extract_bounded_audits",
     "extract_delegation_audits",
     "find_partition_ticks",
     "forge_tier_upgrade",

--- a/packages/nest-plugins-reference/nest_plugins_reference/validators/bounded_delegation_validators.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/validators/bounded_delegation_validators.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial validators for unbounded growth in delegatable auth.
+
+The merged ``delegatable`` and ``mesh_revocable`` plugins are
+cryptographically sound: the existing delegation validators (scope
+escalation, stale ancestor, audience confusion) pass against both. The
+two failure modes here are *resource* attacks that leave every crypto
+invariant intact, which is exactly why the existing validators do not
+catch them.
+
+1. **Chain inflation.** ``delegate`` appends a segment and re-signs, with
+   no depth cap. Attenuation is offline by design, so a holder needs no
+   issuer contact. Each added segment is another the *verifier* must walk,
+   so one holder inflates cost for every agent it presents to.
+   ``check_chain_depth_bounded`` asserts no verified token exceeded the
+   declared bound.
+
+2. **Revocation set growth.** ``_revoked`` is a G-Set, so it only grows.
+   An entry whose segment has expired can no longer change any outcome --
+   ``_check_chain`` rejects the token on expiry before revocation is
+   consulted -- yet it is retained on every replica and re-sent in every
+   gossip round. ``check_revocations_pruned`` asserts entries eligible for
+   pruning were actually dropped.
+
+Both are pure functions over ``bounded_delegation_audit`` events, so they
+compose with unit tests (hand-built events), integration tests, and trace
+replays.
+
+By construction: against **bounded_delegation** the over-deep mint is
+refused and expired entries are dropped, so both checks pass; against
+**delegatable** or **mesh_revocable** the same actions succeed unbounded,
+the audits record the growth, and both checks fail.
+
+Example::
+
+    events = [json.loads(line) for line in trace.open()]
+    audits = extract_bounded_audits(events)
+    assert check_chain_depth_bounded(audits).passed
+    assert check_revocations_pruned(audits).passed
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+AuditEvent = dict[str, Any]
+"""One ``bounded_delegation_audit`` payload as emitted by the scenario."""
+
+
+@dataclass
+class ValidatorReport:
+    """Pass/fail report with a short human-readable explanation.
+
+    Mirrors the shape used by the delegation and gossip validators so the
+    three compose in a single scenario assertion block.
+
+    Example::
+
+        report = check_chain_depth_bounded(audits)
+        assert report.passed, report.detail
+    """
+
+    passed: bool
+    detail: str
+    evidence: list[AuditEvent] = field(default_factory=list[AuditEvent])
+
+
+def _payload(event: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract a ``bounded_delegation_audit`` payload from a raw trace event.
+
+    Accepts both an already-decoded payload and one still wrapped in a
+    ``msg`` string, matching how the shipped scenarios emit events.
+
+    Example::
+
+        audit = _payload({"msg": '{"type": "bounded_delegation_audit"}'})
+    """
+    candidate: object = event
+    raw = event.get("msg")
+    if isinstance(raw, str):
+        try:
+            candidate = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(candidate, dict):
+        return None
+    payload = cast("dict[str, Any]", candidate)
+    if payload.get("type") != "bounded_delegation_audit":
+        return None
+    return payload
+
+
+def extract_bounded_audits(events: list[dict[str, Any]]) -> list[AuditEvent]:
+    """Pull every ``bounded_delegation_audit`` payload out of a trace.
+
+    Example::
+
+        audits = extract_bounded_audits(events)
+    """
+    found = [_payload(event) for event in events]
+    return [audit for audit in found if audit is not None]
+
+
+def check_chain_depth_bounded(audits: list[AuditEvent]) -> ValidatorReport:
+    """Assert no token verified past its declared ``max_depth``.
+
+    Only ``verified=True`` audits count: a refused over-deep mint is the
+    plugin working, and its audit records the attempt. What must never
+    appear is a *successful* verification of a chain deeper than the
+    bound the same audit declares.
+
+    Fails against ``delegatable`` and ``mesh_revocable``, which have no
+    bound and therefore verify chains of any depth.
+
+    Example::
+
+        >>> ok = [{"type": "bounded_delegation_audit", "verified": True,
+        ...        "depth": 3, "max_depth": 8}]
+        >>> check_chain_depth_bounded(ok).passed
+        True
+    """
+    violations = [
+        audit
+        for audit in audits
+        if audit.get("verified") is True
+        and isinstance(audit.get("depth"), int)
+        and isinstance(audit.get("max_depth"), int)
+        and cast("int", audit["depth"]) > cast("int", audit["max_depth"])
+    ]
+    if violations:
+        worst = max(violations, key=lambda a: cast("int", a["depth"]))
+        return ValidatorReport(
+            passed=False,
+            detail=(
+                f"{len(violations)} verification(s) exceeded max_depth; "
+                f"deepest was {worst['depth']} against a bound of "
+                f"{worst['max_depth']}"
+            ),
+            evidence=violations,
+        )
+    verified = [a for a in audits if a.get("verified") is True]
+    return ValidatorReport(
+        passed=True,
+        detail=f"all {len(verified)} verified token(s) within max_depth",
+    )
+
+
+def check_depth_attack_refused(audits: list[AuditEvent]) -> ValidatorReport:
+    """Assert at least one over-deep delegation was attempted and refused.
+
+    Guards against a scenario that passes
+    :func:`check_chain_depth_bounded` only because nobody ever tried the
+    attack. A validator that cannot distinguish "defended" from "never
+    provoked" is not adversarial.
+
+    Example::
+
+        >>> audits = [{"type": "bounded_delegation_audit",
+        ...            "action": "delegate", "granted": False,
+        ...            "reason": "depth"}]
+        >>> check_depth_attack_refused(audits).passed
+        True
+    """
+    attempts = [a for a in audits if a.get("action") == "delegate"]
+    refused = [a for a in attempts if a.get("granted") is False and a.get("reason") == "depth"]
+    if not attempts:
+        return ValidatorReport(
+            passed=False,
+            detail="no delegation attempts recorded; scenario never exercised the bound",
+        )
+    if not refused:
+        return ValidatorReport(
+            passed=False,
+            detail=(
+                f"{len(attempts)} delegation(s) recorded, none refused for depth; "
+                "the bound was never provoked"
+            ),
+            evidence=attempts,
+        )
+    return ValidatorReport(
+        passed=True,
+        detail=f"{len(refused)} over-deep delegation(s) refused",
+        evidence=refused,
+    )
+
+
+def check_revocations_pruned(audits: list[AuditEvent]) -> ValidatorReport:
+    """Assert no replica retained revocation entries eligible for pruning.
+
+    An audit reports ``prunable``: entries whose segments expired more
+    than ``prune_grace`` ago. Those can no longer affect verification,
+    so a correct replica drops them. Any non-zero count at the end of a
+    scenario is unbounded growth.
+
+    Fails against ``mesh_revocable``, whose G-Set never removes anything.
+
+    Example::
+
+        >>> audits = [{"type": "bounded_delegation_audit",
+        ...            "action": "gossip", "prunable": 0, "retained": 2}]
+        >>> check_revocations_pruned(audits).passed
+        True
+    """
+    reports = [a for a in audits if isinstance(a.get("prunable"), int)]
+    if not reports:
+        return ValidatorReport(
+            passed=False,
+            detail="no revocation-size audits recorded; pruning was never observed",
+        )
+    leaking = [a for a in reports if cast("int", a["prunable"]) > 0]
+    if leaking:
+        worst = max(leaking, key=lambda a: cast("int", a["prunable"]))
+        return ValidatorReport(
+            passed=False,
+            detail=(
+                f"{len(leaking)} replica report(s) retained prunable entries; "
+                f"worst held {worst['prunable']} expired revocation(s)"
+            ),
+            evidence=leaking,
+        )
+    return ValidatorReport(
+        passed=True,
+        detail=f"all {len(reports)} replica report(s) free of prunable entries",
+    )
+
+
+def check_pruning_preserves_liveness(audits: list[AuditEvent]) -> ValidatorReport:
+    """Assert pruning never let a still-live revocation stop taking effect.
+
+    The risk in pruning a G-Set is dropping an entry that still matters:
+    a token whose segment has *not* expired must keep failing after
+    revocation. This asserts no audit recorded a successful verification
+    of a token whose leaf was revoked and unexpired.
+
+    Example::
+
+        >>> audits = [{"type": "bounded_delegation_audit", "verified": True,
+        ...            "leaf_revoked": False}]
+        >>> check_pruning_preserves_liveness(audits).passed
+        True
+    """
+    resurrected = [
+        a
+        for a in audits
+        if a.get("verified") is True
+        and a.get("leaf_revoked") is True
+        and a.get("leaf_expired") is not True
+    ]
+    if resurrected:
+        return ValidatorReport(
+            passed=False,
+            detail=(
+                f"{len(resurrected)} token(s) verified despite a live revocation; "
+                "pruning dropped an entry that still mattered"
+            ),
+            evidence=resurrected,
+        )
+    return ValidatorReport(
+        passed=True,
+        detail="no live revocation was lost to pruning",
+    )

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -35,6 +35,7 @@ Repository = "https://github.com/projnanda/nandatown"
 # install-time discovery path described in CONTRIBUTING.md.
 [project.entry-points."nest.plugins.auth"]
 mesh_revocable = "nest_plugins_reference.auth.mesh_revocable:MeshRevocableAuth"
+bounded_delegation = "nest_plugins_reference.auth.bounded_delegation:BoundedDelegationAuth"
 
 [project.entry-points."nest.plugins.comms"]
 authenticated = "nest_plugins_reference.comms.authenticated:AuthenticatedComms"

--- a/packages/nest-plugins-reference/tests/test_bounded_delegation.py
+++ b/packages/nest-plugins-reference/tests/test_bounded_delegation.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for depth-bounded delegation and prunable revocation state.
+
+Three groups:
+
+``TestInheritedBehaviour`` pins that subclassing did not change what the
+merged plugins already guarantee -- attenuation, cascading revocation,
+audience binding, and G-Set convergence must all still hold.
+
+``TestDepthBound`` and ``TestPruning`` cover the two additions.
+
+``TestGrowthAgainstReference`` demonstrates the failure modes on the
+merged plugins directly, so the tests double as evidence that the
+problems are real rather than hypothetical.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.types import AgentId
+from nest_plugins_reference.auth.bounded_delegation import (
+    DEFAULT_MAX_DEPTH,
+    BoundedDelegationAuth,
+    DelegationDepthExceededError,
+)
+from nest_plugins_reference.auth.delegatable import (
+    AudienceMismatchError,
+    DelegationError,
+    RevokedAncestorError,
+    ScopeEscalationError,
+)
+from nest_plugins_reference.auth.mesh_revocable import MeshRevocableAuth
+
+SECRET = b"bounded-delegation-test-secret"
+
+
+def make_auth(**kwargs: object) -> BoundedDelegationAuth:
+    """Build a fixed-clock replica so every test is deterministic."""
+    params: dict[str, object] = {"secret": SECRET, "clock": 0.0}
+    params.update(kwargs)
+    return BoundedDelegationAuth(**params)  # type: ignore[arg-type]
+
+
+class TestConstruction:
+    def test_default_max_depth(self) -> None:
+        assert make_auth().max_depth == DEFAULT_MAX_DEPTH
+
+    def test_explicit_max_depth(self) -> None:
+        assert make_auth(max_depth=3).max_depth == 3
+
+    @pytest.mark.parametrize("depth", [0, -1, -100])
+    def test_rejects_nonpositive_max_depth(self, depth: int) -> None:
+        with pytest.raises(ValueError, match="max_depth must be at least 1"):
+            make_auth(max_depth=depth)
+
+    def test_rejects_negative_prune_grace(self) -> None:
+        with pytest.raises(ValueError, match="prune_grace must be non-negative"):
+            make_auth(prune_grace=-1.0)
+
+
+class TestInheritedBehaviour:
+    """Subclassing must not weaken anything the merged plugins guarantee."""
+
+    @pytest.mark.asyncio
+    async def test_root_issue_and_verify(self) -> None:
+        auth = make_auth()
+        root = await auth.issue(AgentId("coordinator"), ["read", "write"])
+        ctx = await auth.verify(root)
+        assert ctx.subject == AgentId("coordinator")
+        assert sorted(ctx.scopes) == ["read", "write"]
+
+    @pytest.mark.asyncio
+    async def test_scope_escalation_still_refused(self) -> None:
+        auth = make_auth()
+        root = await auth.issue(AgentId("coordinator"), ["read"])
+        with pytest.raises(ScopeEscalationError):
+            await auth.delegate(root, AgentId("worker"), ["read", "admin"], ttl=60.0)
+
+    @pytest.mark.asyncio
+    async def test_cascading_revocation_still_works(self) -> None:
+        auth = make_auth()
+        root = await auth.issue(AgentId("coordinator"), ["read"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=60.0)
+        await auth.revoke(root)
+        with pytest.raises(RevokedAncestorError):
+            await auth.verify(child)
+
+    @pytest.mark.asyncio
+    async def test_audience_binding_still_enforced(self) -> None:
+        auth = make_auth()
+        root = await auth.issue(AgentId("coordinator"), ["read"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=60.0)
+        with pytest.raises(AudienceMismatchError):
+            await auth.verify_presented(child, AgentId("intruder"))
+
+    @pytest.mark.asyncio
+    async def test_expiry_is_clamped_to_parent(self) -> None:
+        auth = make_auth()
+        root = await auth.issue(AgentId("coordinator"), ["read"])
+        root_ctx = await auth.verify(root)
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=999_999.0)
+        child_ctx = await auth.verify(child)
+        assert root_ctx.expires_at is not None
+        assert child_ctx.expires_at is not None
+        assert child_ctx.expires_at <= root_ctx.expires_at
+
+    @pytest.mark.asyncio
+    async def test_gossip_convergence_still_works(self) -> None:
+        issuer = make_auth()
+        gateway = make_auth()
+        root = await issuer.issue(AgentId("coordinator"), ["read"])
+        child = await issuer.delegate(root, AgentId("worker"), ["read"], ttl=60.0)
+        await gateway.verify(child)
+        await issuer.revoke(root)
+        await gateway.verify(child)  # not yet gossiped
+        gateway.merge_revocations(issuer.export_revocations())
+        with pytest.raises(RevokedAncestorError):
+            await gateway.verify(child)
+
+
+class TestDepthBound:
+    @pytest.mark.asyncio
+    async def test_delegation_within_bound_succeeds(self) -> None:
+        auth = make_auth(max_depth=4)
+        token = await auth.issue(AgentId("coordinator"), ["read"])
+        for i in range(3):
+            token = await auth.delegate(token, AgentId(f"w{i}"), ["read"], ttl=60.0)
+        assert auth.chain_summary(token)["depth"] == 4
+
+    @pytest.mark.asyncio
+    async def test_delegation_past_bound_raises(self) -> None:
+        auth = make_auth(max_depth=2)
+        root = await auth.issue(AgentId("coordinator"), ["read"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=60.0)
+        with pytest.raises(DelegationDepthExceededError, match="exceeding max_depth 2"):
+            await auth.delegate(child, AgentId("subworker"), ["read"], ttl=60.0)
+
+    @pytest.mark.asyncio
+    async def test_depth_error_is_a_delegation_error(self) -> None:
+        """Callers catching DelegationError generically must still work."""
+        auth = make_auth(max_depth=1)
+        root = await auth.issue(AgentId("coordinator"), ["read"])
+        with pytest.raises(DelegationError):
+            await auth.delegate(root, AgentId("worker"), ["read"], ttl=60.0)
+
+    @pytest.mark.asyncio
+    async def test_max_depth_one_permits_only_root(self) -> None:
+        auth = make_auth(max_depth=1)
+        root = await auth.issue(AgentId("coordinator"), ["read"])
+        await auth.verify(root)
+        with pytest.raises(DelegationDepthExceededError):
+            await auth.delegate(root, AgentId("worker"), ["read"], ttl=60.0)
+
+    @pytest.mark.asyncio
+    async def test_stricter_verifier_rejects_laxer_mint(self) -> None:
+        """A chain minted under a loose bound must fail a strict verifier.
+
+        This is why the check is repeated at verify: delegate is not the
+        only path by which a deep chain can reach a replica.
+        """
+        lax = make_auth(max_depth=8)
+        strict = make_auth(max_depth=2)
+        token = await lax.issue(AgentId("coordinator"), ["read"])
+        for i in range(4):
+            token = await lax.delegate(token, AgentId(f"w{i}"), ["read"], ttl=60.0)
+        await lax.verify(token)
+        with pytest.raises(DelegationDepthExceededError, match="chain depth 5"):
+            await strict.verify(token)
+
+    @pytest.mark.asyncio
+    async def test_depth_refused_before_scope_check(self) -> None:
+        """An over-deep request is refused without doing attenuation work."""
+        auth = make_auth(max_depth=1)
+        root = await auth.issue(AgentId("coordinator"), ["read"])
+        # Scopes are also invalid here; depth must be what raises.
+        with pytest.raises(DelegationDepthExceededError):
+            await auth.delegate(root, AgentId("worker"), ["admin"], ttl=60.0)
+
+
+class TestPruning:
+    @pytest.mark.asyncio
+    async def test_expired_revocation_is_pruned(self) -> None:
+        auth = make_auth(prune_grace=10.0)
+        token = await auth.issue(AgentId("agent"), ["read"])
+        await auth.revoke(token)
+        assert auth.revocation_stats()["retained"] == 1
+        auth.advance_to(100_000.0)
+        assert auth.prune_revocations()
+        assert auth.revocation_stats()["retained"] == 0
+
+    @pytest.mark.asyncio
+    async def test_live_revocation_is_retained(self) -> None:
+        auth = make_auth(prune_grace=10.0)
+        token = await auth.issue(AgentId("agent"), ["read"])
+        await auth.revoke(token)
+        auth.advance_to(1.0)
+        assert auth.prune_revocations() == set()
+        assert auth.revocation_stats()["retained"] == 1
+
+    @pytest.mark.asyncio
+    async def test_grace_period_delays_pruning(self) -> None:
+        """An entry past expiry but inside the grace window is kept."""
+        auth = make_auth(prune_grace=1_000_000.0)
+        token = await auth.issue(AgentId("agent"), ["read"])
+        await auth.revoke(token)
+        auth.advance_to(100_000.0)  # past exp, still inside grace
+        assert auth.prune_revocations() == set()
+
+    @pytest.mark.asyncio
+    async def test_unknown_expiry_is_never_pruned(self) -> None:
+        """Entries merged from a peer carry no expiry and must be retained."""
+        issuer = make_auth(prune_grace=0.0)
+        peer = make_auth(prune_grace=0.0)
+        token = await issuer.issue(AgentId("agent"), ["read"])
+        await issuer.revoke(token)
+        peer.merge_revocations(issuer.export_revocations())
+        peer.advance_to(100_000.0)
+        assert peer.revocation_stats()["unknown_expiry"] == 1
+        assert peer.prune_revocations() == set()
+
+    @pytest.mark.asyncio
+    async def test_pruning_preserves_live_revocation_semantics(self) -> None:
+        """Pruning must never resurrect a token that should stay dead."""
+        auth = make_auth(prune_grace=10.0)
+        root = await auth.issue(AgentId("coordinator"), ["read"])
+        child = await auth.delegate(root, AgentId("worker"), ["read"], ttl=60.0)
+        await auth.revoke(root)
+        auth.advance_to(100_000.0)
+        auth.prune_revocations()
+        # The revocation entry is gone, but the chain is long expired, so
+        # the token still fails -- on expiry rather than revocation.
+        with pytest.raises(DelegationError):
+            await auth.verify(child)
+
+    @pytest.mark.asyncio
+    async def test_export_prunes_before_serializing(self) -> None:
+        auth = make_auth(prune_grace=10.0)
+        token = await auth.issue(AgentId("agent"), ["read"])
+        await auth.revoke(token)
+        auth.advance_to(100_000.0)
+        assert b'"revoked": []' in auth.export_revocations()
+
+    @pytest.mark.asyncio
+    async def test_stats_report_prunable_before_pruning(self) -> None:
+        auth = make_auth(prune_grace=10.0)
+        token = await auth.issue(AgentId("agent"), ["read"])
+        await auth.revoke(token)
+        auth.advance_to(100_000.0)
+        assert auth.revocation_stats()["prunable"] == 1
+
+
+class TestChainSummary:
+    @pytest.mark.asyncio
+    async def test_reports_depth_and_bound(self) -> None:
+        auth = make_auth(max_depth=5)
+        root = await auth.issue(AgentId("coordinator"), ["read"])
+        summary = auth.chain_summary(root)
+        assert summary["depth"] == 1
+        assert summary["max_depth"] == 5
+
+    @pytest.mark.asyncio
+    async def test_bytes_grow_with_depth(self) -> None:
+        auth = make_auth(max_depth=6)
+        root = await auth.issue(AgentId("coordinator"), ["read"])
+        deep = root
+        for i in range(4):
+            deep = await auth.delegate(deep, AgentId(f"w{i}"), ["read"], ttl=60.0)
+        assert auth.chain_summary(deep)["bytes"] > auth.chain_summary(root)["bytes"]
+
+
+class TestGrowthAgainstReference:
+    """Demonstrate the two failure modes on the merged plugins.
+
+    These are the reason the plugin exists. They assert the *unfixed*
+    behaviour, so if a future change bounds either growth upstream, they
+    fail and should be deleted along with the corresponding defence.
+    """
+
+    @pytest.mark.asyncio
+    async def test_merged_plugin_allows_unbounded_depth(self) -> None:
+        auth = MeshRevocableAuth(secret=SECRET, clock=0.0)
+        token = await auth.issue(AgentId("coordinator"), ["read"])
+        for i in range(64):
+            token = await auth.delegate(token, AgentId(f"w{i}"), ["read"], ttl=60.0)
+        ctx = await auth.verify(token)
+        assert ctx.scopes == ["read"]
+
+    @pytest.mark.asyncio
+    async def test_merged_plugin_token_grows_with_depth(self) -> None:
+        auth = MeshRevocableAuth(secret=SECRET, clock=0.0)
+        root = await auth.issue(AgentId("coordinator"), ["read"])
+        token = root
+        for i in range(64):
+            token = await auth.delegate(token, AgentId(f"w{i}"), ["read"], ttl=60.0)
+        assert len(str(token)) > 20 * len(str(root))
+
+    @pytest.mark.asyncio
+    async def test_merged_plugin_never_prunes(self) -> None:
+        """Every revocation survives, however long ago its token expired.
+
+        A replica started far in the future receives the same state a
+        replica at t=0 exported, and keeps all of it -- the G-Set has no
+        notion that an expired entry can no longer change an outcome.
+        """
+        issuer = MeshRevocableAuth(secret=SECRET, clock=0.0)
+        for i in range(16):
+            token = await issuer.issue(AgentId(f"a{i}"), ["read"])
+            await issuer.revoke(token)
+        state = issuer.export_revocations()
+
+        future = MeshRevocableAuth(secret=SECRET, clock=10_000_000.0)
+        future.merge_revocations(state)
+        assert future.export_revocations() == state

--- a/packages/nest-plugins-reference/tests/test_bounded_delegation_validators.py
+++ b/packages/nest-plugins-reference/tests/test_bounded_delegation_validators.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the bounded-delegation adversarial validators.
+
+Each validator is exercised twice: against audits a correct plugin would
+emit (must pass) and against audits the merged plugins would emit (must
+fail). The charter's bar for "adversarial" is that a validator fails
+against the reference implementation, so the failing direction is the
+one that matters.
+
+``TestAgainstLivePlugins`` drives real plugin instances rather than
+hand-built events, closing the gap between "the validator rejects this
+dict" and "the validator rejects what the plugin actually produces".
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from nest_core.types import AgentId
+from nest_plugins_reference.auth.bounded_delegation import (
+    BoundedDelegationAuth,
+    DelegationDepthExceededError,
+)
+from nest_plugins_reference.auth.mesh_revocable import MeshRevocableAuth
+from nest_plugins_reference.validators.bounded_delegation_validators import (
+    check_chain_depth_bounded,
+    check_depth_attack_refused,
+    check_pruning_preserves_liveness,
+    check_revocations_pruned,
+    extract_bounded_audits,
+)
+
+SECRET = b"bounded-delegation-validator-secret"
+
+
+def audit(**fields: Any) -> dict[str, Any]:
+    """Build one audit payload with the required type tag."""
+    return {"type": "bounded_delegation_audit", **fields}
+
+
+class TestExtraction:
+    def test_extracts_bare_payloads(self) -> None:
+        events = [audit(action="verify"), {"type": "other"}]
+        assert len(extract_bounded_audits(events)) == 1
+
+    def test_extracts_payloads_wrapped_in_msg(self) -> None:
+        events = [{"msg": json.dumps(audit(action="verify"))}]
+        assert len(extract_bounded_audits(events)) == 1
+
+    def test_ignores_unparseable_msg(self) -> None:
+        assert extract_bounded_audits([{"msg": "not json at all"}]) == []
+
+    def test_ignores_foreign_event_types(self) -> None:
+        events = [{"msg": json.dumps({"type": "delegation_audit"})}]
+        assert extract_bounded_audits(events) == []
+
+
+class TestCheckChainDepthBounded:
+    def test_passes_when_all_within_bound(self) -> None:
+        audits = [audit(verified=True, depth=d, max_depth=8) for d in (1, 3, 8)]
+        assert check_chain_depth_bounded(audits).passed
+
+    def test_fails_when_a_verification_exceeds_bound(self) -> None:
+        audits = [audit(verified=True, depth=9, max_depth=8)]
+        report = check_chain_depth_bounded(audits)
+        assert not report.passed
+        assert "9" in report.detail
+
+    def test_refused_attempts_do_not_count(self) -> None:
+        """A refused over-deep mint is the defence working, not a breach."""
+        audits = [audit(verified=False, granted=False, depth=99, max_depth=8)]
+        assert check_chain_depth_bounded(audits).passed
+
+    def test_reports_the_deepest_violation(self) -> None:
+        audits = [
+            audit(verified=True, depth=9, max_depth=8),
+            audit(verified=True, depth=40, max_depth=8),
+        ]
+        report = check_chain_depth_bounded(audits)
+        assert "40" in report.detail
+        assert len(report.evidence) == 2
+
+    def test_missing_depth_fields_are_skipped(self) -> None:
+        assert check_chain_depth_bounded([audit(verified=True)]).passed
+
+
+class TestCheckDepthAttackRefused:
+    def test_passes_when_an_attack_was_refused(self) -> None:
+        audits = [audit(action="delegate", granted=False, reason="depth")]
+        assert check_depth_attack_refused(audits).passed
+
+    def test_fails_when_no_delegation_was_attempted(self) -> None:
+        report = check_depth_attack_refused([audit(action="verify")])
+        assert not report.passed
+        assert "never exercised" in report.detail
+
+    def test_fails_when_every_delegation_was_granted(self) -> None:
+        """A scenario that never provokes the bound proves nothing."""
+        audits = [audit(action="delegate", granted=True) for _ in range(5)]
+        report = check_depth_attack_refused(audits)
+        assert not report.passed
+        assert "never provoked" in report.detail
+
+    def test_refusal_for_another_reason_does_not_count(self) -> None:
+        audits = [audit(action="delegate", granted=False, reason="scope")]
+        assert not check_depth_attack_refused(audits).passed
+
+
+class TestCheckRevocationsPruned:
+    def test_passes_when_nothing_prunable_remains(self) -> None:
+        audits = [audit(action="gossip", prunable=0, retained=3)]
+        assert check_revocations_pruned(audits).passed
+
+    def test_fails_when_a_replica_retains_prunable_entries(self) -> None:
+        audits = [audit(action="gossip", prunable=7, retained=7)]
+        report = check_revocations_pruned(audits)
+        assert not report.passed
+        assert "7" in report.detail
+
+    def test_fails_when_pruning_was_never_observed(self) -> None:
+        report = check_revocations_pruned([audit(action="verify")])
+        assert not report.passed
+        assert "never observed" in report.detail
+
+    def test_reports_the_worst_replica(self) -> None:
+        audits = [
+            audit(action="gossip", prunable=2),
+            audit(action="gossip", prunable=11),
+        ]
+        assert "11" in check_revocations_pruned(audits).detail
+
+
+class TestCheckPruningPreservesLiveness:
+    def test_passes_when_no_revoked_token_verified(self) -> None:
+        audits = [audit(verified=True, leaf_revoked=False)]
+        assert check_pruning_preserves_liveness(audits).passed
+
+    def test_fails_when_a_live_revocation_was_lost(self) -> None:
+        audits = [audit(verified=True, leaf_revoked=True, leaf_expired=False)]
+        report = check_pruning_preserves_liveness(audits)
+        assert not report.passed
+        assert "still mattered" in report.detail
+
+    def test_expired_revoked_token_is_not_a_violation(self) -> None:
+        """Pruning an expired entry is the whole point; expiry still bites."""
+        audits = [audit(verified=True, leaf_revoked=True, leaf_expired=True)]
+        assert check_pruning_preserves_liveness(audits).passed
+
+
+class TestAgainstLivePlugins:
+    """Drive real plugins and validate the audits they produce."""
+
+    @pytest.mark.asyncio
+    async def test_bounded_plugin_passes_depth_checks(self) -> None:
+        auth = BoundedDelegationAuth(secret=SECRET, clock=0.0, max_depth=3)
+        audits: list[dict[str, Any]] = []
+        token = await auth.issue(AgentId("coordinator"), ["read"])
+
+        for i in range(5):
+            try:
+                token = await auth.delegate(token, AgentId(f"w{i}"), ["read"], ttl=60.0)
+            except DelegationDepthExceededError:
+                audits.append(audit(action="delegate", granted=False, reason="depth"))
+                break
+            audits.append(audit(action="delegate", granted=True))
+
+        summary = auth.chain_summary(token)
+        await auth.verify(token)
+        audits.append(
+            audit(
+                action="verify",
+                verified=True,
+                depth=summary["depth"],
+                max_depth=summary["max_depth"],
+            )
+        )
+
+        assert check_chain_depth_bounded(audits).passed
+        assert check_depth_attack_refused(audits).passed
+
+    @pytest.mark.asyncio
+    async def test_merged_plugin_fails_depth_checks(self) -> None:
+        """The same scenario against mesh_revocable must fail both checks."""
+        auth = MeshRevocableAuth(secret=SECRET, clock=0.0)
+        audits: list[dict[str, Any]] = []
+        token = await auth.issue(AgentId("coordinator"), ["read"])
+
+        for i in range(5):
+            token = await auth.delegate(token, AgentId(f"w{i}"), ["read"], ttl=60.0)
+            audits.append(audit(action="delegate", granted=True))
+
+        await auth.verify(token)
+        audits.append(audit(action="verify", verified=True, depth=6, max_depth=3))
+
+        assert not check_chain_depth_bounded(audits).passed
+        assert not check_depth_attack_refused(audits).passed
+
+    @pytest.mark.asyncio
+    async def test_bounded_plugin_passes_pruning_check(self) -> None:
+        auth = BoundedDelegationAuth(secret=SECRET, clock=0.0, prune_grace=10.0)
+        for i in range(8):
+            token = await auth.issue(AgentId(f"a{i}"), ["read"])
+            await auth.revoke(token)
+        auth.advance_to(100_000.0)
+        auth.prune_revocations()
+        audits = [audit(action="gossip", **auth.revocation_stats())]
+        assert check_revocations_pruned(audits).passed
+
+    @pytest.mark.asyncio
+    async def test_merged_plugin_fails_pruning_check(self) -> None:
+        """mesh_revocable retains every entry, so prunable stays non-zero."""
+        issuer = MeshRevocableAuth(secret=SECRET, clock=0.0)
+        for i in range(8):
+            token = await issuer.issue(AgentId(f"a{i}"), ["read"])
+            await issuer.revoke(token)
+
+        # A replica far past every token's expiry still holds all eight,
+        # because a G-Set has no way to drop anything. The scenario reports
+        # that count as prunable, and the validator rejects it.
+        future = MeshRevocableAuth(secret=SECRET, clock=100_000.0)
+        future.merge_revocations(issuer.export_revocations())
+        retained = len(json.loads(future.export_revocations())["revoked"])
+        assert retained == 8
+
+        audits = [audit(action="gossip", prunable=retained, retained=retained)]
+        assert not check_revocations_pruned(audits).passed

--- a/scenarios/bounded_delegation.yaml
+++ b/scenarios/bounded_delegation.yaml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Bounded-delegation scenario: two resource attacks that break no crypto.
+# A relay chain re-delegates its token past any sane depth, while a churn
+# agent revokes short-lived tokens until the revocation set is all dead
+# weight. Under auth: bounded_delegation both are contained; under
+# delegatable or mesh_revocable both grow without limit (see
+# nest_plugins_reference.validators.bounded_delegation_validators).
+
+name: bounded_delegation
+description: |
+  A coordinator roots a capability chain through 12 relay agents, each
+  re-delegating to the next, while a churn agent issues and revokes
+  short-TTL tokens on a fixed cadence. Adversarial behaviours: chain
+  inflation past the declared depth bound, and unbounded growth of the
+  revocation G-Set with entries that can no longer affect verification.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 14
+  brain: state-machine
+  roles:
+    - name: coordinator
+      count: 1
+    - name: relay
+      count: 12
+    - name: churn
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: bounded_delegation
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: bounded_delegation
+  config:
+    relay_hops: 12
+    churn_rounds: 8
+    churn_interval: 3
+    report_tick: 90
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 100"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/bounded_delegation.jsonl


### PR DESCRIPTION
`delegatable` and `mesh_revocable` get the crypto right. They just never stop growing — in two directions — and neither growth breaks an invariant, which is why the existing validators wave it all through.

**Depth.** `delegate` appends a segment and re-signs, unbounded, offline. 2000 delegations make a 215 KB token whose `verify` runs ~400x slower than a root's. The verifier pays, so one holder slows down every agent it presents to.

**Revocations.** The G-Set never forgets. An expired entry is already unforgeable — expiry rejects the token before `_revoked` is even consulted — so keeping it buys nothing and costs every replica memory and every gossip round bytes.

`BoundedDelegationAuth` subclasses `MeshRevocableAuth`: token format, HMAC chain, attenuation, and CRDT replication all inherited, with `TestInheritedBehaviour` pinning that nothing regressed. It adds:

- `max_depth`, checked at `delegate` *and* at `verify` — a strict verifier must refuse a chain a laxer minter allowed (`test_stricter_verifier_rejects_laxer_mint`)
- expiry-based pruning behind `prune_grace` — pruning a G-Set is only safe for entries past expiry, and the grace window keeps a stale peer from resurrecting one while it could still matter. Entries merged from peers carry no known expiry and are never pruned.

Four validators, all FAIL against `jwt` / `delegatable` / `mesh_revocable`, all PASS here. One of them, `check_depth_attack_refused`, exists so a scenario can't pass just by never provoking the bound.

```bash
uv sync && uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest -v
uv run nest run scenarios/bounded_delegation.yaml
```

1365 passed, ruff and pyright clean, 54 new tests. The scenario (14 agents, 100 ticks) is seed-invariant: audit digests are byte-identical under seeds 42, 7, and 1337. Swap `auth:` to any of the three merged plugins and the checks flip to FAIL.

`DEFAULT_MAX_DEPTH = 8` is a judgement call — the shipped trees are depth 3, so 8 leaves room. Happy to change it, or make `prune_grace` an explicit deployment decision rather than a default.