### PR TITLE
feat(payments): Prava sandbox payments adapter [chijian28]

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -42,6 +42,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
     ("payments", "empic_escrow"): f"{_REF}.payments.empic_escrow:EMPICEscrowPayments",
     ("payments", "escrow"): f"{_REF}.payments.escrow:EscrowPayments",
+    ("payments", "prava"): "nest_plugins_prava.plugin:PravaPayments",
     ("coordination", "contract_net"): f"{_REF}.coordination.contract_net:ContractNet",
     ("coordination", "hotstuff"): f"{_REF}.coordination.hotstuff:HotStuff",
     ("negotiation", "alternating_offers"): (

--- a/packages/nest-plugins-prava/README.md
+++ b/packages/nest-plugins-prava/README.md
@@ -1,0 +1,106 @@
+# nest-plugins-prava
+
+Reusable **Prava** payments adapter for [Nanda Town](https://nandatown.projectnanda.org).
+
+Implements the NANDA Town `Payments` protocol (`quote` / `pay` / `verify_payment` / `refund`) and bridges it to Prava's Agentic Payments Sandbox:
+
+`create session → payment-result → report-status`
+
+## Why this exists
+
+NANDA Town agents speak a synchronous ledger API. Prava speaks sessions, credentials, and report-status. This plugin is the production-minded adapter between them: local budget locks, idempotent `PaymentRef`s, typed failures, secret scrubbing, and a dual transport (`mock` / `live` / `hybrid`).
+
+## Install
+
+From the nandatown repo root:
+
+```bash
+uv sync
+# or
+pip install -e packages/nest-plugins-prava
+```
+
+Confirm discovery:
+
+```bash
+nest plugins list | grep -A2 payments
+# should include: prava
+```
+
+## Environment
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `PRAVA_MODE` | `mock` | `mock` \| `live` \| `hybrid` |
+| `PRAVA_API_KEY` | _(required for live/hybrid)_ | `sk_test_...` sandbox key |
+| `PRAVA_BASE_URL` | `https://sandbox.api.prava.space` | API host |
+
+- **mock** — fully deterministic, no network. Use for CI + scenarios.
+- **live** — real HTTP to Prava (needs browser/passkey to finish checkout).
+- **hybrid** — real `POST /v1/sessions` (sandbox evidence) + headless completion for agent sims.
+
+## Quick start
+
+```python
+import asyncio
+from nest_plugins_prava import PravaPayments
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus, ServiceRef
+
+async def main() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000)
+    quote = await pay.quote(ServiceRef("compute-slot"))
+    receipt = await pay.pay(AgentId("bob"), quote.price, PaymentRef("buy-1"))
+    assert await pay.verify_payment(PaymentRef("buy-1")) is PaymentStatus.CONFIRMED
+    print(receipt)
+
+asyncio.run(main())
+```
+
+## Scenario
+
+```bash
+PRAVA_MODE=mock nest run scenarios/prava_marketplace.yaml -o traces/prava.jsonl
+```
+
+## Tests
+
+```bash
+pytest packages/nest-plugins-prava/tests -v
+# optional live session create (needs PRAVA_API_KEY):
+PRAVA_API_KEY=sk_test_... pytest packages/nest-plugins-prava/tests/test_sandbox_live.py -m live -v
+```
+
+## Protocol mapping
+
+| NANDA | Prava |
+|---|---|
+| `quote(service)` | local priced quote + `prava_amount` metadata |
+| `pay(to, amount, ref)` | budget lock → `POST /v1/sessions` → poll result → `report-status` |
+| `verify_payment(ref)` | local state (+ optional poll) |
+| `refund(ref)` | local ledger reverse (confirmed only) |
+
+Currency mapping default: **1 credit = $0.01 USD**.
+
+## Failure handling
+
+Typed errors in `nest_plugins_prava.errors`:
+
+- `InsufficientFundsError` — local budget gate; **never** calls Prava
+- `DuplicatePaymentRefError` — conflicting reuse of `PaymentRef`
+- `PravaAuthError` / `PravaSessionExpiredError` / `PravaTimeoutError`
+- `PravaDeclinedError` — report-status `DECLINED` / failed result
+- `QuoteExpiredError` / `PaymentNotFoundError`
+
+Idempotency: retrying `pay` with the same `ref`, payee, and amount returns the original `Receipt` when status is `PENDING` or `CONFIRMED`.
+
+## Security
+
+- API keys only via env / constructor — never committed
+- `session_token`, PAN, CVV are never stored on `Receipt` or `public_view()`
+- `assert_no_secrets` runs on session/result projections
+
+## Demo
+
+```bash
+python packages/nest-plugins-prava/scripts/demo_fail_then_retry.py
+```

--- a/packages/nest-plugins-prava/README.md
+++ b/packages/nest-plugins-prava/README.md
@@ -68,7 +68,78 @@ PRAVA_MODE=mock nest run scenarios/prava_marketplace.yaml -o traces/prava.jsonl
 pytest packages/nest-plugins-prava/tests -v
 # optional live session create (needs PRAVA_API_KEY):
 PRAVA_API_KEY=sk_test_... pytest packages/nest-plugins-prava/tests/test_sandbox_live.py -m live -v
+# sandbox proof (prints redacted evidence JSON):
+PRAVA_API_KEY=sk_test_... pytest packages/nest-plugins-prava/tests/test_sandbox_proof.py -m live -v -s
 ```
+
+## Sandbox transaction evidence
+
+These are **real** Prava Agentic Payments Sandbox sessions from
+`https://sandbox.api.prava.space` (hybrid / live HTTP). Tokens and API keys are
+redacted. Hybrid means: real `POST /v1/sessions` (the `ses_` / `ord_` IDs below),
+then headless completion so agents can finish without a browser passkey.
+
+### Batch A — README evidence capture (2026-08-02)
+
+| # | Flow | `session_id` | `order_id` | Result |
+|---|---|---|---|---|
+| 1 | `create_session` (live HTTP) | `ses_01KZ1E1AXPZMT7Q0Y1QVWC4DV6` | `ord_01KZ1E1AXPZMT7Q0Y1QVWC4DV7` | session created (`expires_at` 2026-08-02T14:43:51.766Z, `response_id` `4cac332c-3990-4dbd-9e0b-e9098cc256b1`) |
+| 2 | hybrid `quote → pay → verify` (`readme-evidence-1`, $0.50) | `ses_01KZ1E1BP5JGCQT9K353XSJYYE` | `ord_01KZ1E1BP5JGCQT9K353XSJYYF` | `verify=confirmed` |
+| 3 | hybrid `pay` (`readme-evidence-2`, 25 credits) | `ses_01KZ1E1CF38T275M1RTVTM2AZH` | `ord_01KZ1E1CF41D893W3W1EXA4C6N` | `verify=confirmed` |
+
+```json
+{
+  "host": "https://sandbox.api.prava.space",
+  "mode": "hybrid/live",
+  "transactions": [
+    {
+      "label": "create_session (live HTTP)",
+      "session_id": "ses_01KZ1E1AXPZMT7Q0Y1QVWC4DV6",
+      "order_id": "ord_01KZ1E1AXPZMT7Q0Y1QVWC4DV7",
+      "expires_at": "2026-08-02T14:43:51.766Z",
+      "response_id": "4cac332c-3990-4dbd-9e0b-e9098cc256b1",
+      "session_token": "***REDACTED***"
+    },
+    {
+      "label": "hybrid quote → pay → verify",
+      "receipt_ref": "readme-evidence-1",
+      "quote_amount_credits": 50,
+      "prava_amount_usd": "0.50",
+      "session_id": "ses_01KZ1E1BP5JGCQT9K353XSJYYE",
+      "order_id": "ord_01KZ1E1BP5JGCQT9K353XSJYYF",
+      "verify": "confirmed",
+      "phase": "confirmed"
+    },
+    {
+      "label": "hybrid pay (second PaymentRef)",
+      "receipt_ref": "readme-evidence-2",
+      "amount_credits": 25,
+      "session_id": "ses_01KZ1E1CF38T275M1RTVTM2AZH",
+      "order_id": "ord_01KZ1E1CF41D893W3W1EXA4C6N",
+      "verify": "confirmed",
+      "phase": "confirmed"
+    }
+  ]
+}
+```
+
+### Batch B — live pytest suite (same day, earlier run)
+
+`pytest …/test_sandbox_proof.py …/test_sandbox_live.py -m live -v -s` → **4 passed**.
+
+| # | Flow | `session_id` | `order_id` | Result |
+|---|---|---|---|---|
+| 4 | `test_sandbox_create_session_real_response_shape` | `ses_01KZ1E0K6CZFDBWTFP41Z6T9SG` | `ord_01KZ1E0K6CZFDBWTFP41Z6T9SH` | session created |
+| 5 | `test_sandbox_hybrid_quote_pay_verify_receipt` | `ses_01KZ1E0M1324J52V864HBHGMZQ` | `ord_01KZ1E0M1324J52V864HBHGMZR` | `status=confirmed` |
+
+### Batch C — hostile / audit runs (earlier same day)
+
+| # | Flow | `session_id` | `order_id` | Result |
+|---|---|---|---|---|
+| 6 | audit create_session | `ses_01KZ0Z1F5ES1ZT3TSGQ9RTH0MR` | `ord_01KZ0Z1F5ES1ZT3TSGQ9RTH0MS` | session created |
+| 7 | audit hybrid pay (`sandbox-audit-1`) | `ses_01KZ0Z1FY1K42A0S51WPV822J5` | `ord_01KZ0Z1FY1K42A0S51WPV822J6` | `status=confirmed` |
+
+**Total documented sandbox sessions above: 7** (all real `ses_` / `ord_` from Prava sandbox). Re-run the live tests with your own `sk_test_` key to mint fresh evidence; never commit API keys.
 
 ## Protocol mapping
 

--- a/packages/nest-plugins-prava/nest_plugins_prava/__init__.py
+++ b/packages/nest-plugins-prava/nest_plugins_prava/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prava payments adapter for Nanda Town.
+
+Example::
+
+    from nest_plugins_prava import PravaPayments
+    from nest_sdk import AgentId
+
+    payments = PravaPayments(AgentId("buyer"), initial_balance=1000)
+"""
+
+from __future__ import annotations
+
+from nest_plugins_prava.errors import (
+    DuplicatePaymentRefError,
+    InsufficientFundsError,
+    InvalidPaymentStateError,
+    PaymentNotFoundError,
+    PravaAdapterError,
+    PravaAuthError,
+    PravaDeclinedError,
+    PravaSessionExpiredError,
+    PravaTimeoutError,
+    QuoteExpiredError,
+)
+from nest_plugins_prava.plugin import PravaPayments
+
+__all__ = [
+    "DuplicatePaymentRefError",
+    "InsufficientFundsError",
+    "InvalidPaymentStateError",
+    "PaymentNotFoundError",
+    "PravaAdapterError",
+    "PravaAuthError",
+    "PravaDeclinedError",
+    "PravaPayments",
+    "PravaSessionExpiredError",
+    "PravaTimeoutError",
+    "QuoteExpiredError",
+]
+
+__version__ = "0.1.0"

--- a/packages/nest-plugins-prava/nest_plugins_prava/client.py
+++ b/packages/nest-plugins-prava/nest_plugins_prava/client.py
@@ -1,0 +1,580 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prava HTTP + mock clients used by the payments adapter.
+
+Example::
+
+    from nest_plugins_prava.client import MockPravaClient, build_client
+    client = build_client(mode="mock")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol, cast, runtime_checkable
+
+import httpx
+
+from nest_plugins_prava.errors import (
+    PravaApiError,
+    PravaAuthError,
+    PravaSessionExpiredError,
+    PravaTimeoutError,
+    PravaValidationError,
+)
+from nest_plugins_prava.secrets import REDACTED, redact
+
+DEFAULT_BASE_URL = "https://sandbox.api.prava.space"
+PravaMode = Literal["mock", "live", "hybrid"]
+
+
+@dataclass(frozen=True)
+class SessionResult:
+    """Create-session response (secrets redacted in repr helpers)."""
+
+    session_id: str
+    order_id: str | None
+    expires_at: str | None
+    response_id: str | None = None
+    # Kept off public_view; only for live SDK hand-off if needed.
+    session_token: str | None = field(default=None, repr=False)
+
+    def public_view(self) -> dict[str, Any]:
+        """Return a log-safe view of the session."""
+        return {
+            "session_id": self.session_id,
+            "order_id": self.order_id,
+            "expires_at": self.expires_at,
+            "response_id": self.response_id,
+            "session_token": REDACTED if self.session_token else None,
+        }
+
+
+@dataclass(frozen=True)
+class PaymentResultView:
+    """Normalized payment-result poll response."""
+
+    session_id: str
+    status: str
+    order_id: str | None
+    txn_ref_id: str | None
+    response_id: str | None = None
+    raw: dict[str, Any] = field(default_factory=lambda: {}, repr=False)
+
+    def public_view(self) -> dict[str, Any]:
+        """Return a log-safe view (credentials scrubbed)."""
+        return {
+            "session_id": self.session_id,
+            "status": self.status,
+            "order_id": self.order_id,
+            "txn_ref_id": self.txn_ref_id,
+            "response_id": self.response_id,
+            "raw": redact(self.raw),
+        }
+
+
+@dataclass(frozen=True)
+class ReportResult:
+    """Report-status response."""
+
+    status: str
+    txn_ref_id: str
+    txn_status: str
+    response_id: str | None = None
+
+
+@runtime_checkable
+class PravaClient(Protocol):
+    """Minimal Prava surface used by the adapter."""
+
+    async def create_session(self, body: dict[str, Any]) -> SessionResult: ...
+
+    async def get_payment_result(self, session_id: str) -> PaymentResultView: ...
+
+    async def report_status(
+        self,
+        session_id: str,
+        *,
+        txn_ref_id: str,
+        txn_status: str,
+        authorization_code: str = "OK123",
+        response_code: str = "00",
+    ) -> ReportResult: ...
+
+    async def revoke_session(self, session_id: str) -> None: ...
+
+    @property
+    def call_count(self) -> int: ...
+
+
+def _is_retryable_api_error(exc: PravaApiError, status_code: int | None = None) -> bool:
+    """Return True for transient upstream failures that may be retried."""
+    code = exc.code or ""
+    if status_code is not None and status_code >= 500:
+        return True
+    if code.startswith("HTTP_5"):
+        return True
+    return code.endswith("_ERROR") or code in {
+        "MERCHANT_LOOKUP_ERROR",
+        "SESSION_CREATE_ERROR",
+        "REPORT_STATUS_ERROR",
+        "VISA_CONFIRMATION_FAILED",
+    }
+
+
+def _map_http_error(
+    status_code: int, payload: dict[str, Any], response_id: str | None
+) -> Exception:
+    error_obj = payload.get("error")
+    err: dict[str, Any] = cast("dict[str, Any]", error_obj) if isinstance(error_obj, dict) else {}
+    code = str(err.get("code") or payload.get("code") or f"HTTP_{status_code}")
+    message = str(err.get("message") or payload.get("message") or f"HTTP {status_code}")
+    if status_code in (401, 403) or code.startswith("AUTH_"):
+        if code in {"AUTH_1003", "AUTH_1004"}:
+            return PravaSessionExpiredError(message, code=code, response_id=response_id)
+        return PravaAuthError(message, code=code, response_id=response_id)
+    if (
+        status_code == 400
+        or code.startswith("VAL_")
+        or code
+        in {
+            "INVALID_REQUEST",
+            "INVALID_STATE",
+            "CARD_NOT_FOUND",
+            "CARD_INACTIVE",
+            "NOT_FOUND",
+        }
+    ):
+        return PravaValidationError(message, code=code, response_id=response_id)
+    if status_code >= 500:
+        return PravaApiError(message, code=code, response_id=response_id)
+    return PravaApiError(message, code=code, response_id=response_id)
+
+
+def _require_session_payload(payload: dict[str, Any], response_id: str | None) -> SessionResult:
+    """Validate create-session success payload; reject unexpected shapes."""
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        raise PravaValidationError(
+            f"Invalid create-session response: missing session_id in {sorted(payload.keys())}",
+            code="VAL_SCHEMA",
+            response_id=response_id,
+        )
+    order_id = payload.get("order_id")
+    return SessionResult(
+        session_id=session_id,
+        order_id=str(order_id) if order_id is not None else None,
+        expires_at=payload.get("expires_at")
+        if isinstance(payload.get("expires_at"), str)
+        else None,
+        response_id=response_id,
+        session_token=payload.get("session_token")
+        if isinstance(payload.get("session_token"), str)
+        else None,
+    )
+
+
+class MockPravaClient:
+    """Deterministic in-process Prava stand-in for CI and scenario runs.
+
+    Example::
+
+        client = MockPravaClient(fail_on_create=False, decline_report=False)
+    """
+
+    def __init__(
+        self,
+        *,
+        fail_on_create: bool = False,
+        create_error: Exception | None = None,
+        timeout_on: str | None = None,
+        decline_report: bool = False,
+        poll_statuses: list[str] | None = None,
+        latency_s: float = 0.0,
+    ) -> None:
+        self.fail_on_create = fail_on_create
+        self.create_error = create_error
+        self.timeout_on = timeout_on
+        self.decline_report = decline_report
+        self.poll_statuses = list(poll_statuses or ["completed"])
+        self.latency_s = latency_s
+        self._sessions: dict[str, dict[str, Any]] = {}
+        self._poll_idx: dict[str, int] = {}
+        self._calls = 0
+
+    @property
+    def call_count(self) -> int:
+        """Number of API methods invoked."""
+        return self._calls
+
+    async def _maybe_latency(self) -> None:
+        if self.latency_s > 0:
+            await asyncio.sleep(self.latency_s)
+
+    async def create_session(self, body: dict[str, Any]) -> SessionResult:
+        """Create a mock session."""
+        self._calls += 1
+        await self._maybe_latency()
+        if self.timeout_on == "create_session":
+            raise PravaTimeoutError("mock timeout on create_session", code="TIMEOUT")
+        if self.create_error is not None:
+            raise self.create_error
+        if self.fail_on_create:
+            raise PravaApiError("mock create failure", code="SESSION_CREATE_ERROR")
+        session_id = f"sess_mock_{uuid.uuid4().hex[:12]}"
+        order_id = f"ord_mock_{uuid.uuid4().hex[:8]}"
+        self._sessions[session_id] = {
+            "body": body,
+            "order_id": order_id,
+            "status": "pending",
+            "txn_ref_id": f"tli_{uuid.uuid4().hex[:8]}",
+        }
+        self._poll_idx[session_id] = 0
+        return SessionResult(
+            session_id=session_id,
+            order_id=order_id,
+            expires_at=None,
+            response_id=f"resp_mock_{uuid.uuid4().hex[:8]}",
+            session_token=f"tok_mock_{uuid.uuid4().hex}",
+        )
+
+    async def get_payment_result(self, session_id: str) -> PaymentResultView:
+        """Poll mock payment result, advancing through configured statuses."""
+        self._calls += 1
+        await self._maybe_latency()
+        if self.timeout_on == "get_payment_result":
+            raise PravaTimeoutError("mock timeout on get_payment_result", code="TIMEOUT")
+        session = self._sessions.get(session_id)
+        if session is None:
+            raise PravaValidationError("session not found", code="NOT_FOUND")
+        idx = self._poll_idx.get(session_id, 0)
+        status = self.poll_statuses[min(idx, len(self.poll_statuses) - 1)]
+        self._poll_idx[session_id] = idx + 1
+        session["status"] = status
+        return PaymentResultView(
+            session_id=session_id,
+            status=status,
+            order_id=session["order_id"],
+            txn_ref_id=session["txn_ref_id"],
+            response_id=f"resp_mock_{uuid.uuid4().hex[:8]}",
+            raw={"status": status, "token": "4111111111111111", "dynamic_cvv": "123"},
+        )
+
+    async def report_status(
+        self,
+        session_id: str,
+        *,
+        txn_ref_id: str,
+        txn_status: str,
+        authorization_code: str = "OK123",
+        response_code: str = "00",
+    ) -> ReportResult:
+        """Report mock checkout outcome."""
+        self._calls += 1
+        await self._maybe_latency()
+        if self.timeout_on == "report_status":
+            raise PravaTimeoutError("mock timeout on report_status", code="TIMEOUT")
+        if session_id not in self._sessions:
+            raise PravaValidationError("session not found", code="NOT_FOUND")
+        final = "DECLINED" if self.decline_report else txn_status
+        return ReportResult(
+            status="confirmed",
+            txn_ref_id=txn_ref_id,
+            txn_status=final,
+            response_id=f"resp_mock_{uuid.uuid4().hex[:8]}",
+        )
+
+    async def revoke_session(self, session_id: str) -> None:
+        """Revoke a mock session."""
+        self._calls += 1
+        self._sessions.pop(session_id, None)
+
+
+class HttpPravaClient:
+    """Live Prava sandbox/production HTTP client.
+
+    Example::
+
+        client = HttpPravaClient(api_key="sk_test_...", base_url=DEFAULT_BASE_URL)
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout_s: float = 15.0,
+        max_retries: int = 2,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        if not api_key:
+            msg = "PRAVA_API_KEY / api_key is required for live mode"
+            raise PravaAuthError(msg, code="AUTH_1002")
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._timeout_s = timeout_s
+        self._max_retries = max_retries
+        self._transport = transport
+        self._calls = 0
+
+    @property
+    def call_count(self) -> int:
+        """Number of HTTP attempts (including retries)."""
+        return self._calls
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+    ) -> tuple[dict[str, Any], str | None]:
+        url = f"{self._base_url}{path}"
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries + 1):
+            self._calls += 1
+            try:
+                async with httpx.AsyncClient(
+                    timeout=self._timeout_s,
+                    transport=self._transport,
+                ) as client:
+                    response = await client.request(
+                        method,
+                        url,
+                        headers=self._headers(),
+                        json=json_body,
+                    )
+                response_id = response.headers.get("X-Response-ID")
+                try:
+                    parsed: Any = response.json() if response.content else {}
+                except ValueError:
+                    parsed = {"message": response.text}
+                payload: dict[str, Any] = (
+                    cast("dict[str, Any]", parsed) if isinstance(parsed, dict) else {"data": parsed}
+                )
+                if response.status_code >= 400:
+                    mapped = _map_http_error(response.status_code, payload, response_id)
+                    # Attach status for retry classification without changing public API.
+                    if isinstance(mapped, PravaApiError):
+                        mapped.status_code = response.status_code  # type: ignore[attr-defined]
+                    raise mapped
+                return payload, response_id
+            except (httpx.TimeoutException, httpx.TransportError) as exc:
+                last_exc = exc
+                if attempt >= self._max_retries:
+                    break
+                await asyncio.sleep(0.05 * (2**attempt))
+                continue
+            except PravaAuthError:
+                # Never retry auth failures.
+                raise
+            except PravaSessionExpiredError:
+                raise
+            except PravaValidationError:
+                # Never retry validation / schema / 4xx business errors.
+                raise
+            except PravaApiError as exc:
+                last_exc = exc
+                status_code = getattr(exc, "status_code", None)
+                if not _is_retryable_api_error(exc, status_code) or attempt >= self._max_retries:
+                    raise
+                await asyncio.sleep(0.05 * (2**attempt))
+                continue
+        if isinstance(last_exc, PravaApiError):
+            raise last_exc
+        raise PravaTimeoutError(
+            f"Prava request failed after retries: {last_exc}",
+            code="TIMEOUT",
+        ) from last_exc
+
+    async def create_session(self, body: dict[str, Any]) -> SessionResult:
+        """POST /v1/sessions."""
+        payload, response_id = await self._request("POST", "/v1/sessions", json_body=body)
+        return _require_session_payload(payload, response_id)
+
+    async def get_payment_result(self, session_id: str) -> PaymentResultView:
+        """GET /v1/sessions/{id}/payment-result."""
+        payload, response_id = await self._request(
+            "GET", f"/v1/sessions/{session_id}/payment-result"
+        )
+        txn_ref_id: str | None = None
+        transactions_raw = payload.get("transactions")
+        if isinstance(transactions_raw, list) and transactions_raw:
+            transactions = cast("list[Any]", transactions_raw)
+            first_any = transactions[0]
+            if isinstance(first_any, dict):
+                first = cast("dict[str, Any]", first_any)
+                candidate = first.get("txn_ref_id") or first.get("id")
+                if candidate is not None:
+                    txn_ref_id = str(candidate)
+        order_id_raw = payload.get("order_id")
+        return PaymentResultView(
+            session_id=str(payload.get("session_id") or session_id),
+            status=str(payload.get("status") or "pending"),
+            order_id=str(order_id_raw) if order_id_raw is not None else None,
+            txn_ref_id=txn_ref_id,
+            response_id=response_id,
+            raw=payload,
+        )
+
+    async def report_status(
+        self,
+        session_id: str,
+        *,
+        txn_ref_id: str,
+        txn_status: str,
+        authorization_code: str = "OK123",
+        response_code: str = "00",
+    ) -> ReportResult:
+        """POST /v1/sessions/{id}/report-status."""
+        body = {
+            "txn_ref_id": txn_ref_id,
+            "txn_status": txn_status,
+            "authorization_code": authorization_code,
+            "response_code": response_code,
+        }
+        payload, response_id = await self._request(
+            "POST",
+            f"/v1/sessions/{session_id}/report-status",
+            json_body=body,
+        )
+        return ReportResult(
+            status=str(payload.get("status") or "confirmed"),
+            txn_ref_id=str(payload.get("txn_ref_id") or txn_ref_id),
+            txn_status=str(payload.get("txn_status") or txn_status),
+            response_id=response_id,
+        )
+
+    async def revoke_session(self, session_id: str) -> None:
+        """POST /v1/sessions/{id}/revoke."""
+        await self._request("POST", f"/v1/sessions/{session_id}/revoke", json_body={})
+
+
+class HybridPravaClient:
+    """Live create-session + headless completion for agent simulations.
+
+    Creates a real sandbox session (evidence), then completes the remaining
+    payment-result/report steps via an embedded mock so headless agents can
+    finish quote→pay→verify without a browser passkey.
+
+    Example::
+
+        client = HybridPravaClient(api_key="sk_test_...")
+    """
+
+    def __init__(self, http: HttpPravaClient, mock: MockPravaClient | None = None) -> None:
+        self._http = http
+        self._mock = mock or MockPravaClient()
+        self._session_map: dict[str, str] = {}
+        self._calls = 0
+
+    @property
+    def call_count(self) -> int:
+        """Combined live + mock call count."""
+        return self._calls + self._http.call_count + self._mock.call_count
+
+    async def create_session(self, body: dict[str, Any]) -> SessionResult:
+        """Create a real sandbox session, then bind a mock completion lane."""
+        live = await self._http.create_session(body)
+        mock = await self._mock.create_session(body)
+        self._session_map[live.session_id] = mock.session_id
+        self._calls += 1
+        # Preserve live session_id as evidence; completion uses mock lane.
+        return SessionResult(
+            session_id=live.session_id,
+            order_id=live.order_id or mock.order_id,
+            expires_at=live.expires_at,
+            response_id=live.response_id,
+            session_token=live.session_token,
+        )
+
+    def _mock_id(self, session_id: str) -> str:
+        return self._session_map.get(session_id, session_id)
+
+    async def get_payment_result(self, session_id: str) -> PaymentResultView:
+        """Headless poll against the mock lane, tagged with live session id."""
+        view = await self._mock.get_payment_result(self._mock_id(session_id))
+        return PaymentResultView(
+            session_id=session_id,
+            status=view.status,
+            order_id=view.order_id,
+            txn_ref_id=view.txn_ref_id,
+            response_id=view.response_id,
+            raw=view.raw,
+        )
+
+    async def report_status(
+        self,
+        session_id: str,
+        *,
+        txn_ref_id: str,
+        txn_status: str,
+        authorization_code: str = "OK123",
+        response_code: str = "00",
+    ) -> ReportResult:
+        """Headless report-status against the mock lane."""
+        return await self._mock.report_status(
+            self._mock_id(session_id),
+            txn_ref_id=txn_ref_id,
+            txn_status=txn_status,
+            authorization_code=authorization_code,
+            response_code=response_code,
+        )
+
+    async def revoke_session(self, session_id: str) -> None:
+        """Best-effort revoke on live, always drop mock lane."""
+        try:
+            await self._http.revoke_session(session_id)
+        finally:
+            mock_id = self._session_map.pop(session_id, None)
+            if mock_id is not None:
+                await self._mock.revoke_session(mock_id)
+
+
+def resolve_mode(mode: str | None = None) -> PravaMode:
+    """Resolve adapter mode from argument or ``PRAVA_MODE`` env."""
+    raw = (mode or os.environ.get("PRAVA_MODE") or "mock").strip().lower()
+    if raw not in {"mock", "live", "hybrid"}:
+        msg = f"Invalid PRAVA_MODE={raw!r}; expected mock|live|hybrid"
+        raise PravaValidationError(msg, code="VAL_MODE")
+    return raw  # type: ignore[return-value]
+
+
+def build_client(
+    *,
+    mode: str | None = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    mock: MockPravaClient | None = None,
+) -> PravaClient:
+    """Factory for mock / live / hybrid clients.
+
+    Example::
+
+        client = build_client(mode="mock")
+    """
+    resolved = resolve_mode(mode)
+    if resolved == "mock":
+        return mock or MockPravaClient()
+    key = api_key if api_key is not None else os.environ.get("PRAVA_API_KEY", "")
+    url = base_url or os.environ.get("PRAVA_BASE_URL", DEFAULT_BASE_URL)
+    http = HttpPravaClient(api_key=key, base_url=url)
+    if resolved == "live":
+        return http
+    return HybridPravaClient(http, mock or MockPravaClient())
+
+
+def default_service_price(service_name: str) -> int:
+    """Deterministic per-service quote used when no catalog override exists."""
+    # Stable hash → 10..100 credits
+    digest = sum(ord(ch) for ch in service_name) % 91
+    return 10 + digest

--- a/packages/nest-plugins-prava/nest_plugins_prava/errors.py
+++ b/packages/nest-plugins-prava/nest_plugins_prava/errors.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Typed failure taxonomy for the Prava payments adapter.
+
+Example::
+
+    from nest_plugins_prava.errors import InsufficientFundsError
+    raise InsufficientFundsError("balance=5 < amount=50")
+"""
+
+from __future__ import annotations
+
+
+class PravaAdapterError(Exception):
+    """Base error for all adapter failures surfaced to NANDA agents."""
+
+    def __init__(
+        self, message: str, *, code: str | None = None, response_id: str | None = None
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.response_id = response_id
+
+
+class InsufficientFundsError(PravaAdapterError):
+    """Local simulation budget is too low to attempt a Prava session."""
+
+
+class DuplicatePaymentRefError(PravaAdapterError):
+    """PaymentRef was reused with conflicting payee/amount."""
+
+
+class PaymentNotFoundError(PravaAdapterError):
+    """verify/refund referenced an unknown PaymentRef."""
+
+
+class InvalidPaymentStateError(PravaAdapterError):
+    """Operation is illegal for the payment's current state."""
+
+
+class QuoteExpiredError(PravaAdapterError):
+    """Caller tried to pay after the quote TTL elapsed."""
+
+
+class PravaAuthError(PravaAdapterError):
+    """Prava rejected credentials (AUTH_* / missing key)."""
+
+
+class PravaTimeoutError(PravaAdapterError):
+    """Prava HTTP call timed out after retries."""
+
+
+class PravaSessionExpiredError(PravaAdapterError):
+    """Session expired or was revoked (AUTH_1003 / AUTH_1004)."""
+
+
+class PravaDeclinedError(PravaAdapterError):
+    """Checkout completed but the charge was DECLINED."""
+
+
+class PravaValidationError(PravaAdapterError):
+    """Request failed schema/business validation (VAL_* / 400)."""
+
+
+class PravaApiError(PravaAdapterError):
+    """Unexpected Prava API failure (5xx / unknown codes)."""

--- a/packages/nest-plugins-prava/nest_plugins_prava/journal.py
+++ b/packages/nest-plugins-prava/nest_plugins_prava/journal.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Durable-ish idempotency journal for PaymentRef → confirmed receipts.
+
+In-process dict by default. Inject the same dict into a new PravaPayments
+instance to simulate process restart recovery.
+
+Example::
+
+    journal: dict[str, dict] = {}
+    pay = PravaPayments(AgentId("a"), journal=journal)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus
+
+from nest_plugins_prava.state import PaymentPhase, PaymentRecord
+
+
+def record_to_journal_entry(record: PaymentRecord) -> dict[str, Any]:
+    """Serialize a confirmed/refunded record for restart recovery."""
+    return {
+        "ref": str(record.ref),
+        "payer": str(record.payer),
+        "payee": str(record.payee),
+        "amount": record.amount.amount,
+        "currency": record.amount.currency,
+        "status": record.status.value,
+        "phase": record.phase.value,
+        "session_id": record.session_id,
+        "order_id": record.order_id,
+        "txn_ref_id": record.txn_ref_id,
+        "created_at": record.created_at,
+    }
+
+
+def journal_entry_to_record(entry: dict[str, Any]) -> PaymentRecord:
+    """Deserialize a journal entry back into a PaymentRecord."""
+    status = PaymentStatus(entry["status"])
+    phase = PaymentPhase(entry.get("phase", status.value))
+    return PaymentRecord(
+        ref=PaymentRef(str(entry["ref"])),
+        payer=AgentId(str(entry["payer"])),
+        payee=AgentId(str(entry["payee"])),
+        amount=Money(amount=int(entry["amount"]), currency=str(entry.get("currency", "credits"))),
+        phase=phase,
+        status=status,
+        session_id=entry.get("session_id"),
+        order_id=entry.get("order_id"),
+        txn_ref_id=entry.get("txn_ref_id"),
+        created_at=float(entry.get("created_at") or 0.0),
+        locked_credits=0,
+    )
+
+
+def hydrate_from_journal(
+    journal: dict[str, dict[str, Any]],
+    records: dict[PaymentRef, PaymentRecord],
+    payments: dict[PaymentRef, Any],
+) -> None:
+    """Load durable entries into the in-memory ledger sidecars."""
+    for raw_ref, entry in journal.items():
+        ref = PaymentRef(raw_ref)
+        record = journal_entry_to_record(entry)
+        records[ref] = record
+        if record.status is PaymentStatus.CONFIRMED:
+            payments[ref] = record.to_receipt()
+
+
+def persist_record(journal: dict[str, dict[str, Any]] | None, record: PaymentRecord) -> None:
+    """Persist terminal states that must survive restart."""
+    if journal is None:
+        return
+    if record.status in {PaymentStatus.CONFIRMED, PaymentStatus.REFUNDED, PaymentStatus.FAILED}:
+        journal[str(record.ref)] = record_to_journal_entry(record)

--- a/packages/nest-plugins-prava/nest_plugins_prava/mapping.py
+++ b/packages/nest-plugins-prava/nest_plugins_prava/mapping.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Currency and identity mapping between NANDA Town and Prava.
+
+Example::
+
+    from nest_plugins_prava.mapping import credits_to_decimal_amount
+    assert credits_to_decimal_amount(50) == "0.50"
+"""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+
+from nest_sdk import AgentId
+
+# Default: 1 credit == 1 US cent. Override via PravaPayments(credits_per_unit=...).
+DEFAULT_CURRENCY = "USD"
+DEFAULT_MERCHANT_NAME = "NANDA Town Marketplace"
+DEFAULT_MERCHANT_URL = "https://nandatown.projectnanda.org"
+DEFAULT_MERCHANT_COUNTRY = "US"
+
+
+def credits_to_decimal_amount(credits: int, *, credits_per_unit: int = 100) -> str:
+    """Convert integer credits into a Prava decimal amount string.
+
+    Example::
+
+        credits_to_decimal_amount(50)  # "0.50"
+        credits_to_decimal_amount(100, credits_per_unit=100)  # "1.00"
+    """
+    if credits < 0:
+        msg = f"credits must be non-negative, got {credits}"
+        raise ValueError(msg)
+    if credits_per_unit <= 0:
+        msg = f"credits_per_unit must be positive, got {credits_per_unit}"
+        raise ValueError(msg)
+    amount = (Decimal(credits) / Decimal(credits_per_unit)).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
+    return f"{amount:.2f}"
+
+
+def decimal_amount_to_credits(amount: str, *, credits_per_unit: int = 100) -> int:
+    """Convert a Prava decimal amount string back to integer credits.
+
+    Example::
+
+        decimal_amount_to_credits("0.50")  # 50
+    """
+    value = Decimal(amount)
+    credit_amount = (value * Decimal(credits_per_unit)).quantize(
+        Decimal("1"), rounding=ROUND_HALF_UP
+    )
+    return int(credit_amount)
+
+
+def agent_to_user_id(agent: AgentId) -> str:
+    """Map a NANDA AgentId to a stable Prava user_id.
+
+    Example::
+
+        agent_to_user_id(AgentId("buyer-0"))  # "nanda-buyer-0"
+    """
+    raw = str(agent).strip()
+    safe = "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in raw)
+    return f"nanda-{safe}"[:255]
+
+
+def agent_to_email(agent: AgentId) -> str:
+    """Derive a deterministic sandbox email for an agent.
+
+    Example::
+
+        agent_to_email(AgentId("buyer-0"))
+    """
+    user = agent_to_user_id(agent).replace("_", "-")
+    return f"{user}@agents.nandatown.local"

--- a/packages/nest-plugins-prava/nest_plugins_prava/plugin.py
+++ b/packages/nest-plugins-prava/nest_plugins_prava/plugin.py
@@ -1,0 +1,532 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PravaPayments — NANDA Town Payments Protocol adapter for Prava.
+
+Example::
+
+    from nest_plugins_prava import PravaPayments
+    from nest_sdk import AgentId, Money, PaymentRef
+
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000)
+    receipt = await pay.pay(AgentId("bob"), Money(amount=50), PaymentRef("p1"))
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import threading
+import time
+from typing import Any
+
+from nest_sdk import (
+    AgentId,
+    Money,
+    PaymentRef,
+    PaymentStatus,
+    Quote,
+    Receipt,
+    ServiceRef,
+)
+
+from nest_plugins_prava.client import (
+    MockPravaClient,
+    PaymentResultView,
+    PravaClient,
+    build_client,
+    default_service_price,
+)
+from nest_plugins_prava.errors import (
+    DuplicatePaymentRefError,
+    InsufficientFundsError,
+    InvalidPaymentStateError,
+    PaymentNotFoundError,
+    PravaAdapterError,
+    PravaDeclinedError,
+    PravaTimeoutError,
+    QuoteExpiredError,
+)
+from nest_plugins_prava.journal import hydrate_from_journal, persist_record
+from nest_plugins_prava.mapping import (
+    DEFAULT_CURRENCY,
+    DEFAULT_MERCHANT_COUNTRY,
+    DEFAULT_MERCHANT_NAME,
+    DEFAULT_MERCHANT_URL,
+    agent_to_email,
+    agent_to_user_id,
+    credits_to_decimal_amount,
+)
+from nest_plugins_prava.secrets import assert_no_secrets
+from nest_plugins_prava.state import PaymentPhase, PaymentRecord, QuoteRecord
+
+# Sidecar store so marketplace-shared plain dicts still carry Prava records.
+_RECORDS_BY_LEDGER: dict[int, dict[PaymentRef, PaymentRecord]] = {}
+_QUOTES_BY_LEDGER: dict[int, dict[str, QuoteRecord]] = {}
+_CLIENT_BY_LEDGER: dict[int, PravaClient] = {}
+_LOCKS_BY_LEDGER: dict[int, asyncio.Lock] = {}
+# Cross-thread gate (asyncio.Lock alone does NOT protect ThreadPoolExecutor).
+_THREAD_LOCKS_BY_LEDGER: dict[int, threading.Lock] = {}
+
+
+def _records_for(payments: dict[PaymentRef, Any]) -> dict[PaymentRef, PaymentRecord]:
+    key = id(payments)
+    store = _RECORDS_BY_LEDGER.get(key)
+    if store is None:
+        store = {}
+        _RECORDS_BY_LEDGER[key] = store
+    return store
+
+
+def _quotes_for(payments: dict[PaymentRef, Any]) -> dict[str, QuoteRecord]:
+    key = id(payments)
+    store = _QUOTES_BY_LEDGER.get(key)
+    if store is None:
+        store = {}
+        _QUOTES_BY_LEDGER[key] = store
+    return store
+
+
+def _lock_for(payments: dict[PaymentRef, Any]) -> asyncio.Lock:
+    key = id(payments)
+    lock = _LOCKS_BY_LEDGER.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _LOCKS_BY_LEDGER[key] = lock
+    return lock
+
+
+def _thread_lock_for(payments: dict[PaymentRef, Any]) -> threading.Lock:
+    key = id(payments)
+    lock = _THREAD_LOCKS_BY_LEDGER.get(key)
+    if lock is None:
+        lock = threading.Lock()
+        _THREAD_LOCKS_BY_LEDGER[key] = lock
+    return lock
+
+
+async def _acquire_thread_lock(lock: threading.Lock) -> None:
+    """Acquire a threading.Lock without blocking the event loop or deadlocking tasks."""
+    while True:
+        if lock.acquire(blocking=False):
+            return
+        await asyncio.sleep(0.001)
+
+
+class PravaPayments:
+    """Payments Protocol implementation backed by Prava sandbox/mock.
+
+    Compatible with NANDA marketplace construction::
+
+        PravaPayments(agent_id, initial_balance=0, balances=shared, payments=shared)
+
+    Example::
+
+        pay = PravaPayments(AgentId("a1"), initial_balance=1000)
+        q = await pay.quote(ServiceRef("compute"))
+        receipt = await pay.pay(AgentId("a2"), q.price, PaymentRef("r1"))
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        initial_balance: int = 1000,
+        balances: dict[AgentId, int] | None = None,
+        payments: dict[PaymentRef, Any] | None = None,
+        *,
+        client: PravaClient | None = None,
+        mode: str | None = None,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        currency: str = DEFAULT_CURRENCY,
+        credits_per_unit: int = 100,
+        default_fee: int | None = None,
+        poll_attempts: int = 8,
+        poll_interval_s: float = 0.01,
+        merchant_name: str = DEFAULT_MERCHANT_NAME,
+        merchant_url: str = DEFAULT_MERCHANT_URL,
+        merchant_country: str = DEFAULT_MERCHANT_COUNTRY,
+        journal: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        self._agent_id = agent_id
+        self._balances = balances if balances is not None else {}
+        self._balances.setdefault(agent_id, initial_balance)
+        self._payments = payments if payments is not None else {}
+        self._records = _records_for(self._payments)
+        self._quotes = _quotes_for(self._payments)
+        self._lock = _lock_for(self._payments)
+        self._thread_lock = _thread_lock_for(self._payments)
+        self._journal = journal
+        self._currency = currency
+        self._credits_per_unit = credits_per_unit
+        self._default_fee = default_fee
+        self._poll_attempts = poll_attempts
+        self._poll_interval_s = poll_interval_s
+        self._merchant_name = merchant_name
+        self._merchant_url = merchant_url
+        self._merchant_country = merchant_country
+
+        if journal:
+            hydrate_from_journal(journal, self._records, self._payments)
+
+        ledger_key = id(self._payments)
+        if client is not None:
+            self._client = client
+            _CLIENT_BY_LEDGER[ledger_key] = client
+        elif ledger_key in _CLIENT_BY_LEDGER:
+            self._client = _CLIENT_BY_LEDGER[ledger_key]
+        else:
+            self._client = build_client(mode=mode, api_key=api_key, base_url=base_url)
+            _CLIENT_BY_LEDGER[ledger_key] = self._client
+
+    @property
+    def client(self) -> PravaClient:
+        """Underlying Prava client (mock/live/hybrid)."""
+        return self._client
+
+    def balance(self, agent: AgentId) -> int:
+        """Return an agent's available credit balance.
+
+        Example::
+
+            bal = pay.balance(AgentId("alice"))
+        """
+        return self._balances.get(agent, 0)
+
+    def top_up(self, agent: AgentId, amount: int) -> int:
+        """Credit an agent's local budget (simulation helper).
+
+        Example::
+
+            pay.top_up(AgentId("alice"), 100)
+        """
+        if amount <= 0:
+            msg = f"top_up amount must be positive: {amount}"
+            raise ValueError(msg)
+        self._balances[agent] = self._balances.get(agent, 0) + amount
+        return self._balances[agent]
+
+    def payment_record(self, ref: PaymentRef) -> PaymentRecord | None:
+        """Return the internal record for diagnostics (no secrets).
+
+        Example::
+
+            rec = pay.payment_record(PaymentRef("p1"))
+        """
+        return self._records.get(ref)
+
+    async def quote(self, service: ServiceRef) -> Quote:
+        """Return a price quote for a service and cache it with TTL.
+
+        Example::
+
+            q = await pay.quote(ServiceRef("data-cleaning"))
+        """
+        price = (
+            self._default_fee
+            if self._default_fee is not None
+            else default_service_price(str(service))
+        )
+        ttl = 300
+        self._quotes[str(service)] = QuoteRecord(
+            service=str(service),
+            price_credits=price,
+            expires_at=time.time() + ttl,
+            currency="credits",
+        )
+        return Quote(
+            service=service,
+            price=Money(amount=price, currency="credits"),
+            ttl_seconds=ttl,
+            metadata={
+                "rail": "prava",
+                "prava_currency": self._currency,
+                "prava_amount": credits_to_decimal_amount(
+                    price, credits_per_unit=self._credits_per_unit
+                ),
+            },
+        )
+
+    async def pay(self, to: AgentId, amount: Money, ref: PaymentRef) -> Receipt:
+        """Execute a payment: local budget lock → Prava session → confirm.
+
+        Example::
+
+            receipt = await pay.pay(AgentId("bob"), Money(amount=50), PaymentRef("p1"))
+        """
+        # Thread gate first (ThreadPoolExecutor), then asyncio gate (same-loop tasks).
+        await _acquire_thread_lock(self._thread_lock)
+        try:
+            async with self._lock:
+                return await self._pay_locked(to, amount, ref)
+        finally:
+            self._thread_lock.release()
+
+    async def _pay_locked(self, to: AgentId, amount: Money, ref: PaymentRef) -> Receipt:
+        if amount.amount <= 0:
+            msg = f"Payment amount must be positive: {amount.amount}"
+            raise ValueError(msg)
+
+        existing = self._records.get(ref)
+        if existing is not None:
+            if (
+                existing.payee == to
+                and existing.amount.amount == amount.amount
+                and existing.status in {PaymentStatus.CONFIRMED, PaymentStatus.PENDING}
+            ):
+                return existing.to_receipt()
+            if existing.status == PaymentStatus.FAILED:
+                # Allow retry on the same ref after a clean failure.
+                self._records.pop(ref, None)
+                self._payments.pop(ref, None)
+            else:
+                raise DuplicatePaymentRefError(
+                    f"Duplicate payment reference with conflicting state: {ref}",
+                    code="DUPLICATE_REF",
+                )
+
+        # Optional quote TTL enforcement when a quote exists for this amount.
+        self._enforce_quote_freshness(amount.amount)
+
+        payer_balance = self._balances.get(self._agent_id, 0)
+        if payer_balance < amount.amount:
+            raise InsufficientFundsError(
+                f"Insufficient balance: {payer_balance} < {amount.amount}",
+                code="INSUFFICIENT_FUNDS",
+            )
+
+        # Atomic local lock before any network call (prevents overspend on retry).
+        self._balances[self._agent_id] = payer_balance - amount.amount
+        record = PaymentRecord(
+            ref=ref,
+            payer=self._agent_id,
+            payee=to,
+            amount=amount,
+            phase=PaymentPhase.BUDGET_LOCKED,
+            status=PaymentStatus.PENDING,
+            locked_credits=amount.amount,
+        )
+        self._records[ref] = record
+        self._payments[ref] = record.to_receipt()
+
+        try:
+            session = await self._client.create_session(self._session_body(to, amount, ref))
+            record.session_id = session.session_id
+            record.order_id = session.order_id
+            record.response_id = session.response_id
+            record.phase = PaymentPhase.SESSION_CREATED
+            record.touch()
+            assert_no_secrets(session.public_view(), label="session")
+
+            result = await self._poll_until_ready(session.session_id)
+            record.txn_ref_id = result.txn_ref_id
+            record.response_id = result.response_id or record.response_id
+            record.phase = PaymentPhase.AWAITING_RESULT
+            record.touch()
+            assert_no_secrets(result.public_view(), label="payment_result")
+
+            if result.status == "failed":
+                raise PravaDeclinedError(
+                    f"Prava payment-result status=failed for session={session.session_id}",
+                    code="PAYMENT_FAILED",
+                    response_id=result.response_id,
+                )
+
+            txn_ref = result.txn_ref_id or f"tli-{ref}"
+            report = await self._client.report_status(
+                session.session_id,
+                txn_ref_id=txn_ref,
+                txn_status="APPROVED",
+            )
+            record.phase = PaymentPhase.REPORTED
+            record.response_id = report.response_id or record.response_id
+            record.touch()
+
+            if report.txn_status != "APPROVED":
+                raise PravaDeclinedError(
+                    f"Prava declined payment ref={ref} txn_status={report.txn_status}",
+                    code="DECLINED",
+                    response_id=report.response_id,
+                )
+
+            # Settle to payee only after rail confirmation.
+            self._balances[to] = self._balances.get(to, 0) + amount.amount
+            record.phase = PaymentPhase.CONFIRMED
+            record.status = PaymentStatus.CONFIRMED
+            record.locked_credits = 0
+            record.touch()
+            receipt = record.to_receipt()
+            self._payments[ref] = receipt
+            persist_record(self._journal, record)
+            assert_no_secrets(record.public_view(), label="payment_record")
+            return receipt
+        except PravaAdapterError as exc:
+            await self._fail_and_release(record, exc)
+            raise
+        except Exception as exc:
+            wrapped = PravaAdapterError(str(exc), code="UNEXPECTED")
+            await self._fail_and_release(record, wrapped)
+            raise wrapped from exc
+
+    async def verify_payment(self, ref: PaymentRef) -> PaymentStatus:
+        """Verify payment status by reference.
+
+        Example::
+
+            status = await pay.verify_payment(PaymentRef("p1"))
+        """
+        record = self._records.get(ref)
+        if record is None:
+            return PaymentStatus.FAILED
+        if (
+            record.status == PaymentStatus.PENDING
+            and record.session_id
+            and record.phase
+            in {PaymentPhase.SESSION_CREATED, PaymentPhase.AWAITING_RESULT, PaymentPhase.REPORTED}
+        ):
+            try:
+                view = await self._client.get_payment_result(record.session_id)
+                if view.status == "completed":
+                    return PaymentStatus.PENDING
+                if view.status == "failed":
+                    return PaymentStatus.FAILED
+            except PravaAdapterError:
+                return record.status
+        return record.status
+
+    async def refund(self, ref: PaymentRef) -> None:
+        """Refund a confirmed payment back to the payer.
+
+        Example::
+
+            await pay.refund(PaymentRef("p1"))
+        """
+        await _acquire_thread_lock(self._thread_lock)
+        try:
+            async with self._lock:
+                await self._refund_locked(ref)
+        finally:
+            self._thread_lock.release()
+
+    async def _refund_locked(self, ref: PaymentRef) -> None:
+        record = self._records.get(ref)
+        if record is None:
+            raise PaymentNotFoundError(f"Payment not found: {ref}", code="NOT_FOUND")
+        if record.status == PaymentStatus.REFUNDED:
+            # Idempotent no-op: do NOT call Prava again, do NOT double-credit.
+            return
+        if record.status == PaymentStatus.PENDING:
+            raise InvalidPaymentStateError(
+                f"Cannot refund PENDING payment: {ref}",
+                code="INVALID_STATE",
+            )
+        if record.status != PaymentStatus.CONFIRMED:
+            # Covers FAILED / declined — never invent a Prava refund rail call.
+            raise InvalidPaymentStateError(
+                f"Payment not refundable in status={record.status.value}: {ref}",
+                code="INVALID_STATE",
+            )
+
+        payee_balance = self._balances.get(record.payee, 0)
+        if payee_balance < record.amount.amount:
+            raise InsufficientFundsError(
+                f"Insufficient balance for refund: {record.payee} has "
+                f"{payee_balance}, needs {record.amount.amount}",
+                code="INSUFFICIENT_FUNDS",
+            )
+
+        self._balances[record.payee] = payee_balance - record.amount.amount
+        self._balances[record.payer] = self._balances.get(record.payer, 0) + record.amount.amount
+        record.status = PaymentStatus.REFUNDED
+        record.phase = PaymentPhase.REFUNDED
+        record.touch()
+        # Keep record for idempotent re-refund; drop receipt mapping.
+        self._payments.pop(ref, None)
+        persist_record(self._journal, record)
+        # NOTE: refund is local-ledger only today — no Prava refund API is invoked.
+
+    def _enforce_quote_freshness(self, amount: int) -> None:
+        # If any quote matches this amount and all such quotes are expired, reject.
+        matching = [q for q in self._quotes.values() if q.price_credits == amount]
+        if not matching:
+            return
+        now = time.time()
+        if all(q.expires_at < now for q in matching):
+            raise QuoteExpiredError(
+                f"Quote(s) for amount={amount} expired; re-quote before pay",
+                code="QUOTE_EXPIRED",
+            )
+
+    def _session_body(self, to: AgentId, amount: Money, ref: PaymentRef) -> dict[str, Any]:
+        decimal_amount = credits_to_decimal_amount(
+            amount.amount, credits_per_unit=self._credits_per_unit
+        )
+        return {
+            "user_id": agent_to_user_id(self._agent_id),
+            "user_email": agent_to_email(self._agent_id),
+            "total_amount": decimal_amount,
+            "currency": self._currency,
+            "purchase_context": [
+                {
+                    "merchant_details": {
+                        "name": self._merchant_name,
+                        "url": self._merchant_url,
+                        "country_code_iso2": self._merchant_country,
+                    },
+                    "product_details": [
+                        {
+                            "description": f"NANDA transfer {self._agent_id}->{to} ref={ref}",
+                            "unit_price": decimal_amount,
+                            "quantity": 1,
+                        }
+                    ],
+                }
+            ],
+            "integration_type": "full_checkout",
+            "callback_url": f"{self._merchant_url}/prava/callback",
+        }
+
+    async def _poll_until_ready(self, session_id: str) -> PaymentResultView:
+        last: PaymentResultView | None = None
+        for attempt in range(self._poll_attempts):
+            last = await self._client.get_payment_result(session_id)
+            if last.status in {"awaiting_result", "completed", "failed"}:
+                return last
+            await asyncio.sleep(self._poll_interval_s * (1 + attempt * 0.1))
+        last_status = last.status if last is not None else None
+        raise PravaTimeoutError(
+            f"Timed out polling payment-result for session={session_id} last={last_status}",
+            code="POLL_TIMEOUT",
+        )
+
+    async def _fail_and_release(self, record: PaymentRecord, exc: PravaAdapterError) -> None:
+        if record.locked_credits > 0 and record.status != PaymentStatus.CONFIRMED:
+            self._balances[record.payer] = (
+                self._balances.get(record.payer, 0) + record.locked_credits
+            )
+            record.locked_credits = 0
+        if record.session_id:
+            # Best-effort cleanup; original error is what callers need.
+            with contextlib.suppress(Exception):
+                await self._client.revoke_session(record.session_id)
+        record.status = PaymentStatus.FAILED
+        record.phase = PaymentPhase.FAILED
+        record.error_code = exc.code
+        record.error_message = str(exc)
+        record.response_id = exc.response_id or record.response_id
+        record.touch()
+        self._payments[record.ref] = record.to_receipt()
+        persist_record(self._journal, record)
+
+
+def reset_ledger_sidecars() -> None:
+    """Test helper: clear process-wide ledger sidecars."""
+    _RECORDS_BY_LEDGER.clear()
+    _QUOTES_BY_LEDGER.clear()
+    _CLIENT_BY_LEDGER.clear()
+    _LOCKS_BY_LEDGER.clear()
+    _THREAD_LOCKS_BY_LEDGER.clear()
+
+
+def attach_mock_client(payments: PravaPayments, mock: MockPravaClient) -> None:
+    """Test helper: force a mock client onto an existing ledger."""
+    payments._client = mock  # pyright: ignore[reportPrivateUsage]
+    _CLIENT_BY_LEDGER[id(payments._payments)] = mock  # pyright: ignore[reportPrivateUsage]

--- a/packages/nest-plugins-prava/nest_plugins_prava/secrets.py
+++ b/packages/nest-plugins-prava/nest_plugins_prava/secrets.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Secret scrubbing helpers — keep credentials out of traces and receipts.
+
+Example::
+
+    from nest_plugins_prava.secrets import assert_no_secrets, redact
+    safe = redact({"token": "4111111111111111", "ok": True})
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, cast
+
+_SECRET_KEY_RE = re.compile(
+    r"(api[_-]?key|secret|token|password|authorization|bearer|cvv|pan|card_number|sk_test|sk_live|pk_test|pk_live)",
+    re.IGNORECASE,
+)
+_SECRET_VALUE_RE = re.compile(
+    r"(?i)(sk_(test|live)_[A-Za-z0-9]+|pk_(test|live)_[A-Za-z0-9]+|Bearer\s+\S+|"
+    r"\b4[0-9]{12}(?:[0-9]{3})?\b)"
+)
+
+REDACTED = "***REDACTED***"
+
+
+def looks_like_secret_key(key: str) -> bool:
+    """Return True when a mapping key name suggests a credential field."""
+    return bool(_SECRET_KEY_RE.search(key))
+
+
+def redact(value: Any) -> Any:
+    """Recursively redact secret-looking keys and credential-shaped strings.
+
+    Example::
+
+        redact({"session_token": "abc", "amount": 1})
+    """
+    if isinstance(value, dict):
+        mapping = cast("dict[Any, Any]", value)
+        out: dict[Any, Any] = {}
+        for key, item in mapping.items():
+            if isinstance(key, str) and looks_like_secret_key(key):
+                out[key] = REDACTED
+            else:
+                out[key] = redact(item)
+        return out
+    if isinstance(value, list):
+        items = cast("list[Any]", value)
+        return [redact(item) for item in items]
+    if isinstance(value, str):
+        if _SECRET_VALUE_RE.search(value):
+            return REDACTED
+        return value
+    return value
+
+
+def contains_secret(value: Any) -> bool:
+    """Return True if *value* still contains a credential-shaped string."""
+    if isinstance(value, dict):
+        mapping = cast("dict[Any, Any]", value)
+        for key, item in mapping.items():
+            if isinstance(key, str) and looks_like_secret_key(key) and item != REDACTED:
+                return True
+            if contains_secret(item):
+                return True
+        return False
+    if isinstance(value, list):
+        items = cast("list[Any]", value)
+        return any(contains_secret(item) for item in items)
+    if isinstance(value, str):
+        return bool(_SECRET_VALUE_RE.search(value))
+    return False
+
+
+def assert_no_secrets(value: Any, *, label: str = "payload") -> None:
+    """Raise ValueError if a secret-shaped value is present.
+
+    Example::
+
+        assert_no_secrets({"status": "confirmed"})
+    """
+    if contains_secret(value):
+        msg = f"Secret-like material detected in {label}"
+        raise ValueError(msg)

--- a/packages/nest-plugins-prava/nest_plugins_prava/state.py
+++ b/packages/nest-plugins-prava/nest_plugins_prava/state.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Payment state machine records for the Prava adapter.
+
+Example::
+
+    from nest_plugins_prava.state import PaymentRecord, PaymentPhase
+    record = PaymentRecord(ref=..., payer=..., payee=..., amount=...)
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus, Receipt
+
+
+class PaymentPhase(StrEnum):
+    """Internal rail phase — finer grained than PaymentStatus."""
+
+    INIT = "init"
+    BUDGET_LOCKED = "budget_locked"
+    SESSION_CREATED = "session_created"
+    AWAITING_RESULT = "awaiting_result"
+    REPORTED = "reported"
+    CONFIRMED = "confirmed"
+    FAILED = "failed"
+    REFUNDED = "refunded"
+
+
+@dataclass
+class PaymentRecord:
+    """Durable record for one PaymentRef across agent handles.
+
+    Example::
+
+        record.status  # PaymentStatus.PENDING
+    """
+
+    ref: PaymentRef
+    payer: AgentId
+    payee: AgentId
+    amount: Money
+    phase: PaymentPhase = PaymentPhase.INIT
+    status: PaymentStatus = PaymentStatus.PENDING
+    session_id: str | None = None
+    order_id: str | None = None
+    txn_ref_id: str | None = None
+    response_id: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    locked_credits: int = 0
+
+    def touch(self) -> None:
+        """Update the last-modified timestamp."""
+        self.updated_at = time.time()
+
+    def to_receipt(self) -> Receipt:
+        """Project a NANDA Receipt (never includes secrets).
+
+        Example::
+
+            receipt = record.to_receipt()
+        """
+        return Receipt(
+            ref=self.ref,
+            payer=self.payer,
+            payee=self.payee,
+            amount=self.amount,
+            timestamp=self.created_at,
+        )
+
+    def public_view(self) -> dict[str, Any]:
+        """Safe diagnostic dict for logs/tests — no tokens/keys.
+
+        Example::
+
+            view = record.public_view()
+        """
+        return {
+            "ref": str(self.ref),
+            "payer": str(self.payer),
+            "payee": str(self.payee),
+            "amount": self.amount.amount,
+            "currency": self.amount.currency,
+            "phase": self.phase.value,
+            "status": self.status.value,
+            "session_id": self.session_id,
+            "order_id": self.order_id,
+            "txn_ref_id": self.txn_ref_id,
+            "response_id": self.response_id,
+            "error_code": self.error_code,
+            "error_message": self.error_message,
+        }
+
+
+@dataclass
+class QuoteRecord:
+    """Cached quote with absolute expiry."""
+
+    service: str
+    price_credits: int
+    expires_at: float
+    currency: str = "credits"

--- a/packages/nest-plugins-prava/pyproject.toml
+++ b/packages/nest-plugins-prava/pyproject.toml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+[project]
+name = "nest-plugins-prava"
+version = "0.1.0"
+description = "Prava sandbox payments adapter for Nanda Town"
+readme = "README.md"
+requires-python = ">=3.12"
+license = "Apache-2.0"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Typing :: Typed",
+]
+dependencies = [
+    "nest-sdk",
+    "httpx>=0.27",
+]
+
+[project.urls]
+Homepage = "https://github.com/projnanda/nandatown"
+Repository = "https://github.com/projnanda/nandatown"
+
+[project.entry-points."nest.plugins.payments"]
+prava = "nest_plugins_prava.plugin:PravaPayments"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["nest_plugins_prava"]

--- a/packages/nest-plugins-prava/scripts/demo_fail_then_retry.py
+++ b/packages/nest-plugins-prava/scripts/demo_fail_then_retry.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Visual demo: insufficient funds → clean error → top-up → successful Prava pay."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Allow running without install: repo root / package on path.
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "packages" / "nest-plugins-prava"))
+sys.path.insert(0, str(ROOT / "packages" / "nest-sdk"))
+sys.path.insert(0, str(ROOT / "packages" / "nest-core"))
+
+from nest_plugins_prava import InsufficientFundsError, PravaPayments  # noqa: E402
+from nest_plugins_prava.client import MockPravaClient  # noqa: E402
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus, ServiceRef  # noqa: E402
+
+
+async def main() -> None:
+    alice = AgentId("alice")
+    bob = AgentId("bob")
+    client = MockPravaClient()
+    pay = PravaPayments(alice, initial_balance=5, client=client, default_fee=50)
+
+    print("=== Prava adapter demo: fail → retry ===\n")
+    quote = await pay.quote(ServiceRef("compute-slot"))
+    print(
+        f"[1/4] quote(compute-slot) → {quote.price.amount} credits "
+        f"(${quote.metadata.get('prava_amount')})"
+    )
+
+    try:
+        await pay.pay(bob, Money(amount=50), PaymentRef("buy-1"))
+        print("[2/4] unexpected success")
+        sys.exit(1)
+    except InsufficientFundsError as exc:
+        print(f"[2/4] pay ref=buy-1 → FAIL {type(exc).__name__}: {exc}")
+        print(f"       prava_calls={client.call_count} (must be 0)")
+
+    new_bal = pay.top_up(alice, 100)
+    print(f"[3/4] top_up(alice, +100) → balance={new_bal}")
+
+    receipt = await pay.pay(bob, Money(amount=50), PaymentRef("buy-2"))
+    status = await pay.verify_payment(PaymentRef("buy-2"))
+    record = pay.payment_record(PaymentRef("buy-2"))
+    print(f"[4/4] pay ref=buy-2 → OK Receipt payer={receipt.payer} payee={receipt.payee}")
+    print(f"       verify={status.value} session={record.session_id if record else None}")
+    print(
+        f"       alice={pay.balance(alice)} bob={pay.balance(bob)} prava_calls={client.call_count}"
+    )
+
+    assert status is PaymentStatus.CONFIRMED
+    assert client.call_count > 0
+    print("\nDemo passed.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/nest-plugins-prava/scripts/hostile_audit_run.py
+++ b/packages/nest-plugins-prava/scripts/hostile_audit_run.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Run hostile production audit suite and print evidence."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+TESTS = ROOT / "packages" / "nest-plugins-prava" / "tests"
+
+AUDIT_FILES = [
+    "test_duplicate_payment_ref.py",
+    "test_concurrent_payments.py",
+    "test_prava_api_failures.py",
+    "test_state_machine.py",
+    "test_refund_safety.py",
+    "test_no_secret_leak.py",
+    "test_mock_live_consistency.py",
+]
+
+
+def main() -> int:
+    env = os.environ.copy()
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        *[str(TESTS / f) for f in AUDIT_FILES],
+        "-v",
+        "-s",
+        "--tb=short",
+        "-m",
+        "not live",
+    ]
+    print("COMMAND:", " ".join(cmd))
+    print("=" * 72)
+    p1 = subprocess.run(cmd, cwd=str(ROOT), env=env, check=False)
+
+    live_cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        str(TESTS / "test_sandbox_proof.py"),
+        "-v",
+        "-s",
+        "--tb=short",
+        "-m",
+        "live",
+    ]
+    print("\n" + "=" * 72)
+    print("LIVE COMMAND:", " ".join(live_cmd))
+    print(f"PRAVA_API_KEY set: {bool(env.get('PRAVA_API_KEY'))}")
+    p2 = subprocess.run(live_cmd, cwd=str(ROOT), env=env, check=False)
+
+    print("\n" + "=" * 72)
+    print(f"NON_LIVE_EXIT={p1.returncode}")
+    print(f"LIVE_EXIT={p2.returncode}")
+    if p1.returncode != 0:
+        return p1.returncode
+    # Live may fail without key — surface that explicitly.
+    return 0 if p2.returncode == 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/nest-plugins-prava/tests/__init__.py
+++ b/packages/nest-plugins-prava/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/packages/nest-plugins-prava/tests/test_concurrent_payments.py
+++ b/packages/nest-plugins-prava/tests/test_concurrent_payments.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Item 2 — concurrent payment race conditions (100 agents)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from nest_plugins_prava import InsufficientFundsError, PravaPayments
+from nest_plugins_prava.client import MockPravaClient
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+@pytest.mark.asyncio
+async def test_100_concurrent_same_ref_no_double_spend() -> None:
+    balances: dict[AgentId, int] = {AgentId("treasury"): 10_000}
+    payments: dict[PaymentRef, object] = {}
+    client = MockPravaClient(latency_s=0.001)
+    pay = PravaPayments(
+        AgentId("treasury"),
+        initial_balance=0,
+        balances=balances,
+        payments=payments,
+        client=client,
+    )
+    ref = PaymentRef("shared-ref")
+
+    results = await asyncio.gather(
+        *[pay.pay(AgentId("sink"), Money(amount=25), ref) for _ in range(100)],
+        return_exceptions=True,
+    )
+    ok = [r for r in results if not isinstance(r, BaseException)]
+    err = [r for r in results if isinstance(r, BaseException)]
+    print(
+        f"same_ref: ok={len(ok)} err={len(err)} calls={client.call_count} "
+        f"treasury={pay.balance(AgentId('treasury'))} sink={pay.balance(AgentId('sink'))}"
+    )
+    assert len(ok) == 100  # all return same receipt
+    assert len(err) == 0
+    assert client.call_count == 3  # one rail transaction only
+    assert pay.balance(AgentId("treasury")) == 10_000 - 25
+    assert pay.balance(AgentId("sink")) == 25
+    assert await pay.verify_payment(ref) is PaymentStatus.CONFIRMED
+
+
+@pytest.mark.asyncio
+async def test_100_concurrent_different_refs_balance_invariant() -> None:
+    balances: dict[AgentId, int] = {AgentId("treasury"): 1000}
+    payments: dict[PaymentRef, object] = {}
+    client = MockPravaClient(latency_s=0.001)
+    pay = PravaPayments(
+        AgentId("treasury"),
+        initial_balance=0,
+        balances=balances,
+        payments=payments,
+        client=client,
+    )
+
+    async def one(i: int) -> None:
+        await pay.pay(AgentId(f"agent-{i % 10}"), Money(amount=10), PaymentRef(f"ref-{i}"))
+
+    results = await asyncio.gather(*[one(i) for i in range(100)], return_exceptions=True)
+    ok = [r for r in results if not isinstance(r, BaseException)]
+    fail = [r for r in results if isinstance(r, BaseException)]
+    print(
+        f"diff_refs: ok={len(ok)} fail={len(fail)} calls={client.call_count} "
+        f"treasury={pay.balance(AgentId('treasury'))}"
+    )
+    # 1000 / 10 = 100 successes exactly
+    assert len(ok) == 100
+    assert len(fail) == 0
+    assert pay.balance(AgentId("treasury")) == 0
+    # sum of sink balances
+    sinks = sum(pay.balance(AgentId(f"agent-{i}")) for i in range(10))
+    assert sinks == 1000
+    assert all(isinstance(e, InsufficientFundsError) for e in fail) or fail == []
+
+
+@pytest.mark.asyncio
+async def test_100_concurrent_oversubscribe_no_corruption() -> None:
+    balances: dict[AgentId, int] = {AgentId("treasury"): 250}
+    payments: dict[PaymentRef, object] = {}
+    client = MockPravaClient(latency_s=0.001)
+    pay = PravaPayments(
+        AgentId("treasury"),
+        initial_balance=0,
+        balances=balances,
+        payments=payments,
+        client=client,
+    )
+
+    results = await asyncio.gather(
+        *[pay.pay(AgentId("sink"), Money(amount=10), PaymentRef(f"over-{i}")) for i in range(100)],
+        return_exceptions=True,
+    )
+    ok = [r for r in results if not isinstance(r, BaseException)]
+    fail = [r for r in results if isinstance(r, InsufficientFundsError)]
+    other = [
+        r
+        for r in results
+        if isinstance(r, BaseException) and not isinstance(r, InsufficientFundsError)
+    ]
+    print(
+        f"oversubscribe: ok={len(ok)} insuff={len(fail)} other={len(other)} "
+        f"treasury={pay.balance(AgentId('treasury'))} sink={pay.balance(AgentId('sink'))} "
+        f"calls={client.call_count}"
+    )
+    assert len(ok) == 25
+    assert len(fail) == 75
+    assert other == []
+    assert pay.balance(AgentId("treasury")) == 0
+    assert pay.balance(AgentId("sink")) == 250
+    # No partial/corrupt negatives
+    assert pay.balance(AgentId("treasury")) >= 0

--- a/packages/nest-plugins-prava/tests/test_duplicate_payment_ref.py
+++ b/packages/nest-plugins-prava/tests/test_duplicate_payment_ref.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Item 1 — hostile idempotency verification for PaymentRef."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from nest_plugins_prava import DuplicatePaymentRefError, PravaPayments
+from nest_plugins_prava.client import MockPravaClient
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_ref_returns_same_receipt_no_second_api_call() -> None:
+    client = MockPravaClient()
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000, client=client)
+    ref = PaymentRef("abc123")
+
+    r1 = await pay.pay(AgentId("bob"), Money(amount=50), ref)
+    calls_after_first = client.call_count
+    assert calls_after_first > 0
+    assert ref in pay._records  # stored  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+    r2 = await pay.pay(AgentId("bob"), Money(amount=50), ref)
+    assert r2.ref == r1.ref
+    assert r2.payer == r1.payer
+    assert r2.payee == r1.payee
+    assert r2.amount.amount == r1.amount.amount
+    assert client.call_count == calls_after_first  # NO second Prava trip
+    assert pay.balance(AgentId("alice")) == 950  # no double spend
+    assert pay.balance(AgentId("bob")) == 50
+
+
+@pytest.mark.asyncio
+async def test_lookup_atomic_under_concurrent_duplicate_requests() -> None:
+    client = MockPravaClient(latency_s=0.02)
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000, client=client)
+    ref = PaymentRef("abc123")
+
+    results = await asyncio.gather(
+        *[pay.pay(AgentId("bob"), Money(amount=50), ref) for _ in range(20)]
+    )
+    assert len({(r.ref, r.amount.amount, r.payee) for r in results}) == 1
+    # Exactly one create+poll+report lane (3 calls), not 20×
+    assert client.call_count == 3
+    assert pay.balance(AgentId("alice")) == 950
+    assert pay.balance(AgentId("bob")) == 50
+
+
+@pytest.mark.asyncio
+async def test_process_restart_without_journal_loses_idempotency() -> None:
+    """Prove the gap: in-memory only → restart creates a NEW rail call."""
+    client1 = MockPravaClient()
+    pay1 = PravaPayments(AgentId("alice"), initial_balance=1000, client=client1)
+    await pay1.pay(AgentId("bob"), Money(amount=50), PaymentRef("abc123"))
+    assert client1.call_count == 3
+
+    reset_ledger_sidecars()  # simulate process death
+    client2 = MockPravaClient()
+    pay2 = PravaPayments(AgentId("alice"), initial_balance=1000, client=client2)
+    await pay2.pay(AgentId("bob"), Money(amount=50), PaymentRef("abc123"))
+    assert client2.call_count == 3  # second process charged again — RISK without journal
+
+
+@pytest.mark.asyncio
+async def test_process_restart_with_journal_preserves_idempotency() -> None:
+    journal: dict[str, dict[str, Any]] = {}
+    client1 = MockPravaClient()
+    pay1 = PravaPayments(AgentId("alice"), initial_balance=1000, client=client1, journal=journal)
+    r1 = await pay1.pay(AgentId("bob"), Money(amount=50), PaymentRef("abc123"))
+    assert "abc123" in journal
+
+    reset_ledger_sidecars()  # simulate process death
+    client2 = MockPravaClient()
+    # Fresh balances dict but shared durable journal.
+    pay2 = PravaPayments(
+        AgentId("alice"),
+        initial_balance=1000,
+        client=client2,
+        journal=journal,
+    )
+    r2 = await pay2.pay(AgentId("bob"), Money(amount=50), PaymentRef("abc123"))
+    assert r2.ref == r1.ref
+    assert client2.call_count == 0  # no second Prava call after restart
+    assert await pay2.verify_payment(PaymentRef("abc123")) is PaymentStatus.CONFIRMED
+
+
+@pytest.mark.asyncio
+async def test_conflicting_duplicate_ref_rejected() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000, client=MockPravaClient())
+    await pay.pay(AgentId("bob"), Money(amount=50), PaymentRef("abc123"))
+    with pytest.raises(DuplicatePaymentRefError):
+        await pay.pay(AgentId("carol"), Money(amount=50), PaymentRef("abc123"))

--- a/packages/nest-plugins-prava/tests/test_entry_point.py
+++ b/packages/nest-plugins-prava/tests/test_entry_point.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Entry-point / registry discovery for the prava plugin."""
+
+from __future__ import annotations
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_plugins_prava import PravaPayments
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_sdk import AgentId, Payments
+
+
+@pytest.fixture(autouse=True)
+def _clean_sidecars() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+def test_isinstance_protocol() -> None:
+    pay = PravaPayments(AgentId("a1"), initial_balance=10)
+    assert isinstance(pay, Payments)
+
+
+def test_registry_resolves_prava_when_installed() -> None:
+    reg = PluginRegistry()
+    try:
+        cls = reg.resolve("payments", "prava")
+    except KeyError:
+        pytest.skip("prava entry point not installed in this environment")
+    assert cls is PravaPayments or cls.__name__ == "PravaPayments"

--- a/packages/nest-plugins-prava/tests/test_extreme_edge_cases.py
+++ b/packages/nest-plugins-prava/tests/test_extreme_edge_cases.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hostile extreme-edge proofs for the five scenarios reviewers demand."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import httpx
+import pytest
+from nest_plugins_prava import (
+    InvalidPaymentStateError,
+    PravaDeclinedError,
+    PravaPayments,
+    PravaTimeoutError,
+)
+from nest_plugins_prava.client import HttpPravaClient, MockPravaClient
+from nest_plugins_prava.errors import PravaApiError
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+# ---------------------------------------------------------------------------
+# 1) Two-phase: local debit then Prava failure → IMMEDIATE budget restore
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_1_timeout_after_local_debit_rolls_back_budget() -> None:
+    """Lock/debit locally, create_session times out → balance restored."""
+    client = MockPravaClient(timeout_on="create_session")
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=client)
+    assert pay.balance(AgentId("alice")) == 100
+
+    with pytest.raises(PravaTimeoutError):
+        await pay.pay(AgentId("bob"), Money(amount=40), PaymentRef("2pc-timeout"))
+
+    # IMMEDIATE rollback — not "eventually", not deferred.
+    assert pay.balance(AgentId("alice")) == 100
+    assert pay.balance(AgentId("bob")) == 0
+    assert await pay.verify_payment(PaymentRef("2pc-timeout")) is PaymentStatus.FAILED
+    print(
+        f"2PC timeout rollback: alice={pay.balance(AgentId('alice'))} "
+        f"status={await pay.verify_payment(PaymentRef('2pc-timeout'))}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_1_http_500_after_local_debit_rolls_back_budget() -> None:
+    """Same 2PC property against HttpPravaClient returning 500."""
+    hits = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hits["n"] += 1
+        return httpx.Response(
+            500, json={"error": {"code": "SESSION_CREATE_ERROR", "message": "boom"}}
+        )
+
+    http = HttpPravaClient(
+        api_key="sk_test_dummy",
+        transport=httpx.MockTransport(handler),
+        max_retries=1,
+    )
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=http)
+
+    with pytest.raises(PravaApiError):
+        await pay.pay(AgentId("bob"), Money(amount=40), PaymentRef("2pc-500"))
+
+    assert pay.balance(AgentId("alice")) == 100
+    assert hits["n"] >= 2  # retried, still no settle
+    assert await pay.verify_payment(PaymentRef("2pc-500")) is PaymentStatus.FAILED
+    print(f"2PC http500 rollback: alice=100 hits={hits['n']}")
+
+
+# ---------------------------------------------------------------------------
+# 2) True multi-thread same PaymentRef (ThreadPoolExecutor)
+# ---------------------------------------------------------------------------
+
+
+def test_2_threadpool_10_workers_same_payment_ref_single_rail_call() -> None:
+    """10 OS threads hit the SAME PaymentRef at once."""
+    balances: dict[AgentId, int] = {AgentId("alice"): 1000}
+    payments: dict[PaymentRef, object] = {}
+    client = MockPravaClient(latency_s=0.02)
+    pay = PravaPayments(
+        AgentId("alice"),
+        initial_balance=0,
+        balances=balances,
+        payments=payments,
+        client=client,
+    )
+    ref = PaymentRef("thread-same-ref")
+
+    def worker() -> str:
+        receipt = asyncio.run(pay.pay(AgentId("bob"), Money(amount=50), ref))
+        return f"{receipt.ref}:{receipt.amount.amount}:{receipt.payee}"
+
+    results: list[str] = []
+    errors: list[BaseException] = []
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futs = [pool.submit(worker) for _ in range(10)]
+        for fut in as_completed(futs):
+            try:
+                results.append(fut.result())
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+    print(
+        f"threadpool same-ref: results={len(results)} errors={len(errors)} "
+        f"unique={set(results)} create_lane_calls={client.call_count} "
+        f"alice={pay.balance(AgentId('alice'))} bob={pay.balance(AgentId('bob'))}"
+    )
+    assert errors == []
+    assert len(results) == 10
+    assert set(results) == {"thread-same-ref:50:bob"}
+    # Exactly one rail transaction: create + poll + report
+    assert client.call_count == 3
+    assert pay.balance(AgentId("alice")) == 950
+    assert pay.balance(AgentId("bob")) == 50
+
+
+# ---------------------------------------------------------------------------
+# 3) Refund edge cases (declined + double refund)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_3_refund_declined_payment_rejected() -> None:
+    client = MockPravaClient(decline_report=True)
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=client)
+    with pytest.raises(PravaDeclinedError):
+        await pay.pay(AgentId("bob"), Money(amount=20), PaymentRef("declined-1"))
+    assert await pay.verify_payment(PaymentRef("declined-1")) is PaymentStatus.FAILED
+
+    calls_before = client.call_count
+    with pytest.raises(InvalidPaymentStateError) as ei:
+        await pay.refund(PaymentRef("declined-1"))
+    # No additional Prava calls for a rejected refund
+    assert client.call_count == calls_before
+    assert ei.value.code == "INVALID_STATE"
+    print(f"refund declined: {type(ei.value).__name__} prava_calls_delta=0")
+
+
+@pytest.mark.asyncio
+async def test_3_refund_twice_idempotent_no_second_prava_call() -> None:
+    """Honest behavior: 2nd refund is a local no-op — NOT AlreadyRefundedError,
+    and NOT a second Prava refund request (refund rail is local-only)."""
+    client = MockPravaClient()
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=client)
+    await pay.pay(AgentId("bob"), Money(amount=20), PaymentRef("rf-double"))
+    await pay.refund(PaymentRef("rf-double"))
+    calls_after_first_refund = client.call_count
+    bal = pay.balance(AgentId("alice"))
+
+    # Second refund: no exception, no balance change, no new client calls
+    await pay.refund(PaymentRef("rf-double"))
+    assert pay.balance(AgentId("alice")) == bal == 100
+    assert client.call_count == calls_after_first_refund
+    assert await pay.verify_payment(PaymentRef("rf-double")) is PaymentStatus.REFUNDED
+    print(
+        f"refund twice: IDEMPOTENT_NO_OP calls_unchanged={client.call_count} "
+        f"(no AlreadyRefundedError by design; no Prava refund API exists here)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4) Hybrid headless — prove it is mock completion, not webhook magic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_4_hybrid_headless_uses_mock_lane_not_live_payment_result() -> None:
+    """Hybrid: live create_session once, then get_payment_result/report hit MOCK."""
+    live_paths: list[str] = []
+    mock = MockPravaClient()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        live_paths.append(f"{request.method}:{request.url.path}")
+        if request.url.path.endswith("/sessions") and request.method == "POST":
+            return httpx.Response(
+                201,
+                json={
+                    "session_id": "ses_LIVE_REAL_001",
+                    "order_id": "ord_LIVE_REAL_001",
+                    "session_token": "tok_LIVE_SECRET",
+                    "expires_at": "2099-01-01T00:00:00Z",
+                },
+            )
+        # If hybrid wrongly polled live payment-result, this 500 would break pay.
+        return httpx.Response(500, json={"error": {"code": "SHOULD_NOT_HIT", "message": "x"}})
+
+    http = HttpPravaClient(api_key="sk_test_dummy", transport=httpx.MockTransport(handler))
+    from nest_plugins_prava.client import HybridPravaClient
+
+    hybrid = HybridPravaClient(http, mock)
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=hybrid)
+    receipt = await pay.pay(AgentId("bob"), Money(amount=10), PaymentRef("hybrid-proof"))
+    rec = pay.payment_record(PaymentRef("hybrid-proof"))
+    assert rec is not None
+
+    print(
+        f"hybrid live_paths={live_paths} session_id={rec.session_id} "
+        f"mock_calls={mock.call_count} status={rec.status.value}"
+    )
+    # Live HTTP only used for create (+ maybe revoke on failure). Not for poll/report.
+    assert any(p.endswith("/sessions") and p.startswith("POST") for p in live_paths)
+    assert not any("payment-result" in p for p in live_paths)
+    assert not any("report-status" in p for p in live_paths)
+    # Evidence id is the LIVE session id; completion came from mock lane.
+    assert rec.session_id == "ses_LIVE_REAL_001"
+    assert mock.call_count >= 2  # mock create + poll (+ report)
+    assert await pay.verify_payment(PaymentRef("hybrid-proof")) is PaymentStatus.CONFIRMED
+    assert receipt.amount.amount == 10
+
+
+# ---------------------------------------------------------------------------
+# 5) Deep Receipt JSON regex — no sk_ / pk_ anywhere
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_5_receipt_json_regex_forbids_sk_or_pk_prefixes() -> None:
+    # Poison the mock raw payload with credential-shaped strings; Receipt must stay clean.
+    client = MockPravaClient()
+    pay = PravaPayments(
+        AgentId("alice"),
+        initial_balance=100,
+        client=client,
+        api_key="sk_test_SHOULD_NEVER_APPEAR_IN_RECEIPT",
+    )
+    receipt = await pay.pay(AgentId("bob"), Money(amount=7), PaymentRef("sec-deep"))
+    record = pay.payment_record(PaymentRef("sec-deep"))
+    assert record is not None
+
+    # Serialize exactly as a NANDA DB row might.
+    db_row = {
+        "receipt": receipt.model_dump(),
+        "record_public": record.public_view(),
+        "nested": {"meta": {"rail": "prava", "refs": [str(receipt.ref)]}},
+    }
+    blob = json.dumps(db_row)
+    print(f"receipt_json={blob}")
+
+    assert re.search(r"sk_", blob) is None, blob
+    assert re.search(r"pk_", blob) is None, blob
+    assert re.search(r"(?i)session_token", blob) is None or "***REDACTED***" in blob
+    assert "tok_mock" not in blob
+    assert "4111111111111111" not in blob

--- a/packages/nest-plugins-prava/tests/test_failures.py
+++ b/packages/nest-plugins-prava/tests/test_failures.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Failure-path coverage for the Prava adapter."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from nest_plugins_prava import (
+    DuplicatePaymentRefError,
+    InsufficientFundsError,
+    PaymentNotFoundError,
+    PravaDeclinedError,
+    PravaPayments,
+    PravaTimeoutError,
+    QuoteExpiredError,
+)
+from nest_plugins_prava.client import MockPravaClient
+from nest_plugins_prava.errors import PravaApiError, PravaAuthError
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus, ServiceRef
+
+
+@pytest.fixture(autouse=True)
+def _clean_sidecars() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+@pytest.mark.asyncio
+async def test_insufficient_funds_never_hits_client() -> None:
+    client = MockPravaClient()
+    pay = PravaPayments(AgentId("alice"), initial_balance=5, client=client)
+    with pytest.raises(InsufficientFundsError):
+        await pay.pay(AgentId("bob"), Money(amount=50), PaymentRef("buy-1"))
+    assert client.call_count == 0
+    assert pay.balance(AgentId("alice")) == 5
+
+
+@pytest.mark.asyncio
+async def test_duplicate_ref_idempotent_success() -> None:
+    client = MockPravaClient()
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000, client=client)
+    ref = PaymentRef("same")
+    r1 = await pay.pay(AgentId("bob"), Money(amount=10), ref)
+    calls_after_first = client.call_count
+    r2 = await pay.pay(AgentId("bob"), Money(amount=10), ref)
+    assert r1.ref == r2.ref
+    assert client.call_count == calls_after_first  # no second rail trip
+    assert pay.balance(AgentId("alice")) == 990
+
+
+@pytest.mark.asyncio
+async def test_duplicate_ref_conflict_raises() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000, client=MockPravaClient())
+    ref = PaymentRef("same")
+    await pay.pay(AgentId("bob"), Money(amount=10), ref)
+    with pytest.raises(DuplicatePaymentRefError):
+        await pay.pay(AgentId("carol"), Money(amount=10), ref)
+
+
+@pytest.mark.asyncio
+async def test_create_timeout_releases_budget() -> None:
+    client = MockPravaClient(timeout_on="create_session")
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=client)
+    with pytest.raises(PravaTimeoutError):
+        await pay.pay(AgentId("bob"), Money(amount=40), PaymentRef("t1"))
+    assert pay.balance(AgentId("alice")) == 100
+    assert await pay.verify_payment(PaymentRef("t1")) is PaymentStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_auth_error_releases_budget() -> None:
+    client = MockPravaClient(create_error=PravaAuthError("bad key", code="AUTH_1001"))
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=client)
+    with pytest.raises(PravaAuthError):
+        await pay.pay(AgentId("bob"), Money(amount=20), PaymentRef("a1"))
+    assert pay.balance(AgentId("alice")) == 100
+
+
+@pytest.mark.asyncio
+async def test_declined_report_status() -> None:
+    client = MockPravaClient(decline_report=True)
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=client)
+    with pytest.raises(PravaDeclinedError):
+        await pay.pay(AgentId("bob"), Money(amount=20), PaymentRef("d1"))
+    assert pay.balance(AgentId("alice")) == 100
+    assert await pay.verify_payment(PaymentRef("d1")) is PaymentStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_failed_payment_result() -> None:
+    client = MockPravaClient(poll_statuses=["failed"])
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=client)
+    with pytest.raises(PravaDeclinedError):
+        await pay.pay(AgentId("bob"), Money(amount=20), PaymentRef("f1"))
+    assert pay.balance(AgentId("alice")) == 100
+
+
+@pytest.mark.asyncio
+async def test_retry_after_failure_same_ref() -> None:
+    client = MockPravaClient(fail_on_create=True)
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=client)
+    with pytest.raises(PravaApiError):
+        await pay.pay(AgentId("bob"), Money(amount=20), PaymentRef("retry-1"))
+    # Swap in a healthy client on the same ledger.
+    healthy = MockPravaClient()
+    pay._client = healthy  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    receipt = await pay.pay(AgentId("bob"), Money(amount=20), PaymentRef("retry-1"))
+    assert receipt.amount.amount == 20
+    assert pay.balance(AgentId("alice")) == 80
+
+
+@pytest.mark.asyncio
+async def test_quote_expired() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000, client=MockPravaClient())
+    quote = await pay.quote(ServiceRef("svc"))
+    # Expire the cached quote manually.
+    cached = pay._quotes[str(ServiceRef("svc"))]  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    cached.expires_at = time.time() - 1
+    with pytest.raises(QuoteExpiredError):
+        await pay.pay(AgentId("bob"), quote.price, PaymentRef("q1"))
+
+
+@pytest.mark.asyncio
+async def test_refund_unknown_ref() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=MockPravaClient())
+    with pytest.raises(PaymentNotFoundError):
+        await pay.refund(PaymentRef("nope"))
+
+
+@pytest.mark.asyncio
+async def test_reject_non_positive_amount() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=MockPravaClient())
+    with pytest.raises(ValueError):
+        await pay.pay(AgentId("bob"), Money(amount=0), PaymentRef("z"))

--- a/packages/nest-plugins-prava/tests/test_idempotency_concurrency.py
+++ b/packages/nest-plugins-prava/tests/test_idempotency_concurrency.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Idempotency and concurrency invariants."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from nest_plugins_prava import PravaPayments
+from nest_plugins_prava.client import MockPravaClient
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus
+
+
+@pytest.fixture(autouse=True)
+def _clean_sidecars() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_pays_preserve_balance_invariant() -> None:
+    balances: dict[AgentId, int] = {AgentId("alice"): 100}
+    payments: dict[PaymentRef, object] = {}
+    client = MockPravaClient(latency_s=0.005)
+    alice = PravaPayments(
+        AgentId("alice"),
+        initial_balance=0,
+        balances=balances,
+        payments=payments,
+        client=client,
+    )
+
+    async def _one(i: int) -> None:
+        await alice.pay(AgentId("bob"), Money(amount=10), PaymentRef(f"c-{i}"))
+
+    results = await asyncio.gather(
+        *[_one(i) for i in range(20)],
+        return_exceptions=True,
+    )
+    successes = [r for r in results if not isinstance(r, BaseException)]
+    failures = [r for r in results if isinstance(r, BaseException)]
+
+    # 100 credits / 10 = 10 successes max
+    assert len(successes) == 10
+    assert len(failures) == 10
+    assert alice.balance(AgentId("alice")) == 0
+    assert alice.balance(AgentId("bob")) == 100
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_then_completed() -> None:
+    client = MockPravaClient(poll_statuses=["pending", "processing", "awaiting_result"])
+    pay = PravaPayments(
+        AgentId("alice"),
+        initial_balance=100,
+        client=client,
+        poll_attempts=5,
+        poll_interval_s=0.001,
+    )
+    receipt = await pay.pay(AgentId("bob"), Money(amount=15), PaymentRef("poll-1"))
+    assert receipt.amount.amount == 15
+    assert await pay.verify_payment(PaymentRef("poll-1")) is PaymentStatus.CONFIRMED

--- a/packages/nest-plugins-prava/tests/test_mock_live_consistency.py
+++ b/packages/nest-plugins-prava/tests/test_mock_live_consistency.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Item 10 — MockPravaClient vs HttpPravaClient interface + adapter parity."""
+
+from __future__ import annotations
+
+import inspect
+
+import httpx
+import pytest
+from nest_plugins_prava import PravaPayments
+from nest_plugins_prava.client import HttpPravaClient, MockPravaClient, PravaClient
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_sdk import AgentId, PaymentRef, PaymentStatus, ServiceRef
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+REQUIRED_METHODS = (
+    "create_session",
+    "get_payment_result",
+    "report_status",
+    "revoke_session",
+)
+
+
+def test_both_clients_satisfy_protocol() -> None:
+    mock = MockPravaClient()
+    http = HttpPravaClient(
+        api_key="sk_test_dummy", transport=httpx.MockTransport(lambda r: httpx.Response(500))
+    )
+    assert isinstance(mock, PravaClient)
+    assert isinstance(http, PravaClient)
+    for name in REQUIRED_METHODS:
+        assert callable(getattr(mock, name))
+        assert callable(getattr(http, name))
+        m_sig = inspect.signature(getattr(mock, name))
+        h_sig = inspect.signature(getattr(http, name))
+        assert list(m_sig.parameters) == list(h_sig.parameters), (name, m_sig, h_sig)
+    print(f"interface_match methods={REQUIRED_METHODS}")
+
+
+@pytest.mark.asyncio
+async def test_adapter_same_logic_with_mock_and_http_transport() -> None:
+    """Same PravaPayments path must work when client is mock OR http(mock transport)."""
+
+    # Mock client path
+    mock = MockPravaClient()
+    pay_mock = PravaPayments(AgentId("alice"), initial_balance=500, client=mock, default_fee=20)
+    q1 = await pay_mock.quote(ServiceRef("item"))
+    r1 = await pay_mock.pay(AgentId("bob"), q1.price, PaymentRef("parity-1"))
+    assert await pay_mock.verify_payment(PaymentRef("parity-1")) is PaymentStatus.CONFIRMED
+
+    # Http client with deterministic success transport (same response shape as sandbox)
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/sessions") and request.method == "POST":
+            return httpx.Response(
+                201,
+                json={
+                    "session_id": "sess_liveish_001",
+                    "order_id": "ord_liveish_001",
+                    "session_token": "tok_SHOULD_NOT_LEAK",
+                    "expires_at": "2099-01-01T00:00:00Z",
+                },
+            )
+        if path.endswith("/payment-result"):
+            return httpx.Response(
+                200,
+                json={
+                    "session_id": "sess_liveish_001",
+                    "order_id": "ord_liveish_001",
+                    "status": "completed",
+                    "transactions": [{"txn_ref_id": "tli_1", "token": "4111111111111111"}],
+                },
+            )
+        if path.endswith("/report-status"):
+            return httpx.Response(
+                200,
+                json={"status": "confirmed", "txn_ref_id": "tli_1", "txn_status": "APPROVED"},
+            )
+        if path.endswith("/revoke"):
+            return httpx.Response(200, json={"success": True})
+        return httpx.Response(404, json={"error": {"code": "NOT_FOUND", "message": path}})
+
+    http = HttpPravaClient(api_key="sk_test_dummy", transport=httpx.MockTransport(handler))
+    pay_http = PravaPayments(AgentId("alice"), initial_balance=500, client=http, default_fee=20)
+    q2 = await pay_http.quote(ServiceRef("item"))
+    r2 = await pay_http.pay(AgentId("bob"), q2.price, PaymentRef("parity-2"))
+    assert await pay_http.verify_payment(PaymentRef("parity-2")) is PaymentStatus.CONFIRMED
+
+    assert r1.amount.amount == r2.amount.amount == 20
+    rec = pay_http.payment_record(PaymentRef("parity-2"))
+    assert rec is not None
+    assert rec.session_id == "sess_liveish_001"
+    assert "tok_SHOULD_NOT_LEAK" not in str(rec.public_view())
+    print(
+        f"parity: mock_status=confirmed http_session={rec.session_id} "
+        f"amounts={r1.amount.amount}/{r2.amount.amount}"
+    )

--- a/packages/nest-plugins-prava/tests/test_no_secret_leak.py
+++ b/packages/nest-plugins-prava/tests/test_no_secret_leak.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Item 6 — secret leakage audit across receipts, views, exceptions, traces."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from nest_plugins_prava import PravaAuthError, PravaPayments
+from nest_plugins_prava.client import MockPravaClient
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_plugins_prava.secrets import assert_no_secrets, contains_secret, redact
+from nest_sdk import AgentId, Money, PaymentRef
+
+SECRET_PATTERNS = [
+    re.compile(r"sk_(test|live)_[A-Za-z0-9]+"),
+    re.compile(r"pk_(test|live)_[A-Za-z0-9]+"),
+    re.compile(r"Bearer\s+\S+", re.I),
+    re.compile(r"\b4[0-9]{12}(?:[0-9]{3})?\b"),  # test PAN shape
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+def _assert_clean(blob: str, label: str) -> None:
+    for pat in SECRET_PATTERNS:
+        m = pat.search(blob)
+        assert m is None, f"Secret pattern {pat.pattern} found in {label}: {m.group(0)[:8]}..."
+
+
+@pytest.mark.asyncio
+async def test_no_secret_leak_in_receipt_record_exceptions() -> None:
+    client = MockPravaClient()  # payment-result raw contains token+cvv internally
+    pay = PravaPayments(AgentId("alice"), initial_balance=500, client=client)
+    receipt = await pay.pay(AgentId("bob"), Money(amount=12), PaymentRef("sec-1"))
+    record = pay.payment_record(PaymentRef("sec-1"))
+    assert record is not None
+
+    payload = {
+        "receipt": receipt.model_dump(),
+        "public_view": record.public_view(),
+        "session_public": (
+            {
+                "session_id": record.session_id,
+                "order_id": record.order_id,
+            }
+        ),
+    }
+    blob = json.dumps(payload)
+    print(f"audit_blob_keys={list(payload.keys())} sample={blob[:200]}")
+    _assert_clean(blob, "receipt/public_view")
+    assert_no_secrets(record.public_view())
+    assert "4111111111111111" not in blob
+    assert "dynamic_cvv" not in blob or "***REDACTED***" in blob
+    assert "tok_mock" not in blob
+
+
+@pytest.mark.asyncio
+async def test_auth_error_message_does_not_echo_api_key() -> None:
+    # Simulate auth failure path through adapter.
+    from nest_plugins_prava.client import MockPravaClient as M
+
+    client = M(create_error=PravaAuthError("Invalid or missing API key", code="AUTH_1001"))
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=client)
+    with pytest.raises(PravaAuthError) as ei:
+        await pay.pay(AgentId("bob"), Money(amount=5), PaymentRef("sec-auth"))
+    msg = str(ei.value)
+    _assert_clean(msg, "auth exception")
+    assert "sk_test_" not in msg
+    print(f"auth_exception_clean={msg!r}")
+
+
+def test_redact_repo_sensitive_shapes() -> None:
+    dirty = {
+        "authorization": "Bearer sk_test_abc123DEF",
+        "api_key": "sk_live_zzz",
+        "password": "hunter2",
+        "token": "4111111111111111",
+        "secret": "top",
+        "ok": True,
+    }
+    cleaned = redact(dirty)
+    blob = json.dumps(cleaned)
+    _assert_clean(blob, "redacted-dict")
+    assert contains_secret(cleaned) is False
+    print(f"redacted={blob}")
+
+
+@pytest.mark.asyncio
+async def test_trace_file_from_pay_contains_no_secrets(tmp_path: Path) -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=MockPravaClient())
+    receipt = await pay.pay(AgentId("bob"), Money(amount=7), PaymentRef("sec-trace"))
+    record = pay.payment_record(PaymentRef("sec-trace"))
+    assert record is not None
+    trace_path = tmp_path / "trace.jsonl"
+    line = json.dumps(
+        {
+            "event": "payment",
+            "receipt": receipt.model_dump(),
+            "record": record.public_view(),
+        }
+    )
+    trace_path.write_text(line + "\n", encoding="utf-8")
+    text = trace_path.read_text(encoding="utf-8")
+    _assert_clean(text, "trace.jsonl")
+    print(f"trace_bytes={len(text)} path={trace_path}")

--- a/packages/nest-plugins-prava/tests/test_prava_api_failures.py
+++ b/packages/nest-plugins-prava/tests/test_prava_api_failures.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Item 3 + 8 + 9 — Prava API failure simulation, error mapping, retry audit."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from nest_plugins_prava import (
+    PravaAuthError,
+    PravaDeclinedError,
+    PravaPayments,
+    PravaTimeoutError,
+)
+from nest_plugins_prava.client import HttpPravaClient, MockPravaClient
+from nest_plugins_prava.errors import PravaApiError, PravaValidationError
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+def _body() -> dict[str, Any]:
+    return {
+        "user_id": "nanda-alice",
+        "user_email": "nanda-alice@agents.nandatown.local",
+        "total_amount": "0.50",
+        "currency": "USD",
+        "purchase_context": [
+            {
+                "merchant_details": {
+                    "name": "NANDA",
+                    "url": "https://example.com",
+                    "country_code_iso2": "US",
+                },
+                "product_details": [{"description": "x", "unit_price": "0.50", "quantity": 1}],
+            }
+        ],
+        "integration_type": "full_checkout",
+        "callback_url": "https://example.com/cb",
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_timeout_respects_retry_limit_deterministic() -> None:
+    hits = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hits["n"] += 1
+        raise httpx.TimeoutException("simulated hang", request=request)
+
+    transport = httpx.MockTransport(handler)
+    client = HttpPravaClient(
+        api_key="sk_test_dummy",
+        transport=transport,
+        timeout_s=0.05,
+        max_retries=2,
+    )
+    with pytest.raises(PravaTimeoutError) as ei:
+        await client.create_session(_body())
+    assert ei.value.code == "TIMEOUT"
+    # initial + 2 retries = 3
+    assert hits["n"] == 3
+    print(f"timeout: attempts={hits['n']} error={type(ei.value).__name__}:{ei.value}")
+
+
+@pytest.mark.asyncio
+async def test_b_http_500_retries_then_typed_error_no_duplicate_pay() -> None:
+    hits = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hits["n"] += 1
+        return httpx.Response(
+            500, json={"error": {"code": "SESSION_CREATE_ERROR", "message": "boom"}}
+        )
+
+    transport = httpx.MockTransport(handler)
+    http = HttpPravaClient(api_key="sk_test_dummy", transport=transport, max_retries=2)
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=http)
+    with pytest.raises(PravaApiError) as ei:
+        await pay.pay(AgentId("bob"), Money(amount=20), PaymentRef("r500"))
+    assert hits["n"] == 3  # retried
+    assert isinstance(ei.value, PravaApiError)
+    assert not isinstance(ei.value, PravaTimeoutError)
+    assert pay.balance(AgentId("alice")) == 100  # released
+    assert await pay.verify_payment(PaymentRef("r500")) is PaymentStatus.FAILED
+    print(f"500: attempts={hits['n']} balance={pay.balance(AgentId('alice'))} err={ei.value.code}")
+
+
+@pytest.mark.asyncio
+async def test_b_generic_http_500_also_retries() -> None:
+    hits = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hits["n"] += 1
+        return httpx.Response(500, json={"message": "internal"})
+
+    transport = httpx.MockTransport(handler)
+    client = HttpPravaClient(api_key="sk_test_dummy", transport=transport, max_retries=2)
+    with pytest.raises(PravaApiError):
+        await client.create_session(_body())
+    assert hits["n"] == 3
+    print(f"generic_500: attempts={hits['n']}")
+
+
+@pytest.mark.asyncio
+async def test_c_http_401_no_retry() -> None:
+    hits = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hits["n"] += 1
+        return httpx.Response(401, json={"error": {"code": "AUTH_1001", "message": "bad key"}})
+
+    transport = httpx.MockTransport(handler)
+    client = HttpPravaClient(api_key="sk_test_dummy", transport=transport, max_retries=5)
+    with pytest.raises(PravaAuthError) as ei:
+        await client.create_session(_body())
+    assert hits["n"] == 1  # NO retry loop
+    assert ei.value.code == "AUTH_1001"
+    print(f"401: attempts={hits['n']} err={type(ei.value).__name__}")
+
+
+@pytest.mark.asyncio
+async def test_c_http_403_no_retry() -> None:
+    hits = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hits["n"] += 1
+        return httpx.Response(403, json={"error": {"code": "AUTH_1001", "message": "forbidden"}})
+
+    transport = httpx.MockTransport(handler)
+    client = HttpPravaClient(api_key="sk_test_dummy", transport=transport, max_retries=5)
+    with pytest.raises(PravaAuthError):
+        await client.create_session(_body())
+    assert hits["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_d_invalid_response_schema_validation_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"unexpected": "data"})
+
+    transport = httpx.MockTransport(handler)
+    client = HttpPravaClient(api_key="sk_test_dummy", transport=transport)
+    with pytest.raises(PravaValidationError) as ei:
+        await client.create_session(_body())
+    assert ei.value.code == "VAL_SCHEMA"
+    assert "session_id" in str(ei.value)
+    print(f"schema: err={type(ei.value).__name__} code={ei.value.code} msg={ei.value}")
+
+
+@pytest.mark.asyncio
+async def test_declined_no_retry_and_typed() -> None:
+    client = MockPravaClient(decline_report=True)
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=client)
+    with pytest.raises(PravaDeclinedError):
+        await pay.pay(AgentId("bob"), Money(amount=10), PaymentRef("dec"))
+    # create + poll + report (+ revoke on fail) — not a retry storm
+    assert client.call_count <= 4
+    assert pay.balance(AgentId("alice")) == 100
+
+
+@pytest.mark.asyncio
+async def test_error_mapping_never_raw_http_500_string_exception() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": {"code": "SESSION_CREATE_ERROR", "message": "x"}})
+
+    client = HttpPravaClient(
+        api_key="sk_test_dummy", transport=httpx.MockTransport(handler), max_retries=0
+    )
+    with pytest.raises(PravaApiError) as ei:
+        await client.create_session(_body())
+    assert type(ei.value) is PravaApiError
+    assert "HTTP 500" not in type(ei.value).__name__

--- a/packages/nest-plugins-prava/tests/test_protocol.py
+++ b/packages/nest-plugins-prava/tests/test_protocol.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Payments Protocol conformance tests for PravaPayments."""
+
+from __future__ import annotations
+
+import pytest
+from nest_plugins_prava import PravaPayments
+from nest_plugins_prava.client import MockPravaClient
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus, ServiceRef
+
+
+@pytest.fixture(autouse=True)
+def _clean_sidecars() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+@pytest.fixture
+def payments() -> PravaPayments:
+    return PravaPayments(
+        AgentId("alice"),
+        initial_balance=1000,
+        client=MockPravaClient(),
+        default_fee=42,
+    )
+
+
+@pytest.mark.asyncio
+async def test_quote_uses_configured_fee(payments: PravaPayments) -> None:
+    quote = await payments.quote(ServiceRef("svc"))
+    assert quote.price.amount == 42
+    assert quote.metadata["rail"] == "prava"
+    assert quote.metadata["prava_amount"] == "0.42"
+
+
+@pytest.mark.asyncio
+async def test_pay_then_verify_confirmed(payments: PravaPayments) -> None:
+    ref = PaymentRef("r1")
+    receipt = await payments.pay(AgentId("bob"), Money(amount=50), ref)
+    assert receipt.payer == AgentId("alice")
+    assert receipt.payee == AgentId("bob")
+    assert receipt.amount.amount == 50
+    assert await payments.verify_payment(ref) is PaymentStatus.CONFIRMED
+    assert payments.balance(AgentId("alice")) == 950
+    assert payments.balance(AgentId("bob")) == 50
+
+
+@pytest.mark.asyncio
+async def test_verify_unknown_ref_failed(payments: PravaPayments) -> None:
+    assert await payments.verify_payment(PaymentRef("missing")) is PaymentStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_refund_happy_path(payments: PravaPayments) -> None:
+    ref = PaymentRef("r-refund")
+    await payments.pay(AgentId("bob"), Money(amount=40), ref)
+    await payments.refund(ref)
+    assert await payments.verify_payment(ref) is PaymentStatus.REFUNDED
+    assert payments.balance(AgentId("alice")) == 1000
+    assert payments.balance(AgentId("bob")) == 0
+    # Idempotent refund
+    await payments.refund(ref)
+
+
+@pytest.mark.asyncio
+async def test_shared_ledger_like_marketplace() -> None:
+    balances: dict[AgentId, int] = {}
+    payment_records: dict[PaymentRef, object] = {}
+    client = MockPravaClient()
+    buyer = PravaPayments(
+        AgentId("buyer"),
+        initial_balance=1000,
+        balances=balances,
+        payments=payment_records,
+        client=client,
+    )
+    seller = PravaPayments(
+        AgentId("seller"),
+        initial_balance=0,
+        balances=balances,
+        payments=payment_records,
+        client=client,
+    )
+    await buyer.pay(AgentId("seller"), Money(amount=25), PaymentRef("m1"))
+    assert buyer.balance(AgentId("buyer")) == 975
+    assert seller.balance(AgentId("seller")) == 25
+    assert await seller.verify_payment(PaymentRef("m1")) is PaymentStatus.CONFIRMED

--- a/packages/nest-plugins-prava/tests/test_refund_safety.py
+++ b/packages/nest-plugins-prava/tests/test_refund_safety.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Item 5 — refund safety matrix."""
+
+from __future__ import annotations
+
+import pytest
+from nest_plugins_prava import (
+    InvalidPaymentStateError,
+    PaymentNotFoundError,
+    PravaPayments,
+)
+from nest_plugins_prava.client import MockPravaClient
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_plugins_prava.state import PaymentPhase, PaymentRecord
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+@pytest.mark.asyncio
+async def test_refund_confirmed_success() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=MockPravaClient())
+    await pay.pay(AgentId("bob"), Money(amount=40), PaymentRef("rf-1"))
+    await pay.refund(PaymentRef("rf-1"))
+    assert pay.balance(AgentId("alice")) == 100
+    assert pay.balance(AgentId("bob")) == 0
+    assert await pay.verify_payment(PaymentRef("rf-1")) is PaymentStatus.REFUNDED
+    print("refund confirmed: SUCCESS")
+
+
+@pytest.mark.asyncio
+async def test_refund_pending_rejected() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=MockPravaClient())
+    ref = PaymentRef("rf-pend")
+    pay._records[ref] = PaymentRecord(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        ref=ref,
+        payer=AgentId("alice"),
+        payee=AgentId("bob"),
+        amount=Money(amount=10),
+        status=PaymentStatus.PENDING,
+        phase=PaymentPhase.BUDGET_LOCKED,
+    )
+    with pytest.raises(InvalidPaymentStateError) as ei:
+        await pay.refund(ref)
+    print(f"refund pending: REJECTED {type(ei.value).__name__}")
+
+
+@pytest.mark.asyncio
+async def test_refund_twice_idempotent() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=MockPravaClient())
+    await pay.pay(AgentId("bob"), Money(amount=20), PaymentRef("rf-2"))
+    await pay.refund(PaymentRef("rf-2"))
+    bal = pay.balance(AgentId("alice"))
+    await pay.refund(PaymentRef("rf-2"))
+    assert pay.balance(AgentId("alice")) == bal == 100
+    print("refund twice: IDEMPOTENT")
+
+
+@pytest.mark.asyncio
+async def test_refund_unknown_not_found() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=100, client=MockPravaClient())
+    with pytest.raises(PaymentNotFoundError) as ei:
+        await pay.refund(PaymentRef("does-not-exist"))
+    assert ei.value.code == "NOT_FOUND"
+    print(f"refund unknown: {type(ei.value).__name__} code={ei.value.code}")

--- a/packages/nest-plugins-prava/tests/test_sandbox_live.py
+++ b/packages/nest-plugins-prava/tests/test_sandbox_live.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional live sandbox checks (skipped unless -m live + PRAVA_API_KEY)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from nest_plugins_prava import PravaPayments
+from nest_plugins_prava.client import HttpPravaClient
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus
+
+
+@pytest.fixture(autouse=True)
+def _clean_sidecars() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+pytestmark = pytest.mark.live
+
+
+def _api_key() -> str:
+    return os.environ.get("PRAVA_API_KEY", "").strip()
+
+
+@pytest.mark.asyncio
+async def test_live_create_session() -> None:
+    key = _api_key()
+    if not key:
+        pytest.skip("PRAVA_API_KEY not set")
+    client = HttpPravaClient(api_key=key)
+    body = {
+        "user_id": "nanda-live-probe",
+        "user_email": "nanda-live-probe@agents.nandatown.local",
+        "total_amount": "0.50",
+        "currency": "USD",
+        "purchase_context": [
+            {
+                "merchant_details": {
+                    "name": "NANDA Town Marketplace",
+                    "url": "https://nandatown.projectnanda.org",
+                    "country_code_iso2": "US",
+                },
+                "product_details": [
+                    {
+                        "description": "Live probe",
+                        "unit_price": "0.50",
+                        "quantity": 1,
+                    }
+                ],
+            }
+        ],
+        "integration_type": "full_checkout",
+        "callback_url": "https://nandatown.projectnanda.org/prava/callback",
+    }
+    session = await client.create_session(body)
+    assert session.session_id.startswith(("ses_", "sess_"))
+    assert session.session_id
+
+
+@pytest.mark.asyncio
+async def test_hybrid_pay_uses_live_session_id() -> None:
+    key = _api_key()
+    if not key:
+        pytest.skip("PRAVA_API_KEY not set")
+    pay = PravaPayments(
+        AgentId("alice"),
+        initial_balance=1000,
+        mode="hybrid",
+        api_key=key,
+    )
+    receipt = await pay.pay(AgentId("bob"), Money(amount=50), PaymentRef("hybrid-1"))
+    record = pay.payment_record(PaymentRef("hybrid-1"))
+    assert record is not None
+    assert record.session_id is not None
+    assert record.session_id.startswith(("ses_", "sess_"))
+    assert "mock" not in record.session_id
+    assert await pay.verify_payment(PaymentRef("hybrid-1")) is PaymentStatus.CONFIRMED
+    assert receipt.amount.amount == 50

--- a/packages/nest-plugins-prava/tests/test_sandbox_proof.py
+++ b/packages/nest-plugins-prava/tests/test_sandbox_proof.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Item 7 — real Prava sandbox proof (FAIL if no key / network)."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+from nest_plugins_prava import PravaPayments
+from nest_plugins_prava.client import HttpPravaClient
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_plugins_prava.secrets import redact
+from nest_sdk import AgentId, PaymentRef, PaymentStatus, ServiceRef
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+pytestmark = pytest.mark.live
+
+
+def _key() -> str:
+    return os.environ.get("PRAVA_API_KEY", "").strip()
+
+
+@pytest.mark.asyncio
+async def test_sandbox_create_session_real_response_shape() -> None:
+    key = _key()
+    if not key:
+        pytest.fail(
+            "PRAVA_API_KEY not set — cannot prove sandbox integration. "
+            "Export a sk_test_ key and re-run: pytest -m live ..."
+        )
+    client = HttpPravaClient(api_key=key)
+    body = {
+        "user_id": "nanda-audit-probe",
+        "user_email": "nanda-audit-probe@agents.nandatown.local",
+        "total_amount": "0.50",
+        "currency": "USD",
+        "purchase_context": [
+            {
+                "merchant_details": {
+                    "name": "NANDA Town Marketplace",
+                    "url": "https://nandatown.projectnanda.org",
+                    "country_code_iso2": "US",
+                },
+                "product_details": [
+                    {
+                        "description": "Hostile audit probe",
+                        "unit_price": "0.50",
+                        "quantity": 1,
+                    }
+                ],
+            }
+        ],
+        "integration_type": "full_checkout",
+        "callback_url": "https://nandatown.projectnanda.org/prava/callback",
+    }
+    session = await client.create_session(body)
+    public = session.public_view()
+    print("SANDBOX_SESSION_PUBLIC=" + json.dumps(redact(public), indent=2))
+    # Sandbox returns ULID-style ids: ses_01... / ord_01...
+    assert session.session_id.startswith(("ses_", "sess_"))
+    assert public.get("session_token") in {None, "***REDACTED***"}
+
+
+@pytest.mark.asyncio
+async def test_sandbox_hybrid_quote_pay_verify_receipt() -> None:
+    key = _key()
+    if not key:
+        pytest.fail("PRAVA_API_KEY not set — hybrid sandbox proof blocked")
+    pay = PravaPayments(
+        AgentId("alice"),
+        initial_balance=1000,
+        mode="hybrid",
+        api_key=key,
+        default_fee=50,
+    )
+    quote = await pay.quote(ServiceRef("audit-sku"))
+    receipt = await pay.pay(AgentId("bob"), quote.price, PaymentRef("sandbox-audit-1"))
+    status = await pay.verify_payment(PaymentRef("sandbox-audit-1"))
+    record = pay.payment_record(PaymentRef("sandbox-audit-1"))
+    assert record is not None
+    evidence = {
+        "quote_amount": quote.price.amount,
+        "prava_amount": quote.metadata.get("prava_amount"),
+        "receipt_ref": str(receipt.ref),
+        "session_id": record.session_id,
+        "order_id": record.order_id,
+        "status": status.value,
+        "phase": record.phase.value,
+    }
+    print("SANDBOX_FLOW_EVIDENCE=" + json.dumps(evidence, indent=2))
+    assert status is PaymentStatus.CONFIRMED
+    assert record.session_id and record.session_id.startswith(("ses_", "sess_"))
+    assert "mock" not in record.session_id

--- a/packages/nest-plugins-prava/tests/test_secrets_and_mapping.py
+++ b/packages/nest-plugins-prava/tests/test_secrets_and_mapping.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Secret scrubbing + currency mapping tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from nest_plugins_prava import PravaPayments
+from nest_plugins_prava.client import MockPravaClient
+from nest_plugins_prava.mapping import (
+    agent_to_email,
+    agent_to_user_id,
+    credits_to_decimal_amount,
+    decimal_amount_to_credits,
+)
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_plugins_prava.secrets import assert_no_secrets, contains_secret, redact
+from nest_sdk import AgentId, Money, PaymentRef
+
+
+@pytest.fixture(autouse=True)
+def _clean_sidecars() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+def test_credits_mapping_roundtrip() -> None:
+    assert credits_to_decimal_amount(50) == "0.50"
+    assert credits_to_decimal_amount(100) == "1.00"
+    assert decimal_amount_to_credits("0.50") == 50
+    assert agent_to_user_id(AgentId("buyer-0")).startswith("nanda-")
+    assert "@" in agent_to_email(AgentId("buyer-0"))
+
+
+def test_redact_strips_tokens() -> None:
+    raw = {
+        "session_token": "eyJhbGciOi...",
+        "token": "4111111111111111",
+        "dynamic_cvv": "123",
+        "status": "completed",
+        "nested": {"Authorization": "Bearer sk_test_abc123xyz"},
+    }
+    cleaned = redact(raw)
+    blob = json.dumps(cleaned)
+    assert "4111111111111111" not in blob
+    assert "sk_test_abc123xyz" not in blob
+    assert cleaned["status"] == "completed"
+    assert contains_secret(raw) is True
+    assert contains_secret(cleaned) is False
+
+
+@pytest.mark.asyncio
+async def test_no_secrets_in_receipt_or_public_view() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000, client=MockPravaClient())
+    receipt = await pay.pay(AgentId("bob"), Money(amount=12), PaymentRef("sec-1"))
+    record = pay.payment_record(PaymentRef("sec-1"))
+    assert record is not None
+    blob = json.dumps({"receipt": receipt.model_dump(), "view": record.public_view()})
+    assert "sk_test" not in blob
+    assert "4111111111111111" not in blob
+    assert "tok_mock" not in blob
+    assert_no_secrets(record.public_view(), label="view")

--- a/packages/nest-plugins-prava/tests/test_state_machine.py
+++ b/packages/nest-plugins-prava/tests/test_state_machine.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Item 4 — payment state machine audit."""
+
+from __future__ import annotations
+
+import pytest
+from nest_plugins_prava import (
+    DuplicatePaymentRefError,
+    InvalidPaymentStateError,
+    PravaPayments,
+)
+from nest_plugins_prava.client import MockPravaClient
+from nest_plugins_prava.errors import PravaApiError
+from nest_plugins_prava.plugin import reset_ledger_sidecars
+from nest_plugins_prava.state import PaymentPhase, PaymentRecord
+from nest_sdk import AgentId, Money, PaymentRef, PaymentStatus, ServiceRef
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> None:  # pyright: ignore[reportUnusedFunction]
+    reset_ledger_sidecars()
+
+
+STATE_TABLE = """
+Current state | Action              | Expected next state
+--------------|---------------------|--------------------
+(none)        | quote               | quote cached (TTL)
+(none)        | pay                 | PENDING → … → CONFIRMED
+PENDING       | verify              | PENDING (or FAILED if rail failed)
+CONFIRMED     | pay same ref/params | CONFIRMED (idempotent, same receipt)
+CONFIRMED     | pay conflict params | DuplicatePaymentRefError
+CONFIRMED     | refund              | REFUNDED
+FAILED        | refund              | InvalidPaymentStateError
+FAILED        | pay same ref        | retry allowed → CONFIRMED
+REFUNDED      | refund again        | REFUNDED (idempotent no-op)
+REFUNDED      | pay same ref        | DuplicatePaymentRefError
+PENDING       | refund              | InvalidPaymentStateError
+"""
+
+
+@pytest.mark.asyncio
+async def test_happy_path_quote_pay_pending_confirmed() -> None:
+    print(STATE_TABLE)
+    client = MockPravaClient(poll_statuses=["pending", "awaiting_result"])
+    pay = PravaPayments(
+        AgentId("alice"),
+        initial_balance=1000,
+        client=client,
+        poll_attempts=5,
+        poll_interval_s=0.001,
+        default_fee=50,
+    )
+    q = await pay.quote(ServiceRef("sku"))
+    assert q.price.amount == 50
+
+    # Drive pay; during flow record transitions PENDING→CONFIRMED
+    receipt = await pay.pay(AgentId("bob"), q.price, PaymentRef("sm-1"))
+    rec = pay.payment_record(PaymentRef("sm-1"))
+    assert rec is not None
+    assert rec.status is PaymentStatus.CONFIRMED
+    assert rec.phase is PaymentPhase.CONFIRMED
+    assert receipt.ref == PaymentRef("sm-1")
+    assert await pay.verify_payment(PaymentRef("sm-1")) is PaymentStatus.CONFIRMED
+    print(f"happy: phase={rec.phase.value} status={rec.status.value} session={rec.session_id}")
+
+
+@pytest.mark.asyncio
+async def test_confirmed_pay_again_idempotent_not_new_charge() -> None:
+    client = MockPravaClient()
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000, client=client)
+    await pay.pay(AgentId("bob"), Money(amount=10), PaymentRef("sm-2"))
+    n = client.call_count
+    r2 = await pay.pay(AgentId("bob"), Money(amount=10), PaymentRef("sm-2"))
+    assert client.call_count == n
+    assert r2.amount.amount == 10
+
+
+@pytest.mark.asyncio
+async def test_confirmed_pay_conflict_rejected() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000, client=MockPravaClient())
+    await pay.pay(AgentId("bob"), Money(amount=10), PaymentRef("sm-3"))
+    with pytest.raises(DuplicatePaymentRefError):
+        await pay.pay(AgentId("carol"), Money(amount=10), PaymentRef("sm-3"))
+
+
+@pytest.mark.asyncio
+async def test_failed_refund_rejected() -> None:
+    pay = PravaPayments(
+        AgentId("alice"),
+        initial_balance=1000,
+        client=MockPravaClient(fail_on_create=True),
+    )
+    with pytest.raises(PravaApiError):
+        await pay.pay(AgentId("bob"), Money(amount=10), PaymentRef("sm-4"))
+    assert await pay.verify_payment(PaymentRef("sm-4")) is PaymentStatus.FAILED
+    with pytest.raises(InvalidPaymentStateError):
+        await pay.refund(PaymentRef("sm-4"))
+
+
+@pytest.mark.asyncio
+async def test_pending_refund_rejected() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000, client=MockPravaClient())
+    # Inject a stuck PENDING record (illegal to refund).
+    ref = PaymentRef("sm-pending")
+    rec = PaymentRecord(
+        ref=ref,
+        payer=AgentId("alice"),
+        payee=AgentId("bob"),
+        amount=Money(amount=10),
+        phase=PaymentPhase.SESSION_CREATED,
+        status=PaymentStatus.PENDING,
+        session_id="sess_x",
+        locked_credits=0,
+    )
+    pay._records[ref] = rec  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    with pytest.raises(InvalidPaymentStateError):
+        await pay.refund(ref)
+
+
+@pytest.mark.asyncio
+async def test_refunded_refund_again_idempotent() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000, client=MockPravaClient())
+    await pay.pay(AgentId("bob"), Money(amount=10), PaymentRef("sm-5"))
+    await pay.refund(PaymentRef("sm-5"))
+    await pay.refund(PaymentRef("sm-5"))  # no error
+    assert await pay.verify_payment(PaymentRef("sm-5")) is PaymentStatus.REFUNDED
+
+
+@pytest.mark.asyncio
+async def test_refunded_pay_again_rejected() -> None:
+    pay = PravaPayments(AgentId("alice"), initial_balance=1000, client=MockPravaClient())
+    await pay.pay(AgentId("bob"), Money(amount=10), PaymentRef("sm-6"))
+    await pay.refund(PaymentRef("sm-6"))
+    with pytest.raises(DuplicatePaymentRefError):
+        await pay.pay(AgentId("bob"), Money(amount=10), PaymentRef("sm-6"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "nest-scenarios",
     "nest-shell",
     "nest-plugins-reference",
+    "nest-plugins-prava",
     "nest-marketplace",
 ]
 
@@ -63,6 +64,7 @@ members = [
     "packages/nest-scenarios",
     "packages/nest-shell",
     "packages/nest-plugins-reference",
+    "packages/nest-plugins-prava",
     "packages/nest-marketplace",
 ]
 
@@ -88,6 +90,7 @@ nest-mocks = { workspace = true }
 nest-scenarios = { workspace = true }
 nest-shell = { workspace = true }
 nest-plugins-reference = { workspace = true }
+nest-plugins-prava = { workspace = true }
 nest-marketplace = { workspace = true }
 
 [tool.ruff]
@@ -111,6 +114,7 @@ extraPaths = [
     "packages/nest-scenarios",
     "packages/nest-shell",
     "packages/nest-plugins-reference",
+    "packages/nest-plugins-prava",
     "packages/nest-marketplace",
     ".",
 ]

--- a/scenarios/prava_marketplace.yaml
+++ b/scenarios/prava_marketplace.yaml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Prava payments adapter scenario — marketplace with payments: prava
+name: prava_marketplace
+description: |
+  Small marketplace run that exercises the Prava payments adapter
+  (quote/pay/verify) under mock or hybrid mode. Demonstrates agent
+  commerce with a real payments-layer plugin instead of prepaid_credits.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 10
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 5
+    - name: seller
+      count: 5
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prava
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: marketplace
+  config:
+    catalog_size: 20
+    rounds: 3
+
+failures:
+  message_drop: 0.0
+
+duration: "ticks: 2000"
+
+metrics:
+  - success_rate
+  - mean_latency
+  - message_count
+
+output:
+  trace: ./traces/prava_marketplace.jsonl

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,7 @@ members = [
     "nest-core",
     "nest-marketplace",
     "nest-mocks",
+    "nest-plugins-prava",
     "nest-plugins-reference",
     "nest-scenarios",
     "nest-sdk",
@@ -1400,6 +1401,21 @@ dependencies = [
 requires-dist = [{ name = "nest-core", editable = "packages/nest-core" }]
 
 [[package]]
+name = "nest-plugins-prava"
+version = "0.1.0"
+source = { editable = "packages/nest-plugins-prava" }
+dependencies = [
+    { name = "httpx" },
+    { name = "nest-sdk" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "nest-sdk", editable = "packages/nest-sdk" },
+]
+
+[[package]]
 name = "nest-plugins-reference"
 version = "0.1.1"
 source = { editable = "packages/nest-plugins-reference" }
@@ -1480,6 +1496,7 @@ dependencies = [
     { name = "nest-core" },
     { name = "nest-marketplace" },
     { name = "nest-mocks" },
+    { name = "nest-plugins-prava" },
     { name = "nest-plugins-reference" },
     { name = "nest-scenarios" },
     { name = "nest-sdk" },
@@ -1517,6 +1534,7 @@ requires-dist = [
     { name = "nest-core", editable = "packages/nest-core" },
     { name = "nest-marketplace", editable = "packages/nest-marketplace" },
     { name = "nest-mocks", editable = "packages/nest-mocks" },
+    { name = "nest-plugins-prava", editable = "packages/nest-plugins-prava" },
     { name = "nest-plugins-reference", editable = "packages/nest-plugins-reference" },
     { name = "nest-scenarios", editable = "packages/nest-scenarios" },
     { name = "nest-sdk", editable = "packages/nest-sdk" },


### PR DESCRIPTION
## Summary
- Adds `nest-plugins-prava`, a reusable NANDA Town **payments** plugin that implements `quote` / `pay` / `verify_payment` / `refund` against Prava's Agentic Payments Sandbox.
- Supports `mock` (deterministic CI), `live` (real HTTP), and `hybrid` (real `POST /v1/sessions` + headless completion for agent sims).
- Local budget lock before the rail, typed failure mapping, secret scrubbing, idempotent `PaymentRef`s, optional journal for restart safety.
- Includes marketplace scenario `scenarios/prava_marketplace.yaml` (`payments: prava`), install README, demo script, and hostile failure/idempotency tests.

## Design notes
- NANDA agents speak a synchronous ledger API; Prava speaks sessions / payment-result / report-status. This adapter is the bridge.
- Failure cases covered: insufficient funds (never hits Prava), HTTP 5xx retries, 401/403 no-retry, schema validation, declined report-status, concurrent pay, duplicate refs, refund safety.
- Secrets stay out of receipts / `public_view()`; API keys only via env / constructor.

## Verification
```bash
uv sync
uv run nest plugins list | grep -A2 payments   # includes prava
uv run pytest packages/nest-plugins-prava/tests -m "not live" -v
# optional sandbox evidence (needs PRAVA_API_KEY):
PRAVA_API_KEY=sk_test_... PRAVA_MODE=hybrid \
  uv run pytest packages/nest-plugins-prava/tests/test_sandbox_live.py -m live -v
PRAVA_MODE=mock nest run scenarios/prava_marketplace.yaml -o traces/prava.jsonl
python packages/nest-plugins-prava/scripts/demo_fail_then_retry.py
```

Locally: **ruff check/format**, **pyright**, and **63 non-live tests** pass. Live/hybrid runs produce real sandbox `ses_` / `ord_` IDs (key not committed).

## Track
Project NANDA — Best Prava Adapter for NANDA Town (Prava Agentic Commerce Hackathon).
