### PR TITLE
Hackathon/chainaim sathya prava payments

### DIFF
--- a/.railwayignore
+++ b/.railwayignore
@@ -1,3 +1,15 @@
+# Excluded from the Railway build context.
+#
+# CHANGED for the skill service: /packages and /scenarios used to be excluded
+# here. They cannot be. The service imports the Prava plugin from
+# packages/nest-plugins-reference and packages/nest-core, and reads the frozen
+# purchase-intent snapshots from scenarios/intents/. Excluding them was correct
+# when the only thing deployed from this repo was the Node dashboard; it is not
+# correct now.
+#
+# The dashboard runs as a separate Railway service with Root Directory set to
+# apps/nest-dashboard, and uses its own .railwayignore in that folder.
+
 .venv
 .claude
 .git
@@ -6,10 +18,7 @@ node_modules
 /traces
 __pycache__
 *.pyc
-/packages
-/scripts
 /docs
-/scenarios
 /templates
 /examples
 /NandaTown.png

--- a/apps/skill-service/app.py
+++ b/apps/skill-service/app.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP service that serves the Prava skill document and runs the real plugin.
+
+Routes only. All payment behaviour lives in ``runner.py``, which calls the
+actual ``PravaPayments`` plugin from ``nest_plugins_reference``.
+
+Run locally::
+
+    python -m uvicorn app:app --app-dir apps/skill-service --port 8000
+
+Then::
+
+    curl localhost:8000/health
+    curl localhost:8000/skill.md
+    curl "localhost:8000/demo/purchase?case=drift"
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel, Field
+
+from runner import CASES, CaseError, run_purchase
+
+SKILL_PATH = Path(__file__).resolve().parent / "skill.md"
+
+app = FastAPI(
+    title="ChainAIM Nanda Prava-VISA-Payment",
+    description=(
+        "An agent pays a merchant on Visa rails through the Prava mandate API, "
+        "and refuses the charge if the delivered item is not the one that was "
+        "agreed. Demo runs use the plugin's simulated transport: no keys, no "
+        "network, no real money."
+    ),
+    version="1.0",
+)
+
+
+class PurchaseRequest(BaseModel):
+    """Body for ``POST /purchase``.
+
+    Every field has a default, so an empty body runs the good case.
+
+    Example::
+
+        PurchaseRequest(case="drift", days_since_delivery=40)
+    """
+
+    case: str = Field(default="good", description="good | drift | overcap")
+    days_since_delivery: int = Field(default=5, ge=0)
+    payment_ref: str = Field(default="prava-demo-0", min_length=1, max_length=255)
+    mandate_id: str = Field(default="mdt_simulated_demo", min_length=1)
+    cap_minor: int = Field(default=100_000, gt=0)
+    fail_closed: bool = Field(default=True)
+    mode: str = Field(default="simulated", description="simulated | live")
+
+
+@app.get("/health", summary="Liveness check")
+async def health() -> dict[str, str]:
+    """Return a fixed liveness payload.
+
+    Example::
+
+        curl localhost:8000/health
+    """
+    return {"status": "ok", "service": "chainaim-nanda-prava-visa-payment"}
+
+
+@app.get("/skill.md", response_class=PlainTextResponse, summary="The skill document")
+async def skill_document() -> PlainTextResponse:
+    """Serve ``skill.md`` verbatim as markdown.
+
+    Example::
+
+        curl localhost:8000/skill.md
+
+    Raises:
+        HTTPException: 404 if the document is missing from the deployment.
+    """
+    if not SKILL_PATH.is_file():
+        raise HTTPException(status_code=404, detail="skill.md is not present in this deployment")
+    return PlainTextResponse(
+        SKILL_PATH.read_text(encoding="utf-8"),
+        media_type="text/markdown; charset=utf-8",
+    )
+
+
+@app.get("/cases", summary="List the demo cases")
+async def cases() -> dict[str, Any]:
+    """Describe each demo case in plain language.
+
+    Example::
+
+        curl localhost:8000/cases
+    """
+    return {
+        "cases": [
+            {"case": spec.name, "summary": spec.summary, "snapshot": spec.snapshot}
+            for spec in CASES.values()
+        ]
+    }
+
+
+@app.get("/demo/purchase", summary="Run one purchase against the real plugin")
+async def demo_purchase(
+    case: str = Query(default="good", description="good | drift | overcap"),
+    days_since_delivery: int = Query(default=5, ge=0),
+) -> dict[str, Any]:
+    """Run the full cycle in simulated mode and return what happened.
+
+    Always simulated. This route never accepts a mode, so a public URL cannot
+    be made to charge a real card.
+
+    Example::
+
+        curl "localhost:8000/demo/purchase?case=drift"
+
+    Raises:
+        HTTPException: 400 for an unknown case name.
+    """
+    try:
+        return await run_purchase(case=case, days_since_delivery=days_since_delivery)
+    except CaseError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/purchase", summary="Run a purchase with your own settings")
+async def purchase(request: PurchaseRequest) -> dict[str, Any]:
+    """Run the cycle with caller-supplied settings.
+
+    ``mode="live"`` is refused unless the deployment sets ``ALLOW_LIVE=1`` and
+    ``PRAVA_API_KEY``.
+
+    Example::
+
+        curl -X POST localhost:8000/purchase -H "Content-Type: application/json" \
+             -d '{"case":"good","days_since_delivery":40}'
+
+    Raises:
+        HTTPException: 400 for an unknown case, 403 when live mode is refused.
+    """
+    try:
+        return await run_purchase(
+            case=request.case,
+            mode=request.mode,
+            mandate_id=request.mandate_id,
+            payment_ref=request.payment_ref,
+            cap_minor=request.cap_minor,
+            fail_closed=request.fail_closed,
+            days_since_delivery=request.days_since_delivery,
+        )
+    except CaseError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+
+@app.get("/", summary="Where to start")
+async def root() -> dict[str, Any]:
+    """Point a caller at the document and the two demo URLs.
+
+    Example::
+
+        curl localhost:8000/
+    """
+    return {
+        "skill": "/skill.md",
+        "health": "/health",
+        "cases": "/cases",
+        "demo_good": "/demo/purchase?case=good",
+        "demo_drift": "/demo/purchase?case=drift",
+        "demo_overcap": "/demo/purchase?case=overcap",
+        "docs": "/docs",
+    }

--- a/apps/skill-service/requirements.txt
+++ b/apps/skill-service/requirements.txt
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# Runtime dependencies for the skill service only.
+#
+# Kept separate from the uv workspace on purpose: adding fastapi to the root
+# pyproject.toml would change uv.lock, and `make ci-local` runs `uv sync` over
+# that lock. This file installs the web layer without touching the library
+# packages at all.
+#
+# nest_core.types uses pydantic; prava_client uses httpx. Both are listed here
+# because this service imports the packages from source rather than installing
+# them, so their own dependency metadata is never read.
+
+fastapi>=0.115
+uvicorn[standard]>=0.30
+pydantic>=2.7
+httpx>=0.27

--- a/apps/skill-service/runner.py
+++ b/apps/skill-service/runner.py
@@ -1,0 +1,567 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Drives the real Prava payments plugin and renders the result as plain English.
+
+This module contains NO payment logic of its own. It imports
+``nest_plugins_reference.payments.prava`` and calls the same methods the
+``prava_commerce`` scenario calls, in the same order:
+
+    quote -> record_delivery -> check_delivery -> pay -> verify_payment
+          -> refund -> judge_return
+
+Nothing here is mocked. The default ``mode="simulated"`` selects
+``SimulatedPravaTransport``, which is an in-process test double: it moves no
+money, mints no credentials and contacts no network. That is a real code path
+in the plugin, not a stand-in written for this service. Every result returned
+carries ``mode`` so a caller can never mistake a rehearsal for a settlement.
+
+Live mode is reachable only when all three of these hold:
+
+    * ``ALLOW_LIVE=1`` in the environment
+    * ``PRAVA_API_KEY`` is set
+    * the caller passes ``mode="live"`` explicitly
+
+A public URL that could charge a real card from a GET request would be a bad
+idea, so the demo routes never pass ``mode``.
+
+Example::
+
+    result = await run_purchase(case="drift")
+    assert result["verdict"] == "refused"
+    assert result["reason"] == "colour_not_in_intent"
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# --- package resolution -----------------------------------------------------
+# The plugin lives in the repo's uv workspace under packages/. Both packages
+# are pure Python with trivial __init__ files, so putting their source roots on
+# sys.path is enough -- no editable install, no change to uv.lock, no new
+# workspace member. REPO_ROOT is <repo>/ because this file is
+# <repo>/apps/skill-service/runner.py.
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+"""Absolute path to the Nanda Town repo root.
+
+Example::
+
+    snapshot = REPO_ROOT / "scenarios" / "intents" / "libas-98252-2XL.json"
+"""
+
+_PACKAGE_DIRS = ("nest-core", "nest-plugins-reference")
+
+
+def _ensure_packages_on_path() -> None:
+    """Put the workspace package source roots on ``sys.path`` if they are there.
+
+    Silent when a directory is absent: if the packages were installed properly
+    (``uv sync``) the imports below resolve anyway, and if neither is true the
+    ImportError that follows is a clearer error than anything raised here.
+
+    Example::
+
+        _ensure_packages_on_path()
+    """
+    for name in _PACKAGE_DIRS:
+        candidate = REPO_ROOT / "packages" / name
+        if candidate.is_dir():
+            resolved = str(candidate)
+            if resolved not in sys.path:
+                sys.path.insert(0, resolved)
+
+
+_ensure_packages_on_path()
+
+from nest_core.types import (  # noqa: E402
+    AgentId,
+    Money,
+    PaymentRef,
+    ServiceRef,
+)
+from nest_plugins_reference.payments.prava import (  # noqa: E402
+    MODE_LIVE,
+    MODE_SIMULATED,
+    PravaConformanceError,
+    PravaPaymentError,
+    PravaPayments,
+    PravaRefundUnsupportedError,
+)
+from nest_plugins_reference.payments.prava_intent import (  # noqa: E402
+    PurchaseIntent,
+    load_intent,
+)
+
+DEFAULT_INTENTS_DIR = REPO_ROOT / "scenarios" / "intents"
+"""Where the frozen purchase-intent snapshots live in this repo.
+
+Override with the ``NEST_INTENTS_DIR`` environment variable.
+
+Example::
+
+    intents = DEFAULT_INTENTS_DIR
+"""
+
+GOOD_SNAPSHOT = "libas-98252-2XL.json"
+"""Navy kurti, INR 499 listed, settles at 523 USD minor. Conforms."""
+
+DRIFT_SNAPSHOT = "libas-98115-2XL-drift.json"
+"""Maroon kurti, INR 450 listed, settles at 472 USD minor. Cheaper. Does not conform."""
+
+OVERCAP_MINOR = 99_999_900
+"""Deliberately oversized charge, used to provoke the mandate cap refusal."""
+
+
+class CaseError(ValueError):
+    """Raised for an unknown case name.
+
+    Example::
+
+        raise CaseError("no such case: banana")
+    """
+
+
+@dataclass(frozen=True)
+class Case:
+    """One demo scenario: which snapshot, what was delivered, what to charge.
+
+    ``charge_minor_override`` exists only for the ``overcap`` case, which runs
+    with no certified intent so the refusal comes from the mandate cap rather
+    than from the conformance gate. See the note in ``CASES`` below.
+
+    Example::
+
+        case = CASES["drift"]
+    """
+
+    name: str
+    summary: str
+    snapshot: str | None
+    delivery_product_id: str | None
+    delivery_merchant: str | None
+    require_conformance: bool
+    charge_minor_override: int | None = None
+
+
+CASES: dict[str, Case] = {
+    "good": Case(
+        name="good",
+        summary=(
+            "The agent bought the navy kurti it was asked for. Every certified "
+            "term matches, so the charge goes through."
+        ),
+        snapshot=GOOD_SNAPSHOT,
+        delivery_product_id="98252-2XL",
+        delivery_merchant="Libas",
+        require_conformance=True,
+    ),
+    "drift": Case(
+        name="drift",
+        summary=(
+            "The agent could not find navy, so it bought a maroon kurti instead. "
+            "It is CHEAPER than the one that was quoted and sits under the Visa "
+            "decline threshold, so no amount-based control objects. Only the "
+            "certified colour list catches it."
+        ),
+        snapshot=DRIFT_SNAPSHOT,
+        delivery_product_id="98115-2XL",
+        delivery_merchant="Libas",
+        require_conformance=True,
+    ),
+    # No snapshot on purpose. With a certified intent loaded, an oversized
+    # charge fails the `amount_mismatch` check inside the plugin BEFORE any
+    # network call, so it is refused as INTENT_NONCONFORMANT and the mandate cap
+    # is never reached. Running this case without the intent gate is the only
+    # way to show the real THRESHOLD_EXCEEDED refusal coming back from the rail.
+    "overcap": Case(
+        name="overcap",
+        summary=(
+            "No certified intent. The agent tries to charge far more than the "
+            "mandate allows. The refusal comes from the payment rail, not from "
+            "the agent deciding to behave."
+        ),
+        snapshot=None,
+        delivery_product_id=None,
+        delivery_merchant=None,
+        require_conformance=False,
+        charge_minor_override=OVERCAP_MINOR,
+    ),
+}
+
+
+def _step(name: str, ok: bool, detail: str, **extra: Any) -> dict[str, Any]:
+    """Build one entry in the returned ``steps`` list.
+
+    Example::
+
+        _step("pay", True, "charged 523")
+    """
+    entry: dict[str, Any] = {"step": name, "ok": ok, "detail": detail}
+    entry.update(extra)
+    return entry
+
+
+def _intent_summary(intent: PurchaseIntent) -> dict[str, Any]:
+    """Flatten the parts of a snapshot a caller needs to see.
+
+    Example::
+
+        summary = _intent_summary(intent)
+    """
+    certificate = intent.certificate
+    reference = certificate.reference if certificate is not None else None
+    return {
+        "intent_id": intent.intent_id,
+        "sku": intent.sku,
+        "title": intent.title,
+        "colour": intent.colour,
+        "merchant": intent.merchant_name,
+        "service_ref": intent.service_ref,
+        "listed": f"{intent.listed_amount_minor} {intent.listed_currency} minor",
+        "settlement_amount_minor": intent.settlement_amount_minor,
+        "settlement_currency": intent.settlement_currency,
+        "converted": intent.converted,
+        "fx_rate": intent.fx_rate,
+        "fx_source": intent.fx_source,
+        "constructed": intent.constructed,
+        "digest": intent.digest[:12],
+        "mandate_digest": (intent.mandate_digest[:12] if intent.mandate_digest else None),
+        "original_request": (certificate.original_request if certificate else None),
+        "allowed_colours": list(reference.allowed_colours) if reference else [],
+        "return_window_days": reference.return_window_days if reference else None,
+        "decline_threshold_minor": (
+            intent.visa.decline_threshold_minor if intent.visa is not None else None
+        ),
+    }
+
+
+def _resolve_mode(requested: str) -> str:
+    """Return the mode to actually use, refusing live unless all gates are open.
+
+    Example::
+
+        assert _resolve_mode("live") == "simulated"   # when ALLOW_LIVE is unset
+    """
+    if requested != MODE_LIVE:
+        return MODE_SIMULATED
+    if os.environ.get("ALLOW_LIVE") != "1":
+        msg = "live mode is disabled on this deployment; set ALLOW_LIVE=1 to enable it"
+        raise PravaPaymentError(msg, code="LIVE_DISABLED")
+    if not os.environ.get("PRAVA_API_KEY"):
+        msg = "live mode needs PRAVA_API_KEY in the environment"
+        raise PravaPaymentError(msg, code="NO_API_KEY")
+    return MODE_LIVE
+
+
+async def run_purchase(
+    *,
+    case: str = "good",
+    mode: str = MODE_SIMULATED,
+    mandate_id: str = "mdt_simulated_demo",
+    prava_env: str = "sandbox",
+    buyer: str = "buyer-0",
+    seller: str = "seller-0",
+    payment_ref: str = "prava-demo-0",
+    currency: str = "USD",
+    minor_unit_exponent: int = 2,
+    cap_minor: int = 100_000,
+    fail_closed: bool = True,
+    days_since_delivery: int = 5,
+    intents_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Run one full purchase cycle against the real plugin and report what happened.
+
+    Every knob is an explicit keyword argument with a default, so behaviour can
+    be changed by a caller without editing this file.
+
+    Example::
+
+        result = await run_purchase(case="good", days_since_delivery=40)
+
+    Raises:
+        CaseError: If ``case`` is not one of ``good``, ``drift``, ``overcap``.
+        PravaPaymentError: If live mode was asked for but is not permitted.
+    """
+    if case not in CASES:
+        known = ", ".join(sorted(CASES))
+        msg = f"unknown case {case!r}; known cases are: {known}"
+        raise CaseError(msg)
+
+    spec = CASES[case]
+    effective_mode = _resolve_mode(mode)
+    directory = intents_dir or Path(os.environ.get("NEST_INTENTS_DIR", DEFAULT_INTENTS_DIR))
+
+    steps: list[dict[str, Any]] = []
+    intent: PurchaseIntent | None = None
+    snapshot_path: Path | None = None
+    price_book: dict[str, int] | None = None
+    service_ref = f"svc-{seller}"
+    charge_minor = 4_000
+
+    # --- load the frozen snapshot -------------------------------------------
+    if spec.snapshot is not None:
+        snapshot_path = directory / spec.snapshot
+        intent = load_intent(snapshot_path, expected_currency=currency)
+        service_ref = intent.service_ref
+        charge_minor = intent.settlement_amount_minor
+        price_book = {service_ref: charge_minor}
+        steps.append(
+            _step(
+                "load_intent",
+                True,
+                (
+                    f"loaded the agreed purchase: {intent.title} "
+                    f"({intent.colour}) from {intent.merchant_name}"
+                ),
+                snapshot=spec.snapshot,
+                digest=intent.digest[:12],
+            )
+        )
+
+    payments = PravaPayments(
+        AgentId(buyer),
+        mandate_id=mandate_id,
+        mode=effective_mode,
+        prava_env=prava_env,
+        currency=currency,
+        minor_unit_exponent=minor_unit_exponent,
+        unit_price_minor=charge_minor,
+        price_book=price_book,
+        intent_digest=intent.digest if intent is not None else None,
+        intent=intent if spec.require_conformance else None,
+        cap_minor=cap_minor,
+        fail_closed=fail_closed,
+    )
+
+    verdict = "unknown"
+    reason = "unknown"
+    code: str | None = None
+    settled_minor = 0
+
+    try:
+        # --- quote ----------------------------------------------------------
+        quote = await payments.quote(ServiceRef(service_ref))
+        quoted_minor = int(quote.price.amount)
+        steps.append(
+            _step(
+                "quote",
+                True,
+                f"price is {quoted_minor} {quote.price.currency} minor units",
+                service=str(quote.service),
+                source=str(quote.metadata.get("source", "unknown")),
+            )
+        )
+
+        charge_minor = spec.charge_minor_override or quoted_minor
+
+        # --- delivery + conformance check -----------------------------------
+        if spec.delivery_product_id is not None:
+            payments.record_delivery(
+                product_id=spec.delivery_product_id,
+                merchant=spec.delivery_merchant,
+            )
+            result = payments.check_delivery(amount_minor=charge_minor)
+            failed = [
+                {
+                    "check": check.name,
+                    "expected": check.expected,
+                    "actual": check.actual,
+                }
+                for check in result.checks
+                if not check.passed
+            ]
+            steps.append(
+                _step(
+                    "check_delivery",
+                    result.passed,
+                    (
+                        "the delivery matches everything that was agreed"
+                        if result.passed
+                        else f"the delivery does not match: {result.reason}"
+                    ),
+                    delivered=spec.delivery_product_id,
+                    merchant=spec.delivery_merchant,
+                    reason=result.reason,
+                    failed_checks=failed,
+                )
+            )
+
+        # --- pay ------------------------------------------------------------
+        money = Money(amount=charge_minor, currency=currency)
+        ref = PaymentRef(payment_ref)
+        try:
+            receipt = await payments.pay(AgentId(seller), money, ref)
+        except PravaConformanceError as exc:
+            verdict, reason, code = "refused", exc.result.reason, exc.code
+            steps.append(
+                _step(
+                    "pay",
+                    False,
+                    "refused before any network call: the item does not match what was agreed",
+                    code=exc.code,
+                    reason=exc.result.reason,
+                )
+            )
+        except PravaPaymentError as exc:
+            verdict = "refused"
+            reason = "over_mandate_cap" if exc.over_cap else "declined"
+            code = exc.code
+            steps.append(
+                _step(
+                    "pay",
+                    False,
+                    (
+                        "the payment rail refused it: the charge is over the mandate limit"
+                        if exc.over_cap
+                        else "the payment rail refused it"
+                    ),
+                    code=exc.code,
+                    over_cap=exc.over_cap,
+                )
+            )
+        else:
+            settled_minor = int(receipt.amount.amount)
+            verdict, reason = "settled", "conforms"
+            steps.append(
+                _step(
+                    "pay",
+                    True,
+                    f"paid {settled_minor} {receipt.amount.currency} minor units to {seller}",
+                    ref=str(receipt.ref),
+                    confirmed=payments.confirmed(ref),
+                )
+            )
+
+            # --- replay: same reference on purpose ---------------------------
+            replay = await payments.pay(AgentId(seller), money, ref)
+            steps.append(
+                _step(
+                    "replay",
+                    True,
+                    (
+                        "sent the same payment reference again; the rail treated it as "
+                        "the original charge instead of charging twice"
+                    ),
+                    ref=str(replay.ref),
+                )
+            )
+
+        # --- verify against the rail's own ledger ---------------------------
+        status = await payments.verify_payment(ref)
+        steps.append(
+            _step(
+                "verify",
+                True,
+                f"the payment rail says this charge is: {status.value}",
+                status=status.value,
+            )
+        )
+
+        # --- refund: not supported by Prava ---------------------------------
+        try:
+            await payments.refund(ref)
+        except PravaRefundUnsupportedError:
+            steps.append(
+                _step(
+                    "refund",
+                    False,
+                    "no refund was possible: the Prava API has no refund endpoint at all",
+                    error="PravaRefundUnsupportedError",
+                )
+            )
+
+        # --- return window --------------------------------------------------
+        if intent is not None and spec.require_conformance:
+            if verdict == "settled":
+                returned = payments.judge_return(days_since_delivery=days_since_delivery)
+                steps.append(
+                    _step(
+                        "return",
+                        returned.approved,
+                        (
+                            f"a return asked for on day {days_since_delivery} is "
+                            f"{'inside' if returned.approved else 'outside'} the agreed "
+                            f"{returned.window_days}-day window. Approved means it matches "
+                            "the agreed terms; it does not mean money moved."
+                        ),
+                        approved=returned.approved,
+                        reason=returned.reason,
+                        window_days=returned.window_days,
+                        settlement=("unavailable_on_rail" if returned.approved else None),
+                    )
+                )
+            else:
+                steps.append(
+                    _step(
+                        "return",
+                        False,
+                        "no return to judge: nothing was ever paid for",
+                        reason="no_settled_purchase",
+                    )
+                )
+    finally:
+        await payments.aclose()
+
+    payload: dict[str, Any] = {
+        "case": spec.name,
+        "summary": spec.summary,
+        "mode": effective_mode,
+        "mandate_id": mandate_id,
+        "verdict": verdict,
+        "reason": reason,
+        "code": code,
+        "settled_amount_minor": settled_minor,
+        "currency": currency,
+        "steps": steps,
+        "intent": _intent_summary(intent) if intent is not None else None,
+        "snapshot": str(snapshot_path.name) if snapshot_path is not None else None,
+    }
+    payload["display"] = render_display(payload)
+    return payload
+
+
+def render_display(payload: dict[str, Any]) -> str:
+    """Turn a result into a transcript a person can read without a manual.
+
+    Example::
+
+        print(render_display(result))
+    """
+    lines: list[str] = []
+    intent = payload.get("intent")
+    if isinstance(intent, dict):
+        request = intent.get("original_request")
+        if request:
+            lines.append(f'The user asked: "{request}"')
+        lines.append(
+            f"The agent chose: {intent.get('title')} ({intent.get('colour')}) "
+            f"from {intent.get('merchant')}, {intent.get('listed')}."
+        )
+        colours = intent.get("allowed_colours") or []
+        if colours:
+            lines.append(f"Colours that were agreed: {', '.join(colours)}.")
+    else:
+        lines.append("No agreed purchase was loaded for this run.")
+
+    lines.append("")
+    for entry in payload.get("steps", []):
+        mark = "OK  " if entry.get("ok") else "STOP"
+        lines.append(f"  {mark} {entry.get('step')}: {entry.get('detail')}")
+
+    lines.append("")
+    if payload.get("verdict") == "settled":
+        lines.append(
+            f"Result: PAID {payload.get('settled_amount_minor')} "
+            f"{payload.get('currency')} minor units."
+        )
+    else:
+        lines.append(
+            f"Result: NOT PAID. Nothing reached the card rail. "
+            f"Reason: {payload.get('reason')}."
+        )
+    lines.append(f"Mode: {payload.get('mode')} (simulated means no real money moved).")
+    return "\n".join(lines)

--- a/apps/skill-service/skill.md
+++ b/apps/skill-service/skill.md
@@ -1,0 +1,202 @@
+---
+name: chainaim-nanda-prava-visa-payment
+description: Pays a merchant on Visa rails through the Prava mandate API, and refuses the charge if the delivered item is not the one that was agreed. Use when an agent spends against a human-granted card mandate and must only pay for the item that was actually authorised.
+version: "1.0"
+author: ChainAIM
+metadata:
+  openclaw:
+    requires:
+      bins: [curl]
+---
+
+# ChainAIM Nanda Prava-VISA-Payment
+
+**An agent pays a real card rail — but only for the item a human authorised.**
+
+A buyer agent quotes an item, checks what was delivered against terms agreed
+before the purchase, and only then charges a Prava mandate on Visa rails. If the
+delivery does not match, the charge is refused **before any network call**, so
+nothing reaches the card rail: no charge, no credential, nothing to reverse.
+
+**Use this when** an agent must pay a merchant and you need proof it paid only
+for what was authorised.
+
+**The case this exists for is a cheaper swap.** An agent asked for a navy kurti
+under INR 500 buys a maroon one at INR 450 instead. It is cheaper than the
+quote, under the Visa decline threshold, under the mandate cap, and from the
+right merchant — so every amount-based control in the stack lets it through.
+They all ask *how much*. None asks *what*.
+
+**Tags:** payments · visa · prava · mandate · agentic-commerce · idempotency · conformance
+
+## Base URL
+
+Set after deployment. Replace `<base>` below with it.
+
+## Quick start — one call, no setup
+
+```
+curl "<base>/demo/purchase?case=drift"
+```
+
+The `display` field is a transcript anyone can read:
+
+```
+The user asked: "find one kurti under 500 rupees in green, pink or navy on libas and buy one"
+The agent chose: Libas Maroon Printed Cotton Blend Straight Short Kurti (Maroon) from Libas, 45000 INR minor.
+Colours that were agreed: green, pink, navy.
+
+  OK   load_intent: loaded the agreed purchase: Libas Maroon Printed Cotton Blend Straight Short Kurti (Maroon) from Libas
+  OK   quote: price is 472 USD minor units
+  STOP check_delivery: the delivery does not match: colour_not_in_intent
+  STOP pay: refused before any network call: the item does not match what was agreed
+  ...
+
+Result: NOT PAID. Nothing reached the card rail. Reason: colour_not_in_intent.
+Mode: simulated (simulated means no real money moved).
+```
+
+Use `?case=good` for the path that settles.
+
+## How the agent should use this
+
+1. Call `GET /demo/purchase?case=good` or `?case=drift`.
+2. Print the `display` field **verbatim**. It is already a complete transcript.
+3. **Never call a `simulated` result a real transaction.** Every response carries
+   a `mode` field for exactly this reason.
+
+## Judge test
+
+Two calls, no setup.
+
+1. `GET /demo/purchase?case=good` — expect `"verdict":"settled"`,
+   `"settled_amount_minor":523`, and a step where `check_delivery` has
+   `"ok":true`.
+2. `GET /demo/purchase?case=drift` — expect `"verdict":"refused"`,
+   `"reason":"colour_not_in_intent"`, `"code":"INTENT_NONCONFORMANT"`,
+   `"settled_amount_minor":0`, and a `failed_checks` entry with
+   `"expected":"green|pink|navy"` and `"actual":"maroon"`.
+
+Passing both proves the point in under ten seconds: it pays for the item that
+was agreed, and refuses a swap that is *cheaper* than the thing it replaced.
+
+Third call, optional: `GET /demo/purchase?case=overcap` runs with no agreed
+purchase loaded and tries to charge far more than the mandate allows. The
+refusal comes back from the payment rail itself.
+
+## Endpoints
+
+| Route | What it does |
+|---|---|
+| `GET /health` | liveness |
+| `GET /skill.md` | this document |
+| `GET /cases` | the demo cases and what each shows |
+| `GET /demo/purchase?case=good\|drift\|overcap` | one full cycle, always simulated |
+| `POST /purchase` | same cycle with your own settings |
+| `GET /docs` | generated OpenAPI page |
+
+Every response from a purchase route has the same shape:
+
+| field | meaning |
+|---|---|
+| `verdict` | `settled` or `refused` |
+| `reason` | which check decided, e.g. `conforms`, `colour_not_in_intent` |
+| `code` | the plugin's error code, e.g. `INTENT_NONCONFORMANT` |
+| `settled_amount_minor` | what was actually paid, in minor units |
+| `steps` | every step in order, each with `ok` and a plain-English `detail` |
+| `intent` | the agreed purchase: colours allowed, price, merchant, digests |
+| `mode` | `simulated` or `live` |
+| `display` | the printable transcript |
+
+## Nothing here is mocked
+
+The service calls the real plugin. `simulated` mode is a real code path in it:
+an in-process transport that moves no money, mints no credentials and contacts
+no network. It uses a counter instead of random ids, so the same input gives the
+same output every time.
+
+Live mode is off unless three things are all true: `ALLOW_LIVE=1` is set,
+`PRAVA_API_KEY` is set, and the caller asks for it in a POST body. The demo
+routes never pass a mode, so a public URL cannot charge a real card.
+
+## What each method does
+
+| Method | Prava call |
+|---|---|
+| `quote` | None. Local price list. Prava does not price anything. |
+| `pay` | `POST /v1/mandates/{id}/charge`, then `POST /v1/mandates/{id}/charges/{txn}/report` |
+| `verify_payment` | `GET /v1/mandates/{id}`, then find the charge by `reference` |
+| `refund` | Raises. Prava has no refund endpoint. |
+
+`PaymentRef` is sent to Prava as its `reference` field, unchanged. Prava treats
+that as an idempotency key, so a repeat charge with the same reference is
+refused by Prava rather than by our own code. The demo sends the same reference
+twice on purpose to show this.
+
+`verify_payment` reads Prava's own ledger, not local state. If the network fails
+it returns `PENDING`, not `FAILED` — a failed call is not proof the payment did
+not happen.
+
+## The checks
+
+Run before any network call. Each one is skipped if the term is missing.
+
+| Check | Compares |
+|---|---|
+| `colour_not_in_intent` | colour is in the allowed list |
+| `price_over_ceiling` | listed price is under the ceiling |
+| `merchant_mismatch` | merchant matches |
+| `identity_mismatch` | delivered product id matches the sku |
+| `amount_mismatch` | charged amount matches the settlement amount |
+| `over_decline_threshold` | amount is under the Visa decline threshold |
+
+The first four are what catch a cheaper swap. The last two cannot.
+
+## No refunds exist, and we do not pretend otherwise
+
+The Prava API has no refund, credit or reversal endpoint. `refund()` raises
+instead of quietly doing nothing. A reversal has to be modelled as a new forward
+payment back to the buyer, with a fresh reference, recording both legs.
+
+An approved return verdict means the request matches the terms agreed up front.
+It does **not** mean money moved.
+
+## Running it yourself
+
+```bash
+git clone <repo> && cd nandatown
+pip install -r apps/skill-service/requirements.txt
+python -m uvicorn app:app --app-dir apps/skill-service --port 8000
+curl "localhost:8000/demo/purchase?case=drift"
+```
+
+The scenarios behind this also run in the simulator:
+
+```bash
+uv sync
+uv run nest run scenarios/prava_dvp.yaml         # settles
+uv run nest run scenarios/prava_dvp_drift.yaml   # refused
+```
+
+## Limits
+
+- Same-input determinism holds in simulated mode only. Live runs are not.
+- The simulated transport is a test double, not a copy of Prava. It handles four
+  cases: repeat reference, over-cap refusal, the charges read-back, and 404 on an
+  unknown mandate. Anything else raises rather than inventing a response.
+- The drift snapshot is hand-written and marked `"constructed": true`. It is not
+  a recording of a real agent run.
+- `THRESHOLD_EXCEEDED` does not appear in the `good` or `drift` cases. With an
+  agreed purchase loaded, an oversized charge fails the amount check first and
+  never reaches the rail. That is why `case=overcap` runs without one.
+- In simulated mode each buyer has its own ledger. In live mode all buyers
+  charge the same real mandate, so the cap is shared.
+- The demo is small on purpose. It proves the rail works; it does not stress-test it.
+
+## The guarantee
+
+No charge is attempted unless the delivery matches what was agreed beforehand,
+so a refused purchase leaves nothing at the rail. Every charge that is attempted
+carries a fixed reference as Prava's idempotency key, so a repeat is refused by
+the card network, not by our own bookkeeping. And the status reported is what
+Prava's ledger says, not what this process thinks.

--- a/docs/layers/payments.md
+++ b/docs/layers/payments.md
@@ -36,6 +36,18 @@ provider / service binding by payment reference and reject traces that leak
 private keys, API keys, bearer tokens, wallet secrets, or other live rail
 secrets.
 
+`prava` — settles on Visa rails through
+[Prava](https://docs.prava.space)'s agentic-payments mandate API. The
+only payments plugin here that does not settle against a Python
+dictionary. `PaymentRef` is passed through verbatim as Prava's
+`reference` idempotency key, so replaying a simulation is refused by the
+card network rather than by local bookkeeping. `refund` raises rather
+than no-ops, because the Prava API defines no reversal endpoint. Ships
+a simulated transport (a loudly labelled test double, used by CI, which
+holds no credentials) alongside the live one, selected by a `mode` flag.
+
+Details: [`prava_payments.md`](prava_payments.md).
+
 ## Writing your own
 
 See [`writing-a-plugin.md`](../writing-a-plugin.md) — the full

--- a/docs/layers/prava_payments.md
+++ b/docs/layers/prava_payments.md
@@ -1,0 +1,249 @@
+# Prava Payments: settling agent commerce on Visa rails
+
+Plugin: `("payments", "prava")` —
+[`nest_plugins_reference/payments/prava.py`](../../packages/nest-plugins-reference/nest_plugins_reference/payments/prava.py)
+Client: [`prava_client.py`](../../packages/nest-plugins-reference/nest_plugins_reference/payments/prava_client.py)
+Scenario: [`scenarios/prava_commerce.yaml`](../../scenarios/prava_commerce.yaml)
+
+## Problem
+
+Every payments plugin in this repo settles against a Python dictionary.
+`prepaid_credits` moves integers between balances; `escrow` holds them in a
+vault; `streaming` drips them per tick. All three are correct, and none of them
+can tell you what happens when an agent's spending is governed by something
+outside the simulation.
+
+That gap matters most for **replay safety**. Nanda Town derives payment refs
+deterministically from the scenario seed, so re-running a simulation re-issues
+the identical `PaymentRef`. Under an in-process ledger, the protection against
+double-charging is a `if ref in self._payments: raise` — our own bookkeeping
+checking our own bookkeeping. It proves the plugin is internally consistent. It
+proves nothing about whether the same agent, pointed at a real rail, would
+charge a real card twice.
+
+## Solution
+
+`PravaPayments` maps the four `Payments` protocol methods onto
+[Prava](https://docs.prava.space)'s agentic-payments mandate API, and passes
+`PaymentRef` through **verbatim** as Prava's `reference` field — which Prava
+documents as an idempotency key.
+
+| Protocol method | Prava call |
+|---|---|
+| `quote` | None. Local price book; Prava authorizes and settles, it does not price. Keeping it local also keeps `quote` deterministic under replay. |
+| `pay` | `POST /v1/mandates/{id}/charge`, then `POST /v1/mandates/{id}/charges/{txn}/report` |
+| `verify_payment` | `GET /v1/mandates/{id}`, then locate the charge by `reference` |
+| `refund` | Raises. See [No refunds exist](#no-refunds-exist-and-we-do-not-pretend-otherwise). |
+
+The consequence is the point: replay safety stops being an assertion in our code
+and becomes a property enforced by the card network. Replay the simulation, and
+Prava — not `nest_core` — refuses the second charge.
+
+`verify_payment` is authoritative for the same reason. It re-reads the mandate
+and finds the charge in Prava's own `charges[]` array, so it reports what the
+payment rail believes, not what this process believes. A network failure returns
+`PENDING`, never `FAILED`: an unreachable API is not evidence that a payment did
+not happen.
+
+## Install
+
+The plugin ships inside `nest-plugins-reference` and needs no extra step:
+
+```bash
+uv sync
+uv run nest run scenarios/prava_commerce.yaml
+```
+
+`httpx>=0.27` is a declared dependency of `nest-plugins-reference`. The plugin is
+registered two ways, so it resolves whether or not the package is installed as a
+distribution:
+
+```python
+from nest_core.plugins import PluginRegistry
+PluginRegistry().resolve("payments", "prava")   # -> PravaPayments
+```
+
+— via `_BUILTINS` in `nest_core/plugins.py`, and via the
+`[project.entry-points."nest.plugins.payments"]` block in
+`packages/nest-plugins-reference/pyproject.toml`.
+
+### Reuse outside this repo
+
+`prava_client.py` imports **no Nanda Town types**. It is a standalone async Prava
+client — transport protocol, error envelopes, retry policy, and the integer
+minor-unit ↔ decimal-string conversion Prava's wire format requires — and can be
+lifted into any project:
+
+```python
+from nest_plugins_reference.payments.prava_client import (
+    HttpxPravaTransport, PravaClient, SANDBOX_BASE_URL,
+)
+
+client = PravaClient(HttpxPravaTransport(api_key="sk_test_...", base_url=SANDBOX_BASE_URL))
+result = await client.charge("mdt_...", amount_minor=4_000, reference="order-1")
+```
+
+The Nanda Town binding lives entirely in `prava.py`.
+
+## Two modes, never confused
+
+```yaml
+task:
+  config:
+    mode: simulated            # simulated | live
+    prava_env: sandbox         # sandbox | production
+    mandate_id: mdt_simulated_demo
+```
+
+`mode: simulated` selects `SimulatedPravaTransport`, an in-process test double.
+**It moves no money, mints no credentials, and contacts no network.** It exists
+because CI holds no Prava key and because determinism is a graded axis. Its
+identifiers come from a monotonic counter rather than `uuid4` or the clock, so a
+replayed simulation yields a byte-identical trace.
+
+`mode: live` selects `HttpxPravaTransport` against the sandbox or production
+host. The **identical plugin code path** runs in both modes — only the transport
+differs.
+
+There is deliberately **no `dry_run` flag**. An earlier draft had one, returning
+a synthetic `Receipt` without calling out. That was removed: a `dry_run` receipt
+makes a rehearsed trace indistinguishable from a settled one. `PravaPayments.mode`
+is public, `PravaPayments.confirmed(ref)` reports whether the merchant-report leg
+closed, and every scenario broadcast carries `mode=simulated` or `mode=live`. A
+reader can always tell what actually happened.
+
+`HttpxPravaTransport` refuses an `sk_live_` key pointed at the sandbox host and
+an `sk_test_` key pointed at production, because that mistake is silent and
+expensive.
+
+## Mandate provisioning is out of band
+
+Creating a mandate requires `POST /v1/sessions` with a `mandate_setup` block and
+a **human passkey approval**. That cannot happen mid-simulation. So `mandate_id`
+is provisioned beforehand and injected as config, and the API key is read from
+`PRAVA_API_KEY` — never from scenario YAML.
+
+```bash
+export PRAVA_API_KEY=sk_test_...
+# then set mode: live and mandate_id: mdt_<yours> in the YAML
+uv run nest run scenarios/prava_commerce.yaml
+```
+
+This is a real constraint on agentic commerce, not an implementation shortcut:
+an autonomous agent cannot mint its own spending authority. A human grants a
+capped mandate; the agent spends within it; the rail enforces the cap.
+
+## No refunds exist, and we do not pretend otherwise
+
+The Prava OpenAPI 3.1 document was read in full — all 13 paths. **There is no
+refund, credit, or reversal endpoint.**
+
+`refund()` therefore raises `PravaRefundUnsupportedError`. It does not silently
+no-op, and it does not return `None` as though something happened. A plugin that
+swallows an unsupported refund is lying about its capability, and the lie only
+surfaces in production.
+
+Callers needing a reversal must model it as a compensating **forward** payment to
+the original payer, with a fresh `PaymentRef`, recording both legs:
+
+```python
+try:
+    await payments.refund(ref)
+except PravaRefundUnsupportedError:
+    await seller_payments.pay(buyer, amount, PaymentRef(f"{ref}-reversal"))
+```
+
+`PravaRefundUnsupportedError` subclasses `NotImplementedError`, and
+`PravaPaymentError` subclasses `RuntimeError`, on purpose: the scenario in
+`nest_core` catches them by their stdlib bases, so `nest_core` never imports
+`nest_plugins_reference`.
+
+## Configuration
+
+All knobs are explicit keyword arguments with defaults, surfaced through
+`task.config`. Nothing is hardcoded.
+
+| Key | Default | Meaning |
+|---|---|---|
+| `mandate_id` | *required* | Provisioned out of band. |
+| `mode` | `simulated` | `simulated` \| `live`. |
+| `prava_env` | `sandbox` | `sandbox` \| `production`. |
+| `currency` | `USD` | ISO 4217 code sent to Prava. `credits` is accepted as layer-neutral and interpreted as this currency. |
+| `minor_unit_exponent` | `2` | **`0` for JPY/KRW.** A flag, not a constant, so zero-decimal currencies are not silently 100× wrong. |
+| `unit_price_minor` | `4000` | Price returned by `quote`. |
+| `cap_minor` | `100000` | Simulated-mode mandate ceiling. |
+| `fail_closed` | `true` | See below. |
+| `timeout_s` / `max_retries` | `30.0` / `3` | Live transport only; retries `429` and `5xx` with capped exponential backoff, never other `4xx`. |
+| `authorization_code` | `None` | Merchant auth code, if any. |
+
+`fail_closed` governs the report leg. A charge Prava **accepted** but whose
+merchant-side report **failed** is an *unconfirmed* payment, and the plugin
+refuses to guess which it is. With `fail_closed: true` it raises and issues no
+receipt. With `fail_closed: false` it returns a receipt, `confirmed(ref)` is
+`False`, and `verify_payment` reports `PENDING` until the report succeeds —
+useful when a scenario wants to observe the uncertainty rather than abort on it.
+Neither setting ever assumes success.
+
+## Measured behavior
+
+`uv run nest run scenarios/prava_commerce.yaml` — 4 agents, 2 buyer/seller pairs,
+seed 42, simulated mode. 14 `prava:*` broadcasts, ticks 0→11, both pairs
+identical in shape:
+
+```
+t= 0  prava:offering:seller=seller-0
+t= 1  prava:quoted:buyer=buyer-0:service=svc-seller-0:price=4000:currency=USD:mode=simulated
+t= 3  prava:paid:ref=prava-42-0:payer=buyer-0:payee=seller-0:amount=4000:confirmed=1:mode=simulated
+t= 5  prava:replayed:ref=prava-42-0:...:amount=4000:confirmed=1:mode=simulated
+t= 7  prava:verified:ref=prava-42-0:status=confirmed:mode=simulated
+t= 9  prava:refused:step=overcap:ref=prava-42-0-overcap:amount=99999900:over_cap=1:code=THRESHOLD_EXCEEDED
+t=11  prava:refund_unsupported:ref=prava-42-0:reason=PravaRefundUnsupportedError:mode=simulated
+```
+
+The `replayed` event re-issues the **same** `PaymentRef` at t=5. Prava returns
+the original charge with `deduplicated: true`; the mandate's `spent` stays at
+`"40.00"` and `chargeCount` stays at `1`. The oversized charge at t=9 is refused
+by the mandate threshold, not by agent politeness — the budget is enforced by the
+rail.
+
+Test suite: **1403 passed, 1 skipped, 2 deselected**, up from a 1311-passing
+baseline. Every default test is credential-free and runs against the simulated
+transport. The one test that touches the real sandbox carries the `live` marker
+and is deselected by the repo-wide `-m "not live"`:
+
+```bash
+PRAVA_API_KEY=sk_test_... PRAVA_MANDATE_ID=mdt_... uv run pytest -m live
+```
+
+Optional overrides for that test: `PRAVA_LIVE_AMOUNT_MINOR` (default `100`),
+`PRAVA_LIVE_REFERENCE` (default `nest-prava-live-0001`).
+
+## Limits
+
+- **Determinism holds in simulated mode only.** Same seed → byte-identical
+  trace, because the double derives identifiers from a monotonic counter. In
+  `mode: live` the trace carries real transaction ids, real timestamps, and real
+  network timing; **the byte-identical guarantee does not hold and is not
+  claimed**. This is the honest cost of running against a real rail, and it is
+  why simulated is the default.
+- **The simulated transport is a test double, not a Prava emulator.** It
+  reproduces exactly four documented behaviours — idempotent `reference`,
+  `THRESHOLD_EXCEEDED` over cap, the `charges[]` read-back, and 404 on an unknown
+  mandate. Any other path raises `NotImplementedError` rather than inventing a
+  response. Never present its output as a settled transaction.
+- **Trace evidence for dedupe is indirect.** The trace shows the replay returned
+  the same ref and amount; that the mandate was not drawn twice is asserted in
+  the test suite (`test_replayed_ref_does_not_draw_the_mandate_twice`), not
+  visible in the trace itself.
+- **Buyers do not share a ledger in simulated mode.** Each buyer gets its own
+  `PravaPayments` instance and therefore its own double. In `live` mode all
+  buyers charge the **same real mandate**, so the shared cap becomes contended —
+  size `cap_minor` accordingly.
+- **The scenario is deliberately small.** Two pairs, not a marketplace. A
+  50×50×10 run would exhaust a real sandbox mandate long before finishing. This
+  scenario proves the rail; it does not stress-test it.
+- **`quote` is a local price book.** Prava has no quote endpoint. The price is
+  configuration, not a network read.
+- **No refund path exists upstream.** Covered above. This is a property of the
+  Prava API, and if Prava adds a reversal endpoint this plugin will need a real
+  implementation rather than a relaxed exception.

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Nixpacks build plan for the Prava skill service.
+#
+# Use with Railway's Root Directory set to the REPO ROOT (not apps/skill-service):
+# the service imports nest_core and nest_plugins_reference from packages/, and
+# reads the purchase-intent snapshots from scenarios/intents/. Railway only
+# uploads what is under the root directory, so pointing at apps/skill-service
+# would leave both behind.
+#
+# This does NOT use uv. The service installs its own small requirements file and
+# imports the two workspace packages from source, so uv.lock is never touched and
+# `make ci-local` is unaffected.
+#
+# The dashboard at apps/nest-dashboard has its own railway.json and nixpacks.toml
+# and is meant to run as a SEPARATE Railway service with Root Directory set to
+# apps/nest-dashboard. This file does not affect it.
+
+providers = ["python"]
+
+[phases.setup]
+nixPkgs = ["python312"]
+
+[phases.install]
+cmds = [
+  "python -m pip install --upgrade pip",
+  "python -m pip install -r apps/skill-service/requirements.txt",
+]
+
+[start]
+cmd = "python -m uvicorn app:app --app-dir apps/skill-service --host 0.0.0.0 --port $PORT"

--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -42,6 +42,7 @@ _BUILTINS: dict[tuple[str, str], str] = {
     ("payments", "streaming"): f"{_REF}.payments.streaming:StreamingPayments",
     ("payments", "empic_escrow"): f"{_REF}.payments.empic_escrow:EMPICEscrowPayments",
     ("payments", "escrow"): f"{_REF}.payments.escrow:EscrowPayments",
+    ("payments", "prava"): f"{_REF}.payments.prava:PravaPayments",
     ("coordination", "contract_net"): f"{_REF}.coordination.contract_net:ContractNet",
     ("coordination", "hotstuff"): f"{_REF}.coordination.hotstuff:HotStuff",
     ("negotiation", "alternating_offers"): (

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -167,6 +167,12 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("escrow_marketplace", escrow_marketplace_factory)
+    elif name == "prava_commerce":
+        from nest_core.scenarios_builtin.prava_commerce import (
+            prava_commerce_factory,
+        )
+
+        register_scenario("prava_commerce", prava_commerce_factory)
     elif name == "failure_detection":
         from nest_core.scenarios_builtin.failure_detection import (
             failure_detection_factory,

--- a/packages/nest-core/nest_core/scenarios_builtin/prava_commerce.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/prava_commerce.py
@@ -1,0 +1,376 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prava commerce scenario -- buyer/seller pairs settling on a Prava mandate.
+
+Drives the ``prava`` payments plugin through the full agentic-commerce loop the
+hackathon track asks for -- **quote, pay, verify, handle failure** -- plus the
+two behaviours that make a payment rail trustworthy under simulation:
+
+#. **Idempotent replay.** Each buyer pays once, then re-issues the *same*
+   ``PaymentRef``. Prava treats ``reference`` as an idempotency key, so the
+   second call returns the original charge with ``deduplicated: true`` and the
+   mandate is not drawn twice. Nanda Town derives payment refs deterministically
+   from the seed, so replaying the whole simulation is refused by the card
+   network rather than by our own bookkeeping.
+#. **Refusal at the rail.** Each buyer then attempts a deliberately oversized
+   charge. Prava returns ``status: "failed"`` with
+   ``errorCode: "THRESHOLD_EXCEEDED"``; the buyer records the refusal and stops.
+   The budget is enforced by the mandate, not by agent politeness.
+
+The buyer finally calls ``refund()``, which raises because Prava's API defines
+no refund endpoint. That is recorded as an explicit ``unsupported`` event rather
+than hidden -- a plugin that silently no-ops a refund is lying about its
+capability.
+
+Every transition is broadcast as ``prava:<kind>:k=v:...``, mirroring the
+``escrow:*`` convention in :mod:`nest_core.scenarios_builtin.escrow_marketplace`.
+Each event carries ``mode=simulated`` or ``mode=live`` so no reader can mistake
+an in-process rehearsal for a settled transaction.
+
+Exceptions are caught by their **stdlib bases** (``RuntimeError`` for a refused
+charge, ``NotImplementedError`` for the unsupported refund) so that ``nest_core``
+never imports ``nest_plugins_reference``. Under a payments plugin without Prava
+semantics (e.g. ``prepaid_credits``) the agents fall back to a plain ``pay()``
+and emit no ``prava:*`` events at all.
+
+Example::
+
+    agents = prava_commerce_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.types import AgentId, Money, PaymentRef, ServiceRef
+
+_TICK_QUOTE = 1.0
+_TICK_PAY = 3.0
+_TICK_REPLAY = 5.0
+_TICK_VERIFY = 7.0
+_TICK_OVERCAP = 9.0
+_TICK_REFUND = 11.0
+
+_OP_QUOTE = b"op:quote"
+_OP_PAY = b"op:pay"
+_OP_REPLAY = b"op:replay"
+_OP_VERIFY = b"op:verify"
+_OP_OVERCAP = b"op:overcap"
+_OP_REFUND = b"op:refund"
+
+DEFAULT_PAIRS = 2
+"""Number of buyer/seller pairs when ``task.config`` does not say.
+
+Kept small on purpose: a marketplace-sized run would exhaust a sandbox mandate
+cap long before the scenario finished.
+
+Example::
+
+    pairs = DEFAULT_PAIRS
+"""
+
+DEFAULT_UNIT_PRICE_MINOR = 4_000
+"""Default charge size in minor units (``"40.00"`` at exponent 2).
+
+Example::
+
+    price = DEFAULT_UNIT_PRICE_MINOR
+"""
+
+DEFAULT_OVERCAP_MINOR = 99_999_900
+"""Deliberately oversized charge used to provoke ``THRESHOLD_EXCEEDED``.
+
+Large enough to exceed any plausible sandbox mandate, so the failure path is
+exercised identically in ``simulated`` and ``live`` mode.
+
+Example::
+
+    huge = DEFAULT_OVERCAP_MINOR
+"""
+
+
+def _emit(fields: dict[str, str | int]) -> bytes:
+    """Build a ``prava:<kind>:k=v:...`` broadcast payload.
+
+    Mirrors the colon-separated form used by the escrow scenario so a single
+    trace parser handles both.
+
+    Example::
+
+        payload = _emit({"kind": "paid", "ref": "r-1"})
+    """
+    kind = str(fields.pop("kind"))
+    body = ":".join(f"{k}={v}" for k, v in fields.items())
+    return (f"prava:{kind}:{body}" if body else f"prava:{kind}").encode()
+
+
+class PravaBuyerAgent(StateMachineAgent):
+    """Quotes, pays, replays, verifies, overspends, then asks for a refund.
+
+    Holds the payer-side plugin instance. Each step is scheduled on its own
+    tick so the emitted trace has a stable, inspectable order.
+
+    Example::
+
+        agent = PravaBuyerAgent(
+            AgentId("buyer-0"),
+            seller=AgentId("seller-0"),
+            ref=PaymentRef("prava-0"),
+            amount_minor=4_000,
+            overcap_minor=99_999_900,
+            currency="USD",
+        )
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        seller: AgentId,
+        ref: PaymentRef,
+        amount_minor: int,
+        overcap_minor: int,
+        currency: str,
+    ) -> None:
+        self._id = agent_id
+        self._seller = seller
+        self._ref = ref
+        self._overcap_ref = PaymentRef(f"{ref}-overcap")
+        self._amount_minor = amount_minor
+        self._overcap_minor = overcap_minor
+        self._currency = currency
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        await ctx.schedule(_TICK_QUOTE, _OP_QUOTE)
+        await ctx.schedule(_TICK_PAY, _OP_PAY)
+        await ctx.schedule(_TICK_REPLAY, _OP_REPLAY)
+        await ctx.schedule(_TICK_VERIFY, _OP_VERIFY)
+        await ctx.schedule(_TICK_OVERCAP, _OP_OVERCAP)
+        await ctx.schedule(_TICK_REFUND, _OP_REFUND)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        payments = ctx.plugins["payments"]
+        mode = str(getattr(payments, "mode", "unknown"))
+        money = Money(amount=self._amount_minor, currency=self._currency)
+
+        if payload == _OP_QUOTE:
+            quote = await payments.quote(ServiceRef(f"svc-{self._seller}"))
+            await ctx.broadcast(
+                _emit(
+                    {
+                        "kind": "quoted",
+                        "buyer": str(self._id),
+                        "service": str(quote.service),
+                        "price": int(quote.price.amount),
+                        "currency": str(quote.price.currency),
+                        "mode": mode,
+                    }
+                )
+            )
+            return
+
+        if payload == _OP_PAY:
+            await self._attempt_pay(ctx, money, self._ref, mode, kind="paid")
+            return
+
+        if payload == _OP_REPLAY:
+            # Same ref on purpose: Prava must dedupe rather than double-charge.
+            await self._attempt_pay(ctx, money, self._ref, mode, kind="replayed")
+            return
+
+        if payload == _OP_VERIFY:
+            status = await payments.verify_payment(self._ref)
+            await ctx.broadcast(
+                _emit(
+                    {
+                        "kind": "verified",
+                        "ref": str(self._ref),
+                        "status": str(getattr(status, "value", status)),
+                        "mode": mode,
+                    }
+                )
+            )
+            return
+
+        if payload == _OP_OVERCAP:
+            huge = Money(amount=self._overcap_minor, currency=self._currency)
+            await self._attempt_pay(ctx, huge, self._overcap_ref, mode, kind="overcap")
+            return
+
+        if payload == _OP_REFUND:
+            await self._attempt_refund(ctx, mode)
+
+    async def _attempt_pay(
+        self,
+        ctx: AgentContext,
+        money: Money,
+        ref: PaymentRef,
+        mode: str,
+        kind: str,
+    ) -> None:
+        payments = ctx.plugins["payments"]
+        try:
+            receipt = await payments.pay(self._seller, money, ref)
+        except NotImplementedError:
+            raise
+        except (RuntimeError, ValueError) as exc:
+            await ctx.broadcast(
+                _emit(
+                    {
+                        "kind": "refused",
+                        "step": kind,
+                        "ref": str(ref),
+                        "amount": int(money.amount),
+                        "over_cap": int(bool(getattr(exc, "over_cap", False))),
+                        "code": str(getattr(exc, "code", "") or "none"),
+                        "mode": mode,
+                    }
+                )
+            )
+            return
+        await ctx.broadcast(
+            _emit(
+                {
+                    "kind": kind,
+                    "ref": str(receipt.ref),
+                    "payer": str(receipt.payer),
+                    "payee": str(receipt.payee),
+                    "amount": int(receipt.amount.amount),
+                    "currency": str(receipt.amount.currency),
+                    "confirmed": int(bool(getattr(payments, "confirmed", _false)(ref))),
+                    "mode": mode,
+                }
+            )
+        )
+
+    async def _attempt_refund(self, ctx: AgentContext, mode: str) -> None:
+        payments = ctx.plugins["payments"]
+        try:
+            await payments.refund(self._ref)
+        except NotImplementedError as exc:
+            await ctx.broadcast(
+                _emit(
+                    {
+                        "kind": "refund_unsupported",
+                        "ref": str(self._ref),
+                        "reason": type(exc).__name__,
+                        "mode": mode,
+                    }
+                )
+            )
+            return
+        except (RuntimeError, ValueError):
+            await ctx.broadcast(
+                _emit({"kind": "refund_failed", "ref": str(self._ref), "mode": mode})
+            )
+            return
+        await ctx.broadcast(_emit({"kind": "refunded", "ref": str(self._ref), "mode": mode}))
+
+
+def _false(_ref: PaymentRef) -> bool:
+    """Fallback for payments plugins without a ``confirmed`` method.
+
+    Example::
+
+        assert _false(PaymentRef("r")) is False
+    """
+    return False
+
+
+class PravaSellerAgent(StateMachineAgent):
+    """Passive counterparty. Announces itself so the pair is visible in the trace.
+
+    The seller does not settle anything: in the Prava model the buyer's mandate
+    is charged and the funds are routed by the card network, so there is no
+    seller-side call to make.
+
+    Example::
+
+        agent = PravaSellerAgent(AgentId("seller-0"))
+    """
+
+    def __init__(self, agent_id: AgentId) -> None:
+        self._id = agent_id
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        await ctx.broadcast(_emit({"kind": "offering", "seller": str(self._id)}))
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        return None
+
+
+def prava_commerce_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Build buyer/seller pairs and inject per-buyer Prava plugin instances.
+
+    Reads ``task.config`` for every knob (all optional except ``mandate_id``,
+    which is required in ``live`` mode):
+
+    ``pairs``, ``mandate_id``, ``mode``, ``prava_env``, ``currency``,
+    ``minor_unit_exponent``, ``unit_price_minor``, ``cap_minor``,
+    ``overcap_minor``, ``fail_closed``, ``timeout_s``, ``max_retries``,
+    ``authorization_code``.
+
+    The API key is never read from YAML -- the plugin pulls it from
+    ``PRAVA_API_KEY``.
+
+    Only buyers receive a payments instance keyed to themselves, via the
+    ``_agent_plugins`` override channel the runner understands. If the selected
+    payments class does not accept the Prava keyword arguments, the factory
+    falls back to the positional-only constructor so the scenario still runs
+    (and emits no ``prava:*`` events, which is the honest signal that the rail
+    was not exercised).
+
+    Example::
+
+        agents = prava_commerce_factory(config, plugins)
+    """
+    task_config: dict[str, Any] = config.task.config
+    pairs = int(task_config.get("pairs", DEFAULT_PAIRS))
+    unit_price_minor = int(task_config.get("unit_price_minor", DEFAULT_UNIT_PRICE_MINOR))
+    overcap_minor = int(task_config.get("overcap_minor", DEFAULT_OVERCAP_MINOR))
+    currency = str(task_config.get("currency", "USD"))
+
+    plugin_kwargs: dict[str, Any] = {
+        "mandate_id": str(task_config.get("mandate_id", "mdt_simulated_demo")),
+        "mode": str(task_config.get("mode", "simulated")),
+        "prava_env": str(task_config.get("prava_env", "sandbox")),
+        "currency": currency,
+        "minor_unit_exponent": int(task_config.get("minor_unit_exponent", 2)),
+        "unit_price_minor": unit_price_minor,
+        "cap_minor": int(task_config.get("cap_minor", 100_000)),
+        "fail_closed": bool(task_config.get("fail_closed", True)),
+        "timeout_s": float(task_config.get("timeout_s", 30.0)),
+        "max_retries": int(task_config.get("max_retries", 3)),
+        "authorization_code": task_config.get("authorization_code"),
+    }
+
+    payments_cls = plugins["payments"]
+    agents: dict[AgentId, StateMachineAgent] = {}
+    overrides: dict[AgentId, dict[str, Any]] = {}
+
+    for index in range(pairs):
+        buyer_id = AgentId(f"buyer-{index}")
+        seller_id = AgentId(f"seller-{index}")
+        ref = PaymentRef(f"prava-{config.seed}-{index}")
+
+        agents[buyer_id] = PravaBuyerAgent(
+            buyer_id,
+            seller=seller_id,
+            ref=ref,
+            amount_minor=unit_price_minor,
+            overcap_minor=overcap_minor,
+            currency=currency,
+        )
+        agents[seller_id] = PravaSellerAgent(seller_id)
+
+        try:
+            instance = payments_cls(buyer_id, **plugin_kwargs)
+        except TypeError:
+            instance = payments_cls(buyer_id)
+        overrides[buyer_id] = {"payments": instance}
+
+    plugins["_agent_plugins"] = overrides
+    return agents

--- a/packages/nest-core/nest_core/scenarios_builtin/prava_commerce.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/prava_commerce.py
@@ -97,18 +97,23 @@ Example::
 """
 
 
-def _load_intent_snapshot(path: str) -> tuple[str, int, str]:
-    """Read a purchase-intent snapshot and return ``(service_ref, minor, digest)``.
+def _load_intent_snapshot(path: str) -> tuple[str, int, str, str | None, str | None]:
+    """Read a snapshot; return ref, minor units, digest, intent id and mandate digest.
+
+    The **mandate digest** covers only ``certificate.committed_reference`` -- the
+    terms. Those are fixed when the intent is declared and never change, so two
+    snapshots recording different selections against one request share this
+    value while their full digests differ. Stamped into the trace, it is the
+    evidence that the terms were not rewritten to fit what an agent found.
 
     Parsed with the standard library rather than
     ``nest_plugins_reference.payments.prava_intent`` because ``nest_core`` must
     not import the plugin package. That module remains the canonical validated
-    loader for library consumers and for the plugin's own tests; this reads the
-    three fields the scenario needs and lets the plugin reject anything wrong.
+    loader; the canonical JSON form here is identical, so the digests match.
 
     Example::
 
-        ref, minor, digest = _load_intent_snapshot("scenarios/intents/x.json")
+        ref, minor, digest, intent_id, mandate = _load_intent_snapshot(path)
 
     Raises:
         ValueError: If the file is unreadable, is not a JSON object, or lacks
@@ -147,7 +152,23 @@ def _load_intent_snapshot(path: str) -> tuple[str, int, str]:
         ensure_ascii=False,
     )
     digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
-    return service_ref, amount_minor, digest
+
+    mandate_digest: str | None = None
+    certificate = data.get("certificate")
+    if isinstance(certificate, dict):
+        committed = cast("dict[str, Any]", certificate).get("committed_reference")
+        if isinstance(committed, dict):
+            mandate_canonical = json.dumps(
+                cast("dict[str, Any]", committed),
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            )
+            mandate_digest = hashlib.sha256(mandate_canonical.encode("utf-8")).hexdigest()
+
+    raw_id = data.get("intent_id")
+    intent_id = raw_id if isinstance(raw_id, str) and raw_id.strip() else None
+    return service_ref, amount_minor, digest, intent_id, mandate_digest
 
 
 def _emit(fields: dict[str, str | int]) -> bytes:
@@ -196,6 +217,9 @@ class PravaBuyerAgent(StateMachineAgent):
         delivery_product_id: str | None = None,
         delivery_merchant: str | None = None,
         days_since_delivery: int | None = None,
+        intent_digest: str | None = None,
+        intent_id: str | None = None,
+        mandate_digest: str | None = None,
     ) -> None:
         self._id = agent_id
         self._seller = seller
@@ -208,8 +232,36 @@ class PravaBuyerAgent(StateMachineAgent):
         self._delivery_product_id = delivery_product_id
         self._delivery_merchant = delivery_merchant
         self._days_since_delivery = days_since_delivery
+        self._intent_digest = intent_digest
+        self._intent_id = intent_id
+        self._mandate_digest = mandate_digest
         self._quoted_minor: int | None = None
         self._paid = False
+
+    def _stamped(self, fields: dict[str, str | int]) -> bytes:
+        """Attach the intent identifiers to ``fields`` and encode the broadcast.
+
+        Every event this agent emits carries the same three values, so one grep
+        over a trace returns the whole journey -- quote, delivery, conformance,
+        settlement, verification, return -- rather than a single line the reader
+        has to trust the rest of the run agreed with.
+
+        ``mandate`` is the digest of the terms alone and is identical across
+        snapshots that record different selections against one request;
+        ``intent`` covers the selection too and differs. Both are content
+        derived, so an edit made mid-flight would show up as a mismatch.
+
+        Example::
+
+            await ctx.broadcast(agent._stamped({"kind": "paid"}))
+        """
+        if self._intent_id is not None:
+            fields["intent_id"] = self._intent_id
+        if self._intent_digest is not None:
+            fields["intent"] = self._intent_digest[:12]
+        if self._mandate_digest is not None:
+            fields["mandate"] = self._mandate_digest[:12]
+        return _emit(fields)
 
     def _charge_minor(self) -> int:
         """Amount to charge: the quoted price once quoted, else the configured one.
@@ -256,11 +308,8 @@ class PravaBuyerAgent(StateMachineAgent):
                 source = meta.get("source")
                 if source is not None:
                     fields["source"] = str(source)
-                digest = meta.get("intent_digest")
-                if digest is not None:
-                    fields["intent"] = str(digest)[:12]
             fields["mode"] = mode
-            await ctx.broadcast(_emit(fields))
+            await ctx.broadcast(self._stamped(fields))
             return
 
         money = Money(amount=self._charge_minor(), currency=self._currency)
@@ -327,7 +376,7 @@ class PravaBuyerAgent(StateMachineAgent):
             "amount": int(self._charge_minor()),
             "mode": mode,
         }
-        await ctx.broadcast(_emit(fields))
+        await ctx.broadcast(self._stamped(fields))
 
         check = getattr(payments, "check_delivery", None)
         if check is None:
@@ -345,7 +394,7 @@ class PravaBuyerAgent(StateMachineAgent):
                 verdict["actual"] = str(getattr(check_item, "actual", ""))
                 break
         verdict["mode"] = mode
-        await ctx.broadcast(_emit(verdict))
+        await ctx.broadcast(self._stamped(verdict))
 
     async def _request_return(self, ctx: AgentContext, mode: str) -> None:
         """Ask whether a return falls inside the certified window.
@@ -365,7 +414,7 @@ class PravaBuyerAgent(StateMachineAgent):
             return
         if not self._paid:
             await ctx.broadcast(
-                _emit(
+                self._stamped(
                     {
                         "kind": "return",
                         "ref": str(self._ref),
@@ -394,7 +443,7 @@ class PravaBuyerAgent(StateMachineAgent):
         if approved:
             fields["settlement"] = "unavailable_on_rail"
         fields["mode"] = mode
-        await ctx.broadcast(_emit(fields))
+        await ctx.broadcast(self._stamped(fields))
 
     async def _attempt_pay(
         self,
@@ -411,7 +460,7 @@ class PravaBuyerAgent(StateMachineAgent):
             raise
         except (RuntimeError, ValueError) as exc:
             await ctx.broadcast(
-                _emit(
+                self._stamped(
                     {
                         "kind": "refused",
                         "step": kind,
@@ -425,7 +474,7 @@ class PravaBuyerAgent(StateMachineAgent):
             )
             return
         await ctx.broadcast(
-            _emit(
+            self._stamped(
                 {
                     "kind": kind,
                     "ref": str(receipt.ref),
@@ -447,7 +496,7 @@ class PravaBuyerAgent(StateMachineAgent):
             await payments.refund(self._ref)
         except NotImplementedError as exc:
             await ctx.broadcast(
-                _emit(
+                self._stamped(
                     {
                         "kind": "refund_unsupported",
                         "ref": str(self._ref),
@@ -459,10 +508,12 @@ class PravaBuyerAgent(StateMachineAgent):
             return
         except (RuntimeError, ValueError):
             await ctx.broadcast(
-                _emit({"kind": "refund_failed", "ref": str(self._ref), "mode": mode})
+                self._stamped({"kind": "refund_failed", "ref": str(self._ref), "mode": mode})
             )
             return
-        await ctx.broadcast(_emit({"kind": "refunded", "ref": str(self._ref), "mode": mode}))
+        await ctx.broadcast(
+            self._stamped({"kind": "refunded", "ref": str(self._ref), "mode": mode})
+        )
 
 
 def _false(_ref: PaymentRef) -> bool:
@@ -551,8 +602,16 @@ def prava_commerce_factory(
     service_ref: str | None = None
     price_book: dict[str, int] | None = None
     intent_digest: str | None = None
+    intent_id: str | None = None
+    mandate_digest: str | None = None
     if snapshot_path:
-        service_ref, unit_price_minor, intent_digest = _load_intent_snapshot(str(snapshot_path))
+        (
+            service_ref,
+            unit_price_minor,
+            intent_digest,
+            intent_id,
+            mandate_digest,
+        ) = _load_intent_snapshot(str(snapshot_path))
         price_book = {service_ref: unit_price_minor}
 
     require_conformance = bool(task_config.get("require_conformance", False))
@@ -602,6 +661,9 @@ def prava_commerce_factory(
             delivery_product_id=(str(delivery_product_id) if delivery_product_id else None),
             delivery_merchant=(str(delivery_merchant) if delivery_merchant else None),
             days_since_delivery=days_since_delivery,
+            intent_digest=intent_digest,
+            intent_id=intent_id,
+            mandate_digest=mandate_digest,
         )
         agents[seller_id] = PravaSellerAgent(seller_id)
 

--- a/packages/nest-core/nest_core/scenarios_builtin/prava_commerce.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/prava_commerce.py
@@ -49,18 +49,22 @@ from nest_core.sim.agent import AgentContext, StateMachineAgent
 from nest_core.types import AgentId, Money, PaymentRef, ServiceRef
 
 _TICK_QUOTE = 1.0
+_TICK_DELIVERY = 2.0
 _TICK_PAY = 3.0
 _TICK_REPLAY = 5.0
 _TICK_VERIFY = 7.0
 _TICK_OVERCAP = 9.0
 _TICK_REFUND = 11.0
+_TICK_RETURN = 13.0
 
 _OP_QUOTE = b"op:quote"
+_OP_DELIVERY = b"op:delivery"
 _OP_PAY = b"op:pay"
 _OP_REPLAY = b"op:replay"
 _OP_VERIFY = b"op:verify"
 _OP_OVERCAP = b"op:overcap"
 _OP_REFUND = b"op:refund"
+_OP_RETURN = b"op:return"
 
 DEFAULT_PAIRS = 2
 """Number of buyer/seller pairs when ``task.config`` does not say.
@@ -189,6 +193,9 @@ class PravaBuyerAgent(StateMachineAgent):
         overcap_minor: int,
         currency: str,
         service_ref: str | None = None,
+        delivery_product_id: str | None = None,
+        delivery_merchant: str | None = None,
+        days_since_delivery: int | None = None,
     ) -> None:
         self._id = agent_id
         self._seller = seller
@@ -198,7 +205,11 @@ class PravaBuyerAgent(StateMachineAgent):
         self._overcap_minor = overcap_minor
         self._currency = currency
         self._service_ref = service_ref if service_ref else f"svc-{seller}"
+        self._delivery_product_id = delivery_product_id
+        self._delivery_merchant = delivery_merchant
+        self._days_since_delivery = days_since_delivery
         self._quoted_minor: int | None = None
+        self._paid = False
 
     def _charge_minor(self) -> int:
         """Amount to charge: the quoted price once quoted, else the configured one.
@@ -215,11 +226,15 @@ class PravaBuyerAgent(StateMachineAgent):
 
     async def on_start(self, ctx: AgentContext) -> None:
         await ctx.schedule(_TICK_QUOTE, _OP_QUOTE)
+        if self._delivery_product_id is not None:
+            await ctx.schedule(_TICK_DELIVERY, _OP_DELIVERY)
         await ctx.schedule(_TICK_PAY, _OP_PAY)
         await ctx.schedule(_TICK_REPLAY, _OP_REPLAY)
         await ctx.schedule(_TICK_VERIFY, _OP_VERIFY)
         await ctx.schedule(_TICK_OVERCAP, _OP_OVERCAP)
         await ctx.schedule(_TICK_REFUND, _OP_REFUND)
+        if self._days_since_delivery is not None:
+            await ctx.schedule(_TICK_RETURN, _OP_RETURN)
 
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
         payments = ctx.plugins["payments"]
@@ -249,6 +264,10 @@ class PravaBuyerAgent(StateMachineAgent):
             return
 
         money = Money(amount=self._charge_minor(), currency=self._currency)
+
+        if payload == _OP_DELIVERY:
+            await self._announce_delivery(ctx, mode)
+            return
 
         if payload == _OP_PAY:
             await self._attempt_pay(ctx, money, self._ref, mode, kind="paid")
@@ -280,6 +299,102 @@ class PravaBuyerAgent(StateMachineAgent):
 
         if payload == _OP_REFUND:
             await self._attempt_refund(ctx, mode)
+            return
+
+        if payload == _OP_RETURN:
+            await self._request_return(ctx, mode)
+
+    async def _announce_delivery(self, ctx: AgentContext, mode: str) -> None:
+        """Record what is being delivered, then judge it against the certified intent.
+
+        The verdict is broadcast before the pay tick, so a reader sees the check
+        that decided whether a charge was ever attempted.
+
+        Example::
+
+            await agent._announce_delivery(ctx, "simulated")
+        """
+        payments = ctx.plugins["payments"]
+        record = getattr(payments, "record_delivery", None)
+        if record is None:
+            return
+        record(product_id=self._delivery_product_id, merchant=self._delivery_merchant)
+        fields: dict[str, str | int] = {
+            "kind": "delivery",
+            "buyer": str(self._id),
+            "product": str(self._delivery_product_id),
+            "merchant": str(self._delivery_merchant or "unspecified"),
+            "amount": int(self._charge_minor()),
+            "mode": mode,
+        }
+        await ctx.broadcast(_emit(fields))
+
+        check = getattr(payments, "check_delivery", None)
+        if check is None:
+            return
+        result = check(amount_minor=self._charge_minor())
+        verdict: dict[str, str | int] = {
+            "kind": "conformance",
+            "buyer": str(self._id),
+            "result": "pass" if bool(getattr(result, "passed", False)) else "fail",
+            "reason": str(getattr(result, "reason", "unknown")),
+        }
+        for check_item in getattr(result, "checks", ()):
+            if not bool(getattr(check_item, "passed", True)):
+                verdict["expected"] = str(getattr(check_item, "expected", ""))
+                verdict["actual"] = str(getattr(check_item, "actual", ""))
+                break
+        verdict["mode"] = mode
+        await ctx.broadcast(_emit(verdict))
+
+    async def _request_return(self, ctx: AgentContext, mode: str) -> None:
+        """Ask whether a return falls inside the certified window.
+
+        An approved verdict means the request conforms to terms agreed before
+        the purchase. It does not mean money moved: the Prava API defines no
+        reversal endpoint, so settlement of an approved return happens off this
+        rail. The broadcast says so rather than implying a credit.
+
+        Example::
+
+            await agent._request_return(ctx, "simulated")
+        """
+        payments = ctx.plugins["payments"]
+        judge = getattr(payments, "judge_return", None)
+        if judge is None or self._days_since_delivery is None:
+            return
+        if not self._paid:
+            await ctx.broadcast(
+                _emit(
+                    {
+                        "kind": "return",
+                        "ref": str(self._ref),
+                        "result": "not_applicable",
+                        "reason": "no_settled_purchase",
+                        "day": int(self._days_since_delivery),
+                        "mode": mode,
+                    }
+                )
+            )
+            return
+        try:
+            verdict = judge(days_since_delivery=self._days_since_delivery)
+        except (RuntimeError, ValueError):
+            return
+        approved = bool(getattr(verdict, "approved", False))
+        window = getattr(verdict, "window_days", None)
+        fields: dict[str, str | int] = {
+            "kind": "return",
+            "ref": str(self._ref),
+            "result": "approved" if approved else "denied",
+            "reason": str(getattr(verdict, "reason", "unknown")),
+            "day": int(self._days_since_delivery),
+            "window": int(window) if isinstance(window, int) else -1,
+        }
+        if approved:
+            fields["settlement"] = "unavailable_on_rail"
+        fields["mode"] = mode
+        await ctx.broadcast(_emit(fields))
 
     async def _attempt_pay(
         self,
@@ -323,6 +438,8 @@ class PravaBuyerAgent(StateMachineAgent):
                 }
             )
         )
+        if ref == self._ref:
+            self._paid = True
 
     async def _attempt_refund(self, ctx: AgentContext, mode: str) -> None:
         payments = ctx.plugins["payments"]
@@ -391,8 +508,17 @@ def prava_commerce_factory(
 
     ``pairs``, ``mandate_id``, ``mode``, ``prava_env``, ``currency``,
     ``minor_unit_exponent``, ``unit_price_minor``, ``intent_snapshot``,
+    ``require_conformance``, ``delivery``, ``days_since_delivery``,
     ``cap_minor``, ``overcap_minor``, ``fail_closed``, ``timeout_s``,
     ``max_retries``, ``authorization_code``.
+
+    ``require_conformance`` is opt-in and defaults to ``False``. Only when it is
+    set does the plugin receive the certified intent and gate ``pay`` on it, so
+    an existing scenario that merely names an ``intent_snapshot`` keeps its
+    previous behaviour byte for byte. ``delivery`` (``product_id``,
+    ``merchant``) is what a counterparty claims to be shipping, and
+    ``days_since_delivery`` drives the return verdict -- supplied as config
+    rather than read from the clock so the trace stays reproducible.
 
     ``intent_snapshot`` is a path to a frozen purchase-intent file describing an
     item an upstream LLM shopper selected. When present it supplies the service
@@ -429,6 +555,16 @@ def prava_commerce_factory(
         service_ref, unit_price_minor, intent_digest = _load_intent_snapshot(str(snapshot_path))
         price_book = {service_ref: unit_price_minor}
 
+    require_conformance = bool(task_config.get("require_conformance", False))
+    delivery_raw = task_config.get("delivery")
+    delivery: dict[str, Any] = (
+        cast("dict[str, Any]", delivery_raw) if isinstance(delivery_raw, dict) else {}
+    )
+    delivery_product_id = delivery.get("product_id")
+    delivery_merchant = delivery.get("merchant")
+    days_raw = task_config.get("days_since_delivery")
+    days_since_delivery = int(days_raw) if days_raw is not None else None
+
     plugin_kwargs: dict[str, Any] = {
         "mandate_id": str(task_config.get("mandate_id", "mdt_simulated_demo")),
         "mode": str(task_config.get("mode", "simulated")),
@@ -438,6 +574,7 @@ def prava_commerce_factory(
         "unit_price_minor": unit_price_minor,
         "price_book": price_book,
         "intent_digest": intent_digest,
+        "intent_snapshot": str(snapshot_path) if (snapshot_path and require_conformance) else None,
         "cap_minor": int(task_config.get("cap_minor", 100_000)),
         "fail_closed": bool(task_config.get("fail_closed", True)),
         "timeout_s": float(task_config.get("timeout_s", 30.0)),
@@ -462,6 +599,9 @@ def prava_commerce_factory(
             overcap_minor=overcap_minor,
             currency=currency,
             service_ref=service_ref,
+            delivery_product_id=(str(delivery_product_id) if delivery_product_id else None),
+            delivery_merchant=(str(delivery_merchant) if delivery_merchant else None),
+            days_since_delivery=days_since_delivery,
         )
         agents[seller_id] = PravaSellerAgent(seller_id)
 

--- a/packages/nest-core/nest_core/scenarios_builtin/prava_commerce.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/prava_commerce.py
@@ -39,7 +39,10 @@ Example::
 
 from __future__ import annotations
 
-from typing import Any
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, cast
 
 from nest_core.scenario import ScenarioConfig
 from nest_core.sim.agent import AgentContext, StateMachineAgent
@@ -90,6 +93,59 @@ Example::
 """
 
 
+def _load_intent_snapshot(path: str) -> tuple[str, int, str]:
+    """Read a purchase-intent snapshot and return ``(service_ref, minor, digest)``.
+
+    Parsed with the standard library rather than
+    ``nest_plugins_reference.payments.prava_intent`` because ``nest_core`` must
+    not import the plugin package. That module remains the canonical validated
+    loader for library consumers and for the plugin's own tests; this reads the
+    three fields the scenario needs and lets the plugin reject anything wrong.
+
+    Example::
+
+        ref, minor, digest = _load_intent_snapshot("scenarios/intents/x.json")
+
+    Raises:
+        ValueError: If the file is unreadable, is not a JSON object, or lacks
+            ``item.service_ref`` or ``settlement.amount_minor``.
+    """
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+        payload: Any = json.loads(text)
+    except (OSError, json.JSONDecodeError) as exc:
+        msg = f"cannot read purchase-intent snapshot {path!r}: {exc}"
+        raise ValueError(msg) from exc
+    if not isinstance(payload, dict):
+        msg = f"purchase-intent snapshot {path!r} must contain a JSON object"
+        raise ValueError(msg)
+    data = cast("dict[str, Any]", payload)
+    item = data.get("item")
+    settlement = data.get("settlement")
+    if not isinstance(item, dict) or not isinstance(settlement, dict):
+        msg = f"purchase-intent snapshot {path!r} needs 'item' and 'settlement' objects"
+        raise ValueError(msg)
+    service_ref = cast("dict[str, Any]", item).get("service_ref")
+    amount_minor = cast("dict[str, Any]", settlement).get("amount_minor")
+    if not isinstance(service_ref, str) or not service_ref.strip():
+        msg = f"purchase-intent snapshot {path!r} has no usable item.service_ref"
+        raise ValueError(msg)
+    if isinstance(amount_minor, bool) or not isinstance(amount_minor, int) or amount_minor <= 0:
+        msg = (
+            f"purchase-intent snapshot {path!r} settlement.amount_minor must be a "
+            f"positive integer, got {amount_minor!r}"
+        )
+        raise ValueError(msg)
+    canonical = json.dumps(
+        data,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return service_ref, amount_minor, digest
+
+
 def _emit(fields: dict[str, str | int]) -> bytes:
     """Build a ``prava:<kind>:k=v:...`` broadcast payload.
 
@@ -120,6 +176,7 @@ class PravaBuyerAgent(StateMachineAgent):
             amount_minor=4_000,
             overcap_minor=99_999_900,
             currency="USD",
+            service_ref="libas:98252-2XL",
         )
     """
 
@@ -131,6 +188,7 @@ class PravaBuyerAgent(StateMachineAgent):
         amount_minor: int,
         overcap_minor: int,
         currency: str,
+        service_ref: str | None = None,
     ) -> None:
         self._id = agent_id
         self._seller = seller
@@ -139,6 +197,21 @@ class PravaBuyerAgent(StateMachineAgent):
         self._amount_minor = amount_minor
         self._overcap_minor = overcap_minor
         self._currency = currency
+        self._service_ref = service_ref if service_ref else f"svc-{seller}"
+        self._quoted_minor: int | None = None
+
+    def _charge_minor(self) -> int:
+        """Amount to charge: the quoted price once quoted, else the configured one.
+
+        The quote is authoritative. Charging a separately configured constant
+        would let the quoted price and the settled amount drift apart silently,
+        which is exactly the bug an agentic payment rail must not have.
+
+        Example::
+
+            minor = agent._charge_minor()
+        """
+        return self._quoted_minor if self._quoted_minor is not None else self._amount_minor
 
     async def on_start(self, ctx: AgentContext) -> None:
         await ctx.schedule(_TICK_QUOTE, _OP_QUOTE)
@@ -151,23 +224,31 @@ class PravaBuyerAgent(StateMachineAgent):
     async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
         payments = ctx.plugins["payments"]
         mode = str(getattr(payments, "mode", "unknown"))
-        money = Money(amount=self._amount_minor, currency=self._currency)
 
         if payload == _OP_QUOTE:
-            quote = await payments.quote(ServiceRef(f"svc-{self._seller}"))
-            await ctx.broadcast(
-                _emit(
-                    {
-                        "kind": "quoted",
-                        "buyer": str(self._id),
-                        "service": str(quote.service),
-                        "price": int(quote.price.amount),
-                        "currency": str(quote.price.currency),
-                        "mode": mode,
-                    }
-                )
-            )
+            quote = await payments.quote(ServiceRef(self._service_ref))
+            self._quoted_minor = int(quote.price.amount)
+            fields: dict[str, str | int] = {
+                "kind": "quoted",
+                "buyer": str(self._id),
+                "service": str(quote.service),
+                "price": int(quote.price.amount),
+                "currency": str(quote.price.currency),
+            }
+            metadata = getattr(quote, "metadata", None)
+            if isinstance(metadata, dict):
+                meta = cast("dict[str, Any]", metadata)
+                source = meta.get("source")
+                if source is not None:
+                    fields["source"] = str(source)
+                digest = meta.get("intent_digest")
+                if digest is not None:
+                    fields["intent"] = str(digest)[:12]
+            fields["mode"] = mode
+            await ctx.broadcast(_emit(fields))
             return
+
+        money = Money(amount=self._charge_minor(), currency=self._currency)
 
         if payload == _OP_PAY:
             await self._attempt_pay(ctx, money, self._ref, mode, kind="paid")
@@ -309,9 +390,16 @@ def prava_commerce_factory(
     which is required in ``live`` mode):
 
     ``pairs``, ``mandate_id``, ``mode``, ``prava_env``, ``currency``,
-    ``minor_unit_exponent``, ``unit_price_minor``, ``cap_minor``,
-    ``overcap_minor``, ``fail_closed``, ``timeout_s``, ``max_retries``,
-    ``authorization_code``.
+    ``minor_unit_exponent``, ``unit_price_minor``, ``intent_snapshot``,
+    ``cap_minor``, ``overcap_minor``, ``fail_closed``, ``timeout_s``,
+    ``max_retries``, ``authorization_code``.
+
+    ``intent_snapshot`` is a path to a frozen purchase-intent file describing an
+    item an upstream LLM shopper selected. When present it supplies the service
+    ref the buyer quotes and the price book the plugin prices from, so the
+    amount charged is the amount that shopper agreed to rather than a constant
+    in YAML. When absent the scenario keeps its synthetic ``svc-<seller>`` ref
+    and ``unit_price_minor``.
 
     The API key is never read from YAML -- the plugin pulls it from
     ``PRAVA_API_KEY``.
@@ -333,6 +421,14 @@ def prava_commerce_factory(
     overcap_minor = int(task_config.get("overcap_minor", DEFAULT_OVERCAP_MINOR))
     currency = str(task_config.get("currency", "USD"))
 
+    snapshot_path = task_config.get("intent_snapshot")
+    service_ref: str | None = None
+    price_book: dict[str, int] | None = None
+    intent_digest: str | None = None
+    if snapshot_path:
+        service_ref, unit_price_minor, intent_digest = _load_intent_snapshot(str(snapshot_path))
+        price_book = {service_ref: unit_price_minor}
+
     plugin_kwargs: dict[str, Any] = {
         "mandate_id": str(task_config.get("mandate_id", "mdt_simulated_demo")),
         "mode": str(task_config.get("mode", "simulated")),
@@ -340,6 +436,8 @@ def prava_commerce_factory(
         "currency": currency,
         "minor_unit_exponent": int(task_config.get("minor_unit_exponent", 2)),
         "unit_price_minor": unit_price_minor,
+        "price_book": price_book,
+        "intent_digest": intent_digest,
         "cap_minor": int(task_config.get("cap_minor", 100_000)),
         "fail_closed": bool(task_config.get("fail_closed", True)),
         "timeout_s": float(task_config.get("timeout_s", 30.0)),
@@ -363,6 +461,7 @@ def prava_commerce_factory(
             amount_minor=unit_price_minor,
             overcap_minor=overcap_minor,
             currency=currency,
+            service_ref=service_ref,
         )
         agents[seller_id] = PravaSellerAgent(seller_id)
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/prava.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/prava.py
@@ -1,0 +1,518 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prava payments plugin -- settles Nanda Town payments on Visa rails via Prava.
+
+Maps the four ``Payments`` protocol methods onto Prava's agentic-payments
+mandate API:
+
+===================  ==========================================================
+``quote``            Local price book; no network call. Prava has no quote API.
+``pay``              ``POST /v1/mandates/{id}/charge`` then
+                     ``POST /v1/mandates/{id}/charges/{txn}/report``.
+``verify_payment``   ``GET /v1/mandates/{id}``, then locate the charge by its
+                     idempotency ``reference``. Authoritative: the answer comes
+                     from Prava's ledger, not from local state.
+``refund``           Raises :class:`PravaRefundUnsupportedError`. The Prava
+                     OpenAPI document defines no refund, credit or reversal
+                     endpoint, so a silent no-op here would be a fabricated
+                     capability.
+===================  ==========================================================
+
+**The binding.** ``PaymentRef`` is passed straight through as Prava's
+``reference``, which Prava documents as an idempotency key. Nanda Town derives
+payment refs deterministically from the scenario seed, so replaying a
+simulation emits the same references and the *card network itself* refuses the
+second charge. Replay safety stops being an assertion in our code and becomes a
+property enforced by the payment rail.
+
+**Two modes, never confused.** ``mode="simulated"`` runs against
+:class:`~nest_plugins_reference.payments.prava_client.SimulatedPravaTransport`
+-- an in-process test double that moves no money. ``mode="live"`` runs against
+the real sandbox or production host. There is deliberately no ``dry_run`` flag
+that returns a synthetic ``Receipt``: that would make a simulated trace
+indistinguishable from a settled one. :attr:`PravaPayments.mode` is public and
+:meth:`PravaPayments.confirmed` reports whether the merchant-report leg closed,
+so a reader can always tell what actually happened. (``Receipt`` itself carries
+no metadata field, so the mode is surfaced on the plugin and in the scenario's
+broadcast events rather than smuggled into the receipt.)
+
+**Mandate provisioning is out of band.** Creating a mandate requires
+``POST /v1/sessions`` with a ``mandate_setup`` block and a *human passkey
+approval*. That cannot happen mid-simulation, so ``mandate_id`` is provisioned
+beforehand and injected as config. The API key is read from ``PRAVA_API_KEY``
+and never appears in scenario YAML.
+
+Example::
+
+    payments = PravaPayments(
+        AgentId("buyer-0"),
+        mandate_id="mdt_demo",
+        mode="simulated",
+        cap_minor=10_000,
+        unit_price_minor=4_000,
+    )
+    receipt = await payments.pay(
+        AgentId("seller-0"), Money(amount=4_000, currency="USD"), PaymentRef("r-1")
+    )
+"""
+
+from __future__ import annotations
+
+import os
+
+from nest_core.types import (
+    AgentId,
+    Money,
+    PaymentRef,
+    PaymentStatus,
+    Quote,
+    Receipt,
+    ServiceRef,
+)
+
+from nest_plugins_reference.payments.prava_client import (
+    PRODUCTION_BASE_URL,
+    SANDBOX_BASE_URL,
+    ChargeResult,
+    HttpxPravaTransport,
+    PravaClient,
+    PravaConfigError,
+    PravaError,
+    PravaTransport,
+    SimulatedPravaTransport,
+)
+
+MODE_SIMULATED = "simulated"
+"""Run against the in-process test double. No money moves.
+
+Example::
+
+    payments = PravaPayments(AgentId("a"), mandate_id="m", mode=MODE_SIMULATED)
+"""
+
+MODE_LIVE = "live"
+"""Run against a real Prava host. Requires ``PRAVA_API_KEY``.
+
+Example::
+
+    payments = PravaPayments(AgentId("a"), mandate_id="m", mode=MODE_LIVE)
+"""
+
+ENV_SANDBOX = "sandbox"
+"""Target ``https://sandbox.api.prava.space``.
+
+Example::
+
+    env = ENV_SANDBOX
+"""
+
+ENV_PRODUCTION = "production"
+"""Target ``https://api.prava.space``.
+
+Example::
+
+    env = ENV_PRODUCTION
+"""
+
+_MODES = (MODE_SIMULATED, MODE_LIVE)
+_ENVS = (ENV_SANDBOX, ENV_PRODUCTION)
+_NEUTRAL_CURRENCY = "credits"
+
+
+class PravaPaymentError(RuntimeError):
+    """Raised when a Prava charge is refused, declined or left unconfirmed.
+
+    ``over_cap`` is ``True`` only for the mandate-threshold refusal
+    (``THRESHOLD_EXCEEDED``), which is terminal for the mandate; an ordinary
+    decline is not.
+
+    Example::
+
+        try:
+            await payments.pay(seller, Money(amount=999_999), PaymentRef("r"))
+        except PravaPaymentError as exc:
+            if exc.over_cap:
+                stop_buying()
+    """
+
+    def __init__(self, message: str, over_cap: bool = False, code: str | None = None) -> None:
+        self.over_cap = over_cap
+        self.code = code
+        super().__init__(message)
+
+
+class PravaRefundUnsupportedError(NotImplementedError):
+    """Raised by :meth:`PravaPayments.refund`. Prava exposes no refund endpoint.
+
+    Verified against the official OpenAPI 3.1 document at
+    https://docs.prava.space/api-reference/openapi.json -- all 13 paths were
+    read; none is a refund, credit or reversal. Callers needing a reversal must
+    model it as a compensating *forward* payment to the original payer, using a
+    fresh ``PaymentRef``, and record both legs.
+
+    Example::
+
+        try:
+            await payments.refund(PaymentRef("r-1"))
+        except PravaRefundUnsupportedError:
+            await seller_payments.pay(buyer, amount, PaymentRef("r-1-reversal"))
+    """
+
+
+class PravaPayments:
+    """Nanda Town payments plugin backed by the Prava mandate API.
+
+    Configuration is explicit keyword arguments with defaults, all surfaced
+    through the scenario's ``task.config`` block:
+
+    ==========================  =============  =================================
+    Argument                    Default        Meaning
+    ==========================  =============  =================================
+    ``mandate_id``              *required*     Provisioned out of band.
+    ``mode``                    ``simulated``  ``simulated`` | ``live``.
+    ``prava_env``               ``sandbox``    ``sandbox`` | ``production``.
+    ``api_key``                 ``$PRAVA_API_KEY``  Never put this in YAML.
+    ``currency``                ``USD``        ISO 4217 code sent to Prava.
+    ``minor_unit_exponent``     ``2``          0 for JPY/KRW.
+    ``unit_price_minor``        ``4_000``      Price returned by ``quote``.
+    ``cap_minor``               ``100_000``    Simulated-mode mandate ceiling.
+    ``fail_closed``             ``True``       See below.
+    ``timeout_s``               ``30.0``       Live transport only.
+    ``max_retries``             ``3``          Live transport only; 429/5xx.
+    ``authorization_code``      ``None``       Merchant auth code, if any.
+    ==========================  =============  =================================
+
+    ``fail_closed`` governs the *report* leg. A charge that Prava accepted but
+    whose merchant-side report failed is an **unconfirmed** payment. With
+    ``fail_closed=True`` (default) that raises :class:`PravaPaymentError` and no
+    receipt is issued. With ``fail_closed=False`` the receipt is returned marked
+    ``reported=False``, and :meth:`verify_payment` will report ``PENDING`` until
+    the report succeeds -- useful when a scenario wants to observe the
+    uncertainty rather than abort on it. Neither setting ever assumes success.
+
+    Example::
+
+        payments = PravaPayments(
+            AgentId("buyer-0"),
+            mandate_id="mdt_demo",
+            mode="simulated",
+            cap_minor=10_000,
+        )
+        receipt = await payments.pay(
+            AgentId("seller-0"),
+            Money(amount=4_000, currency="USD"),
+            PaymentRef("scenario-42-buyer0-trade0"),
+        )
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        mandate_id: str = "",
+        mode: str = MODE_SIMULATED,
+        prava_env: str = ENV_SANDBOX,
+        api_key: str | None = None,
+        currency: str = "USD",
+        minor_unit_exponent: int = 2,
+        unit_price_minor: int = 4_000,
+        cap_minor: int = 100_000,
+        fail_closed: bool = True,
+        timeout_s: float = 30.0,
+        max_retries: int = 3,
+        authorization_code: str | None = None,
+        transport: PravaTransport | None = None,
+        receipts: dict[PaymentRef, Receipt] | None = None,
+    ) -> None:
+        if mode not in _MODES:
+            msg = f"mode must be one of {_MODES}: {mode!r}"
+            raise PravaConfigError(msg)
+        if prava_env not in _ENVS:
+            msg = f"prava_env must be one of {_ENVS}: {prava_env!r}"
+            raise PravaConfigError(msg)
+        if not mandate_id:
+            msg = (
+                "mandate_id is required. Prava mandates are created by "
+                "POST /v1/sessions with a human passkey approval, which cannot "
+                "happen mid-simulation -- provision one first and inject it."
+            )
+            raise PravaConfigError(msg)
+
+        self._agent_id = agent_id
+        self._mandate_id = mandate_id
+        self._mode = mode
+        self._currency = currency
+        self._exponent = minor_unit_exponent
+        self._unit_price_minor = unit_price_minor
+        self._fail_closed = fail_closed
+        self._authorization_code = authorization_code
+        self._receipts: dict[PaymentRef, Receipt] = receipts if receipts is not None else {}
+        self._confirmed: dict[PaymentRef, bool] = {}
+
+        chosen = (
+            transport
+            if transport is not None
+            else self._build_transport(
+                mode=mode,
+                prava_env=prava_env,
+                api_key=api_key,
+                cap_minor=cap_minor,
+                currency=currency,
+                minor_unit_exponent=minor_unit_exponent,
+                timeout_s=timeout_s,
+                max_retries=max_retries,
+                mandate_id=mandate_id,
+            )
+        )
+        self._client = PravaClient(chosen, minor_unit_exponent=minor_unit_exponent)
+
+    def _build_transport(
+        self,
+        mode: str,
+        prava_env: str,
+        api_key: str | None,
+        cap_minor: int,
+        currency: str,
+        minor_unit_exponent: int,
+        timeout_s: float,
+        max_retries: int,
+        mandate_id: str,
+    ) -> PravaTransport:
+        if mode == MODE_SIMULATED:
+            return SimulatedPravaTransport(
+                mandate_id=mandate_id,
+                cap_minor=cap_minor,
+                currency=currency,
+                exponent=minor_unit_exponent,
+            )
+        key = api_key if api_key is not None else os.environ.get("PRAVA_API_KEY", "")
+        if not key:
+            msg = (
+                "mode='live' requires a Prava secret key. Set PRAVA_API_KEY in the "
+                "environment; never place it in scenario YAML."
+            )
+            raise PravaConfigError(msg)
+        base = PRODUCTION_BASE_URL if prava_env == ENV_PRODUCTION else SANDBOX_BASE_URL
+        return HttpxPravaTransport(
+            api_key=key,
+            base_url=base,
+            timeout_s=timeout_s,
+            max_retries=max_retries,
+        )
+
+    # -- introspection ---------------------------------------------------
+
+    @property
+    def mode(self) -> str:
+        """``"simulated"`` or ``"live"``. Never inferred; always explicit.
+
+        Example::
+
+            assert payments.mode == "simulated"
+        """
+        return self._mode
+
+    @property
+    def mandate_id(self) -> str:
+        """The out-of-band provisioned mandate this plugin charges against.
+
+        Example::
+
+            print(payments.mandate_id)
+        """
+        return self._mandate_id
+
+    def receipt(self, ref: PaymentRef) -> Receipt | None:
+        """Return the locally cached receipt for ``ref``, if this agent made it.
+
+        Local cache only. :meth:`verify_payment` is the authoritative check.
+
+        Example::
+
+            r = payments.receipt(PaymentRef("r-1"))
+        """
+        return self._receipts.get(ref)
+
+    def confirmed(self, ref: PaymentRef) -> bool:
+        """Whether the merchant-report leg closed for ``ref`` in this process.
+
+        ``False`` for a charge Prava accepted but whose report failed under
+        ``fail_closed=False``. Local view only; :meth:`verify_payment` is
+        authoritative.
+
+        Example::
+
+            assert payments.confirmed(PaymentRef("r-1"))
+        """
+        return self._confirmed.get(ref, False)
+
+    # -- Payments protocol -----------------------------------------------
+
+    async def quote(self, service: ServiceRef) -> Quote:
+        """Return the configured unit price. Local; Prava has no quote endpoint.
+
+        The price is a plugin config value rather than a network read because
+        Prava prices nothing -- it authorizes and settles. Keeping the quote
+        local also keeps ``quote`` deterministic under replay.
+
+        Example::
+
+            q = await payments.quote(ServiceRef("svc-1"))
+        """
+        return Quote(
+            service=service,
+            price=Money(amount=self._unit_price_minor, currency=self._currency),
+            metadata={"source": "prava_plugin_price_book", "mode": self._mode},
+        )
+
+    async def pay(self, to: AgentId, amount: Money, ref: PaymentRef) -> Receipt:
+        """Charge the mandate for ``amount``, keyed on ``ref``, then report it.
+
+        ``ref`` becomes Prava's ``reference`` idempotency key verbatim. A
+        replayed ``ref`` returns Prava's original charge with
+        ``deduplicated: true``; the receipt records that, and the mandate is not
+        drawn twice.
+
+        Example::
+
+            receipt = await payments.pay(
+                AgentId("seller-0"),
+                Money(amount=4_000, currency="USD"),
+                PaymentRef("scenario-42-trade-0"),
+            )
+
+        Raises:
+            PravaConfigError: If ``amount`` is not positive or its currency is
+                neither the configured currency nor the layer-neutral
+                ``"credits"``.
+            PravaPaymentError: If Prava refuses the charge, or if the charge was
+                accepted but could not be confirmed and ``fail_closed`` is set.
+        """
+        self._check_currency(amount)
+        if amount.amount <= 0:
+            msg = f"payment amount must be positive: {amount.amount}"
+            raise PravaConfigError(msg)
+
+        try:
+            result = await self._client.charge(
+                self._mandate_id,
+                amount_minor=amount.amount,
+                reference=str(ref),
+                purchase_context=[{"description": f"nest payment {ref} to {to}"}],
+            )
+        except PravaError as exc:
+            msg = f"charge call failed for {ref}: {exc}"
+            raise PravaPaymentError(msg, code=exc.code) from exc
+
+        if not result.accepted:
+            msg = (
+                f"Prava refused charge {ref}: "
+                f"{result.error_code or result.status} {result.error_message or ''}".strip()
+            )
+            raise PravaPaymentError(msg, over_cap=result.over_cap, code=result.error_code)
+
+        self._confirmed[ref] = await self._report(result, amount)
+        receipt = Receipt(
+            ref=ref,
+            payer=self._agent_id,
+            payee=to,
+            amount=Money(amount=amount.amount, currency=self._currency),
+        )
+        self._receipts[ref] = receipt
+        return receipt
+
+    async def _report(self, result: ChargeResult, amount: Money) -> bool:
+        """Run the merchant-report leg. Returns whether it confirmed."""
+        if result.transaction_id is None:
+            if self._fail_closed:
+                msg = "charge accepted but Prava returned no transactionId; cannot confirm"
+                raise PravaPaymentError(msg)
+            return False
+        try:
+            response = await self._client.report_charge(
+                self._mandate_id,
+                transaction_id=result.transaction_id,
+                approved=True,
+                amount_minor=amount.amount,
+                authorization_code=self._authorization_code,
+            )
+        except PravaError as exc:
+            if self._fail_closed:
+                msg = (
+                    f"charge {result.transaction_id} accepted but the report leg "
+                    f"failed ({exc}); payment is UNCONFIRMED and fail_closed is set"
+                )
+                raise PravaPaymentError(msg, code=exc.code) from exc
+            return False
+        return str(response.get("status")) == "completed"
+
+    async def verify_payment(self, ref: PaymentRef) -> PaymentStatus:
+        """Read the charge back from Prava's ledger and map it to a status.
+
+        Authoritative by construction: it re-reads ``GET /v1/mandates/{id}`` and
+        locates the charge by ``reference``, so it reports what the payment rail
+        believes, not what this process believes. A network failure yields
+        ``PENDING`` rather than ``FAILED`` -- an unreachable API is not evidence
+        that a payment did not happen.
+
+        Example::
+
+            status = await payments.verify_payment(PaymentRef("r-1"))
+
+        """
+        try:
+            charge = await self._client.find_charge(self._mandate_id, str(ref))
+        except PravaError:
+            return PaymentStatus.PENDING
+        if charge is None:
+            return PaymentStatus.FAILED
+        status = str(charge.get("status", "")).lower()
+        if status in ("approved", "completed", "settled"):
+            return PaymentStatus.CONFIRMED
+        if status in ("declined", "failed"):
+            return PaymentStatus.FAILED
+        return PaymentStatus.PENDING
+
+    async def refund(self, ref: PaymentRef) -> None:
+        """Always raises. Prava exposes no refund, credit or reversal endpoint.
+
+        See :class:`PravaRefundUnsupportedError` for the verification note and
+        the compensating-payment workaround.
+
+        Example::
+
+            with pytest.raises(PravaRefundUnsupportedError):
+                await payments.refund(PaymentRef("r-1"))
+
+        Raises:
+            PravaRefundUnsupportedError: Always.
+        """
+        msg = (
+            f"cannot refund {ref}: the Prava API defines no refund, credit or "
+            "reversal endpoint (verified against the official OpenAPI document, "
+            "all 13 paths). Model reversals as a compensating forward payment "
+            "with a fresh PaymentRef."
+        )
+        raise PravaRefundUnsupportedError(msg)
+
+    # -- lifecycle -------------------------------------------------------
+
+    async def aclose(self) -> None:
+        """Close the underlying transport.
+
+        Example::
+
+            await payments.aclose()
+        """
+        await self._client.aclose()
+
+    # -- private ---------------------------------------------------------
+
+    def _check_currency(self, amount: Money) -> None:
+        if amount.currency in (self._currency, _NEUTRAL_CURRENCY):
+            return
+        msg = (
+            f"currency mismatch: plugin is configured for {self._currency!r} but "
+            f"was handed {amount.currency!r}. Nanda Town's layer-neutral "
+            f"{_NEUTRAL_CURRENCY!r} is also accepted and interpreted as "
+            f"{self._currency!r}."
+        )
+        raise PravaConfigError(msg)

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/prava.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/prava.py
@@ -80,6 +80,16 @@ from nest_plugins_reference.payments.prava_client import (
     PravaTransport,
     SimulatedPravaTransport,
 )
+from nest_plugins_reference.payments.prava_intent import (
+    ConformanceResult,
+    PurchaseIntent,
+    ReturnVerdict,
+    check_conformance,
+    load_intent,
+)
+from nest_plugins_reference.payments.prava_intent import (
+    judge_return as _judge_return,
+)
 
 MODE_SIMULATED = "simulated"
 """Run against the in-process test double. No money moves.
@@ -158,6 +168,31 @@ class PravaRefundUnsupportedError(NotImplementedError):
     """
 
 
+class PravaConformanceError(PravaPaymentError):
+    """Raised when a delivery does not match the certified purchase intent.
+
+    Raised *before* any network call, so a non-conforming purchase leaves no
+    trace at the payment rail: no charge, no credential, nothing to reverse.
+
+    The failure this exists for is a *cheaper* substitution. An item that costs
+    less than the quoted price passes every amount-based control -- Visa's
+    decline threshold, the mandate cap, the network's own ceiling -- because
+    each of those asks only how much. Comparing the delivery to the certified
+    intent is what catches an item the user never authorised.
+
+    Example::
+
+        try:
+            await payments.pay(seller, amount, ref)
+        except PravaConformanceError as exc:
+            print(exc.result.reason)
+    """
+
+    def __init__(self, message: str, result: ConformanceResult) -> None:
+        self.result = result
+        super().__init__(message, over_cap=False, code="INTENT_NONCONFORMANT")
+
+
 class PravaPayments:
     """Nanda Town payments plugin backed by the Prava mandate API.
 
@@ -176,6 +211,8 @@ class PravaPayments:
     ``unit_price_minor``        ``4_000``      Fallback price when no price book.
     ``price_book``              ``None``       ``service_ref -> minor units``.
     ``intent_digest``           ``None``       Snapshot digest, stamped on quotes.
+    ``intent``                  ``None``       Certified intent; enables the gate.
+    ``intent_snapshot``         ``None``       Path to load that intent from.
     ``cap_minor``               ``100_000``    Simulated-mode mandate ceiling.
     ``fail_closed``             ``True``       See below.
     ``timeout_s``               ``30.0``       Live transport only.
@@ -218,6 +255,8 @@ class PravaPayments:
         unit_price_minor: int = 4_000,
         price_book: dict[str, int] | None = None,
         intent_digest: str | None = None,
+        intent: PurchaseIntent | None = None,
+        intent_snapshot: str | None = None,
         cap_minor: int = 100_000,
         fail_closed: bool = True,
         timeout_s: float = 30.0,
@@ -248,6 +287,11 @@ class PravaPayments:
         self._unit_price_minor = unit_price_minor
         self._price_book = dict(price_book) if price_book is not None else None
         self._intent_digest = intent_digest
+        if intent is None and intent_snapshot:
+            intent = load_intent(intent_snapshot, expected_currency=currency)
+        self._intent = intent
+        self._delivered_product_id: str | None = None
+        self._delivered_merchant: str | None = None
         self._fail_closed = fail_closed
         self._authorization_code = authorization_code
         self._receipts: dict[PaymentRef, Receipt] = receipts if receipts is not None else {}
@@ -350,6 +394,81 @@ class PravaPayments:
         """
         return self._confirmed.get(ref, False)
 
+    # -- intent conformance ----------------------------------------------
+
+    @property
+    def intent(self) -> PurchaseIntent | None:
+        """The certified purchase intent this plugin gates against, if any.
+
+        Example::
+
+            if payments.intent is not None:
+                print(payments.intent.sku)
+        """
+        return self._intent
+
+    def record_delivery(
+        self,
+        product_id: str | None = None,
+        merchant: str | None = None,
+    ) -> None:
+        """Record what a counterparty says it is actually delivering.
+
+        Held on the plugin rather than passed to :meth:`pay`, whose signature is
+        fixed by the ``Payments`` protocol. Recording is optional: with no
+        delivery recorded the gate still judges the *selection* against the
+        certified terms.
+
+        Example::
+
+            payments.record_delivery(product_id="98115-2XL", merchant="Libas")
+        """
+        self._delivered_product_id = product_id
+        self._delivered_merchant = merchant
+
+    def check_delivery(self, amount_minor: int | None = None) -> ConformanceResult:
+        """Judge the recorded delivery against the certified intent.
+
+        Returns a passing, empty result when no intent is configured, so a
+        scenario without a certificate behaves exactly as it did before.
+
+        Example::
+
+            result = payments.check_delivery(amount_minor=472)
+            print(result.passed, result.reason)
+        """
+        if self._intent is None:
+            return ConformanceResult(passed=True)
+        return check_conformance(
+            self._intent,
+            delivered_product_id=self._delivered_product_id,
+            delivered_amount_minor=amount_minor,
+            delivered_merchant=self._delivered_merchant,
+        )
+
+    def judge_return(self, days_since_delivery: int) -> ReturnVerdict:
+        """Decide whether a return request falls inside the certified window.
+
+        ``days_since_delivery`` is supplied by the caller, never read from the
+        clock, so the verdict is reproducible.
+
+        An approved verdict means the request conforms to terms agreed before
+        the purchase. It does not mean money moved: see
+        :class:`PravaRefundUnsupportedError`.
+
+        Example::
+
+            verdict = payments.judge_return(days_since_delivery=5)
+            assert verdict.approved
+
+        Raises:
+            PravaConfigError: If no certified intent is configured.
+        """
+        if self._intent is None:
+            msg = "judge_return needs a certified intent; none was configured on this plugin"
+            raise PravaConfigError(msg)
+        return _judge_return(self._intent, days_since_delivery=days_since_delivery)
+
     # -- Payments protocol -----------------------------------------------
 
     async def quote(self, service: ServiceRef) -> Quote:
@@ -423,6 +542,7 @@ class PravaPayments:
         if amount.amount <= 0:
             msg = f"payment amount must be positive: {amount.amount}"
             raise PravaConfigError(msg)
+        self._assert_conforms(amount, ref)
 
         try:
             result = await self._client.charge(
@@ -525,6 +645,26 @@ class PravaPayments:
             "with a fresh PaymentRef."
         )
         raise PravaRefundUnsupportedError(msg)
+
+    # -- private ---------------------------------------------------------
+
+    def _assert_conforms(self, amount: Money, ref: PaymentRef) -> None:
+        """Refuse a non-conforming charge before any network call is made."""
+        if self._intent is None:
+            return
+        result = self.check_delivery(amount_minor=amount.amount)
+        if result.passed:
+            return
+        detail = "; ".join(
+            f"{c.name} (expected {c.expected}, got {c.actual})"
+            for c in result.checks
+            if not c.passed
+        )
+        msg = (
+            f"refusing to charge {ref}: the delivery does not conform to the "
+            f"certified purchase intent -- {detail}. No charge was attempted."
+        )
+        raise PravaConformanceError(msg, result)
 
     # -- lifecycle -------------------------------------------------------
 

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/prava.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/prava.py
@@ -173,7 +173,9 @@ class PravaPayments:
     ``api_key``                 ``$PRAVA_API_KEY``  Never put this in YAML.
     ``currency``                ``USD``        ISO 4217 code sent to Prava.
     ``minor_unit_exponent``     ``2``          0 for JPY/KRW.
-    ``unit_price_minor``        ``4_000``      Price returned by ``quote``.
+    ``unit_price_minor``        ``4_000``      Fallback price when no price book.
+    ``price_book``              ``None``       ``service_ref -> minor units``.
+    ``intent_digest``           ``None``       Snapshot digest, stamped on quotes.
     ``cap_minor``               ``100_000``    Simulated-mode mandate ceiling.
     ``fail_closed``             ``True``       See below.
     ``timeout_s``               ``30.0``       Live transport only.
@@ -214,6 +216,8 @@ class PravaPayments:
         currency: str = "USD",
         minor_unit_exponent: int = 2,
         unit_price_minor: int = 4_000,
+        price_book: dict[str, int] | None = None,
+        intent_digest: str | None = None,
         cap_minor: int = 100_000,
         fail_closed: bool = True,
         timeout_s: float = 30.0,
@@ -242,6 +246,8 @@ class PravaPayments:
         self._currency = currency
         self._exponent = minor_unit_exponent
         self._unit_price_minor = unit_price_minor
+        self._price_book = dict(price_book) if price_book is not None else None
+        self._intent_digest = intent_digest
         self._fail_closed = fail_closed
         self._authorization_code = authorization_code
         self._receipts: dict[PaymentRef, Receipt] = receipts if receipts is not None else {}
@@ -347,20 +353,47 @@ class PravaPayments:
     # -- Payments protocol -----------------------------------------------
 
     async def quote(self, service: ServiceRef) -> Quote:
-        """Return the configured unit price. Local; Prava has no quote endpoint.
+        """Price ``service`` from the price book, or fall back to the unit price.
 
-        The price is a plugin config value rather than a network read because
-        Prava prices nothing -- it authorizes and settles. Keeping the quote
-        local also keeps ``quote`` deterministic under replay.
+        No network call: Prava prices nothing -- it authorizes and settles --
+        and a live catalogue read would make ``quote`` non-deterministic under
+        replay. When a ``price_book`` is supplied it is a *frozen* mapping built
+        from purchase-intent snapshots, so the price an upstream agent agreed to
+        is the price this method returns.
+
+        An unknown ``service`` raises rather than falling back. A silent
+        fallback would quote the default unit price for an item nobody priced,
+        and the trace would look healthy while the wrong amount was charged.
 
         Example::
 
-            q = await payments.quote(ServiceRef("svc-1"))
+            q = await payments.quote(ServiceRef("libas:98252-2XL"))
+
+        Raises:
+            PravaConfigError: If a price book is configured and ``service`` is
+                not in it.
         """
+        metadata = {"source": "prava_plugin_price_book", "mode": self._mode}
+        if self._price_book is None:
+            amount_minor = self._unit_price_minor
+        else:
+            key = str(service)
+            if key not in self._price_book:
+                known = ", ".join(sorted(self._price_book)) or "<empty>"
+                msg = (
+                    f"no price for service {key!r} in the purchase-intent price book. "
+                    f"Known refs: {known}. The scenario asked to quote an item that no "
+                    "snapshot priced -- fix the service ref or capture a snapshot for it."
+                )
+                raise PravaConfigError(msg)
+            amount_minor = self._price_book[key]
+            metadata["source"] = "prava_intent_snapshot"
+        if self._intent_digest is not None:
+            metadata["intent_digest"] = self._intent_digest
         return Quote(
             service=service,
-            price=Money(amount=self._unit_price_minor, currency=self._currency),
-            metadata={"source": "prava_plugin_price_book", "mode": self._mode},
+            price=Money(amount=amount_minor, currency=self._currency),
+            metadata=metadata,
         )
 
     async def pay(self, to: AgentId, amount: Money, ref: PaymentRef) -> Receipt:

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/prava_client.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/prava_client.py
@@ -1,0 +1,714 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Async transport + client for the Prava agentic-payments REST API.
+
+A pure API client: it owns HTTP, error envelopes, retry policy and the
+integer-minor-unit <-> decimal-string conversion Prava's wire format requires.
+It holds no Nanda Town types and no simulation state, so it is reusable
+outside this repo.
+
+Two transports ship here, and the difference matters:
+
+* :class:`HttpxPravaTransport` -- the real network path, against
+  ``https://sandbox.api.prava.space`` or ``https://api.prava.space``.
+* :class:`SimulatedPravaTransport` -- a deterministic in-process **test
+  double**. It is NOT Prava. It moves no money, mints no credentials and
+  contacts no network. It exists because Nanda Town grades determinism
+  (same seed -> byte-identical trace) and because CI holds no Prava key.
+  Never present its output as a settled transaction.
+
+Endpoints covered (transcribed from the official OpenAPI 3.1 document at
+https://docs.prava.space/api-reference/openapi.json):
+
+* ``POST /v1/mandates/{id}/charge``
+* ``POST /v1/mandates/{id}/charges/{txn_id}/report``
+* ``GET  /v1/mandates/{id}``
+
+The spec exposes **no** refund, credit or reversal endpoint. Callers that
+need a reversal must model it as a compensating forward payment; this client
+deliberately offers no ``refund`` method rather than faking one.
+
+Example::
+
+    transport = SimulatedPravaTransport(mandate_id="mdt_demo", cap_minor=10_000)
+    client = PravaClient(transport=transport)
+    result = await client.charge("mdt_demo", amount_minor=4_000, reference="r-1")
+"""
+
+from __future__ import annotations
+
+import asyncio
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from typing import Any, Protocol, cast, runtime_checkable
+
+import httpx
+
+SANDBOX_BASE_URL = "https://sandbox.api.prava.space"
+"""Prava sandbox server root.
+
+Example::
+
+    base = SANDBOX_BASE_URL
+"""
+
+PRODUCTION_BASE_URL = "https://api.prava.space"
+"""Prava production server root.
+
+Example::
+
+    base = PRODUCTION_BASE_URL
+"""
+
+THRESHOLD_EXCEEDED = "THRESHOLD_EXCEEDED"
+"""Prava ``errorCode`` returned when a charge would exceed the mandate cap.
+
+Example::
+
+    if result.error_code == THRESHOLD_EXCEEDED:
+        ...
+"""
+
+CHARGE_STATUS_AWAITING = "awaiting_result"
+"""``MandateChargeResult.status`` for an accepted, unreported charge.
+
+Example::
+
+    accepted = result.status == CHARGE_STATUS_AWAITING
+"""
+
+CHARGE_STATUS_FAILED = "failed"
+"""``MandateChargeResult.status`` for a refused charge.
+
+Example::
+
+    refused = result.status == CHARGE_STATUS_FAILED
+"""
+
+_DEFAULT_EXPONENT = 2
+_RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+
+
+def _as_dict(value: object) -> dict[str, Any] | None:
+    """Narrow a decoded-JSON value to a string-keyed mapping, or ``None``.
+
+    ``isinstance(x, dict)`` alone narrows to ``dict[Unknown, Unknown]`` under
+    pyright strict, which propagates as partially-unknown types through every
+    subsequent ``.get()``. Every JSON object Prava returns is string-keyed by
+    construction, so the cast is sound and this is the single place it happens.
+    """
+    if isinstance(value, dict):
+        return cast("dict[str, Any]", value)
+    return None
+
+
+class PravaError(RuntimeError):
+    """Raised on a non-2xx Prava response, carrying its structured envelope.
+
+    Prava returns ``{"error": {"code": ..., "message": ..., "details": ...}}``.
+    ``status`` is the HTTP status, ``code`` the Prava error code (``None`` if
+    the body was unparseable).
+
+    Example::
+
+        try:
+            await client.get_mandate("mdt_missing")
+        except PravaError as exc:
+            print(exc.status, exc.code)
+    """
+
+    def __init__(self, status: int, body: Any) -> None:
+        self.status = status
+        self.body = body
+        outer = _as_dict(body)
+        envelope = _as_dict(outer.get("error")) if outer is not None else None
+        code = envelope.get("code") if envelope is not None else None
+        message = envelope.get("message") if envelope is not None else None
+        self.code: str | None = str(code) if code is not None else None
+        self.message: str = str(message) if message is not None else str(body)[:300]
+        super().__init__(f"[{status}] {self.code}: {self.message}")
+
+
+class PravaConfigError(ValueError):
+    """Raised when client or plugin configuration is unusable.
+
+    Example::
+
+        raise PravaConfigError("mandate_id is required")
+    """
+
+
+def minor_to_decimal_string(amount_minor: int, exponent: int = _DEFAULT_EXPONENT) -> str:
+    """Convert integer minor units to the decimal string Prava expects.
+
+    Nanda Town's ``Money.amount`` is an ``int``. Prava's ``amount`` field is a
+    decimal string such as ``"40.00"``. ``exponent`` is the currency's minor-unit
+    exponent (2 for USD/EUR/INR, 0 for JPY/KRW); it is a flag rather than a
+    constant precisely so zero-decimal currencies are not silently wrong.
+
+    Example::
+
+        assert minor_to_decimal_string(4_000) == "40.00"
+        assert minor_to_decimal_string(4_000, exponent=0) == "4000"
+
+    Raises:
+        PravaConfigError: If ``exponent`` is negative.
+    """
+    if exponent < 0:
+        msg = f"exponent must be >= 0: {exponent}"
+        raise PravaConfigError(msg)
+    if exponent == 0:
+        return str(amount_minor)
+    scaled = Decimal(amount_minor).scaleb(-exponent)
+    quantum = Decimal(1).scaleb(-exponent)
+    return str(scaled.quantize(quantum, rounding=ROUND_HALF_UP))
+
+
+def decimal_string_to_minor(amount: str, exponent: int = _DEFAULT_EXPONENT) -> int:
+    """Convert a Prava decimal string back to integer minor units.
+
+    Inverse of :func:`minor_to_decimal_string` for any value representable at
+    ``exponent`` decimal places. Round-trip is asserted by the plugin test suite.
+
+    Example::
+
+        assert decimal_string_to_minor("40.00") == 4_000
+
+    Raises:
+        PravaConfigError: If ``amount`` is not a valid decimal or ``exponent``
+            is negative.
+    """
+    if exponent < 0:
+        msg = f"exponent must be >= 0: {exponent}"
+        raise PravaConfigError(msg)
+    try:
+        value = Decimal(amount)
+    except InvalidOperation as exc:
+        msg = f"not a decimal amount: {amount!r}"
+        raise PravaConfigError(msg) from exc
+    scaled = value.scaleb(exponent)
+    return int(scaled.quantize(Decimal(1), rounding=ROUND_HALF_UP))
+
+
+@runtime_checkable
+class PravaTransport(Protocol):
+    """Structural interface for anything that can carry a Prava request.
+
+    Implemented by :class:`HttpxPravaTransport` (real network) and
+    :class:`SimulatedPravaTransport` (deterministic test double). Injecting
+    the transport is what lets the scenario run credential-free in CI while
+    the identical plugin code path runs live against the sandbox.
+
+    Example::
+
+        async def run(transport: PravaTransport) -> dict[str, object]:
+            return await transport.request("GET", "/v1/mandates/mdt_1")
+    """
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Issue one request and return the decoded JSON object.
+
+        Example::
+
+            data = await transport.request("GET", "/v1/mandates/mdt_1")
+        """
+        ...
+
+    async def aclose(self) -> None:
+        """Release any underlying resources.
+
+        Example::
+
+            await transport.aclose()
+        """
+        ...
+
+
+class HttpxPravaTransport:
+    """Real HTTP transport for Prava, backed by ``httpx.AsyncClient``.
+
+    Retries only idempotent-safe failures (``429`` and ``5xx``) with capped
+    exponential backoff. A ``4xx`` other than ``429`` is never retried: Prava
+    charge semantics are idempotent on ``reference``, but a client-side
+    rejection will not become valid by repetition.
+
+    Refuses a ``sk_live_`` key pointed at the sandbox host and vice versa,
+    because that mistake is silent and expensive.
+
+    Example::
+
+        transport = HttpxPravaTransport(
+            api_key="sk_test_abc",
+            base_url=SANDBOX_BASE_URL,
+            timeout_s=30.0,
+            max_retries=3,
+        )
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = SANDBOX_BASE_URL,
+        timeout_s: float = 30.0,
+        max_retries: int = 3,
+        backoff_base_s: float = 0.25,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        if not api_key:
+            msg = "api_key is required for the live Prava transport"
+            raise PravaConfigError(msg)
+        is_live_key = api_key.startswith("sk_live_")
+        is_sandbox_host = "sandbox" in base_url
+        if is_live_key and is_sandbox_host:
+            msg = "live key (sk_live_) against the sandbox host - refusing"
+            raise PravaConfigError(msg)
+        if not is_live_key and not is_sandbox_host:
+            msg = "test key (sk_test_) against the production host - refusing"
+            raise PravaConfigError(msg)
+        if max_retries < 0:
+            msg = f"max_retries must be >= 0: {max_retries}"
+            raise PravaConfigError(msg)
+
+        self._base_url = base_url.rstrip("/")
+        self._max_retries = max_retries
+        self._backoff_base_s = backoff_base_s
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(
+            timeout=timeout_s,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Issue one request, retrying transient failures.
+
+        Example::
+
+            data = await transport.request("GET", "/v1/mandates/mdt_1")
+
+        Raises:
+            PravaError: On a non-2xx response that is not retryable, or after
+                the retry budget is exhausted.
+        """
+        url = f"{self._base_url}{path}"
+        last: PravaError | None = None
+        for attempt in range(self._max_retries + 1):
+            response = await self._client.request(method, url, json=body, params=params)
+            decoded = self._decode(response)
+            if response.status_code < 400:
+                return decoded
+            error = PravaError(response.status_code, decoded)
+            if response.status_code not in _RETRYABLE_STATUS:
+                raise error
+            last = error
+            if attempt < self._max_retries:
+                await asyncio.sleep(self._backoff_base_s * (2**attempt))
+        raise last if last is not None else PravaError(0, {})
+
+    async def aclose(self) -> None:
+        """Close the underlying ``httpx.AsyncClient`` if this transport owns it.
+
+        Example::
+
+            await transport.aclose()
+        """
+        if self._owns_client:
+            await self._client.aclose()
+
+    @staticmethod
+    def _decode(response: httpx.Response) -> dict[str, Any]:
+        try:
+            decoded: Any = response.json()
+        except ValueError:
+            return {"raw": response.text[:500]}
+        as_object = _as_dict(decoded)
+        if as_object is not None:
+            return as_object
+        return {"raw": decoded}
+
+
+class SimulatedPravaTransport:
+    """Deterministic in-process test double for the Prava API. NOT Prava.
+
+    **This moves no money.** It reproduces four documented behaviours the
+    plugin must handle, so that CI (which has no ``PRAVA_API_KEY``) still
+    exercises the real plugin code path:
+
+    #. ``reference`` is an idempotency key -- replaying one returns the
+       original charge with ``deduplicated: true``.
+    #. Exceeding ``cap_minor`` returns ``status: "failed"`` with
+       ``errorCode: "THRESHOLD_EXCEEDED"``.
+    #. ``GET /v1/mandates/{id}`` reports ``spent``, ``chargeCount`` and the
+       ``charges[]`` array that ``verify_payment`` reads back.
+    #. An unknown mandate id raises a 404 :class:`PravaError`.
+
+    Identifiers are derived from a monotonic counter, never from ``uuid4`` or
+    the clock, so a replayed simulation yields a byte-identical trace.
+
+    Example::
+
+        transport = SimulatedPravaTransport(mandate_id="mdt_demo", cap_minor=10_000)
+        result = await transport.request(
+            "POST",
+            "/v1/mandates/mdt_demo/charge",
+            body={"amount": "40.00", "reference": "r-1"},
+        )
+        assert result["status"] == CHARGE_STATUS_AWAITING
+    """
+
+    def __init__(
+        self,
+        mandate_id: str,
+        cap_minor: int,
+        currency: str = "USD",
+        exponent: int = _DEFAULT_EXPONENT,
+        fail_references: frozenset[str] = frozenset(),
+    ) -> None:
+        self._mandate_id = mandate_id
+        self._cap_minor = cap_minor
+        self._currency = currency
+        self._exponent = exponent
+        self._fail_references = fail_references
+        self._spent_minor = 0
+        self._seq = 0
+        self._by_reference: dict[str, dict[str, Any]] = {}
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Route a simulated request. See the class docstring for coverage.
+
+        Example::
+
+            detail = await transport.request("GET", "/v1/mandates/mdt_demo")
+
+        Raises:
+            PravaError: 404 for an unknown mandate or transaction id.
+            NotImplementedError: For a path this double does not simulate.
+        """
+        del params
+        parts = path.strip("/").split("/")
+        if len(parts) >= 3 and parts[0] == "v1" and parts[1] == "mandates":
+            mandate_id = parts[2]
+            if mandate_id != self._mandate_id:
+                raise PravaError(404, {"error": {"code": "MANDATE_NOT_FOUND"}})
+            if method == "GET" and len(parts) == 3:
+                return self._mandate_detail()
+            if method == "POST" and len(parts) == 4 and parts[3] == "charge":
+                return self._charge(body or {})
+            if method == "POST" and len(parts) == 6 and parts[5] == "report":
+                return self._report(parts[4], body or {})
+        msg = f"SimulatedPravaTransport does not simulate {method} {path}"
+        raise NotImplementedError(msg)
+
+    async def aclose(self) -> None:
+        """No-op; the double owns no resources.
+
+        Example::
+
+            await transport.aclose()
+        """
+        return None
+
+    def _next_id(self, prefix: str) -> str:
+        self._seq += 1
+        return f"{prefix}_sim{self._seq:06d}"
+
+    def _charge(self, body: dict[str, Any]) -> dict[str, Any]:
+        reference = str(body.get("reference", ""))
+        amount = str(body.get("amount", "0"))
+        existing = self._by_reference.get(reference)
+        if existing is not None:
+            return {**existing, "deduplicated": True}
+
+        if reference in self._fail_references:
+            return {
+                "mandateId": self._mandate_id,
+                "status": CHARGE_STATUS_FAILED,
+                "errorCode": "CHARGE_DECLINED",
+                "errorMessage": "simulated decline for reference in fail_references",
+                "deduplicated": False,
+            }
+
+        amount_minor = decimal_string_to_minor(amount, self._exponent)
+        if self._spent_minor + amount_minor > self._cap_minor:
+            return {
+                "mandateId": self._mandate_id,
+                "status": CHARGE_STATUS_FAILED,
+                "errorCode": THRESHOLD_EXCEEDED,
+                "errorMessage": "charge would exceed the mandate threshold",
+                "deduplicated": False,
+            }
+
+        self._spent_minor += amount_minor
+        result: dict[str, Any] = {
+            "mandateId": self._mandate_id,
+            "instructionId": self._next_id("ins"),
+            "transactionId": self._next_id("txn"),
+            "orderId": self._next_id("ord"),
+            "status": CHARGE_STATUS_AWAITING,
+            "fetchStatus": "ready",
+            "deduplicated": False,
+            "_amount": amount,
+            "_reference": reference,
+        }
+        self._by_reference[reference] = result
+        return result
+
+    def _report(self, txn_id: str, body: dict[str, Any]) -> dict[str, Any]:
+        record = next(
+            (r for r in self._by_reference.values() if r.get("transactionId") == txn_id),
+            None,
+        )
+        if record is None:
+            raise PravaError(404, {"error": {"code": "TRANSACTION_NOT_FOUND"}})
+        approved = str(body.get("txn_status")) == "APPROVED"
+        record["_reported"] = "APPROVED" if approved else "DECLINED"
+        return {
+            "status": "completed" if approved else "failed",
+            "mandateStatus": "active",
+            "visaConfirmation": self._next_id("vis"),
+        }
+
+    def _mandate_detail(self) -> dict[str, Any]:
+        charges: list[dict[str, Any]] = [
+            {
+                "transactionId": r["transactionId"],
+                "amount": r["_amount"],
+                "currency": self._currency,
+                "status": r.get("_reported", "awaiting_result"),
+                "reference": r["_reference"],
+                "createdAt": f"sim-tick-{i}",
+            }
+            for i, r in enumerate(self._by_reference.values())
+        ]
+        return {
+            "id": self._mandate_id,
+            "status": "active",
+            "currency": self._currency,
+            "spent": minor_to_decimal_string(self._spent_minor, self._exponent),
+            "remaining": minor_to_decimal_string(
+                self._cap_minor - self._spent_minor, self._exponent
+            ),
+            "chargeCount": len(charges),
+            "charges": charges,
+        }
+
+
+class ChargeResult:
+    """Normalized outcome of ``POST /v1/mandates/{id}/charge``.
+
+    ``accepted`` collapses Prava's ``status`` plus ``errorCode`` into the one
+    question the payments layer actually asks. ``over_cap`` distinguishes the
+    mandate-threshold refusal, which is terminal for the run, from a decline,
+    which is not.
+
+    Example::
+
+        result = await client.charge("mdt_1", amount_minor=4_000, reference="r-1")
+        if result.over_cap:
+            ...
+    """
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+        self.status: str = str(payload.get("status", ""))
+        self.transaction_id: str | None = _opt_str(payload.get("transactionId"))
+        self.order_id: str | None = _opt_str(payload.get("orderId"))
+        self.instruction_id: str | None = _opt_str(payload.get("instructionId"))
+        self.error_code: str | None = _opt_str(payload.get("errorCode"))
+        self.error_message: str | None = _opt_str(payload.get("errorMessage"))
+        self.deduplicated: bool = bool(payload.get("deduplicated", False))
+
+    @property
+    def accepted(self) -> bool:
+        """True when Prava took the charge (including an idempotent replay).
+
+        Example::
+
+            assert result.accepted
+        """
+        return self.status != CHARGE_STATUS_FAILED and self.error_code is None
+
+    @property
+    def over_cap(self) -> bool:
+        """True when the refusal was the mandate threshold, not a decline.
+
+        Example::
+
+            if result.over_cap:
+                stop()
+        """
+        return self.error_code == THRESHOLD_EXCEEDED
+
+
+def _opt_str(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+class PravaClient:
+    """Thin async wrapper over the three Prava endpoints the plugin needs.
+
+    Owns the minor-unit conversion so callers never build decimal strings by
+    hand. Deliberately exposes **no** ``refund``: the Prava OpenAPI document
+    defines no refund, credit or reversal path.
+
+    Example::
+
+        client = PravaClient(
+            transport=SimulatedPravaTransport("mdt_demo", cap_minor=10_000),
+            minor_unit_exponent=2,
+        )
+        result = await client.charge("mdt_demo", amount_minor=4_000, reference="r-1")
+    """
+
+    def __init__(
+        self,
+        transport: PravaTransport,
+        minor_unit_exponent: int = _DEFAULT_EXPONENT,
+    ) -> None:
+        self._transport = transport
+        self._exponent = minor_unit_exponent
+
+    @property
+    def minor_unit_exponent(self) -> int:
+        """Minor-unit exponent this client formats amounts with.
+
+        Example::
+
+            assert client.minor_unit_exponent == 2
+        """
+        return self._exponent
+
+    async def charge(
+        self,
+        mandate_id: str,
+        amount_minor: int,
+        reference: str,
+        purchase_context: list[dict[str, Any]] | None = None,
+    ) -> ChargeResult:
+        """Draw ``amount_minor`` against ``mandate_id``, keyed on ``reference``.
+
+        ``reference`` is Prava's idempotency key (max 255 chars): the same
+        mandate id plus reference returns the original charge with
+        ``deduplicated: true`` instead of double-charging.
+
+        Example::
+
+            result = await client.charge("mdt_1", amount_minor=4_000, reference="r-1")
+
+        Raises:
+            PravaConfigError: If ``amount_minor`` is not positive or
+                ``reference`` is empty or longer than 255 characters.
+            PravaError: On a non-2xx response.
+        """
+        if amount_minor <= 0:
+            msg = f"amount_minor must be positive: {amount_minor}"
+            raise PravaConfigError(msg)
+        if not reference or len(reference) > 255:
+            msg = f"reference must be 1..255 chars, got {len(reference)}"
+            raise PravaConfigError(msg)
+        body: dict[str, Any] = {
+            "amount": minor_to_decimal_string(amount_minor, self._exponent),
+            "reference": reference,
+        }
+        if purchase_context:
+            body["purchase_context"] = purchase_context
+        payload = await self._transport.request(
+            "POST", f"/v1/mandates/{mandate_id}/charge", body=body
+        )
+        return ChargeResult(payload)
+
+    async def report_charge(
+        self,
+        mandate_id: str,
+        transaction_id: str,
+        approved: bool,
+        amount_minor: int | None = None,
+        authorization_code: str | None = None,
+        response_code: str | None = None,
+    ) -> dict[str, Any]:
+        """Report the merchant-side outcome so the network settles the charge.
+
+        Example::
+
+            await client.report_charge("mdt_1", "txn_1", approved=True)
+
+        Raises:
+            PravaError: On a non-2xx response.
+        """
+        body: dict[str, Any] = {
+            "txn_status": "APPROVED" if approved else "DECLINED",
+            "txn_type": "PURCHASE",
+        }
+        if amount_minor is not None:
+            body["amount_paid"] = minor_to_decimal_string(amount_minor, self._exponent)
+        if authorization_code:
+            body["authorization_code"] = authorization_code
+        if response_code:
+            body["response_code"] = response_code
+        return await self._transport.request(
+            "POST",
+            f"/v1/mandates/{mandate_id}/charges/{transaction_id}/report",
+            body=body,
+        )
+
+    async def get_mandate(self, mandate_id: str) -> dict[str, Any]:
+        """Read the mandate back, including its ``charges[]`` array.
+
+        Example::
+
+            detail = await client.get_mandate("mdt_1")
+
+        Raises:
+            PravaError: On a non-2xx response.
+        """
+        return await self._transport.request("GET", f"/v1/mandates/{mandate_id}")
+
+    async def find_charge(self, mandate_id: str, reference: str) -> dict[str, Any] | None:
+        """Locate a charge in ``charges[]`` by its idempotency ``reference``.
+
+        This is the read-back that makes ``verify_payment`` authoritative:
+        the answer comes from Prava's own ledger, not from local state.
+
+        Example::
+
+            charge = await client.find_charge("mdt_1", "r-1")
+
+        Raises:
+            PravaError: On a non-2xx response.
+        """
+        detail = await self.get_mandate(mandate_id)
+        raw = detail.get("charges")
+        if not isinstance(raw, list):
+            return None
+        for item in cast("list[object]", raw):
+            entry = _as_dict(item)
+            if entry is not None and str(entry.get("reference")) == reference:
+                return entry
+        return None
+
+    async def aclose(self) -> None:
+        """Close the underlying transport.
+
+        Example::
+
+            await client.aclose()
+        """
+        await self._transport.aclose()

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/prava_intent.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/prava_intent.py
@@ -1,0 +1,337 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Frozen purchase-intent snapshots -- the handoff from an LLM shopper to Nanda Town.
+
+An LLM agent picks a product out of a live merchant catalogue. That decision is
+non-deterministic and involves network I/O, so it cannot happen inside a Nanda
+Town scenario: the simulator guarantees that the same seed produces a
+byte-identical trace. The decision is therefore made *once, out of band* and
+written to a snapshot file. The scenario reads the snapshot.
+
+The snapshot carries the item identity, the price the merchant listed, and --
+when the listing currency differs from the settlement currency -- the converted
+amount together with the exact FX rate, its source and its capture time. Nothing
+is recomputed at run time. A run is reproducible because every number it needs is
+already written down.
+
+This module holds no Nanda Town types and performs no network I/O. It reads a
+file and validates it.
+
+Example::
+
+    intent = load_intent(Path("scenarios/intents/libas-98252-2XL.json"))
+    assert intent.service_ref == "libas:98252-2XL"
+    assert intent.settlement_amount_minor == 523
+    book = price_book([intent])
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+SCHEMA_V1 = "nest.prava.intent/v1"
+"""The only schema identifier this module accepts.
+
+Example::
+
+    assert intent.schema == SCHEMA_V1
+"""
+
+_REQUIRED_TOP = ("schema", "captured_at", "source", "merchant", "item", "settlement")
+_REQUIRED_MERCHANT = ("name",)
+_REQUIRED_ITEM = ("sku", "title", "service_ref", "listed_price")
+_REQUIRED_PRICE = ("amount_minor", "currency", "minor_unit_exponent")
+_REQUIRED_FX = ("rate", "source", "captured_at")
+
+
+class PravaIntentError(ValueError):
+    """Raised when a snapshot is missing, malformed or internally inconsistent.
+
+    Deliberately strict: a snapshot is the record of what a human or an LLM
+    agreed to buy, and a silently-defaulted field here becomes a wrong amount
+    charged to a real card.
+
+    Example::
+
+        try:
+            load_intent(path)
+        except PravaIntentError as exc:
+            print(f"bad snapshot: {exc}")
+    """
+
+
+@dataclass(frozen=True)
+class PurchaseIntent:
+    """One item an upstream agent selected, frozen with everything needed to charge it.
+
+    ``settlement_amount_minor`` is what ``quote`` returns and what ``pay``
+    charges. ``listed_amount_minor`` and the ``fx_*`` fields exist for
+    provenance: they let a reader reconstruct how the settlement figure was
+    reached without trusting it blindly.
+
+    Example::
+
+        intent = load_intent(path)
+        print(intent.sku, intent.settlement_amount_minor)
+    """
+
+    schema: str
+    captured_at: str
+    source: str
+    merchant_name: str
+    merchant_endpoint: str | None
+    sku: str
+    title: str
+    service_ref: str
+    listed_amount_minor: int
+    listed_currency: str
+    listed_exponent: int
+    settlement_amount_minor: int
+    settlement_currency: str
+    settlement_exponent: int
+    fx_rate: str | None
+    fx_source: str | None
+    fx_captured_at: str | None
+    fx_rounding: str | None
+    note: str | None
+    digest: str
+
+    @property
+    def converted(self) -> bool:
+        """Whether settlement currency differs from the merchant's listing currency.
+
+        Example::
+
+            if intent.converted:
+                print(intent.fx_rate, intent.fx_source)
+        """
+        return self.listed_currency != self.settlement_currency
+
+
+def canonical_digest(payload: dict[str, Any]) -> str:
+    """Return a stable SHA-256 hex digest of ``payload``.
+
+    Keys are sorted and separators fixed, so reformatting or reordering the
+    source file does not change the digest -- only a change of *content* does.
+
+    Example::
+
+        digest = canonical_digest({"b": 2, "a": 1})
+    """
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _require(mapping: dict[str, Any], keys: tuple[str, ...], where: str) -> None:
+    missing = [k for k in keys if k not in mapping]
+    if missing:
+        msg = f"{where} is missing required field(s): {', '.join(sorted(missing))}"
+        raise PravaIntentError(msg)
+
+
+def _object(value: Any, where: str) -> dict[str, Any]:
+    """Narrow a decoded JSON value to a string-keyed mapping.
+
+    ``json.loads`` is typed ``Any`` and ``isinstance(x, dict)`` narrows only to
+    ``dict[Unknown, Unknown]``, so the cast is what makes the rest of this
+    module checkable under strict type checking. JSON object keys are strings by
+    construction, so the cast is sound.
+
+    Example::
+
+        item = _object(payload["item"], "snapshot.item")
+    """
+    if not isinstance(value, dict):
+        msg = f"{where} must be a JSON object, got {type(value).__name__}"
+        raise PravaIntentError(msg)
+    return cast("dict[str, Any]", value)
+
+
+def _positive_int(value: Any, where: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = f"{where} must be an integer number of minor units, got {value!r}"
+        raise PravaIntentError(msg)
+    if value <= 0:
+        msg = f"{where} must be positive, got {value}"
+        raise PravaIntentError(msg)
+    return value
+
+
+def _exponent(value: Any, where: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= 4:
+        msg = f"{where} must be an integer between 0 and 4, got {value!r}"
+        raise PravaIntentError(msg)
+    return value
+
+
+def _currency(value: Any, where: str) -> str:
+    if not isinstance(value, str) or len(value) != 3 or not value.isalpha():
+        msg = f"{where} must be a three-letter ISO 4217 code, got {value!r}"
+        raise PravaIntentError(msg)
+    return value.upper()
+
+
+def _optional_str(mapping: dict[str, Any], key: str) -> str | None:
+    value = mapping.get(key)
+    return str(value) if value is not None else None
+
+
+def parse_intent(payload: dict[str, Any], *, expected_schema: str = SCHEMA_V1) -> PurchaseIntent:
+    """Validate a decoded snapshot mapping and build a :class:`PurchaseIntent`.
+
+    Separated from :func:`load_intent` so callers holding a snapshot in memory
+    (a test, an upstream generator) can validate it without touching disk.
+
+    Example::
+
+        intent = parse_intent(json.loads(text))
+
+    Raises:
+        PravaIntentError: If the schema is unknown, a required field is absent,
+            an amount is not a positive integer, or a converted snapshot omits
+            its FX provenance.
+    """
+    _require(payload, _REQUIRED_TOP, "snapshot")
+    schema = str(payload["schema"])
+    if schema != expected_schema:
+        msg = f"unsupported snapshot schema {schema!r}; this build accepts {expected_schema!r}"
+        raise PravaIntentError(msg)
+
+    merchant = _object(payload["merchant"], "snapshot.merchant")
+    item = _object(payload["item"], "snapshot.item")
+    settlement = _object(payload["settlement"], "snapshot.settlement")
+    _require(merchant, _REQUIRED_MERCHANT, "snapshot.merchant")
+    _require(item, _REQUIRED_ITEM, "snapshot.item")
+    _require(settlement, _REQUIRED_PRICE, "snapshot.settlement")
+
+    listed = _object(item["listed_price"], "snapshot.item.listed_price")
+    _require(listed, _REQUIRED_PRICE, "snapshot.item.listed_price")
+
+    service_ref = item["service_ref"]
+    if not isinstance(service_ref, str) or not service_ref.strip():
+        msg = f"snapshot.item.service_ref must be a non-empty string, got {service_ref!r}"
+        raise PravaIntentError(msg)
+
+    listed_currency = _currency(listed["currency"], "snapshot.item.listed_price.currency")
+    settlement_currency = _currency(settlement["currency"], "snapshot.settlement.currency")
+
+    fx: dict[str, Any] = {}
+    if "fx" in payload:
+        fx = _object(payload["fx"], "snapshot.fx")
+    if listed_currency != settlement_currency:
+        if not fx:
+            msg = (
+                f"snapshot converts {listed_currency} to {settlement_currency} but carries no "
+                "'fx' block; the rate, its source and its capture time must be recorded so "
+                "the conversion can be audited and reproduced"
+            )
+            raise PravaIntentError(msg)
+        _require(fx, _REQUIRED_FX, "snapshot.fx")
+
+    return PurchaseIntent(
+        schema=schema,
+        captured_at=str(payload["captured_at"]),
+        source=str(payload["source"]),
+        merchant_name=str(merchant["name"]),
+        merchant_endpoint=_optional_str(merchant, "endpoint"),
+        sku=str(item["sku"]),
+        title=str(item["title"]),
+        service_ref=service_ref,
+        listed_amount_minor=_positive_int(
+            listed["amount_minor"], "snapshot.item.listed_price.amount_minor"
+        ),
+        listed_currency=listed_currency,
+        listed_exponent=_exponent(
+            listed["minor_unit_exponent"], "snapshot.item.listed_price.minor_unit_exponent"
+        ),
+        settlement_amount_minor=_positive_int(
+            settlement["amount_minor"], "snapshot.settlement.amount_minor"
+        ),
+        settlement_currency=settlement_currency,
+        settlement_exponent=_exponent(
+            settlement["minor_unit_exponent"], "snapshot.settlement.minor_unit_exponent"
+        ),
+        fx_rate=_optional_str(fx, "rate"),
+        fx_source=_optional_str(fx, "source"),
+        fx_captured_at=_optional_str(fx, "captured_at"),
+        fx_rounding=_optional_str(fx, "rounding"),
+        note=_optional_str(payload, "note"),
+        digest=canonical_digest(payload),
+    )
+
+
+def load_intent(
+    path: str | Path,
+    *,
+    expected_schema: str = SCHEMA_V1,
+    expected_currency: str | None = None,
+) -> PurchaseIntent:
+    """Read and validate a snapshot file.
+
+    ``expected_currency`` is an optional guard for the caller: pass the plugin's
+    configured settlement currency and a mismatched snapshot is rejected here,
+    at load time, rather than several ticks later inside ``pay``.
+
+    Example::
+
+        intent = load_intent(path, expected_currency="USD")
+
+    Raises:
+        PravaIntentError: If the file is absent, is not an object, fails
+            validation, or settles in a currency other than
+            ``expected_currency``.
+    """
+    p = Path(path)
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        msg = f"cannot read purchase-intent snapshot {p}: {exc}"
+        raise PravaIntentError(msg) from exc
+    try:
+        decoded: Any = json.loads(text)
+    except json.JSONDecodeError as exc:
+        msg = f"purchase-intent snapshot {p} is not valid JSON: {exc}"
+        raise PravaIntentError(msg) from exc
+    if not isinstance(decoded, dict):
+        msg = f"purchase-intent snapshot {p} must contain a JSON object at the top level"
+        raise PravaIntentError(msg)
+
+    intent = parse_intent(cast("dict[str, Any]", decoded), expected_schema=expected_schema)
+    if expected_currency is not None and intent.settlement_currency != expected_currency.upper():
+        msg = (
+            f"snapshot {p} settles in {intent.settlement_currency!r} but the caller expects "
+            f"{expected_currency.upper()!r}; convert upstream and record the rate, or "
+            "reconfigure the plugin"
+        )
+        raise PravaIntentError(msg)
+    return intent
+
+
+def price_book(intents: list[PurchaseIntent]) -> dict[str, int]:
+    """Build the ``service_ref -> settlement minor units`` mapping ``quote`` looks up.
+
+    Duplicate service refs are rejected rather than last-write-wins: two
+    snapshots claiming different prices for one item is an upstream bug, and
+    silently picking one would charge an amount nobody agreed to.
+
+    Example::
+
+        book = price_book([intent])
+        assert book["libas:98252-2XL"] == 523
+
+    Raises:
+        PravaIntentError: If two intents share a ``service_ref``.
+    """
+    book: dict[str, int] = {}
+    for intent in intents:
+        if intent.service_ref in book:
+            msg = (
+                f"duplicate service_ref {intent.service_ref!r} across purchase-intent "
+                "snapshots; each item must appear exactly once"
+            )
+            raise PravaIntentError(msg)
+        book[intent.service_ref] = intent.settlement_amount_minor
+    return book

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/prava_intent.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/prava_intent.py
@@ -7,28 +7,40 @@ Town scenario: the simulator guarantees that the same seed produces a
 byte-identical trace. The decision is therefore made *once, out of band* and
 written to a snapshot file. The scenario reads the snapshot.
 
-The snapshot carries the item identity, the price the merchant listed, and --
-when the listing currency differs from the settlement currency -- the converted
-amount together with the exact FX rate, its source and its capture time. Nothing
-is recomputed at run time. A run is reproducible because every number it needs is
-already written down.
+The snapshot carries three things. The **item** the agent selected, with the
+price the merchant listed and -- when the listing currency differs from the
+settlement currency -- the converted amount plus the exact FX rate, its source
+and its capture time. The **certificate**: the user's original request turned
+into a machine-checkable committed reference (allowed colours, a price ceiling,
+the merchant, the quantity, the return window) by an out-of-band certifier. And
+the **visa_intent**: the same commitment expressed in Visa Intelligent Commerce
+purchase-intent vocabulary, recorded for conformance and audit -- it is not sent
+to Visa.
+
+Nothing is recomputed at run time. A run is reproducible because every number it
+needs is already written down.
+
+The certificate is what makes a *verdict* possible. A request like "one kurti
+under 500 rupees in green, pink or navy on Libas" cannot be checked against a
+delivery; ``allowed_colours``, ``max_price`` and ``merchant_name`` can.
 
 This module holds no Nanda Town types and performs no network I/O. It reads a
-file and validates it.
+file, validates it, and judges selections and returns against it.
 
 Example::
 
     intent = load_intent(Path("scenarios/intents/libas-98252-2XL.json"))
-    assert intent.service_ref == "libas:98252-2XL"
     assert intent.settlement_amount_minor == 523
-    book = price_book([intent])
+    result = check_conformance(intent)
+    assert result.passed
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, cast
 
@@ -64,13 +76,153 @@ class PravaIntentError(ValueError):
 
 
 @dataclass(frozen=True)
+class CommittedReference:
+    """The user's request as terms a delivery can be judged against.
+
+    Produced out of band by a certifier. Every field is optional: a snapshot may
+    commit to colours only, or to nothing at all, and each check is simply
+    skipped when its term is absent.
+
+    Example::
+
+        ref = intent.certificate.reference
+        assert "navy" in ref.allowed_colours
+    """
+
+    allowed_colours: tuple[str, ...] = ()
+    max_price_minor: int | None = None
+    max_price_currency: str | None = None
+    merchant_name: str | None = None
+    quantity: int | None = None
+    return_window_days: int | None = None
+
+
+@dataclass(frozen=True)
+class Certificate:
+    """An out-of-band certifier's anchored statement of what was agreed.
+
+    ``digest`` is computed over the committed reference, so editing a term after
+    certification changes the digest and the edit is detectable.
+
+    Example::
+
+        print(intent.certificate.certifier, intent.certificate.digest[:12])
+    """
+
+    certifier: str
+    certified_at: str | None
+    original_request: str | None
+    reference: CommittedReference
+    digest: str
+
+
+@dataclass(frozen=True)
+class VisaIntent:
+    """The commitment in Visa Intelligent Commerce purchase-intent vocabulary.
+
+    Field names mirror ``POST /acp/v1/instructions``. Recorded for conformance
+    and audit only -- this artifact is not sent to Visa.
+
+    Example::
+
+        print(intent.visa.consumer_prompt, intent.visa.decline_threshold_minor)
+    """
+
+    consumer_prompt: str | None = None
+    mandate_id: str | None = None
+    preferred_merchant_name: str | None = None
+    decline_threshold_minor: int | None = None
+    decline_threshold_currency: str | None = None
+    effective_until_time: str | None = None
+    description: str | None = None
+    product_id: str | None = None
+    product_name: str | None = None
+    refund_policy: str | None = None
+
+
+@dataclass(frozen=True)
+class ConformanceCheck:
+    """One named term, whether it held, and the two values compared.
+
+    Example::
+
+        for check in result.checks:
+            print(check.name, check.passed, check.expected, check.actual)
+    """
+
+    name: str
+    passed: bool
+    expected: str
+    actual: str
+
+
+@dataclass(frozen=True)
+class ConformanceResult:
+    """The verdict, plus every check that produced it.
+
+    Example::
+
+        if not result.passed:
+            print(result.reason)
+    """
+
+    passed: bool
+    checks: tuple[ConformanceCheck, ...] = ()
+
+    @property
+    def reason(self) -> str:
+        """Name of the first failed check, or ``"conforms"``.
+
+        Example::
+
+            assert result.reason == "colour_not_in_intent"
+        """
+        for check in self.checks:
+            if not check.passed:
+                return check.name
+        return "conforms"
+
+    @property
+    def failed(self) -> tuple[str, ...]:
+        """Names of every failed check.
+
+        Example::
+
+            assert result.failed == ("colour_not_in_intent",)
+        """
+        return tuple(c.name for c in self.checks if not c.passed)
+
+
+@dataclass(frozen=True)
+class ReturnVerdict:
+    """Whether a return request falls inside the certified window.
+
+    ``approved`` means the request conforms to the terms agreed up front. It
+    does **not** mean money moved: the Prava API defines no reversal endpoint,
+    so settlement of an approved return has to happen off this rail.
+
+    Example::
+
+        verdict = judge_return(intent, days_since_delivery=5)
+        assert verdict.approved and verdict.reason == "within_window"
+    """
+
+    approved: bool
+    reason: str
+    days_since_delivery: int
+    window_days: int | None = None
+    policy: str | None = None
+
+
+@dataclass(frozen=True)
 class PurchaseIntent:
     """One item an upstream agent selected, frozen with everything needed to charge it.
 
     ``settlement_amount_minor`` is what ``quote`` returns and what ``pay``
     charges. ``listed_amount_minor`` and the ``fx_*`` fields exist for
-    provenance: they let a reader reconstruct how the settlement figure was
-    reached without trusting it blindly.
+    provenance. ``certificate`` and ``visa`` carry the terms the selection and
+    any delivery are judged against; both are optional, and a snapshot without
+    them behaves exactly as it did before they existed.
 
     Example::
 
@@ -98,6 +250,11 @@ class PurchaseIntent:
     fx_rounding: str | None
     note: str | None
     digest: str
+    colour: str | None = None
+    size: str | None = None
+    constructed: bool = False
+    certificate: Certificate | None = None
+    visa: VisaIntent | None = field(default=None)
 
     @property
     def converted(self) -> bool:
@@ -150,6 +307,13 @@ def _object(value: Any, where: str) -> dict[str, Any]:
     return cast("dict[str, Any]", value)
 
 
+def _array(value: Any, where: str) -> list[Any]:
+    if not isinstance(value, list):
+        msg = f"{where} must be a JSON array, got {type(value).__name__}"
+        raise PravaIntentError(msg)
+    return cast("list[Any]", value)
+
+
 def _positive_int(value: Any, where: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int):
         msg = f"{where} must be an integer number of minor units, got {value!r}"
@@ -177,6 +341,137 @@ def _currency(value: Any, where: str) -> str:
 def _optional_str(mapping: dict[str, Any], key: str) -> str | None:
     value = mapping.get(key)
     return str(value) if value is not None else None
+
+
+def _optional_int(mapping: dict[str, Any], key: str, where: str) -> int | None:
+    value = mapping.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        msg = f"{where}.{key} must be a non-negative integer, got {value!r}"
+        raise PravaIntentError(msg)
+    return value
+
+
+def _amount_to_minor(value: str, exponent: int, where: str) -> int:
+    """Convert a decimal amount string to integer minor units, half up.
+
+    Example::
+
+        assert _amount_to_minor("5.30", 2, "x") == 530
+    """
+    try:
+        scaled = Decimal(value).scaleb(exponent)
+        return int(scaled.to_integral_value(rounding=ROUND_HALF_UP))
+    except (InvalidOperation, ValueError) as exc:
+        msg = f"{where} must be a decimal amount string, got {value!r}"
+        raise PravaIntentError(msg) from exc
+
+
+def _parse_certificate(payload: dict[str, Any]) -> Certificate | None:
+    raw = payload.get("certificate")
+    if raw is None:
+        return None
+    cert = _object(raw, "snapshot.certificate")
+    _require(cert, ("certifier", "committed_reference"), "snapshot.certificate")
+    committed = _object(cert["committed_reference"], "snapshot.certificate.committed_reference")
+
+    colours: tuple[str, ...] = ()
+    if "allowed_colours" in committed:
+        entries = _array(
+            committed["allowed_colours"], "snapshot.certificate.committed_reference.allowed_colours"
+        )
+        colours = tuple(str(c).strip().lower() for c in entries if str(c).strip())
+
+    max_minor: int | None = None
+    max_currency: str | None = None
+    if "max_price" in committed:
+        price = _object(
+            committed["max_price"], "snapshot.certificate.committed_reference.max_price"
+        )
+        _require(price, _REQUIRED_PRICE, "snapshot.certificate.committed_reference.max_price")
+        max_minor = _positive_int(
+            price["amount_minor"], "snapshot.certificate.committed_reference.max_price.amount_minor"
+        )
+        max_currency = _currency(
+            price["currency"], "snapshot.certificate.committed_reference.max_price.currency"
+        )
+
+    reference = CommittedReference(
+        allowed_colours=colours,
+        max_price_minor=max_minor,
+        max_price_currency=max_currency,
+        merchant_name=_optional_str(committed, "merchant_name"),
+        quantity=_optional_int(committed, "quantity", "snapshot.certificate.committed_reference"),
+        return_window_days=_optional_int(
+            committed, "return_window_days", "snapshot.certificate.committed_reference"
+        ),
+    )
+    return Certificate(
+        certifier=str(cert["certifier"]),
+        certified_at=_optional_str(cert, "certified_at"),
+        original_request=_optional_str(cert, "original_request"),
+        reference=reference,
+        digest=canonical_digest(committed),
+    )
+
+
+def _parse_visa_intent(payload: dict[str, Any], exponent: int) -> VisaIntent | None:
+    raw = payload.get("visa_intent")
+    if raw is None:
+        return None
+    visa = _object(raw, "snapshot.visa_intent")
+
+    mandate: dict[str, Any] = {}
+    if "mandates" in visa:
+        mandates = _array(visa["mandates"], "snapshot.visa_intent.mandates")
+        if mandates:
+            mandate = _object(mandates[0], "snapshot.visa_intent.mandates[0]")
+
+    threshold_minor: int | None = None
+    threshold_currency: str | None = None
+    if "declineThreshold" in mandate:
+        threshold = _object(
+            mandate["declineThreshold"], "snapshot.visa_intent.mandates[0].declineThreshold"
+        )
+        _require(
+            threshold,
+            ("amount", "currencyCode"),
+            "snapshot.visa_intent.mandates[0].declineThreshold",
+        )
+        threshold_minor = _amount_to_minor(
+            str(threshold["amount"]),
+            exponent,
+            "snapshot.visa_intent.mandates[0].declineThreshold.amount",
+        )
+        threshold_currency = _currency(
+            threshold["currencyCode"],
+            "snapshot.visa_intent.mandates[0].declineThreshold.currencyCode",
+        )
+
+    product: dict[str, Any] = {}
+    if "products" in visa:
+        products = _array(visa["products"], "snapshot.visa_intent.products")
+        if products:
+            product = _object(products[0], "snapshot.visa_intent.products[0]")
+
+    refund_policy: str | None = None
+    if "policies" in product:
+        policies = _object(product["policies"], "snapshot.visa_intent.products[0].policies")
+        refund_policy = _optional_str(policies, "refundPolicy")
+
+    return VisaIntent(
+        consumer_prompt=_optional_str(visa, "consumerPrompt"),
+        mandate_id=_optional_str(mandate, "mandateId"),
+        preferred_merchant_name=_optional_str(mandate, "preferredMerchantName"),
+        decline_threshold_minor=threshold_minor,
+        decline_threshold_currency=threshold_currency,
+        effective_until_time=_optional_str(mandate, "effectiveUntilTime"),
+        description=_optional_str(mandate, "description"),
+        product_id=_optional_str(product, "productId"),
+        product_name=_optional_str(product, "productName"),
+        refund_policy=refund_policy,
+    )
 
 
 def parse_intent(payload: dict[str, Any], *, expected_schema: str = SCHEMA_V1) -> PurchaseIntent:
@@ -217,6 +512,9 @@ def parse_intent(payload: dict[str, Any], *, expected_schema: str = SCHEMA_V1) -
 
     listed_currency = _currency(listed["currency"], "snapshot.item.listed_price.currency")
     settlement_currency = _currency(settlement["currency"], "snapshot.settlement.currency")
+    settlement_exponent = _exponent(
+        settlement["minor_unit_exponent"], "snapshot.settlement.minor_unit_exponent"
+    )
 
     fx: dict[str, Any] = {}
     if "fx" in payload:
@@ -251,15 +549,18 @@ def parse_intent(payload: dict[str, Any], *, expected_schema: str = SCHEMA_V1) -
             settlement["amount_minor"], "snapshot.settlement.amount_minor"
         ),
         settlement_currency=settlement_currency,
-        settlement_exponent=_exponent(
-            settlement["minor_unit_exponent"], "snapshot.settlement.minor_unit_exponent"
-        ),
+        settlement_exponent=settlement_exponent,
         fx_rate=_optional_str(fx, "rate"),
         fx_source=_optional_str(fx, "source"),
         fx_captured_at=_optional_str(fx, "captured_at"),
         fx_rounding=_optional_str(fx, "rounding"),
         note=_optional_str(payload, "note"),
         digest=canonical_digest(payload),
+        colour=_optional_str(item, "colour"),
+        size=_optional_str(item, "size"),
+        constructed=bool(payload.get("constructed", False)),
+        certificate=_parse_certificate(payload),
+        visa=_parse_visa_intent(payload, settlement_exponent),
     )
 
 
@@ -335,3 +636,155 @@ def price_book(intents: list[PurchaseIntent]) -> dict[str, int]:
             raise PravaIntentError(msg)
         book[intent.service_ref] = intent.settlement_amount_minor
     return book
+
+
+def check_conformance(
+    intent: PurchaseIntent,
+    *,
+    delivered_product_id: str | None = None,
+    delivered_amount_minor: int | None = None,
+    delivered_merchant: str | None = None,
+) -> ConformanceResult:
+    """Judge a selection, and optionally a delivery, against the certified terms.
+
+    Two independent axes. **Selection against the committed reference** catches
+    an agent that drifted from what the user asked for -- a colour outside the
+    allowed set, a price over the ceiling, the wrong merchant. **Delivery
+    against the selection** catches a substitution at fulfilment -- a different
+    product id, or an amount that is not the one quoted.
+
+    Every check is skipped when the term it needs is absent, so a snapshot
+    without a certificate yields an empty, passing result and the caller
+    behaves exactly as it did before certificates existed. Delivery arguments
+    default to the intent's own selection.
+
+    Note that a cheaper substitution passes every amount-based control -- a
+    decline threshold, a mandate cap, the network's own ceiling -- because all
+    of those ask only *how much*. The colour and identity terms are what catch
+    it.
+
+    Example::
+
+        result = check_conformance(intent, delivered_product_id="98115-2XL")
+        assert not result.passed
+        assert result.reason == "identity_mismatch"
+    """
+    checks: list[ConformanceCheck] = []
+    product_id = delivered_product_id if delivered_product_id is not None else intent.sku
+    amount_minor = (
+        delivered_amount_minor
+        if delivered_amount_minor is not None
+        else intent.settlement_amount_minor
+    )
+    merchant = delivered_merchant if delivered_merchant is not None else intent.merchant_name
+
+    reference = intent.certificate.reference if intent.certificate is not None else None
+
+    if reference is not None and reference.allowed_colours:
+        actual = (intent.colour or "").strip().lower()
+        checks.append(
+            ConformanceCheck(
+                name="colour_not_in_intent",
+                passed=actual in reference.allowed_colours,
+                expected="|".join(reference.allowed_colours),
+                actual=actual or "unspecified",
+            )
+        )
+
+    if (
+        reference is not None
+        and reference.max_price_minor is not None
+        and reference.max_price_currency == intent.listed_currency
+    ):
+        checks.append(
+            ConformanceCheck(
+                name="price_over_ceiling",
+                passed=intent.listed_amount_minor <= reference.max_price_minor,
+                expected=f"<={reference.max_price_minor}",
+                actual=str(intent.listed_amount_minor),
+            )
+        )
+
+    if reference is not None and reference.merchant_name is not None:
+        checks.append(
+            ConformanceCheck(
+                name="merchant_mismatch",
+                passed=merchant.strip().lower() == reference.merchant_name.strip().lower(),
+                expected=reference.merchant_name,
+                actual=merchant,
+            )
+        )
+
+    checks.append(
+        ConformanceCheck(
+            name="identity_mismatch",
+            passed=product_id == intent.sku,
+            expected=intent.sku,
+            actual=product_id,
+        )
+    )
+
+    checks.append(
+        ConformanceCheck(
+            name="amount_mismatch",
+            passed=amount_minor == intent.settlement_amount_minor,
+            expected=str(intent.settlement_amount_minor),
+            actual=str(amount_minor),
+        )
+    )
+
+    if intent.visa is not None and intent.visa.decline_threshold_minor is not None:
+        checks.append(
+            ConformanceCheck(
+                name="over_decline_threshold",
+                passed=amount_minor <= intent.visa.decline_threshold_minor,
+                expected=f"<={intent.visa.decline_threshold_minor}",
+                actual=str(amount_minor),
+            )
+        )
+
+    return ConformanceResult(passed=all(c.passed for c in checks), checks=tuple(checks))
+
+
+def judge_return(intent: PurchaseIntent, *, days_since_delivery: int) -> ReturnVerdict:
+    """Decide whether a return request falls inside the certified window.
+
+    ``days_since_delivery`` is supplied by the caller rather than derived from
+    the clock: a wall-clock read would make the verdict, and therefore the
+    trace, non-reproducible.
+
+    An approved verdict means the request conforms to terms agreed before the
+    purchase. It does not mean money moved -- the Prava API defines no reversal
+    endpoint, so settling an approved return happens off this rail.
+
+    Example::
+
+        verdict = judge_return(intent, days_since_delivery=5)
+        assert verdict.approved
+
+    Raises:
+        PravaIntentError: If ``days_since_delivery`` is negative.
+    """
+    if days_since_delivery < 0:
+        msg = f"days_since_delivery must not be negative, got {days_since_delivery}"
+        raise PravaIntentError(msg)
+
+    policy = intent.visa.refund_policy if intent.visa is not None else None
+    window = (
+        intent.certificate.reference.return_window_days if intent.certificate is not None else None
+    )
+    if window is None:
+        return ReturnVerdict(
+            approved=False,
+            reason="no_return_window_certified",
+            days_since_delivery=days_since_delivery,
+            policy=policy,
+        )
+    inside = days_since_delivery <= window
+    return ReturnVerdict(
+        approved=inside,
+        reason="within_window" if inside else "outside_window",
+        days_since_delivery=days_since_delivery,
+        window_days=window,
+        policy=policy,
+    )

--- a/packages/nest-plugins-reference/nest_plugins_reference/payments/prava_intent.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/payments/prava_intent.py
@@ -253,8 +253,29 @@ class PurchaseIntent:
     colour: str | None = None
     size: str | None = None
     constructed: bool = False
+    intent_id: str | None = None
     certificate: Certificate | None = None
     visa: VisaIntent | None = field(default=None)
+
+    @property
+    def mandate_digest(self) -> str | None:
+        """Digest over the certified terms alone, or ``None`` without a certificate.
+
+        Distinct from :attr:`digest`, which covers the whole snapshot including
+        the selection. The terms are fixed when the intent is declared and never
+        change afterwards, so two snapshots recording different selections
+        against the same request share this value while their full digests
+        differ. That difference is the evidence that the terms were not rewritten
+        to fit whatever an agent happened to find.
+
+        Derived rather than stored: a literal in the file could disagree with the
+        terms it claims to cover.
+
+        Example::
+
+            assert conforming.mandate_digest == drifted.mandate_digest
+        """
+        return self.certificate.digest if self.certificate is not None else None
 
     @property
     def converted(self) -> bool:
@@ -559,6 +580,7 @@ def parse_intent(payload: dict[str, Any], *, expected_schema: str = SCHEMA_V1) -
         colour=_optional_str(item, "colour"),
         size=_optional_str(item, "size"),
         constructed=bool(payload.get("constructed", False)),
+        intent_id=_optional_str(payload, "intent_id"),
         certificate=_parse_certificate(payload),
         visa=_parse_visa_intent(payload, settlement_exponent),
     )

--- a/packages/nest-plugins-reference/pyproject.toml
+++ b/packages/nest-plugins-reference/pyproject.toml
@@ -23,6 +23,11 @@ dependencies = [
     # Required at runtime, so it lives in the package's hard
     # dependencies — a bare `uv sync` installs it.
     "cryptography>=42.0",
+    # Async HTTP for the Prava payments plugin's live transport. Already
+    # present in uv.lock transitively (nest-shell -> openai -> httpx), so
+    # declaring it here is lock-neutral; it is stated explicitly because the
+    # plugin imports it directly and must not rely on a transitive pin.
+    "httpx>=0.27",
 ]
 
 [project.urls]
@@ -55,6 +60,9 @@ cid_facts = "nest_plugins_reference.datafacts.cid_facts:CidFacts"
 [project.entry-points."nest.plugins.failure_detector"]
 heartbeat = "nest_plugins_reference.failure_detection.heartbeat:HeartbeatFailureDetector"
 phi_accrual = "nest_plugins_reference.failure_detection.phi_accrual:PhiAccrualFailureDetector"
+
+[project.entry-points."nest.plugins.payments"]
+prava = "nest_plugins_reference.payments.prava:PravaPayments"
 
 [project.entry-points."nest.plugins.trust"]
 parc = "nest_plugins_reference.trust.parc:ParcTrust"

--- a/packages/nest-plugins-reference/tests/test_prava_intent.py
+++ b/packages/nest-plugins-reference/tests/test_prava_intent.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for purchase-intent snapshots and the price book they feed ``quote``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nest_core.types import AgentId, Money, PaymentRef, ServiceRef
+from nest_plugins_reference.payments.prava import PravaPayments
+from nest_plugins_reference.payments.prava_client import PravaConfigError
+from nest_plugins_reference.payments.prava_intent import (
+    SCHEMA_V1,
+    PravaIntentError,
+    canonical_digest,
+    load_intent,
+    parse_intent,
+    price_book,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SHIPPED_SNAPSHOT = REPO_ROOT / "scenarios" / "intents" / "libas-98252-2XL.json"
+
+
+def _snapshot(**overrides: Any) -> dict[str, Any]:
+    """Build a valid snapshot mapping, with optional top-level overrides."""
+    payload: dict[str, Any] = {
+        "schema": SCHEMA_V1,
+        "captured_at": "2026-08-02T06:52:43Z",
+        "source": "test",
+        "merchant": {"name": "Libas", "endpoint": "https://www.libas.in/api/ucp/mcp"},
+        "item": {
+            "sku": "98252-2XL",
+            "title": "Navy kurti",
+            "service_ref": "libas:98252-2XL",
+            "listed_price": {
+                "amount_minor": 49_900,
+                "currency": "INR",
+                "minor_unit_exponent": 2,
+            },
+        },
+        "settlement": {"amount_minor": 523, "currency": "USD", "minor_unit_exponent": 2},
+        "fx": {
+            "pair": "USD/INR",
+            "rate": "95.4340",
+            "source": "xe.com mid-market",
+            "captured_at": "2026-08-02T02:20:00Z",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    path = tmp_path / "intent.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _payments(**kwargs: Any) -> PravaPayments:
+    defaults: dict[str, Any] = {
+        "mandate_id": "mdt_test",
+        "mode": "simulated",
+        "cap_minor": 100_000,
+    }
+    defaults.update(kwargs)
+    return PravaPayments(AgentId("buyer-0"), **defaults)
+
+
+# -- snapshot parsing ----------------------------------------------------
+
+
+def test_parse_intent_reads_both_prices() -> None:
+    intent = parse_intent(_snapshot())
+    assert intent.service_ref == "libas:98252-2XL"
+    assert intent.listed_amount_minor == 49_900
+    assert intent.listed_currency == "INR"
+    assert intent.settlement_amount_minor == 523
+    assert intent.settlement_currency == "USD"
+    assert intent.converted is True
+
+
+def test_unconverted_snapshot_needs_no_fx_block() -> None:
+    payload = _snapshot()
+    payload["item"]["listed_price"]["currency"] = "USD"
+    payload["item"]["listed_price"]["amount_minor"] = 523
+    del payload["fx"]
+    intent = parse_intent(payload)
+    assert intent.converted is False
+    assert intent.fx_rate is None
+
+
+def test_converted_snapshot_without_fx_is_rejected() -> None:
+    payload = _snapshot()
+    del payload["fx"]
+    with pytest.raises(PravaIntentError, match="carries no 'fx' block"):
+        parse_intent(payload)
+
+
+def test_unknown_schema_is_rejected() -> None:
+    with pytest.raises(PravaIntentError, match="unsupported snapshot schema"):
+        parse_intent(_snapshot(schema="nest.prava.intent/v99"))
+
+
+def test_blank_service_ref_is_rejected() -> None:
+    payload = _snapshot()
+    payload["item"]["service_ref"] = "   "
+    with pytest.raises(PravaIntentError, match="service_ref"):
+        parse_intent(payload)
+
+
+def test_non_positive_settlement_amount_is_rejected() -> None:
+    payload = _snapshot()
+    payload["settlement"]["amount_minor"] = 0
+    with pytest.raises(PravaIntentError, match="must be positive"):
+        parse_intent(payload)
+
+
+def test_float_amount_is_rejected() -> None:
+    payload = _snapshot()
+    payload["settlement"]["amount_minor"] = 5.23
+    with pytest.raises(PravaIntentError, match="minor units"):
+        parse_intent(payload)
+
+
+def test_digest_ignores_key_order() -> None:
+    payload = _snapshot()
+    reordered = dict(reversed(list(payload.items())))
+    assert canonical_digest(payload) == canonical_digest(reordered)
+
+
+def test_digest_changes_with_content() -> None:
+    changed = _snapshot()
+    changed["settlement"]["amount_minor"] = 524
+    assert canonical_digest(_snapshot()) != canonical_digest(changed)
+
+
+# -- loading -------------------------------------------------------------
+
+
+def test_load_intent_round_trips(tmp_path: Path) -> None:
+    intent = load_intent(_write(tmp_path, _snapshot()), expected_currency="USD")
+    assert intent.settlement_amount_minor == 523
+
+
+def test_load_intent_rejects_wrong_settlement_currency(tmp_path: Path) -> None:
+    with pytest.raises(PravaIntentError, match="expects 'EUR'"):
+        load_intent(_write(tmp_path, _snapshot()), expected_currency="EUR")
+
+
+def test_load_intent_reports_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(PravaIntentError, match="cannot read"):
+        load_intent(tmp_path / "absent.json")
+
+
+def test_load_intent_reports_bad_json(tmp_path: Path) -> None:
+    path = tmp_path / "intent.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(PravaIntentError, match="not valid JSON"):
+        load_intent(path)
+
+
+def test_shipped_snapshot_is_valid() -> None:
+    if not SHIPPED_SNAPSHOT.exists():
+        pytest.skip("shipped snapshot not present in this checkout")
+    intent = load_intent(SHIPPED_SNAPSHOT, expected_currency="USD")
+    assert intent.service_ref == "libas:98252-2XL"
+    assert intent.settlement_amount_minor == 523
+    assert intent.listed_amount_minor == 49_900
+
+
+# -- price book ----------------------------------------------------------
+
+
+def test_price_book_maps_service_ref_to_settlement_amount() -> None:
+    assert price_book([parse_intent(_snapshot())]) == {"libas:98252-2XL": 523}
+
+
+def test_price_book_rejects_duplicate_service_refs() -> None:
+    intent = parse_intent(_snapshot())
+    with pytest.raises(PravaIntentError, match="duplicate service_ref"):
+        price_book([intent, intent])
+
+
+# -- quote uses the book -------------------------------------------------
+
+
+async def test_quote_prices_from_the_book() -> None:
+    payments = _payments(price_book={"libas:98252-2XL": 523})
+    quote = await payments.quote(ServiceRef("libas:98252-2XL"))
+    assert quote.price.amount == 523
+    assert quote.metadata["source"] == "prava_intent_snapshot"
+
+
+async def test_quote_raises_on_an_item_no_snapshot_priced() -> None:
+    payments = _payments(price_book={"libas:98252-2XL": 523})
+    with pytest.raises(PravaConfigError, match="no price for service"):
+        await payments.quote(ServiceRef("libas:00000-XS"))
+
+
+async def test_quote_without_a_book_keeps_the_configured_unit_price() -> None:
+    payments = _payments(unit_price_minor=4_000)
+    quote = await payments.quote(ServiceRef("svc-seller-0"))
+    assert quote.price.amount == 4_000
+    assert quote.metadata["source"] == "prava_plugin_price_book"
+
+
+async def test_quote_stamps_the_intent_digest() -> None:
+    payments = _payments(price_book={"libas:98252-2XL": 523}, intent_digest="deadbeef")
+    quote = await payments.quote(ServiceRef("libas:98252-2XL"))
+    assert quote.metadata["intent_digest"] == "deadbeef"
+
+
+async def test_charged_amount_equals_quoted_amount() -> None:
+    payments = _payments(price_book={"libas:98252-2XL": 523})
+    quote = await payments.quote(ServiceRef("libas:98252-2XL"))
+    receipt = await payments.pay(
+        AgentId("seller-0"),
+        Money(amount=quote.price.amount, currency=quote.price.currency),
+        PaymentRef("prava-42-0"),
+    )
+    assert receipt.amount.amount == quote.price.amount == 523
+    await payments.aclose()

--- a/packages/nest-plugins-reference/tests/test_prava_payments.py
+++ b/packages/nest-plugins-reference/tests/test_prava_payments.py
@@ -1,0 +1,770 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Prava payments plugin and its API client.
+
+Every test in the default suite is credential-free: it runs against
+``SimulatedPravaTransport``, the in-process test double, so CI needs no
+``PRAVA_API_KEY``. The one test that touches the real sandbox carries the
+``live`` marker and is deselected by the repo-wide ``-m "not live"``.
+
+Coverage: minor-unit conversion, quote, pay/report, idempotent replay,
+authoritative verify_payment read-back, mandate-cap refusal, the deliberate
+refund refusal, currency handling, live-transport key/host guards, the
+unconfirmed-report policy, and registry resolution.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+from nest_core.plugins import PluginRegistry
+from nest_core.types import AgentId, Money, PaymentRef, PaymentStatus, ServiceRef
+from nest_plugins_reference.payments.prava import (
+    ENV_SANDBOX,
+    MODE_LIVE,
+    MODE_SIMULATED,
+    PravaPaymentError,
+    PravaPayments,
+    PravaRefundUnsupportedError,
+)
+from nest_plugins_reference.payments.prava_client import (
+    CHARGE_STATUS_AWAITING,
+    CHARGE_STATUS_FAILED,
+    PRODUCTION_BASE_URL,
+    SANDBOX_BASE_URL,
+    THRESHOLD_EXCEEDED,
+    ChargeResult,
+    HttpxPravaTransport,
+    PravaClient,
+    PravaConfigError,
+    PravaError,
+    PravaTransport,
+    SimulatedPravaTransport,
+)
+
+MANDATE_ID = "mdt_test_0001"
+BUYER = AgentId("buyer-0")
+SELLER = AgentId("seller-0")
+
+# Environment variables that drive the single `live` test. Names are constants
+# rather than literals so the README and the test cannot drift apart.
+ENV_API_KEY = "PRAVA_API_KEY"
+ENV_MANDATE_ID = "PRAVA_MANDATE_ID"
+ENV_LIVE_AMOUNT_MINOR = "PRAVA_LIVE_AMOUNT_MINOR"
+ENV_LIVE_REFERENCE = "PRAVA_LIVE_REFERENCE"
+
+
+def _transport(
+    *,
+    cap_minor: int = 100_000,
+    currency: str = "USD",
+    exponent: int = 2,
+    fail_references: frozenset[str] = frozenset(),
+) -> SimulatedPravaTransport:
+    """Build the in-process test double. Moves no money, contacts no network."""
+    return SimulatedPravaTransport(
+        mandate_id=MANDATE_ID,
+        cap_minor=cap_minor,
+        currency=currency,
+        exponent=exponent,
+        fail_references=fail_references,
+    )
+
+
+def _payments(
+    *,
+    cap_minor: int = 100_000,
+    currency: str = "USD",
+    exponent: int = 2,
+    unit_price_minor: int = 4_000,
+    fail_closed: bool = True,
+    fail_references: frozenset[str] = frozenset(),
+    agent: AgentId = BUYER,
+) -> tuple[PravaPayments, SimulatedPravaTransport]:
+    """Build a plugin bound to a fresh double, returning both for inspection."""
+    transport = _transport(
+        cap_minor=cap_minor,
+        currency=currency,
+        exponent=exponent,
+        fail_references=fail_references,
+    )
+    payments = PravaPayments(
+        agent,
+        mandate_id=MANDATE_ID,
+        mode=MODE_SIMULATED,
+        currency=currency,
+        minor_unit_exponent=exponent,
+        unit_price_minor=unit_price_minor,
+        fail_closed=fail_closed,
+        transport=transport,
+    )
+    return payments, transport
+
+
+async def _detail(transport: PravaTransport) -> dict[str, Any]:
+    """Read the mandate back the way ``verify_payment`` does."""
+    return await transport.request("GET", f"/v1/mandates/{MANDATE_ID}")
+
+
+def _references(detail: dict[str, Any]) -> list[str]:
+    charges: list[Any] = detail["charges"]
+    return [str(entry["reference"]) for entry in charges]
+
+
+class _FlakyTransport:
+    """Wrapper that injects transport failures. A TEST DOUBLE, not Prava.
+
+    Failures are selected by flag rather than hardcoded so one class covers
+    both the failed-merchant-report policy and the unreachable-API policy.
+    """
+
+    def __init__(
+        self,
+        inner: SimulatedPravaTransport,
+        *,
+        fail_report: bool = False,
+        fail_get: bool = False,
+        status: int = 503,
+        code: str = "UPSTREAM_UNAVAILABLE",
+    ) -> None:
+        self._inner = inner
+        self._fail_report = fail_report
+        self._fail_get = fail_get
+        self._status = status
+        self._code = code
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        if self._fail_report and path.endswith("/report"):
+            raise PravaError(self._status, {"error": {"code": self._code}})
+        if self._fail_get and method == "GET":
+            raise PravaError(self._status, {"error": {"code": self._code}})
+        return await self._inner.request(method, path, body, params)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Minor-unit <-> decimal-string conversion
+# ---------------------------------------------------------------------------
+
+
+class TestAmountConversion:
+    """Nanda Town Money is integer minor units; Prava wants a decimal string."""
+
+    @pytest.mark.parametrize(
+        ("minor", "exponent", "expected"),
+        [
+            (4_000, 2, "40.00"),
+            (0, 2, "0.00"),
+            (1, 2, "0.01"),
+            (100, 2, "1.00"),
+            (123_456, 2, "1234.56"),
+            (4_000, 0, "4000"),
+            (0, 0, "0"),
+            (1_234, 3, "1.234"),
+        ],
+    )
+    def test_minor_to_decimal_string(self, minor: int, exponent: int, expected: str) -> None:
+        from nest_plugins_reference.payments.prava_client import minor_to_decimal_string
+
+        assert minor_to_decimal_string(minor, exponent) == expected
+
+    @pytest.mark.parametrize(
+        ("amount", "exponent", "expected"),
+        [
+            ("40.00", 2, 4_000),
+            ("40", 2, 4_000),
+            ("0.01", 2, 1),
+            ("1234.56", 2, 123_456),
+            ("4000", 0, 4_000),
+            ("1.234", 3, 1_234),
+        ],
+    )
+    def test_decimal_string_to_minor(self, amount: str, exponent: int, expected: int) -> None:
+        from nest_plugins_reference.payments.prava_client import decimal_string_to_minor
+
+        assert decimal_string_to_minor(amount, exponent) == expected
+
+    @pytest.mark.parametrize("minor", [0, 1, 7, 99, 100, 4_000, 999_999])
+    @pytest.mark.parametrize("exponent", [0, 2, 3])
+    def test_round_trip(self, minor: int, exponent: int) -> None:
+        from nest_plugins_reference.payments.prava_client import (
+            decimal_string_to_minor,
+            minor_to_decimal_string,
+        )
+
+        assert decimal_string_to_minor(minor_to_decimal_string(minor, exponent), exponent) == minor
+
+    def test_half_up_rounding_is_explicit(self) -> None:
+        from nest_plugins_reference.payments.prava_client import decimal_string_to_minor
+
+        # 40.005 -> 4000.5 minor units -> ROUND_HALF_UP -> 4001, not banker's 4000.
+        assert decimal_string_to_minor("40.005", 2) == 4_001
+        assert decimal_string_to_minor("40.004", 2) == 4_000
+
+    def test_zero_decimal_currency_is_not_silently_wrong(self) -> None:
+        from nest_plugins_reference.payments.prava_client import minor_to_decimal_string
+
+        # JPY has exponent 0: 4000 yen is "4000", never "40.00".
+        assert minor_to_decimal_string(4_000, 0) == "4000"
+        assert minor_to_decimal_string(4_000, 2) == "40.00"
+
+    def test_negative_exponent_rejected(self) -> None:
+        from nest_plugins_reference.payments.prava_client import (
+            decimal_string_to_minor,
+            minor_to_decimal_string,
+        )
+
+        with pytest.raises(PravaConfigError, match="exponent must be"):
+            minor_to_decimal_string(100, -1)
+        with pytest.raises(PravaConfigError, match="exponent must be"):
+            decimal_string_to_minor("1.00", -1)
+
+    def test_non_decimal_string_rejected(self) -> None:
+        from nest_plugins_reference.payments.prava_client import decimal_string_to_minor
+
+        with pytest.raises(PravaConfigError, match="not a decimal amount"):
+            decimal_string_to_minor("forty dollars")
+
+
+# ---------------------------------------------------------------------------
+# ChargeResult envelope normalization
+# ---------------------------------------------------------------------------
+
+
+class TestChargeResult:
+    """``accepted`` and ``over_cap`` collapse Prava's status + errorCode."""
+
+    def test_accepted_charge(self) -> None:
+        result = ChargeResult(
+            {
+                "status": CHARGE_STATUS_AWAITING,
+                "transactionId": "txn_1",
+                "orderId": "ord_1",
+                "instructionId": "ins_1",
+                "deduplicated": False,
+            }
+        )
+        assert result.accepted is True
+        assert result.over_cap is False
+        assert result.transaction_id == "txn_1"
+
+    def test_over_cap_refusal(self) -> None:
+        result = ChargeResult({"status": CHARGE_STATUS_FAILED, "errorCode": THRESHOLD_EXCEEDED})
+        assert result.accepted is False
+        assert result.over_cap is True
+
+    def test_ordinary_decline_is_not_over_cap(self) -> None:
+        result = ChargeResult({"status": CHARGE_STATUS_FAILED, "errorCode": "CHARGE_DECLINED"})
+        assert result.accepted is False
+        assert result.over_cap is False
+
+
+# ---------------------------------------------------------------------------
+# The simulated transport is a labelled double, and it is honest about limits
+# ---------------------------------------------------------------------------
+
+
+class TestSimulatedTransport:
+    """The double must satisfy the Protocol and refuse to invent behaviour."""
+
+    def test_satisfies_transport_protocol(self) -> None:
+        assert isinstance(_transport(), PravaTransport)
+        assert isinstance(_FlakyTransport(_transport()), PravaTransport)
+
+    @pytest.mark.asyncio
+    async def test_unknown_mandate_is_404(self) -> None:
+        transport = _transport()
+        with pytest.raises(PravaError) as exc_info:
+            await transport.request("GET", "/v1/mandates/mdt_someone_else")
+        assert exc_info.value.status == 404
+        assert exc_info.value.code == "MANDATE_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_unsimulated_path_raises_rather_than_faking(self) -> None:
+        transport = _transport()
+        with pytest.raises(NotImplementedError, match="does not simulate"):
+            await transport.request("POST", "/v1/sessions", body={"mandate_setup": {}})
+
+    @pytest.mark.asyncio
+    async def test_identifiers_are_deterministic_across_runs(self) -> None:
+        seen: list[list[str]] = []
+        for _ in range(2):
+            payments, transport = _payments()
+            await payments.pay(SELLER, Money(amount=4_000, currency="USD"), PaymentRef("r-1"))
+            await payments.pay(SELLER, Money(amount=1_500, currency="USD"), PaymentRef("r-2"))
+            detail = await _detail(transport)
+            charges: list[Any] = detail["charges"]
+            seen.append([str(entry["transactionId"]) for entry in charges])
+        assert seen[0] == seen[1]
+
+
+# ---------------------------------------------------------------------------
+# Construction and configuration
+# ---------------------------------------------------------------------------
+
+
+class TestConfiguration:
+    """Every knob is validated at construction, before any money is at risk."""
+
+    def test_mandate_id_is_required(self) -> None:
+        with pytest.raises(PravaConfigError, match="mandate_id is required"):
+            PravaPayments(BUYER, mandate_id="", mode=MODE_SIMULATED)
+
+    def test_unknown_mode_rejected(self) -> None:
+        with pytest.raises(PravaConfigError, match="mode must be one of"):
+            PravaPayments(BUYER, mandate_id=MANDATE_ID, mode="dry_run")
+
+    def test_unknown_env_rejected(self) -> None:
+        with pytest.raises(PravaConfigError, match="prava_env must be one of"):
+            PravaPayments(BUYER, mandate_id=MANDATE_ID, prava_env="staging")
+
+    def test_live_mode_without_key_refuses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_API_KEY, raising=False)
+        with pytest.raises(PravaConfigError, match="requires a Prava secret key"):
+            PravaPayments(BUYER, mandate_id=MANDATE_ID, mode=MODE_LIVE)
+
+    def test_mode_and_mandate_are_public(self) -> None:
+        payments, _ = _payments()
+        assert payments.mode == MODE_SIMULATED
+        assert payments.mandate_id == MANDATE_ID
+
+
+class TestHttpxTransportGuards:
+    """A key/host mismatch is silent and expensive, so it is refused up front."""
+
+    def test_empty_key_rejected(self) -> None:
+        with pytest.raises(PravaConfigError, match="api_key is required"):
+            HttpxPravaTransport(api_key="", base_url=SANDBOX_BASE_URL)
+
+    def test_live_key_against_sandbox_rejected(self) -> None:
+        with pytest.raises(PravaConfigError, match="live key"):
+            HttpxPravaTransport(api_key="sk_live_abc", base_url=SANDBOX_BASE_URL)
+
+    def test_test_key_against_production_rejected(self) -> None:
+        with pytest.raises(PravaConfigError, match="test key"):
+            HttpxPravaTransport(api_key="sk_test_abc", base_url=PRODUCTION_BASE_URL)
+
+    def test_negative_retries_rejected(self) -> None:
+        with pytest.raises(PravaConfigError, match="max_retries must be"):
+            HttpxPravaTransport(api_key="sk_test_abc", base_url=SANDBOX_BASE_URL, max_retries=-1)
+
+
+# ---------------------------------------------------------------------------
+# quote
+# ---------------------------------------------------------------------------
+
+
+class TestQuote:
+    """Prava has no quote endpoint; the price book is local and deterministic."""
+
+    @pytest.mark.asyncio
+    async def test_quote_returns_configured_price(self) -> None:
+        payments, _ = _payments(unit_price_minor=2_500)
+        quote = await payments.quote(ServiceRef("svc-1"))
+        assert quote.service == ServiceRef("svc-1")
+        assert quote.price.amount == 2_500
+        assert quote.price.currency == "USD"
+
+    @pytest.mark.asyncio
+    async def test_quote_discloses_mode(self) -> None:
+        payments, _ = _payments()
+        quote = await payments.quote(ServiceRef("svc-1"))
+        assert quote.metadata["mode"] == MODE_SIMULATED
+
+    @pytest.mark.asyncio
+    async def test_quote_makes_no_charge(self) -> None:
+        payments, transport = _payments()
+        await payments.quote(ServiceRef("svc-1"))
+        detail = await _detail(transport)
+        assert detail["chargeCount"] == 0
+
+
+# ---------------------------------------------------------------------------
+# pay
+# ---------------------------------------------------------------------------
+
+
+class TestPay:
+    """``pay`` charges the mandate, then reports the merchant-side outcome."""
+
+    @pytest.mark.asyncio
+    async def test_pay_returns_receipt(self) -> None:
+        payments, _ = _payments()
+        ref = PaymentRef("scenario-42-trade-0")
+        receipt = await payments.pay(SELLER, Money(amount=4_000, currency="USD"), ref)
+        assert receipt.ref == ref
+        assert receipt.payer == BUYER
+        assert receipt.payee == SELLER
+        assert receipt.amount.amount == 4_000
+        assert receipt.amount.currency == "USD"
+
+    @pytest.mark.asyncio
+    async def test_pay_appears_in_the_mandate_ledger(self) -> None:
+        payments, transport = _payments()
+        await payments.pay(SELLER, Money(amount=4_000, currency="USD"), PaymentRef("r-1"))
+        detail = await _detail(transport)
+        assert detail["chargeCount"] == 1
+        assert detail["spent"] == "40.00"
+        assert detail["remaining"] == "960.00"
+        assert _references(detail) == ["r-1"]
+
+    @pytest.mark.asyncio
+    async def test_pay_caches_receipt_and_confirmation(self) -> None:
+        payments, _ = _payments()
+        ref = PaymentRef("r-1")
+        await payments.pay(SELLER, Money(amount=4_000, currency="USD"), ref)
+        cached = payments.receipt(ref)
+        assert cached is not None
+        assert cached.ref == ref
+        assert payments.confirmed(ref) is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_ref_has_no_cached_receipt(self) -> None:
+        payments, _ = _payments()
+        assert payments.receipt(PaymentRef("never-paid")) is None
+        assert payments.confirmed(PaymentRef("never-paid")) is False
+
+    @pytest.mark.asyncio
+    async def test_non_positive_amount_rejected(self) -> None:
+        payments, _ = _payments()
+        with pytest.raises(PravaConfigError, match="must be positive"):
+            await payments.pay(SELLER, Money(amount=0, currency="USD"), PaymentRef("r-1"))
+
+    @pytest.mark.asyncio
+    async def test_zero_decimal_currency_charges_whole_units(self) -> None:
+        payments, transport = _payments(currency="JPY", exponent=0, cap_minor=10_000)
+        await payments.pay(SELLER, Money(amount=4_000, currency="JPY"), PaymentRef("r-jpy"))
+        detail = await _detail(transport)
+        assert detail["spent"] == "4000"
+        assert detail["currency"] == "JPY"
+
+
+class TestIdempotentReplay:
+    """PaymentRef is Prava's idempotency key: replay safety is rail-enforced."""
+
+    @pytest.mark.asyncio
+    async def test_replayed_ref_does_not_draw_the_mandate_twice(self) -> None:
+        payments, transport = _payments()
+        ref = PaymentRef("scenario-42-trade-0")
+        money = Money(amount=4_000, currency="USD")
+
+        first = await payments.pay(SELLER, money, ref)
+        after_first = await _detail(transport)
+        second = await payments.pay(SELLER, money, ref)
+        after_second = await _detail(transport)
+
+        assert first.ref == second.ref
+        assert after_second["spent"] == after_first["spent"] == "40.00"
+        assert after_second["chargeCount"] == 1
+        assert _references(after_second) == [str(ref)]
+
+    @pytest.mark.asyncio
+    async def test_replay_is_flagged_deduplicated_at_the_client(self) -> None:
+        client = PravaClient(_transport(), minor_unit_exponent=2)
+        first = await client.charge(MANDATE_ID, amount_minor=4_000, reference="r-1")
+        second = await client.charge(MANDATE_ID, amount_minor=4_000, reference="r-1")
+        assert first.deduplicated is False
+        assert second.deduplicated is True
+        assert second.transaction_id == first.transaction_id
+
+    @pytest.mark.asyncio
+    async def test_distinct_refs_are_distinct_charges(self) -> None:
+        payments, transport = _payments()
+        money = Money(amount=1_000, currency="USD")
+        await payments.pay(SELLER, money, PaymentRef("r-1"))
+        await payments.pay(SELLER, money, PaymentRef("r-2"))
+        detail = await _detail(transport)
+        assert detail["chargeCount"] == 2
+        assert detail["spent"] == "20.00"
+
+
+class TestClientValidation:
+    """The client refuses malformed charges without spending a round trip."""
+
+    @pytest.mark.asyncio
+    async def test_non_positive_amount_rejected(self) -> None:
+        client = PravaClient(_transport())
+        with pytest.raises(PravaConfigError, match="amount_minor must be positive"):
+            await client.charge(MANDATE_ID, amount_minor=0, reference="r-1")
+
+    @pytest.mark.asyncio
+    async def test_empty_reference_rejected(self) -> None:
+        client = PravaClient(_transport())
+        with pytest.raises(PravaConfigError, match="reference must be"):
+            await client.charge(MANDATE_ID, amount_minor=100, reference="")
+
+    @pytest.mark.asyncio
+    async def test_overlong_reference_rejected(self) -> None:
+        client = PravaClient(_transport())
+        with pytest.raises(PravaConfigError, match="reference must be"):
+            await client.charge(MANDATE_ID, amount_minor=100, reference="x" * 256)
+
+    @pytest.mark.asyncio
+    async def test_max_length_reference_accepted(self) -> None:
+        client = PravaClient(_transport())
+        result = await client.charge(MANDATE_ID, amount_minor=100, reference="x" * 255)
+        assert result.accepted is True
+
+    @pytest.mark.asyncio
+    async def test_find_charge_returns_none_for_unknown_reference(self) -> None:
+        client = PravaClient(_transport())
+        assert await client.find_charge(MANDATE_ID, "never-charged") is None
+
+
+# ---------------------------------------------------------------------------
+# verify_payment -- authoritative read-back
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyPayment:
+    """The answer comes from Prava's ledger, never from local state."""
+
+    @pytest.mark.asyncio
+    async def test_confirmed_after_pay(self) -> None:
+        payments, _ = _payments()
+        ref = PaymentRef("r-1")
+        await payments.pay(SELLER, Money(amount=4_000, currency="USD"), ref)
+        assert await payments.verify_payment(ref) == PaymentStatus.CONFIRMED
+
+    @pytest.mark.asyncio
+    async def test_failed_for_unknown_ref(self) -> None:
+        payments, _ = _payments()
+        assert await payments.verify_payment(PaymentRef("never-paid")) == PaymentStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_pending_for_charged_but_unreported(self) -> None:
+        payments, transport = _payments()
+        client = PravaClient(transport, minor_unit_exponent=2)
+        # Charge without the merchant-report leg: Prava's ledger still says
+        # awaiting_result, so the honest answer is PENDING, not CONFIRMED.
+        await client.charge(MANDATE_ID, amount_minor=1_000, reference="r-unreported")
+        status = await payments.verify_payment(PaymentRef("r-unreported"))
+        assert status == PaymentStatus.PENDING
+
+    @pytest.mark.asyncio
+    async def test_unreachable_api_is_pending_not_failed(self) -> None:
+        # An unreachable API is not evidence that a payment did not happen.
+        inner = _transport()
+        payments = PravaPayments(
+            BUYER,
+            mandate_id=MANDATE_ID,
+            mode=MODE_SIMULATED,
+            transport=_FlakyTransport(inner, fail_get=True),
+        )
+        assert await payments.verify_payment(PaymentRef("r-1")) == PaymentStatus.PENDING
+
+    @pytest.mark.asyncio
+    async def test_refused_charge_is_not_in_the_ledger(self) -> None:
+        payments, _ = _payments(cap_minor=5_000)
+        await payments.pay(SELLER, Money(amount=4_000, currency="USD"), PaymentRef("r-1"))
+        with pytest.raises(PravaPaymentError):
+            await payments.pay(SELLER, Money(amount=4_000, currency="USD"), PaymentRef("r-2"))
+        assert await payments.verify_payment(PaymentRef("r-2")) == PaymentStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Refusals: mandate cap, decline, unconfirmed report
+# ---------------------------------------------------------------------------
+
+
+class TestRefusals:
+    """Prava's refusals are surfaced, never swallowed or retried into success."""
+
+    @pytest.mark.asyncio
+    async def test_over_cap_raises_with_threshold_code(self) -> None:
+        payments, transport = _payments(cap_minor=5_000)
+        await payments.pay(SELLER, Money(amount=4_000, currency="USD"), PaymentRef("r-1"))
+        with pytest.raises(PravaPaymentError) as exc_info:
+            await payments.pay(SELLER, Money(amount=4_000, currency="USD"), PaymentRef("r-2"))
+        assert exc_info.value.over_cap is True
+        assert exc_info.value.code == THRESHOLD_EXCEEDED
+        detail = await _detail(transport)
+        assert detail["spent"] == "40.00"
+        assert detail["chargeCount"] == 1
+
+    @pytest.mark.asyncio
+    async def test_decline_is_not_over_cap(self) -> None:
+        payments, _ = _payments(fail_references=frozenset({"r-declined"}))
+        with pytest.raises(PravaPaymentError) as exc_info:
+            await payments.pay(
+                SELLER, Money(amount=1_000, currency="USD"), PaymentRef("r-declined")
+            )
+        assert exc_info.value.over_cap is False
+        assert exc_info.value.code == "CHARGE_DECLINED"
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_refuses_a_receipt_when_report_fails(self) -> None:
+        payments = PravaPayments(
+            BUYER,
+            mandate_id=MANDATE_ID,
+            mode=MODE_SIMULATED,
+            fail_closed=True,
+            transport=_FlakyTransport(_transport(), fail_report=True),
+        )
+        with pytest.raises(PravaPaymentError, match="UNCONFIRMED"):
+            await payments.pay(SELLER, Money(amount=1_000, currency="USD"), PaymentRef("r-1"))
+
+    @pytest.mark.asyncio
+    async def test_fail_open_returns_an_unconfirmed_receipt(self) -> None:
+        inner = _transport()
+        payments = PravaPayments(
+            BUYER,
+            mandate_id=MANDATE_ID,
+            mode=MODE_SIMULATED,
+            fail_closed=False,
+            transport=_FlakyTransport(inner, fail_report=True),
+        )
+        ref = PaymentRef("r-1")
+        receipt = await payments.pay(SELLER, Money(amount=1_000, currency="USD"), ref)
+        assert receipt.ref == ref
+        # The receipt exists, but the plugin does not claim confirmation...
+        assert payments.confirmed(ref) is False
+        # ...and the ledger read-back agrees it is still in flight.
+        assert await payments.verify_payment(ref) == PaymentStatus.PENDING
+
+
+class TestRefundIsUnsupported:
+    """Prava defines no refund, credit or reversal path. We do not fake one."""
+
+    @pytest.mark.asyncio
+    async def test_refund_raises(self) -> None:
+        payments, _ = _payments()
+        ref = PaymentRef("r-1")
+        await payments.pay(SELLER, Money(amount=4_000, currency="USD"), ref)
+        with pytest.raises(PravaRefundUnsupportedError, match="no refund"):
+            await payments.refund(ref)
+
+    @pytest.mark.asyncio
+    async def test_refund_raises_even_for_unknown_ref(self) -> None:
+        payments, _ = _payments()
+        with pytest.raises(PravaRefundUnsupportedError):
+            await payments.refund(PaymentRef("never-paid"))
+
+    def test_error_is_a_notimplementederror(self) -> None:
+        # Rooted in a stdlib base on purpose: nest_core catches it in the
+        # scenario without importing nest_plugins_reference.
+        assert issubclass(PravaRefundUnsupportedError, NotImplementedError)
+
+    def test_payment_error_is_a_runtimeerror(self) -> None:
+        assert issubclass(PravaPaymentError, RuntimeError)
+
+    def test_config_error_is_a_valueerror(self) -> None:
+        assert issubclass(PravaConfigError, ValueError)
+
+    def test_client_exposes_no_refund_method(self) -> None:
+        assert not hasattr(PravaClient, "refund")
+
+
+# ---------------------------------------------------------------------------
+# Currency handling
+# ---------------------------------------------------------------------------
+
+
+class TestCurrency:
+    """Configured ISO code, plus Nanda Town's layer-neutral ``credits``."""
+
+    @pytest.mark.asyncio
+    async def test_mismatched_currency_rejected(self) -> None:
+        payments, _ = _payments(currency="USD")
+        with pytest.raises(PravaConfigError, match="currency mismatch"):
+            await payments.pay(SELLER, Money(amount=1_000, currency="EUR"), PaymentRef("r-1"))
+
+    @pytest.mark.asyncio
+    async def test_credits_accepted_and_settled_in_configured_currency(self) -> None:
+        payments, transport = _payments(currency="USD")
+        receipt = await payments.pay(
+            SELLER, Money(amount=1_000, currency="credits"), PaymentRef("r-1")
+        )
+        assert receipt.amount.currency == "USD"
+        detail = await _detail(transport)
+        assert detail["currency"] == "USD"
+
+    @pytest.mark.asyncio
+    async def test_mismatch_is_rejected_before_any_charge(self) -> None:
+        payments, transport = _payments(currency="USD")
+        with pytest.raises(PravaConfigError):
+            await payments.pay(SELLER, Money(amount=1_000, currency="GBP"), PaymentRef("r-1"))
+        detail = await _detail(transport)
+        assert detail["chargeCount"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    """The plugin must be reachable by name, which is how scenarios load it."""
+
+    def test_resolves_by_layer_and_name(self) -> None:
+        assert PluginRegistry().resolve("payments", "prava") is PravaPayments
+
+    def test_listed_under_the_payments_layer(self) -> None:
+        assert ("payments", "prava") in PluginRegistry().list_plugins("payments")
+
+
+# ---------------------------------------------------------------------------
+# Live sandbox test -- deselected by default via the repo-wide -m "not live"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_live_sandbox_charge_is_idempotent() -> None:
+    """Charge a real sandbox mandate twice and prove the rail deduplicates.
+
+    Requires a mandate provisioned out of band (POST /v1/sessions plus a human
+    passkey approval). Run with::
+
+        PRAVA_API_KEY=sk_test_... PRAVA_MANDATE_ID=mdt_... \
+            uv run pytest -m live -k live_sandbox
+    """
+    api_key = os.environ.get(ENV_API_KEY, "")
+    mandate_id = os.environ.get(ENV_MANDATE_ID, "")
+    if not api_key or not mandate_id:
+        pytest.skip(f"set {ENV_API_KEY} and {ENV_MANDATE_ID} to run the live Prava test")
+    if not api_key.startswith("sk_test_"):
+        pytest.skip("live test runs against the sandbox only; expected an sk_test_ key")
+
+    amount_minor = int(os.environ.get(ENV_LIVE_AMOUNT_MINOR, "100"))
+    reference = os.environ.get(ENV_LIVE_REFERENCE, "nest-prava-live-0001")
+
+    payments = PravaPayments(
+        BUYER,
+        mandate_id=mandate_id,
+        mode=MODE_LIVE,
+        prava_env=ENV_SANDBOX,
+        api_key=api_key,
+        unit_price_minor=amount_minor,
+    )
+    try:
+        ref = PaymentRef(reference)
+        receipt = await payments.pay(SELLER, Money(amount=amount_minor, currency="USD"), ref)
+        assert receipt.amount.amount == amount_minor
+        assert await payments.verify_payment(ref) in (
+            PaymentStatus.CONFIRMED,
+            PaymentStatus.PENDING,
+        )
+
+        client = PravaClient(
+            HttpxPravaTransport(api_key=api_key, base_url=SANDBOX_BASE_URL),
+            minor_unit_exponent=2,
+        )
+        try:
+            replay = await client.charge(mandate_id, amount_minor=amount_minor, reference=reference)
+            assert replay.deduplicated is True
+            charge = await client.find_charge(mandate_id, reference)
+            assert charge is not None
+        finally:
+            await client.aclose()
+    finally:
+        await payments.aclose()

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "nixpacksConfigPath": "nixpacks.toml"
+  },
+  "deploy": {
+    "startCommand": "python -m uvicorn app:app --app-dir apps/skill-service --host 0.0.0.0 --port $PORT",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 120,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/scenarios/intents/libas-98115-2XL-drift.json
+++ b/scenarios/intents/libas-98115-2XL-drift.json
@@ -1,5 +1,6 @@
 {
   "schema": "nest.prava.intent/v1",
+  "intent_id": "int_2026-08-02_libas_kurti_001",
   "captured_at": "2026-08-02T20:14:11Z",
   "source": "CONSTRUCTED drift case, hand-written. Models an agent that could not find the requested colour in stock and settled for a cheaper near-match. Not the output of a live agent run.",
   "constructed": true,

--- a/scenarios/intents/libas-98115-2XL-drift.json
+++ b/scenarios/intents/libas-98115-2XL-drift.json
@@ -1,26 +1,27 @@
 {
   "schema": "nest.prava.intent/v1",
-  "captured_at": "2026-08-02T06:52:43Z",
-  "source": "openclaw agent 'main', session libas-test, openai/gpt-5.5, product discovery via prava shop against https://www.libas.in/api/ucp/mcp",
+  "captured_at": "2026-08-02T20:14:11Z",
+  "source": "CONSTRUCTED drift case, hand-written. Models an agent that could not find the requested colour in stock and settled for a cheaper near-match. Not the output of a live agent run.",
+  "constructed": true,
   "merchant": {
     "name": "Libas",
     "endpoint": "https://www.libas.in/api/ucp/mcp"
   },
   "item": {
-    "sku": "98252-2XL",
-    "title": "Libas Navy Blue Printed Cotton Blend Straight Short Kurti",
-    "service_ref": "libas:98252-2XL",
-    "colour": "Navy",
+    "sku": "98115-2XL",
+    "title": "Libas Maroon Printed Cotton Blend Straight Short Kurti",
+    "service_ref": "libas:98115-2XL",
+    "colour": "Maroon",
     "size": "XXL",
     "stock": "in_stock",
     "listed_price": {
-      "amount_minor": 49900,
+      "amount_minor": 45000,
       "currency": "INR",
       "minor_unit_exponent": 2
     }
   },
   "settlement": {
-    "amount_minor": 523,
+    "amount_minor": 472,
     "currency": "USD",
     "minor_unit_exponent": 2
   },
@@ -49,7 +50,7 @@
   },
   "visa_intent": {
     "conformance_note": "Structured to the Visa Intelligent Commerce purchase-intent schema (POST /acp/v1/instructions). Recorded for conformance and audit only; this artifact is NOT sent to Visa. Settlement is executed on Visa rails through Prava, a Visa Intelligent Commerce partner.",
-    "consumerPrompt": "Authorize payment of USD 5.23 to Libas for one kurti",
+    "consumerPrompt": "Authorize payment of USD 4.72 to Libas for one kurti",
     "mandates": [
       {
         "mandateId": "ord_01KZ1BBCET63XJJFF2Z0FYMHST",
@@ -66,11 +67,11 @@
     ],
     "products": [
       {
-        "productId": "98252-2XL",
-        "productName": "Libas Navy Blue Printed Cotton Blend Straight Short Kurti",
+        "productId": "98115-2XL",
+        "productName": "Libas Maroon Printed Cotton Blend Straight Short Kurti",
         "quantity": "1",
         "unitPrice": {
-          "amount": "5.23",
+          "amount": "4.72",
           "currency": "USD"
         },
         "productUrl": "https://www.libas.in",
@@ -80,5 +81,5 @@
       }
     ]
   },
-  "note": "49900 INR minor / 95.4340 = 5.2287 USD, rounded half up to 523 USD minor. The rate is mid-market and is recorded for audit only: the card network applies its own conversion rate plus any issuer fee at settlement, so a real statement will not show exactly 499.00 INR. A second source (bookmyforex.com, 2026-08-02, 95.4025) rounds to the same 523 minor units."
+  "note": "45000 INR minor / 95.4340 = 4.7154 USD, rounded half up to 472 USD minor. This selection is CHEAPER than the navy kurti (472 vs 523 minor) and sits UNDER the declineThreshold of 5.30 USD, so every amount-based control in the stack accepts it. It violates the certified intent on one axis only: Maroon is not in the allowed colour set green|pink|navy. That is the case this scenario exists to catch."
 }

--- a/scenarios/intents/libas-98252-2XL.json
+++ b/scenarios/intents/libas-98252-2XL.json
@@ -1,5 +1,6 @@
 {
   "schema": "nest.prava.intent/v1",
+  "intent_id": "int_2026-08-02_libas_kurti_001",
   "captured_at": "2026-08-02T06:52:43Z",
   "source": "openclaw agent 'main', session libas-test, openai/gpt-5.5, product discovery via prava shop against https://www.libas.in/api/ucp/mcp",
   "merchant": {

--- a/scenarios/intents/libas-98252-2XL.json
+++ b/scenarios/intents/libas-98252-2XL.json
@@ -1,0 +1,35 @@
+{
+  "schema": "nest.prava.intent/v1",
+  "captured_at": "2026-08-02T06:52:43Z",
+  "source": "openclaw agent 'main', session libas-test, openai/gpt-5.5, product discovery via prava shop against https://www.libas.in/api/ucp/mcp",
+  "merchant": {
+    "name": "Libas",
+    "endpoint": "https://www.libas.in/api/ucp/mcp"
+  },
+  "item": {
+    "sku": "98252-2XL",
+    "title": "Libas Navy Blue Printed Cotton Blend Straight Short Kurti",
+    "service_ref": "libas:98252-2XL",
+    "colour": "Navy",
+    "size": "XXL",
+    "stock": "in_stock",
+    "listed_price": {
+      "amount_minor": 49900,
+      "currency": "INR",
+      "minor_unit_exponent": 2
+    }
+  },
+  "settlement": {
+    "amount_minor": 523,
+    "currency": "USD",
+    "minor_unit_exponent": 2
+  },
+  "fx": {
+    "pair": "USD/INR",
+    "rate": "95.4340",
+    "source": "xe.com mid-market",
+    "captured_at": "2026-08-02T02:20:00Z",
+    "rounding": "half_up_to_minor_unit"
+  },
+  "note": "49900 INR minor / 95.4340 = 5.2287 USD, rounded half up to 523 USD minor. The rate is mid-market and is recorded for audit only: the card network applies its own conversion rate plus any issuer fee at settlement, so a real statement will not show exactly 499.00 INR. A second source (bookmyforex.com, 2026-08-02, 95.4025) rounds to the same 523 minor units."
+}

--- a/scenarios/prava_commerce.yaml
+++ b/scenarios/prava_commerce.yaml
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# Prava commerce: buyer/seller pairs settling on a Prava mandate.
+#
+# Deliberately SMALL. A marketplace-sized run (50 buyers x 50 sellers x 10
+# rounds) would exhaust a real sandbox mandate cap long before finishing, so
+# this scenario proves the rail rather than stress-testing it.
+#
+# DEFAULT MODE IS `simulated`. That runs against SimulatedPravaTransport, an
+# in-process test double: no network, no money, no credentials, and a
+# byte-identical trace for a given seed. This is what CI runs, because CI holds
+# no Prava key.
+#
+# To settle for real against the Prava sandbox:
+#   1. Provision a mandate out of band (POST /v1/sessions + human passkey tap).
+#      A mandate cannot be created mid-simulation, so the id is injected here.
+#   2. export PRAVA_API_KEY=sk_test_...      # NEVER put the key in this file
+#   3. Set mode: live and mandate_id: mdt_<yours> below.
+# A live run makes real network calls, so the "same seed -> byte-identical
+# trace" guarantee no longer holds. That is disclosed here and in the README.
+
+name: prava_commerce
+description: |
+  Two buyer/seller pairs exercise the Prava payments rail end to end:
+  quote -> pay -> replay the same PaymentRef (Prava dedupes, no double
+  charge) -> verify against Prava's own ledger -> attempt an oversized
+  charge (refused with THRESHOLD_EXCEEDED) -> request a refund (raises,
+  because the Prava API defines no refund endpoint).
+
+tier: 1
+seed: 42
+
+agents:
+  count: 4
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 2
+      config: {}
+    - name: seller
+      count: 2
+      config: {}
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prava
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: prava_commerce
+  config:
+    pairs: 2
+    # ----- rail selection -------------------------------------------------
+    mode: simulated              # simulated | live
+    prava_env: sandbox           # sandbox | production
+    mandate_id: mdt_simulated_demo
+    # ----- money ----------------------------------------------------------
+    currency: USD
+    minor_unit_exponent: 2       # 0 for zero-decimal currencies (JPY, KRW)
+    unit_price_minor: 4000       # "40.00"
+    cap_minor: 100000            # "1000.00"; simulated-mode mandate ceiling
+    overcap_minor: 99999900      # oversized on purpose -> THRESHOLD_EXCEEDED
+    # ----- behaviour ------------------------------------------------------
+    fail_closed: true            # an unconfirmed charge is a failure, never a success
+    timeout_s: 30.0
+    max_retries: 3
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 200"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/prava_commerce.jsonl

--- a/scenarios/prava_commerce.yaml
+++ b/scenarios/prava_commerce.yaml
@@ -26,6 +26,10 @@ description: |
   charge (refused with THRESHOLD_EXCEEDED) -> request a refund (raises,
   because the Prava API defines no refund endpoint).
 
+  The quoted price comes from a frozen purchase-intent snapshot rather than
+  from this file, so the amount settled is the amount an upstream shopping
+  agent actually agreed to for a specific catalogue item.
+
 tier: 1
 seed: 42
 
@@ -65,7 +69,17 @@ task:
     # ----- money ----------------------------------------------------------
     currency: USD
     minor_unit_exponent: 2       # 0 for zero-decimal currencies (JPY, KRW)
-    unit_price_minor: 4000       # "40.00"
+    # The price is NOT set here. It comes from a frozen purchase-intent
+    # snapshot: the record of an item an upstream LLM shopper selected from a
+    # live merchant catalogue, with the listed price, the settlement amount and
+    # the FX rate that connects them. Product discovery is non-deterministic and
+    # networked, so it happens out of band and its result is written down; the
+    # scenario reads the file and never queries a catalogue. The buyer quotes
+    # the snapshot's service_ref and pays exactly what the quote returned.
+    # Remove this line to fall back to the synthetic svc-<seller> ref priced at
+    # unit_price_minor below.
+    intent_snapshot: ./scenarios/intents/libas-98252-2XL.json
+    unit_price_minor: 4000       # "40.00"; fallback only, unused with a snapshot
     cap_minor: 100000            # "1000.00"; simulated-mode mandate ceiling
     overcap_minor: 99999900      # oversized on purpose -> THRESHOLD_EXCEEDED
     # ----- behaviour ------------------------------------------------------

--- a/scenarios/prava_dvp.yaml
+++ b/scenarios/prava_dvp.yaml
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# IntentDvP: delivery-versus-payment against a certified purchase intent.
+#
+# WHAT THIS DEMONSTRATES, AND WHY IT MATTERS
+#
+# An LLM shopping agent was asked: "find one kurti under 500 rupees in green,
+# pink or navy on libas and buy one". That sentence cannot be checked against a
+# delivery. An out-of-band certifier turns it into terms that can be --
+# allowed_colours, a price ceiling, the merchant, the quantity, a return window
+# -- and anchors them with a digest. That is the `certificate` block in the
+# snapshot this scenario reads.
+#
+# The plugin then refuses to charge unless the delivery matches those terms,
+# BEFORE any network call is made. A refused purchase leaves nothing at the
+# payment rail: no charge, no credential, nothing to reverse.
+#
+# The failure worth understanding is a CHEAPER substitution. Point this scenario
+# at the drift snapshot and the agent has settled for a maroon kurti at INR 450
+# instead of the navy one at INR 499. It is cheaper than the quote, under the
+# declineThreshold, and from the same merchant -- so every amount-based control
+# in the stack accepts it: Visa's decline threshold, the mandate cap, the card
+# network's own ceiling. All of those ask only HOW MUCH. None asks WHAT. The
+# user authorised green, pink or navy; maroon was never in scope. Comparing the
+# delivery to the certified intent is the only thing that catches it.
+#
+# RUN THE TWO CASES
+#   Conforming:      intent_snapshot -> libas-98252-2XL.json
+#                    delivery.product_id -> 98252-2XL
+#   Drifted:         intent_snapshot -> libas-98115-2XL-drift.json
+#                    delivery.product_id -> 98115-2XL
+#
+# RETURNS
+#   days_since_delivery is CONFIG, never the wall clock -- a clock read would
+#   make the verdict, and the trace, non-reproducible. Set 5 for a verdict
+#   inside the certified 30-day window, 40 for outside it. An approved verdict
+#   means the request conforms to terms agreed up front; it does NOT mean money
+#   moved. The Prava API defines no reversal endpoint, so settling an approved
+#   return happens off this rail, and the broadcast says so.
+#
+# LIVE MODE
+#   Default is `simulated`: in-process, no network, no credentials,
+#   byte-identical per seed. To settle for real, provision a mandate out of
+#   band, export PRAVA_API_KEY (never put it in this file), then set
+#   mode: live and mandate_id below. A live run is not byte-deterministic.
+
+name: prava_dvp
+description: |
+  One buyer settles a kurti on the Prava rail only if the delivery conforms
+  to a certified purchase intent: colour within the authorised set, price
+  under the ceiling, the agreed merchant, the selected product id, and the
+  quoted amount. A non-conforming delivery is refused before any charge is
+  attempted, so nothing reaches the card network.
+
+  A return request is then judged against the same certificate's window.
+  Approved means the request conforms to terms agreed before purchase -- not
+  that a credit was issued; Prava exposes no reversal endpoint.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 2
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 1
+      config: {}
+    - name: seller
+      count: 1
+      config: {}
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prava
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: prava_commerce
+  config:
+    pairs: 1                     # one mandate, one charge per cycle
+    # ----- rail selection -------------------------------------------------
+    mode: simulated              # simulated | live
+    prava_env: sandbox           # sandbox | production
+    mandate_id: mdt_simulated_demo
+    # ----- money ----------------------------------------------------------
+    currency: USD
+    minor_unit_exponent: 2
+    # The certified intent. Swap to libas-98115-2XL-drift.json for the
+    # non-conforming case.
+    intent_snapshot: ./scenarios/intents/libas-98252-2XL.json
+    unit_price_minor: 4000       # fallback only, unused with a snapshot
+    cap_minor: 100000
+    overcap_minor: 99999900      # oversized on purpose -> THRESHOLD_EXCEEDED
+    # ----- IntentDvP ------------------------------------------------------
+    # Opt-in. Without this the plugin never receives the certified intent and
+    # pay() behaves exactly as it does in prava_commerce.yaml.
+    require_conformance: true
+    # What the counterparty says it is actually shipping. Change product_id to
+    # 98115-2XL (with the drift snapshot) to see the refusal.
+    delivery:
+      product_id: "98252-2XL"
+      merchant: Libas
+    # 5 -> within the certified 30-day window; 40 -> outside it.
+    days_since_delivery: 5
+    # ----- behaviour ------------------------------------------------------
+    fail_closed: true
+    timeout_s: 30.0
+    max_retries: 3
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 200"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/prava_dvp.jsonl

--- a/scenarios/prava_dvp_drift.yaml
+++ b/scenarios/prava_dvp_drift.yaml
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# IntentDvP -- the NON-CONFORMING case. Companion to prava_dvp.yaml.
+#
+# Identical to prava_dvp.yaml except for two lines: the intent snapshot and the
+# delivered product id. Kept as a separate file so the two cases can be run back
+# to back with no editing in between.
+#
+# THE DRIFT
+#   The user asked for "one kurti under 500 rupees in green, pink or navy on
+#   libas". Navy was unavailable, so the agent settled for a maroon kurti at
+#   INR 450 -- cheaper than the INR 499 navy one, and still under the ceiling.
+#
+#   That substitution passes EVERY amount-based control in the stack: Visa's
+#   declineThreshold (USD 5.30), the mandate cap, the card network's own
+#   ceiling. All of them ask only HOW MUCH. None asks WHAT. Maroon was never in
+#   the authorised colour set, so only the check against the certified intent
+#   catches it -- and it catches it before any network call is made.
+#
+#   The drift snapshot is HAND-WRITTEN and marked "constructed": true. It models
+#   an agent that settled for close enough; it is not the capture of a live
+#   agent run, and it does not claim to be.
+#
+# EXPECTED TRACE
+#   prava:conformance:...:result=fail:reason=colour_not_in_intent:
+#       expected=green|pink|navy:actual=maroon
+#   prava:refused:step=paid:...:code=INTENT_NONCONFORMANT
+#   ...and NO prava:paid line anywhere. Nothing reached the rail: no charge, no
+#   credential, nothing to reverse. The absence is the evidence.
+
+name: prava_dvp_drift
+description: |
+  The agent drifted: asked for green, pink or navy under INR 500 on Libas, it
+  settled for maroon at INR 450. Cheaper than the quote and under every cap,
+  so no amount-based control objects. The certified purchase intent refuses
+  the charge before it is attempted.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 2
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 1
+      config: {}
+    - name: seller
+      count: 1
+      config: {}
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prava
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: prava_commerce
+  config:
+    pairs: 1
+    # ----- rail selection -------------------------------------------------
+    mode: simulated
+    prava_env: sandbox
+    mandate_id: mdt_simulated_demo
+    # ----- money ----------------------------------------------------------
+    currency: USD
+    minor_unit_exponent: 2
+    intent_snapshot: ./scenarios/intents/libas-98115-2XL-drift.json
+    unit_price_minor: 4000
+    cap_minor: 100000
+    overcap_minor: 99999900
+    # ----- IntentDvP ------------------------------------------------------
+    require_conformance: true
+    delivery:
+      product_id: "98115-2XL"
+      merchant: Libas
+    days_since_delivery: 5
+    # ----- behaviour ------------------------------------------------------
+    fail_closed: true
+    timeout_s: 30.0
+    max_retries: 3
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 200"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/prava_dvp_drift.jsonl

--- a/scenarios/prava_dvp_return_denied.yaml
+++ b/scenarios/prava_dvp_return_denied.yaml
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# IntentDvP: delivery-versus-payment against a certified purchase intent.
+#
+# WHAT THIS DEMONSTRATES, AND WHY IT MATTERS
+#
+# An LLM shopping agent was asked: "find one kurti under 500 rupees in green,
+# pink or navy on libas and buy one". That sentence cannot be checked against a
+# delivery. An out-of-band certifier turns it into terms that can be --
+# allowed_colours, a price ceiling, the merchant, the quantity, a return window
+# -- and anchors them with a digest. That is the `certificate` block in the
+# snapshot this scenario reads.
+#
+# The plugin then refuses to charge unless the delivery matches those terms,
+# BEFORE any network call is made. A refused purchase leaves nothing at the
+# payment rail: no charge, no credential, nothing to reverse.
+#
+# The failure worth understanding is a CHEAPER substitution. Point this scenario
+# at the drift snapshot and the agent has settled for a maroon kurti at INR 450
+# instead of the navy one at INR 499. It is cheaper than the quote, under the
+# declineThreshold, and from the same merchant -- so every amount-based control
+# in the stack accepts it: Visa's decline threshold, the mandate cap, the card
+# network's own ceiling. All of those ask only HOW MUCH. None asks WHAT. The
+# user authorised green, pink or navy; maroon was never in scope. Comparing the
+# delivery to the certified intent is the only thing that catches it.
+#
+# RUN THE TWO CASES
+#   Conforming:      intent_snapshot -> libas-98252-2XL.json
+#                    delivery.product_id -> 98252-2XL
+#   Drifted:         intent_snapshot -> libas-98115-2XL-drift.json
+#                    delivery.product_id -> 98115-2XL
+#
+# RETURNS
+#   days_since_delivery is CONFIG, never the wall clock -- a clock read would
+#   make the verdict, and the trace, non-reproducible. Set 5 for a verdict
+#   inside the certified 30-day window, 40 for outside it. An approved verdict
+#   means the request conforms to terms agreed up front; it does NOT mean money
+#   moved. The Prava API defines no reversal endpoint, so settling an approved
+#   return happens off this rail, and the broadcast says so.
+#
+# LIVE MODE
+#   Default is `simulated`: in-process, no network, no credentials,
+#   byte-identical per seed. To settle for real, provision a mandate out of
+#   band, export PRAVA_API_KEY (never put it in this file), then set
+#   mode: live and mandate_id below. A live run is not byte-deterministic.
+
+name: prava_dvp_return_denied
+description: |
+  One buyer settles a kurti on the Prava rail only if the delivery conforms
+  to a certified purchase intent: colour within the authorised set, price
+  under the ceiling, the agreed merchant, the selected product id, and the
+  quoted amount. A non-conforming delivery is refused before any charge is
+  attempted, so nothing reaches the card network.
+
+  A return request is then judged against the same certificate's window.
+  Approved means the request conforms to terms agreed before purchase -- not
+  that a credit was issued; Prava exposes no reversal endpoint.
+
+tier: 1
+seed: 42
+
+agents:
+  count: 2
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 1
+      config: {}
+    - name: seller
+      count: 1
+      config: {}
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prava
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: prava_commerce
+  config:
+    pairs: 1                     # one mandate, one charge per cycle
+    # ----- rail selection -------------------------------------------------
+    mode: simulated              # simulated | live
+    prava_env: sandbox           # sandbox | production
+    mandate_id: mdt_simulated_demo
+    # ----- money ----------------------------------------------------------
+    currency: USD
+    minor_unit_exponent: 2
+    # The certified intent. Swap to libas-98115-2XL-drift.json for the
+    # non-conforming case.
+    intent_snapshot: ./scenarios/intents/libas-98252-2XL.json
+    unit_price_minor: 4000       # fallback only, unused with a snapshot
+    cap_minor: 100000
+    overcap_minor: 99999900      # oversized on purpose -> THRESHOLD_EXCEEDED
+    # ----- IntentDvP ------------------------------------------------------
+    # Opt-in. Without this the plugin never receives the certified intent and
+    # pay() behaves exactly as it does in prava_commerce.yaml.
+    require_conformance: true
+    # What the counterparty says it is actually shipping. Change product_id to
+    # 98115-2XL (with the drift snapshot) to see the refusal.
+    delivery:
+      product_id: "98252-2XL"
+      merchant: Libas
+    # 5 -> within the certified 30-day window; 40 -> outside it.
+    days_since_delivery: 40
+    # ----- behaviour ------------------------------------------------------
+    fail_closed: true
+    timeout_s: 30.0
+    max_retries: 3
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 200"
+
+metrics:
+  - message_count
+  - agent_count
+
+output:
+  trace: ./traces/prava_dvp_return_denied.jsonl

--- a/uv.lock
+++ b/uv.lock
@@ -1405,6 +1405,7 @@ version = "0.1.1"
 source = { editable = "packages/nest-plugins-reference" }
 dependencies = [
     { name = "cryptography" },
+    { name = "httpx" },
     { name = "nest-core" },
     { name = "nest-sdk" },
 ]
@@ -1412,6 +1413,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=42.0" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "nest-core", editable = "packages/nest-core" },
     { name = "nest-sdk", editable = "packages/nest-sdk" },
 ]

--- a/w
+++ b/w
@@ -1,0 +1,28 @@
+* [32mmain[m
+  [31mremotes/origin/HEAD[m -> origin/main
+  [31mremotes/origin/hackathon/chainaim-sathya-nattr-comprehensive-negotiator[m
+  [31mremotes/origin/main[m
+  [31mremotes/upstream/HEAD[m -> upstream/main
+  [31mremotes/upstream/claude/bold-mayer-1Yz2y[m
+  [31mremotes/upstream/feat/agentic-commerce-hackathon-page[m
+  [31mremotes/upstream/feature/skill-likes[m
+  [31mremotes/upstream/hackathon/a2r-commerce-checkout-frontier[m
+  [31mremotes/upstream/hackathon/cmu-robotics-sealed-bid-coordination[m
+  [31mremotes/upstream/hackathon/coinbase-crypto-htlc-escrow[m
+  [31mremotes/upstream/hackathon/cybersec-blackhat-dpop-auth[m
+  [31mremotes/upstream/hackathon/google-staff-netem-transport[m
+  [31mremotes/upstream/hackathon/harvard-phd-eigentrust[m
+  [31mremotes/upstream/hackathon/linux-kernel-latency-transport[m
+  [31mremotes/upstream/hackathon/meta-backend-realistic-transport[m
+  [31mremotes/upstream/hackathon/mit-undergrad-eigentrust[m
+  [31mremotes/upstream/hackathon/openai-llm-semantic-memory[m
+  [31mremotes/upstream/hackathon/stanford-ml-phd-eigentrust[m
+  [31mremotes/upstream/main[m
+  [31mremotes/upstream/platform/ci-hygiene[m
+  [31mremotes/upstream/platform/integration[m
+  [31mremotes/upstream/platform/judge-panel[m
+  [31mremotes/upstream/platform/marketplace-ui[m
+  [31mremotes/upstream/platform/open-problems[m
+  [31mremotes/upstream/platform/research-harness[m
+  [31mremotes/upstream/revert-184-hackathon/distributed-sys-engg-deterministic-negotiation-ids[m
+  [31mremotes/upstream/revert-41-hackathon/edge-empic-escrow-payments[m


### PR DESCRIPTION
What it does:

Connects the user-Intent for agentic commerce to Delivery Versus Payments constructs.  

and is the conformance layer that defines what the intent of the transaction is to a comittable refererance to clamp the actions fro loosely-guided LLM as brain. 

Conforms to the NANDA uv checks 

Gate is enforced per tick and every verdict is recorded. 

Chainaim translates intent in to Visa Intelligent commerce definitions and certifies the  digest along the jouney from the user intent where it caputres a bigger surface area for vertical domains beyond the payment networks themselves, basically helping them grow.


Conforms to the NANDA `uv` checks.

## Skill document

**https://prava-payment-production.up.railway.app/skill.md**

Source in this PR: `apps/skill-service/skill.md`, served verbatim by `GET /skill.md`.

## The case this exists for

An agent asked for a navy kurti under ₹500 buys a **maroon** one at ₹450 instead.
Cheaper than the quote, under the Visa decline threshold, under the mandate cap, right
merchant — so every amount-based control in the stack lets it through. They all ask
*how much*. None asks *what*.

## Judge test — two calls, no setup, under ten seconds

```bash
curl "https://prava-payment-production.up.railway.app/demo/purchase?case=good"
curl "https://prava-payment-production.up.railway.app/demo/purchase?case=drift"
```

| case | expect |
|---|---|
| `good` | `"verdict":"settled"`, `"settled_amount_minor":523`, `check_delivery` step with `"ok":true` |
| `drift` | `"verdict":"refused"`, `"reason":"colour_not_in_intent"`, `"code":"INTENT_NONCONFORMANT"`, `"settled_amount_minor":0`, `failed_checks` entry with `"expected":"green\|pink\|navy"` / `"actual":"maroon"` |

Print the `display` field verbatim — it is already a readable transcript.

## Endpoints

- https://prava-payment-production.up.railway.app/
- https://prava-payment-production.up.railway.app/health
- https://prava-payment-production.up.railway.app/skill.md
- https://prava-payment-production.up.railway.app/cases
- https://prava-payment-production.up.railway.app/demo/purchase?case=good
- https://prava-payment-production.up.railway.app/demo/purchase?case=drift
- https://prava-payment-production.up.railway.app/demo/purchase?case=overcap
- https://prava-payment-production.up.railway.app/docs

`POST /purchase` runs the same cycle with your own settings — see `/docs`.

### The checks

Run before any network call. Each is skipped if the term is missing.

| Check | Compares |
|---|---|
| `colour_not_in_intent` | colour is in the allowed list |
| `price_over_ceiling` | listed price is under the ceiling |
| `merchant_mismatch` | merchant matches |
| `identity_mismatch` | delivered product id matches the sku |
| `amount_mismatch` | charged amount matches the settlement amount |
| `over_decline_threshold` | amount is under the Visa decline threshold |

The first four are what catch a cheaper swap. The last two cannot.

### Prava calls behind each step

| step | Prava call |
|---|---|
| `quote` | none — local price list; Prava prices nothing |
| `pay` | `POST /v1/mandates/{id}/charge`, then `POST /v1/mandates/{id}/charges/{txn}/report` |
| `verify_payment` | `GET /v1/mandates/{id}`, then find the charge by `reference` |
| `refund` | raises — Prava has no refund endpoint |

`PaymentRef` goes to Prava unchanged as its `reference`, which Prava treats as an
idempotency key, so a replay is refused by the rail rather than by our bookkeeping.
`verify_payment` reads Prava's ledger, not local state — a network failure returns
`PENDING`, not `FAILED`.

## Where it lives in this PR

| path | what |
|---|---|
| `packages/nest-plugins-reference/nest_plugins_reference/payments/prava.py` | the payments plugin |
| `.../payments/prava_intent.py` | the conformance checks |
| `.../payments/prava_client.py` | Prava mandate API client |
| `packages/nest-core/nest_core/scenarios_builtin/prava_commerce.py` | scenario |
| `scenarios/prava_dvp.yaml`, `prava_dvp_drift.yaml`, `prava_dvp_return_denied.yaml` | simulator scenarios |
| `scenarios/intents/libas-98252-2XL.json`, `libas-98115-2XL-drift.json` | frozen intent snapshots |
| `apps/skill-service/` | the deployed service + `skill.md` |
| `docs/layers/prava_payments.md` | layer docs |
| `.../tests/test_prava_intent.py`, `test_prava_payments.py` | tests |

## Running it yourself

```bash
pip install -r apps/skill-service/requirements.txt
python -m uvicorn app:app --app-dir apps/skill-service --port 8000
curl "localhost:8000/demo/purchase?case=drift"
```

The same scenarios in the simulator:

```bash
uv sync
uv run nest run scenarios/prava_dvp.yaml         # settles
uv run nest run scenarios/prava_dvp_drift.yaml   # refused
```