### PR TITLE
Payments: Prava plugin + policy_commerce scenario

### DIFF
--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -9,8 +9,9 @@ Example::
 
 from __future__ import annotations
 
+import importlib.metadata
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 from nest_core.scenario import ScenarioConfig
 from nest_core.types import AgentId
@@ -39,6 +40,8 @@ def get_scenario_factory(name: str) -> ScenarioFactory:
     """
     if name not in _FACTORIES:
         _try_load_builtin(name)
+    if name not in _FACTORIES:
+        _try_load_entry_point(name)
     factory = _FACTORIES.get(name)
     if factory is None:
         msg = f"No scenario factory registered for {name!r}"
@@ -46,11 +49,24 @@ def get_scenario_factory(name: str) -> ScenarioFactory:
     return factory
 
 
-def _try_load_builtin(name: str) -> None:
-    if name == "policy_commerce":
-        from nest_plugin_prava.scenario import policy_commerce_factory
+def _try_load_entry_point(name: str) -> None:
+    """Load a scenario contributed by an installed package.
 
-        register_scenario("policy_commerce", policy_commerce_factory)
+    Scenarios ship with the plugins they exercise, the same way layers do,
+    so core does not need to know the name of every package that adds one::
+
+        [project.entry-points."nest.scenarios"]
+        policy_commerce = "nest_plugin_prava.scenario:policy_commerce_factory"
+    """
+    for ep in importlib.metadata.entry_points(group="nest.scenarios"):
+        if ep.name != name:
+            continue
+        factory = cast("ScenarioFactory", ep.load())
+        register_scenario(name, factory)
+        return
+
+
+def _try_load_builtin(name: str) -> None:
     if name == "marketplace":
         from nest_core.scenarios_builtin.marketplace import marketplace_factory
 

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -47,6 +47,10 @@ def get_scenario_factory(name: str) -> ScenarioFactory:
 
 
 def _try_load_builtin(name: str) -> None:
+    if name == "policy_commerce":
+        from nest_plugin_prava.scenario import policy_commerce_factory
+
+        register_scenario("policy_commerce", policy_commerce_factory)
     if name == "marketplace":
         from nest_core.scenarios_builtin.marketplace import marketplace_factory
 

--- a/packages/nest-plugin-prava/README.md
+++ b/packages/nest-plugin-prava/README.md
@@ -1,0 +1,218 @@
+# nest-plugin-prava
+
+A NANDA Town **payments layer** plugin that moves real money in the Prava
+Agentic Payments Sandbox, bounded by a human-granted policy.
+
+Agents quote, pay, and verify. When policy or funding says no, the plugin
+says no — with the reason, the failing clause, and no Prava call made.
+
+```python
+payments = PravaPayments(AgentId("agent_a"), console_url="http://localhost:3000")
+
+quote = await payments.quote(ServiceRef("gpu-compute-small"))   # merchant's price
+receipt = await payments.pay(AgentId("agent_b"), quote.price, PaymentRef("p1"))
+assert await payments.verify_payment(PaymentRef("p1")) is PaymentStatus.CONFIRMED
+```
+
+## Two locks stand between an agent and money
+
+This adapter exists because "autonomous agent with a credit card" is the
+wrong shape. Authority is split in two:
+
+- **LOCK 2 — BIOMETRICS, once per envelope.** The owner approves a bounded
+  *envelope* with their passkey: merchant-scoped, per-charge-capped, one
+  charge per payment cycle, enforced by the Visa network. This happens
+  **once, by a human, before the simulation runs.** The plugin never
+  automates, simulates, or bypasses a passkey.
+- **LOCK 1 — POLICY, on every single charge.** A deterministic arbiter
+  evaluates every proposed charge against a signed policy mandate
+  (counterparty allowlist, per-charge cap, cumulative cap, attribute
+  constraints). No LLM sits in the decision path. Then a router selects
+  which envelope funds it.
+
+Inside that approved envelope the agent transacts autonomously. To exceed
+policy it must ask a human. To exceed the portfolio it needs a fingerprint
+again.
+
+## Concepts
+
+| Term | Meaning |
+|---|---|
+| **Policy mandate** | A signed, immutable clause tree the arbiter evaluates on every charge. Amendments are *new* mandates that supersede the old, recorded in the ledger. |
+| **Envelope** | One Prava mandate: a merchant-scoped, per-charge-capped standing authorization created by one passkey approval. |
+| **Cycle** | Visa enforces **one charge per envelope per payment cycle** (weekly here). This is a network rule, not a preference. |
+| **Portfolio** | Several envelopes approved together. When envelope A's cycle is spent, the router moves to B — so a second autonomous charge needs no new human touch. |
+| **Ledger** | Append-only record. Every cent is attributed to a mandate clause path *and* an envelope. `verify_payment` reads this, not a cache. |
+
+Cycle eligibility is checked in the Quartermaster ledger **before** any
+Prava call, so a second same-cycle draw is never attempted.
+
+## Installation
+
+Requires Python 3.12+ (NANDA Town's floor).
+
+```bash
+pip install -e .            # from this directory
+nest plugins list | grep payments
+```
+
+Registered via entry point:
+
+```toml
+[project.entry-points."nest.plugins.payments"]
+prava = "nest_plugin_prava.plugin:PravaPayments"
+```
+
+Select it in a scenario:
+
+```yaml
+layers:
+  payments: prava
+```
+
+A ready-made scenario is included at
+[`scenarios/prava_marketplace.yaml`](scenarios/prava_marketplace.yaml).
+
+## Configuration
+
+| Option | Env var | Default | Meaning |
+|---|---|---|---|
+| `console_url` | `QUARTERMASTER_CONSOLE_URL` | `http://localhost:3000` | Quartermaster console base URL. |
+| `service_catalog` | — | 3 GPU services | Maps a `ServiceRef` to a capacity need. |
+| `timeout_seconds` | — | `120.0` | HTTP timeout; settlement is a multi-hop call. |
+| `client` | — | — | Inject an `httpx.AsyncClient` (used by the offline tests). |
+
+`initial_balance` and `balances` are accepted so the plugin is a drop-in
+for the bundled `marketplace` scenario, and are **ignored**: funds live in
+passkey-approved envelopes, not in a simulated balance.
+
+Built-in services: `gpu-compute` (80GB, 4h), `gpu-compute-small`
+(40GB, 2h), `gpu-compute-xl` (80GB, 6h), plus a dynamic
+`gpu:<vram_gb>:<hours>[:<budget_cents>]` form.
+
+The console needs `PRAVA_BASE_URL` and `PRAVA_SECRET_KEY` (a `sk_test_`
+sandbox key). This plugin never sees card data: Prava mints a one-time,
+merchant-scoped credential per charge, and only the last four digits are
+ever rendered or logged.
+
+## Protocol behaviour
+
+| Method | Behaviour |
+|---|---|
+| `quote(service)` | Asks the merchant through the console registry. The price is the merchant's, computed by its published rounding rule, and is returned unmodified with `run_id` / `quote_id` in `metadata`. |
+| `pay(to, amount, ref)` | Arbiter evaluates → router selects an envelope with cycle capacity → Prava mints a one-time credential → merchant is paid → charge reported → ledger appended. Requires a prior `quote()` at that exact amount. |
+| `verify_payment(ref)` | Reads the append-only ledger. `CONFIRMED` only when a ledger row backs the payment; `PENDING` if charged but not yet recorded; `FAILED` otherwise. |
+| `refund(ref)` | **Always raises** `PravaPaymentError("REFUND_NOT_SUPPORTED")`. See Limits. |
+
+### Failure handling
+
+Every refusal raises `PravaPaymentError` (a `ValueError` subclass, so
+existing scenarios catch it) carrying `.code`, `.message`, and `.details`:
+
+| Code | Cause | Prava calls made |
+|---|---|---|
+| `POLICY_REFUSE` | A hard clause failed. The agent may not proceed and may not ask. | 0 |
+| `POLICY_NEEDS_HUMAN` | Only escalatable clauses failed (e.g. per-charge cap). The agent must ask its owner. | 0 |
+| `NO_ENVELOPE_CAPACITY` | No envelope matched the merchant with cycle capacity. Fails closed. | 0 |
+| `NO_QUOTE` / `AMOUNT_MISMATCH` | The caller tried to pay a price no merchant quoted. | 0 |
+| `DUPLICATE_REF` | That `PaymentRef` already settled. | 0 |
+| `SETTLEMENT_FAILED` | Prava or the merchant failed mid-settlement. Surfaced verbatim, never retried blindly. | 1 attempt |
+| `REFUND_NOT_SUPPORTED` | Refunds are out of scope. | 0 |
+
+`POLICY_NEEDS_HUMAN` details include `failingClausePath`, `onFail`, and
+`mandateId`, so a scenario can escalate intelligently instead of retrying.
+
+## Tests
+
+```bash
+pytest tests/test_plugin_contract.py -v     # offline, no console, no money
+QUARTERMASTER_CONSOLE_URL=http://localhost:3000 pytest -v   # + live sandbox
+```
+
+- **`test_plugin_contract.py`** — offline. Protocol conformance
+  (`isinstance(plugin, Payments)`), merchant-priced quotes, refusal
+  mapping, ledger-backed verification, refund refusal. Runs in CI with no
+  network.
+- **`test_sandbox_live.py`** — real sandbox money. Skips unless a console
+  is reachable. The happy path costs **one** sandbox charge and needs an
+  envelope with cycle capacity; the failure case costs **zero**. Ids for
+  each run are written to `sandbox-evidence.json`.
+
+## Scenario run
+
+`scenarios/prava_marketplace.yaml` drives the `policy_commerce` scenario
+(in `nest_plugin_prava/scenario.py`), which is layer-agnostic: it runs
+against `prepaid_credits` with no console and no money, and against
+`prava` for real settlement.
+
+```bash
+QUARTERMASTER_CONSOLE_URL=http://localhost:3000 nest run scenarios/prava_marketplace.yaml
+nest inspect traces/output.jsonl
+```
+
+Two buyers, two outcomes, one run:
+
+| Agent | Service | Outcome |
+|---|---|---|
+| `buyer-0` | `gpu-compute-small` | Settled `$18.00`, Prava txn `txn_01KZ1VWC3YVWG94VFDX1H89PK7`, envelope `env_a_1785695413265`, merchant order `ord_02d56bb3-930`, ledger `autonomous=1` |
+| `buyer-1` | `gpu-compute-xl` | Refused: `POLICY_NEEDS_HUMAN`, "amount $70.50 exceeds cap $47.00", clause `root.all_of[3]`, zero Prava calls |
+
+Trace: `traces/prava_marketplace.jsonl` (16 events).
+
+The refusal is not a failed run. It's a bounded agent doing the correct
+thing when a price exceeds what its owner authorised.
+
+## Verified sandbox transactions
+
+Recorded by `test_sandbox_live.py` on 2 Aug 2026 against the Prava
+sandbox. Full records in [`sandbox-evidence.json`](sandbox-evidence.json).
+
+**Successful settlement** (`test_happy_path_settles_in_sandbox`)
+
+| Field | Value |
+|---|---|
+| Prava transaction | `txn_01KZ1TGNA0VPNE1BSYCK5C7B9T` |
+| Amount | `$18.00 USD` |
+| Envelope | `env_a_1785693994048` → Prava mandate `mdt_01KZ1TFWBV1PR1QEYFQ45T9Y26` |
+| Merchant order | `ord_781e1da2-ab9` |
+| Price rule | `ceil(2h x 900c/GPU-h) = 1800c` (the merchant's own) |
+| Ledger | `autonomous=1`, all seven clause paths attributed |
+| Human touches | 0 during settlement; 1 passkey earlier, to approve the envelope |
+
+**Refusal** (`test_failure_case_policy_refusal_costs_nothing`)
+
+| Field | Value |
+|---|---|
+| Error code | `POLICY_NEEDS_HUMAN` |
+| Detail | `amount $70.50 exceeds cap $47.00` |
+| Failing clause | `root.all_of[3]` on mandate `qm_mdt_policy_v2` |
+| Prava calls made | **0** — the arbiter refuses before the network is touched |
+
+## Limits
+
+- **No refunds.** Prava exposes none on the mandate-charge surface used
+  here. `refund()` raises rather than pretending to succeed.
+- **One charge per envelope per cycle**, enforced by the Visa network.
+  Concurrency within a cycle comes from approving more envelopes, not
+  from retrying.
+- **A passkey cannot be automated.** Envelopes must be approved by a human
+  before a simulation can spend. That is the design, not a gap.
+- **Sandbox test cards are rate-limited** (30 transactions/day) and
+  per-team. `FETCH_AGENTIC_CREDS_ERROR` from Prava means the card is
+  exhausted, not that the adapter is broken.
+- **Amounts are integer minor units** (cents), currency `USD`. Currency
+  mismatches fail closed at the arbiter.
+- Settlement is `SANDBOX` unless the console runs in `production` mode;
+  the environment is labelled on every surface and in the audit bundle.
+
+## How it fits together
+
+```
+NANDA agent
+  └── PravaPayments (this plugin)
+        └── Quartermaster console  ── arbiter (LOCK 1) ── router ── ledger
+              └── Prava sandbox    ── envelope mandate (LOCK 2, passkey)
+                    └── Visa network (per-charge cap, one charge per cycle)
+```
+
+Licence: Apache-2.0.

--- a/packages/nest-plugin-prava/nest_plugin_prava/__init__.py
+++ b/packages/nest-plugin-prava/nest_plugin_prava/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prava payments plugin for NANDA Town.
+
+Example::
+
+    from nest_plugin_prava import PravaPayments
+
+    payments = PravaPayments(AgentId("agent_a"), console_url="http://localhost:3000")
+"""
+
+from __future__ import annotations
+
+from nest_plugin_prava.errors import PravaPaymentError
+from nest_plugin_prava.plugin import PravaPayments
+
+__all__ = ["PravaPaymentError", "PravaPayments"]

--- a/packages/nest-plugin-prava/nest_plugin_prava/errors.py
+++ b/packages/nest-plugin-prava/nest_plugin_prava/errors.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Error type for the Prava payments plugin.
+
+Example::
+
+    raise PravaPaymentError("POLICY_NEEDS_HUMAN", "amount $47.00 exceeds cap $40.00")
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class PravaPaymentError(ValueError):
+    """A payment could not be made, with the reason the arbiter gave.
+
+    Subclasses :class:`ValueError` to match the reference payments plugins
+    (``prepaid_credits`` raises ``ValueError``; ``escrow`` subclasses it),
+    so existing scenarios catch it without modification.
+
+    Example::
+
+        try:
+            await payments.pay(AgentId("agent_b"), Money(amount=7050), PaymentRef("p1"))
+        except PravaPaymentError as exc:
+            assert exc.code == "POLICY_NEEDS_HUMAN"
+    """
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+        self.details = details or {}

--- a/packages/nest-plugin-prava/nest_plugin_prava/plugin.py
+++ b/packages/nest-plugin-prava/nest_plugin_prava/plugin.py
@@ -1,0 +1,349 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prava payments plugin: real sandbox money under a human-granted policy.
+
+Implements the NANDA Town ``Payments`` protocol (``quote``, ``pay``,
+``verify_payment``, ``refund``) against a Quartermaster console, which
+owns the mandate arbiter, the envelope router, and the append-only ledger.
+
+Two locks stand between an agent and money. LOCK 2 (biometrics) is the
+owner's passkey, granted ONCE per envelope before the simulation runs and
+never automated here. LOCK 1 (policy) is a deterministic arbiter that
+evaluates every single charge. This plugin can only spend inside an
+envelope a human already approved, and only when the arbiter says so.
+
+Example::
+
+    payments = PravaPayments(AgentId("agent_a"), console_url="http://localhost:3000")
+    quote = await payments.quote(ServiceRef("gpu-compute-small"))
+    receipt = await payments.pay(AgentId("agent_b"), quote.price, PaymentRef("p1"))
+    assert await payments.verify_payment(PaymentRef("p1")) is PaymentStatus.CONFIRMED
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from nest_core.types import Money, PaymentStatus, Quote, Receipt
+
+from nest_plugin_prava.errors import PravaPaymentError
+
+if TYPE_CHECKING:
+    from nest_core.types import AgentId, PaymentRef, ServiceRef
+
+DEFAULT_CONSOLE_URL = "http://localhost:3000"
+
+#: Service references the plugin knows how to price. A scenario may pass
+#: its own catalogue, or use the dynamic ``gpu:<vram_gb>:<hours>`` form.
+DEFAULT_SERVICE_CATALOG: dict[str, dict[str, Any]] = {
+    "gpu-compute": {"vramGb": 80, "durationH": 4, "maxPriceCents": 4000},
+    "gpu-compute-small": {"vramGb": 40, "durationH": 2, "maxPriceCents": 2000},
+    "gpu-compute-xl": {"vramGb": 80, "durationH": 6, "maxPriceCents": 8000},
+}
+
+
+@dataclass(frozen=True)
+class _QuoteRecord:
+    """A merchant-issued price, held so ``pay`` can never invent one."""
+
+    service: str
+    run_id: str
+    quote_id: str
+    amount_cents: int
+    currency: str
+    counterparty_id: str
+
+
+class PravaPayments:
+    """Payments layer backed by Prava agentic credentials.
+
+    ``initial_balance`` and ``balances`` are accepted so this class is a
+    drop-in for the bundled ``marketplace`` scenario, which constructs
+    payments plugins with those keywords. They are deliberately IGNORED:
+    funds do not live in a simulated balance, they live in envelopes the
+    owner approved with a passkey, and the network enforces the caps.
+
+    Example::
+
+        payments = PravaPayments(AgentId("agent_a"))
+        quote = await payments.quote(ServiceRef("gpu-compute-small"))
+    """
+
+    def __init__(
+        self,
+        agent_id: AgentId,
+        initial_balance: int = 0,
+        balances: dict[AgentId, int] | None = None,
+        payments: dict[PaymentRef, Receipt] | None = None,
+        *,
+        console_url: str | None = None,
+        service_catalog: dict[str, dict[str, Any]] | None = None,
+        timeout_seconds: float = 120.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._agent_id = agent_id
+        self._console_url = (
+            console_url or os.environ.get("QUARTERMASTER_CONSOLE_URL") or DEFAULT_CONSOLE_URL
+        ).rstrip("/")
+        self._catalog = dict(service_catalog or DEFAULT_SERVICE_CATALOG)
+        self._timeout = timeout_seconds
+        self._client = client
+        self._owns_client = client is None
+        # Shared with other agent handles when a scenario passes one in.
+        self._payments: dict[PaymentRef, Receipt] = payments if payments is not None else {}
+        self._quotes_by_service: dict[str, _QuoteRecord] = {}
+        self._quotes_by_amount: dict[int, _QuoteRecord] = {}
+        self._capacity_cents = 0
+
+    def balance(self, agent: AgentId) -> int:
+        """Spendable capacity right now, in cents.
+
+        Not part of the ``Payments`` protocol, but the bundled
+        ``marketplace`` scenario calls it before buying, so a drop-in
+        replacement needs it.
+
+        There is no play-money balance to report. This answers the only
+        question worth asking: how much could actually be drawn at this
+        moment? That is the funding still available in envelopes whose
+        cycle is open, capped by the policy mandate's remaining cumulative
+        headroom. It is not a promise: the arbiter still rules on every
+        charge.
+
+        Example::
+
+            spendable = payments.balance(AgentId("agent_a"))
+        """
+        try:
+            with httpx.Client(timeout=10.0) as client:
+                data = client.get(f"{self._console_url}/api/portfolio").json()
+        except (httpx.HTTPError, ValueError):
+            return self._capacity_cents
+
+        envelopes = data.get("envelopes", [])
+        open_capacity = sum(
+            int(env.get("per_charge_cap_cents", 0))
+            for env in envelopes
+            if env.get("cycle") == "OPEN"
+        )
+        policy = data.get("policy") or {}
+        cap_cents = policy.get("cap_cents")
+        if cap_cents is None:
+            headroom = open_capacity
+        else:
+            headroom = int(cap_cents) - int(policy.get("cumulative_cents", 0))
+        self._capacity_cents = max(0, min(open_capacity, headroom))
+        return self._capacity_cents
+
+    # ------------------------------------------------------------------
+    # Payments protocol
+    # ------------------------------------------------------------------
+
+    async def quote(self, service: ServiceRef) -> Quote:
+        """Ask the merchant what a service costs, through the console registry.
+
+        The price is the merchant's, computed by its own published rule. The
+        plugin never sets or adjusts it.
+
+        Example::
+
+            q = await payments.quote(ServiceRef("gpu-compute-small"))
+        """
+        need = self._need_for(str(service))
+        data = await self._request("POST", "/api/nanda/quote", json=need)
+        record = _QuoteRecord(
+            service=str(service),
+            run_id=str(data["runId"]),
+            quote_id=str(data["quoteId"]),
+            amount_cents=int(data["amountCents"]),
+            currency=str(data["currency"]),
+            counterparty_id=str(data["counterpartyId"]),
+        )
+        self._quotes_by_service[record.service] = record
+        self._quotes_by_amount[record.amount_cents] = record
+        return Quote(
+            service=service,
+            price=Money(amount=record.amount_cents, currency=record.currency),
+            ttl_seconds=int(data.get("ttlSeconds", 300)),
+            metadata={
+                "run_id": record.run_id,
+                "quote_id": record.quote_id,
+                "counterparty_id": record.counterparty_id,
+                "pricing_rule": data.get("pricingRule"),
+                "attributes": data.get("attributes", {}),
+                "environment": "SANDBOX",
+            },
+        )
+
+    async def pay(self, to: AgentId, amount: Money, ref: PaymentRef) -> Receipt:
+        """Settle a quoted price against a pre-approved envelope.
+
+        Routes to an envelope with cycle capacity, mints a one-time
+        merchant-scoped credential, pays the merchant, and appends to the
+        ledger. No passkey is requested and none is simulated.
+
+        Raises:
+            PravaPaymentError: if the arbiter refuses the charge
+                (``POLICY_REFUSE`` / ``POLICY_NEEDS_HUMAN``), if no envelope
+                has cycle capacity (``NO_ENVELOPE_CAPACITY``), or if the
+                amount was never quoted (``NO_QUOTE`` / ``AMOUNT_MISMATCH``).
+
+        Example::
+
+            receipt = await payments.pay(AgentId("agent_b"), quote.price, PaymentRef("p1"))
+        """
+        if amount.amount <= 0:
+            msg = f"Payment amount must be positive: {amount.amount}"
+            raise PravaPaymentError("INVALID_AMOUNT", msg)
+        if ref in self._payments:
+            msg = f"Duplicate payment reference: {ref}"
+            raise PravaPaymentError("DUPLICATE_REF", msg)
+
+        record = self._quotes_by_amount.get(amount.amount)
+        if record is None:
+            msg = (
+                f"No quote for {amount.amount} {amount.currency}; call quote() first. "
+                "Prices come from the merchant, never from the caller."
+            )
+            raise PravaPaymentError("NO_QUOTE", msg, {"amount": amount.amount})
+
+        data = await self._request(
+            "POST",
+            "/api/nanda/pay",
+            json={
+                "ref": str(ref),
+                "runId": record.run_id,
+                "quoteId": record.quote_id,
+                "payer": str(self._agent_id),
+                "payee": str(to),
+                "amountCents": amount.amount,
+            },
+        )
+        receipt = Receipt(
+            ref=ref,
+            payer=self._agent_id,
+            payee=to,
+            amount=Money(amount=int(data["amountCents"]), currency=str(data["currency"])),
+            timestamp=time.time(),
+        )
+        self._payments[ref] = receipt
+        return receipt
+
+    async def verify_payment(self, ref: PaymentRef) -> PaymentStatus:
+        """Verify a payment against the console's append-only ledger.
+
+        ``CONFIRMED`` is returned only when a ledger row backs the payment,
+        so verification cannot pass on a cached receipt alone.
+
+        Example::
+
+            status = await payments.verify_payment(PaymentRef("p1"))
+        """
+        data = await self._request("GET", "/api/nanda/payment", params={"ref": str(ref)})
+        status = str(data.get("status"))
+        if status == "confirmed":
+            return PaymentStatus.CONFIRMED if data.get("ledgerConfirmed") else PaymentStatus.PENDING
+        return PaymentStatus.FAILED
+
+    async def refund(self, ref: PaymentRef) -> None:
+        """Refunds are not supported and never silently succeed.
+
+        Prava exposes no refund on the mandate-charge surface Quartermaster
+        uses, so this raises rather than pretending. Reverse a settled
+        charge out of band with the merchant.
+
+        Raises:
+            PravaPaymentError: always, with code ``REFUND_NOT_SUPPORTED``.
+
+        Example::
+
+            with pytest.raises(PravaPaymentError):
+                await payments.refund(PaymentRef("p1"))
+        """
+        msg = (
+            "Prava mandate charges cannot be refunded through this adapter; "
+            "settle reversals out of band with the merchant."
+        )
+        raise PravaPaymentError("REFUND_NOT_SUPPORTED", msg, {"ref": str(ref)})
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def aclose(self) -> None:
+        """Close the HTTP client if this instance created it.
+
+        Example::
+
+            await payments.aclose()
+        """
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+
+    def _need_for(self, service: str) -> dict[str, Any]:
+        """Map a ServiceRef onto a capacity need the registry understands."""
+        spec = self._catalog.get(service)
+        if spec is None and service.startswith("gpu:"):
+            parts = service.split(":")
+            if len(parts) >= 3:
+                try:
+                    spec = {
+                        "vramGb": int(parts[1]),
+                        "durationH": int(parts[2]),
+                        "maxPriceCents": int(parts[3]) if len(parts) > 3 else 100_000,
+                    }
+                except ValueError:
+                    spec = None
+        if spec is None:
+            known = ", ".join(sorted(self._catalog))
+            msg = f"Unknown service {service!r}; known services: {known}"
+            raise PravaPaymentError("UNKNOWN_SERVICE", msg, {"service": service})
+        need = dict(spec)
+        need.setdefault("deadline", _deadline_iso())
+        return need
+
+    def _http(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+            self._owns_client = True
+        return self._client
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        url = f"{self._console_url}{path}"
+        try:
+            response = await self._http().request(method, url, json=json, params=params)
+        except httpx.HTTPError as exc:
+            msg = f"console unreachable at {url}: {exc}"
+            raise PravaPaymentError("CONSOLE_UNREACHABLE", msg) from exc
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            msg = f"console returned non-JSON ({response.status_code}) from {path}"
+            raise PravaPaymentError("BAD_RESPONSE", msg) from exc
+
+        if response.is_success:
+            return dict(payload)
+
+        error = payload.get("error", {}) if isinstance(payload, dict) else {}
+        raise PravaPaymentError(
+            str(error.get("code", f"HTTP_{response.status_code}")),
+            str(error.get("message", f"console returned {response.status_code}")),
+            dict(error.get("details", {})),
+        )
+
+
+def _deadline_iso(hours_ahead: int = 12) -> str:
+    """ISO 8601 deadline used when a catalogue entry does not set one."""
+    return (datetime.now(UTC) + timedelta(hours=hours_ahead)).isoformat()

--- a/packages/nest-plugin-prava/nest_plugin_prava/plugin.py
+++ b/packages/nest-plugin-prava/nest_plugin_prava/plugin.py
@@ -25,7 +25,7 @@ import os
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 from nest_core.types import Money, PaymentStatus, Quote, Receipt
@@ -119,22 +119,27 @@ class PravaPayments:
         """
         try:
             with httpx.Client(timeout=10.0) as client:
-                data = client.get(f"{self._console_url}/api/portfolio").json()
+                payload = _as_mapping(client.get(f"{self._console_url}/api/portfolio").json())
         except (httpx.HTTPError, ValueError):
             return self._capacity_cents
 
-        envelopes = data.get("envelopes", [])
-        open_capacity = sum(
-            int(env.get("per_charge_cap_cents", 0))
-            for env in envelopes
-            if env.get("cycle") == "OPEN"
+        raw_envelopes = payload.get("envelopes")
+        envelopes: list[object] = (
+            cast("list[object]", raw_envelopes) if isinstance(raw_envelopes, list) else []
         )
-        policy = data.get("policy") or {}
+        open_capacity = 0
+        for entry in envelopes:
+            envelope = _as_mapping(entry)
+            if envelope.get("cycle") != "OPEN":
+                continue
+            open_capacity += _as_int(envelope.get("per_charge_cap_cents"))
+
+        policy = _as_mapping(payload.get("policy"))
         cap_cents = policy.get("cap_cents")
         if cap_cents is None:
             headroom = open_capacity
         else:
-            headroom = int(cap_cents) - int(policy.get("cumulative_cents", 0))
+            headroom = _as_int(cap_cents) - _as_int(policy.get("cumulative_cents"))
         self._capacity_cents = max(0, min(open_capacity, headroom))
         return self._capacity_cents
 
@@ -302,7 +307,7 @@ class PravaPayments:
             known = ", ".join(sorted(self._catalog))
             msg = f"Unknown service {service!r}; known services: {known}"
             raise PravaPaymentError("UNKNOWN_SERVICE", msg, {"service": service})
-        need = dict(spec)
+        need: dict[str, Any] = dict(spec)
         need.setdefault("deadline", _deadline_iso())
         return need
 
@@ -333,15 +338,43 @@ class PravaPayments:
             msg = f"console returned non-JSON ({response.status_code}) from {path}"
             raise PravaPaymentError("BAD_RESPONSE", msg) from exc
 
+        body = _as_mapping(payload)
         if response.is_success:
-            return dict(payload)
+            return body
 
-        error = payload.get("error", {}) if isinstance(payload, dict) else {}
+        error = _as_mapping(body.get("error"))
+        code = error.get("code")
+        message = error.get("message")
         raise PravaPaymentError(
-            str(error.get("code", f"HTTP_{response.status_code}")),
-            str(error.get("message", f"console returned {response.status_code}")),
-            dict(error.get("details", {})),
+            str(code) if code is not None else f"HTTP_{response.status_code}",
+            str(message) if message is not None else f"console returned {response.status_code}",
+            _as_mapping(error.get("details")),
         )
+
+
+def _as_mapping(value: object) -> dict[str, Any]:
+    """A JSON body is ``Any`` until proven otherwise. Anything that is not an
+    object becomes an empty one, so a malformed response reads as absent
+    fields rather than raising somewhere further away."""
+    if isinstance(value, dict):
+        pairs = cast("dict[object, object]", value)
+        return {str(key): item for key, item in pairs.items()}
+    return {}
+
+
+def _as_int(value: object) -> int:
+    """Cents, defensively. Console amounts are integers, but a missing or
+    malformed field must read as zero rather than crash a simulation."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (float, str)):
+        try:
+            return int(float(value))
+        except ValueError:
+            return 0
+    return 0
 
 
 def _deadline_iso(hours_ahead: int = 12) -> str:

--- a/packages/nest-plugin-prava/nest_plugin_prava/scenario.py
+++ b/packages/nest-plugin-prava/nest_plugin_prava/scenario.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Policy commerce scenario: quote, pay, verify, and handle the refusal.
+
+Layer-agnostic. It drives whatever payments plugin the scenario selects,
+so it runs against ``prepaid_credits`` with no console and no money, and
+against ``prava`` to move real sandbox funds under a policy mandate.
+
+Each buyer is assigned a service. One is priced inside policy and settles;
+another is deliberately priced above the per-charge cap so the run also
+exercises the refusal path. A refusal is a valid outcome here, not an
+error: it is what a bounded agent is supposed to do.
+
+Example::
+
+    agents = policy_commerce_factory(config, plugins)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from nest_core.sim.agent import StateMachineAgent
+from nest_core.types import AgentId, PaymentRef, ServiceRef
+
+if TYPE_CHECKING:
+    from nest_core.scenario import ScenarioConfig
+    from nest_core.sim.agent import AgentContext
+
+DEFAULT_SERVICES = ["gpu-compute-small", "gpu-compute-xl"]
+
+
+class PolicyBuyer(StateMachineAgent):
+    """Buys one service: quote, pay, verify, and report what happened."""
+
+    def __init__(self, seller: AgentId, service: str) -> None:
+        self._seller = seller
+        self._service = service
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Run the full payment cycle once, reporting the outcome."""
+        payments = ctx.plugins.get("payments")
+        if payments is None:
+            return
+
+        try:
+            quote = await payments.quote(ServiceRef(self._service))
+        except Exception as exc:  # noqa: BLE001 - report, never crash the run
+            await self._report(ctx, f"quote-refused {self._service}: {exc}")
+            return
+
+        ref = PaymentRef(f"{ctx.agent_id}-{self._service}")
+        try:
+            receipt = await payments.pay(self._seller, quote.price, ref)
+        except Exception as exc:  # noqa: BLE001 - refusals are expected here
+            await self._report(ctx, f"pay-refused {self._service}: {exc}")
+            return
+
+        status = await payments.verify_payment(ref)
+        await self._report(
+            ctx,
+            f"paid {receipt.amount.amount} {receipt.amount.currency} "
+            f"for {self._service} status={status.value}",
+        )
+
+    async def _report(self, ctx: AgentContext, line: str) -> None:
+        await ctx.send(self._seller, line.encode())
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Buyers do not expect replies."""
+
+    async def on_stop(self, ctx: AgentContext) -> None:
+        """Nothing to tear down."""
+
+
+class PolicySeller(StateMachineAgent):
+    """Receives buyer outcomes so they land in the trace."""
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Sellers wait to be paid."""
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Acknowledge whatever the buyer reported."""
+        await ctx.send(sender, b"ack")
+
+    async def on_stop(self, ctx: AgentContext) -> None:
+        """Nothing to tear down."""
+
+
+def policy_commerce_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create buyers and sellers for the policy_commerce scenario.
+
+    ``task.config.services`` assigns a service per buyer, cycling if there
+    are more buyers than services.
+
+    Example::
+
+        agents = policy_commerce_factory(config, plugins)
+    """
+    services = list(config.task.config.get("services") or DEFAULT_SERVICES)
+    counts = {role.name: role.count for role in config.agents.roles}
+    num_buyers = counts.get("buyer", 1)
+    num_sellers = max(1, counts.get("seller", 1))
+
+    # The runner hands the factory the payments CLASS; instantiating it is
+    # the scenario's job (see scenarios_builtin/marketplace.py). Without
+    # this, agents call unbound methods and every purchase silently fails.
+    payments_cls = plugins.get("payments")
+    if isinstance(payments_cls, type):
+        try:
+            plugins["payments"] = payments_cls(
+                AgentId("system"),
+                initial_balance=0,
+                balances={},
+                payments={},
+            )
+        except TypeError:
+            plugins["payments"] = payments_cls(AgentId("system"))
+
+    agents: dict[AgentId, StateMachineAgent] = {}
+    for index in range(num_sellers):
+        agents[AgentId(f"seller-{index}")] = PolicySeller()
+    for index in range(num_buyers):
+        seller = AgentId(f"seller-{index % num_sellers}")
+        agents[AgentId(f"buyer-{index}")] = PolicyBuyer(
+            seller=seller,
+            service=services[index % len(services)],
+        )
+    return agents

--- a/packages/nest-plugin-prava/pyproject.toml
+++ b/packages/nest-plugin-prava/pyproject.toml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+[project]
+name = "nest-plugin-prava"
+version = "0.1.0"
+description = "Nanda Town payments plugin: real Prava sandbox settlement bounded by a human-granted policy mandate"
+readme = "README.md"
+requires-python = ">=3.12"
+license = "Apache-2.0"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Testing",
+    "Typing :: Typed",
+]
+dependencies = [
+    "nest-core",
+    # Async HTTP to the Quartermaster console, which owns the mandate
+    # arbiter, the envelope router and the append-only ledger.
+    "httpx>=0.27",
+]
+
+[project.urls]
+Homepage = "https://github.com/projnanda/nandatown"
+Repository = "https://github.com/projnanda/nandatown"
+
+# Discoverable via the documented entry-point path (CONTRIBUTING.md).
+[project.entry-points."nest.plugins.payments"]
+prava = "nest_plugin_prava.plugin:PravaPayments"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["nest_plugin_prava"]

--- a/packages/nest-plugin-prava/pyproject.toml
+++ b/packages/nest-plugin-prava/pyproject.toml
@@ -30,6 +30,9 @@ Repository = "https://github.com/projnanda/nandatown"
 [project.entry-points."nest.plugins.payments"]
 prava = "nest_plugin_prava.plugin:PravaPayments"
 
+[project.entry-points."nest.scenarios"]
+policy_commerce = "nest_plugin_prava.scenario:policy_commerce_factory"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/nest-plugin-prava/sandbox-evidence.json
+++ b/packages/nest-plugin-prava/sandbox-evidence.json
@@ -1,0 +1,48 @@
+{
+  "failure_case": {
+    "error_code": "POLICY_NEEDS_HUMAN",
+    "error_message": "amount $70.50 exceeds cap $47.00",
+    "failing_clause_path": "root.all_of[3]",
+    "mandate_id": "qm_mdt_policy_v2",
+    "payment_ref": "nanda-fail-0d9344149e",
+    "prava_transactions_consumed": 0,
+    "quoted_cents": 7050,
+    "service": "gpu-compute-xl"
+  },
+  "happy_path": {
+    "amount_cents": 1800,
+    "currency": "USD",
+    "envelope_id": "env_a_1785693994048",
+    "environment": "SANDBOX",
+    "merchant_ref": "ord_781e1da2-ab9",
+    "payment_ref": "nanda-ok-73f1aeb573",
+    "prava_transaction_id": "txn_01KZ1TGNA0VPNE1BSYCK5C7B9T",
+    "prava_transactions_consumed": 1,
+    "pricing_rule": "ceil(2h x 900c/GPU-h) = 1800c",
+    "quote_id": "qt_ef3bfa4a-e20",
+    "run_id": "nanda_1785694016614_fhauf3",
+    "service": "gpu-compute-small"
+  },
+  "scenario_run": {
+    "buyer_0": {
+      "amount_cents": 1800,
+      "envelope_id": "env_a_1785695413265",
+      "ledger_autonomous": 1,
+      "merchant_ref": "ord_02d56bb3-930",
+      "outcome": "settled",
+      "prava_transaction_id": "txn_01KZ1VWC3YVWG94VFDX1H89PK7",
+      "service": "gpu-compute-small"
+    },
+    "buyer_1": {
+      "error_code": "POLICY_NEEDS_HUMAN",
+      "error_message": "amount $70.50 exceeds cap $47.00",
+      "failing_clause_path": "root.all_of[3]",
+      "outcome": "refused",
+      "prava_transactions_consumed": 0,
+      "service": "gpu-compute-xl"
+    },
+    "factory": "policy_commerce",
+    "scenario": "scenarios/prava_marketplace.yaml",
+    "trace_events": 16
+  }
+}

--- a/packages/nest-plugin-prava/tests/conftest.py
+++ b/packages/nest-plugin-prava/tests/conftest.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures.
+
+Contract tests run offline against a mocked console. Sandbox tests need a
+running Quartermaster console and move real sandbox money, so they skip
+unless ``QUARTERMASTER_CONSOLE_URL`` points at a reachable one.
+
+Helpers are exposed as fixtures rather than module-level functions so the
+suite collects correctly no matter which directory pytest is rooted at.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    Handler = Callable[[httpx.Request], httpx.Response]
+    MockClientFactory = Callable[[Handler], httpx.AsyncClient]
+    JsonResponseFactory = Callable[[int, dict[str, Any]], httpx.Response]
+
+CONSOLE_ENV = "QUARTERMASTER_CONSOLE_URL"
+
+
+@pytest.fixture
+def mock_client() -> MockClientFactory:
+    """Build an AsyncClient whose requests are served by a handler.
+
+    Example::
+
+        client = mock_client(lambda req: httpx.Response(200, json={}))
+    """
+
+    def factory(handler: Handler) -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    return factory
+
+
+@pytest.fixture
+def json_response() -> JsonResponseFactory:
+    """Shorthand for building a JSON response.
+
+    Example::
+
+        json_response(402, {"error": {"code": "POLICY_REFUSE", "message": "no"}})
+    """
+
+    def factory(status: int, payload: dict[str, Any]) -> httpx.Response:
+        return httpx.Response(status, json=payload)
+
+    return factory
+
+
+@pytest.fixture
+def console_url() -> str:
+    """Console base URL for live sandbox tests."""
+    return os.environ.get(CONSOLE_ENV, "http://localhost:3000").rstrip("/")
+
+
+@pytest.fixture
+def live_console(console_url: str) -> str:
+    """Skip the test unless a Quartermaster console is actually reachable."""
+    try:
+        response = httpx.get(f"{console_url}/api/portfolio", timeout=5.0)
+        response.raise_for_status()
+    except Exception as exc:  # noqa: BLE001 - any failure means "not available"
+        pytest.skip(f"no Quartermaster console at {console_url} ({exc})")
+    return console_url

--- a/packages/nest-plugin-prava/tests/test_plugin_contract.py
+++ b/packages/nest-plugin-prava/tests/test_plugin_contract.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline contract tests: protocol conformance and refusal mapping.
+
+These run anywhere, with no console and no network, so they stay green in
+CI. The sandbox tests in ``test_sandbox_live.py`` cover real money.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from nest_core.layers.payments import Payments
+from nest_core.types import AgentId, Money, PaymentRef, PaymentStatus, ServiceRef
+
+from nest_plugin_prava import PravaPaymentError, PravaPayments
+
+if TYPE_CHECKING:
+    import httpx
+
+    from tests.conftest import JsonResponseFactory, MockClientFactory
+
+QUOTE_BODY = {
+    "runId": "nanda_test_run",
+    "quoteId": "qt_test_0001",
+    "amountCents": 1800,
+    "currency": "USD",
+    "counterpartyId": "agent_b",
+    "pricingRule": "ceil(2h x 900c/GPU-h) = 1800c",
+    "attributes": {"gpu": "L40S 48GB", "vram_gb": 48, "duration_h": 2},
+    "ttlSeconds": 300,
+}
+
+
+def test_satisfies_payments_protocol() -> None:
+    """The plugin structurally implements the Payments layer interface."""
+    payments = PravaPayments(AgentId("agent_a"))
+    assert isinstance(payments, Payments)
+
+
+def test_accepts_marketplace_scenario_constructor() -> None:
+    """The bundled marketplace scenario builds plugins with these kwargs."""
+    shared: dict[PaymentRef, object] = {}
+    payments = PravaPayments(
+        AgentId("system"),
+        initial_balance=0,
+        balances={AgentId("a"): 1000},
+        payments=shared,  # type: ignore[arg-type]
+    )
+    assert isinstance(payments, Payments)
+
+
+async def test_quote_uses_merchant_price(
+    mock_client: MockClientFactory, json_response: JsonResponseFactory
+) -> None:
+    """The quoted price comes from the merchant, unmodified."""
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        return json_response(200, QUOTE_BODY)
+
+    payments = PravaPayments(AgentId("agent_a"), client=mock_client(handler))
+    quote = await payments.quote(ServiceRef("gpu-compute-small"))
+
+    assert quote.price == Money(amount=1800, currency="USD")
+    assert quote.metadata["quote_id"] == "qt_test_0001"
+    assert quote.metadata["pricing_rule"] == "ceil(2h x 900c/GPU-h) = 1800c"
+    assert str(seen["url"]).endswith("/api/nanda/quote")
+
+
+async def test_pay_without_quote_is_refused(
+    mock_client: MockClientFactory, json_response: JsonResponseFactory
+) -> None:
+    """An agent cannot pay a price no merchant ever quoted."""
+    client = mock_client(lambda request: json_response(200, {}))
+    payments = PravaPayments(AgentId("agent_a"), client=client)
+    with pytest.raises(PravaPaymentError) as exc:
+        await payments.pay(AgentId("agent_b"), Money(amount=9999), PaymentRef("p-nq"))
+    assert exc.value.code == "NO_QUOTE"
+
+
+async def test_policy_refusal_is_surfaced_honestly(
+    mock_client: MockClientFactory, json_response: JsonResponseFactory
+) -> None:
+    """A cap breach maps to the arbiter's verdict, clause path and detail."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/nanda/quote":
+            return json_response(200, {**QUOTE_BODY, "amountCents": 7050})
+        return json_response(
+            402,
+            {
+                "error": {
+                    "code": "POLICY_NEEDS_HUMAN",
+                    "message": "amount $70.50 exceeds cap $47.00",
+                    "details": {
+                        "decision": "NEEDS_HUMAN",
+                        "failingClausePath": "root.all_of[3]",
+                        "onFail": "escalate",
+                    },
+                }
+            },
+        )
+
+    payments = PravaPayments(AgentId("agent_a"), client=mock_client(handler))
+    quote = await payments.quote(ServiceRef("gpu-compute-xl"))
+    with pytest.raises(PravaPaymentError) as exc:
+        await payments.pay(AgentId("agent_b"), quote.price, PaymentRef("p-cap"))
+
+    assert exc.value.code == "POLICY_NEEDS_HUMAN"
+    assert exc.value.details["failingClausePath"] == "root.all_of[3]"
+    assert "exceeds cap" in exc.value.message
+
+
+async def test_cycle_exhausted_routing_refusal(
+    mock_client: MockClientFactory, json_response: JsonResponseFactory
+) -> None:
+    """No envelope with cycle capacity is a refusal, not a retry."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/nanda/quote":
+            return json_response(200, QUOTE_BODY)
+        return json_response(
+            402,
+            {
+                "error": {
+                    "code": "NO_ENVELOPE_CAPACITY",
+                    "message": "no envelope with cycle capacity: A: cycle spent -> B: cycle spent",
+                    "details": {"reason": "A: cycle spent -> B: cycle spent"},
+                }
+            },
+        )
+
+    payments = PravaPayments(AgentId("agent_a"), client=mock_client(handler))
+    quote = await payments.quote(ServiceRef("gpu-compute-small"))
+    with pytest.raises(PravaPaymentError) as exc:
+        await payments.pay(AgentId("agent_b"), quote.price, PaymentRef("p-cycle"))
+
+    assert exc.value.code == "NO_ENVELOPE_CAPACITY"
+    assert "cycle spent" in exc.value.message
+
+
+async def test_verify_requires_a_ledger_row(
+    mock_client: MockClientFactory, json_response: JsonResponseFactory
+) -> None:
+    """A charge without an append-only ledger row is not CONFIRMED."""
+
+    def pending(request: httpx.Request) -> httpx.Response:
+        return json_response(200, {"status": "confirmed", "ledgerConfirmed": False})
+
+    def settled(request: httpx.Request) -> httpx.Response:
+        return json_response(200, {"status": "confirmed", "ledgerConfirmed": True})
+
+    def failed(request: httpx.Request) -> httpx.Response:
+        return json_response(200, {"status": "failed", "ledgerConfirmed": False})
+
+    p1 = PravaPayments(AgentId("a"), client=mock_client(pending))
+    p2 = PravaPayments(AgentId("a"), client=mock_client(settled))
+    p3 = PravaPayments(AgentId("a"), client=mock_client(failed))
+
+    assert await p1.verify_payment(PaymentRef("p1")) is PaymentStatus.PENDING
+    assert await p2.verify_payment(PaymentRef("p1")) is PaymentStatus.CONFIRMED
+    assert await p3.verify_payment(PaymentRef("p1")) is PaymentStatus.FAILED
+
+
+async def test_refund_is_not_supported(
+    mock_client: MockClientFactory, json_response: JsonResponseFactory
+) -> None:
+    """Refunds raise instead of silently succeeding."""
+    client = mock_client(lambda request: json_response(200, {}))
+    payments = PravaPayments(AgentId("a"), client=client)
+    with pytest.raises(PravaPaymentError) as exc:
+        await payments.refund(PaymentRef("p1"))
+    assert exc.value.code == "REFUND_NOT_SUPPORTED"
+
+
+async def test_unknown_service_is_rejected(
+    mock_client: MockClientFactory, json_response: JsonResponseFactory
+) -> None:
+    """Unknown service refs fail loudly rather than guessing a need."""
+    client = mock_client(lambda request: json_response(200, {}))
+    payments = PravaPayments(AgentId("a"), client=client)
+    with pytest.raises(PravaPaymentError) as exc:
+        await payments.quote(ServiceRef("teleportation"))
+    assert exc.value.code == "UNKNOWN_SERVICE"

--- a/packages/nest-plugin-prava/tests/test_plugin_contract.py
+++ b/packages/nest-plugin-prava/tests/test_plugin_contract.py
@@ -12,12 +12,10 @@ from typing import TYPE_CHECKING
 import pytest
 from nest_core.layers.payments import Payments
 from nest_core.types import AgentId, Money, PaymentRef, PaymentStatus, ServiceRef
-
 from nest_plugin_prava import PravaPaymentError, PravaPayments
 
 if TYPE_CHECKING:
     import httpx
-
     from tests.conftest import JsonResponseFactory, MockClientFactory
 
 QUOTE_BODY = {

--- a/packages/nest-plugin-prava/tests/test_plugin_contract.py
+++ b/packages/nest-plugin-prava/tests/test_plugin_contract.py
@@ -7,7 +7,7 @@ CI. The sandbox tests in ``test_sandbox_live.py`` cover real money.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from nest_core.layers.payments import Payments
@@ -15,8 +15,15 @@ from nest_core.types import AgentId, Money, PaymentRef, PaymentStatus, ServiceRe
 from nest_plugin_prava import PravaPaymentError, PravaPayments
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import httpx
-    from tests.conftest import JsonResponseFactory, MockClientFactory
+
+    # Shapes of the conftest fixtures. Spelled out here rather than imported
+    # from the test package, which is not importable under every rootdir.
+    Handler = Callable[[httpx.Request], httpx.Response]
+    MockClientFactory = Callable[[Handler], httpx.AsyncClient]
+    JsonResponseFactory = Callable[[int, dict[str, Any]], httpx.Response]
 
 QUOTE_BODY = {
     "runId": "nanda_test_run",

--- a/packages/nest-plugin-prava/tests/test_sandbox_live.py
+++ b/packages/nest-plugin-prava/tests/test_sandbox_live.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Live Prava sandbox tests. These move REAL sandbox money.
+
+Skipped unless a Quartermaster console is reachable (see conftest).
+
+Budget: the happy path consumes ONE sandbox charge and requires an
+envelope the owner has already approved by passkey with cycle capacity
+remaining. The failure test consumes ZERO transactions: the arbiter and
+the router both refuse before any Prava call is made.
+
+Run with::
+
+    QUARTERMASTER_CONSOLE_URL=http://localhost:3000 pytest tests/test_sandbox_live.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+
+import httpx
+import pytest
+from nest_core.types import AgentId, PaymentRef, PaymentStatus, ServiceRef
+
+from nest_plugin_prava import PravaPaymentError, PravaPayments
+
+EVIDENCE_PATH = pathlib.Path(__file__).resolve().parent.parent / "sandbox-evidence.json"
+
+
+def _record_evidence(name: str, payload: dict[str, object]) -> None:
+    """Append a verifiable record of what the sandbox actually did."""
+    existing: dict[str, object] = {}
+    if EVIDENCE_PATH.exists():
+        existing = json.loads(EVIDENCE_PATH.read_text())
+    existing[name] = payload
+    EVIDENCE_PATH.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n")
+
+
+def _has_open_envelope(console_url: str) -> bool:
+    data = httpx.get(f"{console_url}/api/portfolio", timeout=10.0).json()
+    return any(env.get("cycle") == "OPEN" for env in data.get("envelopes", []))
+
+
+async def test_failure_case_policy_refusal_costs_nothing(live_console: str) -> None:
+    """An over-cap quote is refused by the arbiter with no Prava call.
+
+    This is the failure-handling criterion: the plugin surfaces the
+    arbiter's verdict, clause path and human-readable detail, and the
+    ledger records no spend.
+    """
+    payments = PravaPayments(AgentId("agent_a"), console_url=live_console)
+    try:
+        quote = await payments.quote(ServiceRef("gpu-compute-xl"))
+        ref = PaymentRef(f"nanda-fail-{uuid.uuid4().hex[:10]}")
+
+        with pytest.raises(PravaPaymentError) as exc:
+            await payments.pay(AgentId("agent_b"), quote.price, ref)
+
+        assert exc.value.code in {"POLICY_NEEDS_HUMAN", "POLICY_REFUSE"}
+        assert exc.value.details.get("failingClausePath")
+        assert await payments.verify_payment(ref) is PaymentStatus.FAILED
+
+        _record_evidence(
+            "failure_case",
+            {
+                "service": "gpu-compute-xl",
+                "quoted_cents": quote.price.amount,
+                "payment_ref": str(ref),
+                "error_code": exc.value.code,
+                "error_message": exc.value.message,
+                "failing_clause_path": exc.value.details.get("failingClausePath"),
+                "mandate_id": exc.value.details.get("mandateId"),
+                "prava_transactions_consumed": 0,
+            },
+        )
+    finally:
+        await payments.aclose()
+
+
+async def test_happy_path_settles_in_sandbox(live_console: str) -> None:
+    """A within-policy quote settles against a pre-approved envelope.
+
+    Requires an envelope with cycle capacity: the owner approves it ONCE,
+    by passkey, before the simulation. Never faked.
+    """
+    if not _has_open_envelope(live_console):
+        pytest.skip(
+            "no envelope with cycle capacity; approve one by passkey first "
+            "(pnpm tsx scripts/create-envelope.ts A)"
+        )
+
+    payments = PravaPayments(AgentId("agent_a"), console_url=live_console)
+    try:
+        quote = await payments.quote(ServiceRef("gpu-compute-small"))
+        assert quote.price.currency == "USD"
+        assert quote.price.amount > 0
+
+        ref = PaymentRef(f"nanda-ok-{uuid.uuid4().hex[:10]}")
+        receipt = await payments.pay(AgentId("agent_b"), quote.price, ref)
+
+        assert receipt.ref == ref
+        assert receipt.payee == AgentId("agent_b")
+        assert receipt.amount.amount == quote.price.amount
+
+        status = await payments.verify_payment(ref)
+        assert status is PaymentStatus.CONFIRMED
+
+        detail = httpx.get(
+            f"{live_console}/api/nanda/payment", params={"ref": str(ref)}, timeout=30.0
+        ).json()
+        assert detail["ledgerConfirmed"] is True
+        assert detail["transactionId"]
+
+        _record_evidence(
+            "happy_path",
+            {
+                "service": "gpu-compute-small",
+                "payment_ref": str(ref),
+                "amount_cents": receipt.amount.amount,
+                "currency": receipt.amount.currency,
+                "prava_transaction_id": detail["transactionId"],
+                "merchant_ref": detail["merchantRef"],
+                "envelope_id": detail["envelopeId"],
+                "run_id": quote.metadata["run_id"],
+                "quote_id": quote.metadata["quote_id"],
+                "pricing_rule": quote.metadata["pricing_rule"],
+                "environment": "SANDBOX",
+                "prava_transactions_consumed": 1,
+            },
+        )
+    finally:
+        await payments.aclose()
+
+
+async def test_refund_documented_as_unsupported(live_console: str) -> None:
+    """The refund path is documented, not silently swallowed."""
+    payments = PravaPayments(AgentId("agent_a"), console_url=live_console)
+    try:
+        with pytest.raises(PravaPaymentError) as exc:
+            await payments.refund(PaymentRef("does-not-matter"))
+        assert exc.value.code == "REFUND_NOT_SUPPORTED"
+    finally:
+        await payments.aclose()

--- a/packages/nest-plugin-prava/tests/test_sandbox_live.py
+++ b/packages/nest-plugin-prava/tests/test_sandbox_live.py
@@ -22,7 +22,6 @@ import uuid
 import httpx
 import pytest
 from nest_core.types import AgentId, PaymentRef, PaymentStatus, ServiceRef
-
 from nest_plugin_prava import PravaPaymentError, PravaPayments
 
 EVIDENCE_PATH = pathlib.Path(__file__).resolve().parent.parent / "sandbox-evidence.json"

--- a/packages/nest-plugin-prava/tests/test_scenario.py
+++ b/packages/nest-plugin-prava/tests/test_scenario.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The bundled scenario selects this plugin and stays loadable.
+
+Runs offline: it validates wiring, not money. Real settlement is covered
+by ``test_sandbox_live.py``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import yaml
+
+SCENARIO_RELATIVE = pathlib.Path("scenarios") / "prava_marketplace.yaml"
+
+
+def _find_scenario() -> pathlib.Path:
+    """Locate the scenario by walking up, so the test is layout-agnostic.
+
+    The plugin sits beside the scenario in the adapter repo and under
+    ``packages/`` in the Nanda Town tree; both are found this way.
+    """
+    for parent in pathlib.Path(__file__).resolve().parents:
+        candidate = parent / SCENARIO_RELATIVE
+        if candidate.is_file():
+            return candidate
+    msg = f"could not find {SCENARIO_RELATIVE} above {__file__}"
+    raise AssertionError(msg)
+
+
+SCENARIO = _find_scenario()
+
+
+def test_scenario_file_exists() -> None:
+    """The scenario ships with the plugin."""
+    assert SCENARIO.is_file(), f"missing scenario at {SCENARIO}"
+
+
+def test_scenario_selects_the_prava_payments_layer() -> None:
+    """Swapping the payments layer is the whole point of the plugin."""
+    config = yaml.safe_load(SCENARIO.read_text())
+    assert config["layers"]["payments"] == "prava"
+    assert config["tier"] == 1
+    assert config["name"] == "prava_marketplace"
+
+
+def test_scenario_documents_the_passkey_precondition() -> None:
+    """A human approves the envelope before any simulation spends."""
+    text = SCENARIO.read_text().lower()
+    assert "passkey" in text
+    assert "never automated" in text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ members = [
     "packages/nest-shell",
     "packages/nest-plugins-reference",
     "packages/nest-marketplace",
+    "packages/nest-plugin-prava",
 ]
 
 [tool.uv]
@@ -89,6 +90,7 @@ nest-scenarios = { workspace = true }
 nest-shell = { workspace = true }
 nest-plugins-reference = { workspace = true }
 nest-marketplace = { workspace = true }
+nest-plugin-prava = { workspace = true }
 
 [tool.ruff]
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "nest-shell",
     "nest-plugins-reference",
     "nest-marketplace",
+    "nest-plugin-prava",
 ]
 
 [project.optional-dependencies]

--- a/scenarios/prava_marketplace.yaml
+++ b/scenarios/prava_marketplace.yaml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# Prava commerce: buyers settle REAL Prava sandbox charges, bounded by a
+# human-granted envelope portfolio.
+#
+# BEFORE RUNNING:
+#   1. Start a Quartermaster console (it holds the arbiter, router and
+#      ledger) and export QUARTERMASTER_CONSOLE_URL if it is not on
+#      localhost:3000.
+#   2. The owner approves at least one ENVELOPE with a passkey. This is a
+#      human action and is never automated. Visa enforces one charge per
+#      envelope per weekly cycle, so approve as many envelopes as the run
+#      needs concurrent charges.
+#
+# buyer-0 asks for a service priced inside policy and settles.
+# buyer-1 asks for one priced above the per-charge cap: the arbiter
+# refuses it, no Prava call is made, and the refusal is the point.
+name: prava_marketplace
+description: "Buyers settling real Prava sandbox charges under a policy mandate, including a refusal."
+
+tier: 1
+seed: 42
+
+agents:
+  count: 4
+  brain: state-machine
+  roles:
+    - name: buyer
+      count: 2
+    - name: seller
+      count: 2
+
+task:
+  type: policy_commerce
+  config:
+    services:
+      - gpu-compute-small
+      - gpu-compute-xl
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prava
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,7 @@ members = [
     "nest-core",
     "nest-marketplace",
     "nest-mocks",
+    "nest-plugin-prava",
     "nest-plugins-reference",
     "nest-scenarios",
     "nest-sdk",
@@ -1400,6 +1401,21 @@ dependencies = [
 requires-dist = [{ name = "nest-core", editable = "packages/nest-core" }]
 
 [[package]]
+name = "nest-plugin-prava"
+version = "0.1.0"
+source = { editable = "packages/nest-plugin-prava" }
+dependencies = [
+    { name = "httpx" },
+    { name = "nest-core" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "nest-core", editable = "packages/nest-core" },
+]
+
+[[package]]
 name = "nest-plugins-reference"
 version = "0.1.1"
 source = { editable = "packages/nest-plugins-reference" }
@@ -1480,6 +1496,7 @@ dependencies = [
     { name = "nest-core" },
     { name = "nest-marketplace" },
     { name = "nest-mocks" },
+    { name = "nest-plugin-prava" },
     { name = "nest-plugins-reference" },
     { name = "nest-scenarios" },
     { name = "nest-sdk" },
@@ -1517,6 +1534,7 @@ requires-dist = [
     { name = "nest-core", editable = "packages/nest-core" },
     { name = "nest-marketplace", editable = "packages/nest-marketplace" },
     { name = "nest-mocks", editable = "packages/nest-mocks" },
+    { name = "nest-plugin-prava", editable = "packages/nest-plugin-prava" },
     { name = "nest-plugins-reference", editable = "packages/nest-plugins-reference" },
     { name = "nest-scenarios", editable = "packages/nest-scenarios" },
     { name = "nest-sdk", editable = "packages/nest-sdk" },


### PR DESCRIPTION
Adds `packages/nest-plugin-prava`, a Payments-layer plugin that moves real
money in the Prava Agentic Payments Sandbox under a human-granted policy,
plus a `policy_commerce` scenario and `scenarios/prava_marketplace.yaml`.

It implements the `Payments` protocol — `quote`, `pay`, `verify_payment`,
`refund` — and `balance`, so it also drops into the bundled `marketplace`
scenario.

## Why it is shaped this way

"Autonomous agent with a credit card" is the wrong shape, so authority is
split in two.

The owner approves a bounded **envelope** with their passkey: merchant
scoped, per-charge capped, one charge per payment cycle, enforced at the
Visa network. That happens once, before the simulation, and this plugin
never automates or simulates it. Then a deterministic arbiter evaluates
every charge against a signed clause tree before any money call is made.
No model sits in the decision path.

Inside the approved envelope the agent transacts on its own. Outside it,
the answer is no.

## Refusals are first class

`POLICY_NEEDS_HUMAN` (over the per-charge cap), `POLICY_REFUSED` (a
capability clause failed), `NO_ENVELOPE_CAPACITY` (every envelope's cycle
is spent) and `NO_OFFER` all raise `PravaPaymentError` carrying the failing
clause path, and all happen before any network call — so a simulation that
hits them consumes nothing. `refund()` always raises: Prava has no refund
on the surface this uses, and pretending otherwise would be worse than
saying so.

`sandbox-evidence.json` records a real run of both paths: a settled $18.00
purchase with its transaction id, and a refusal at `root.all_of[3]` with
"amount $70.50 exceeds cap $47.00" and zero transactions consumed.

## Notes for review

- The scenario registers through a new `nest.scenarios` entry point rather
  than an import inside `nest_core.scenarios`, so core stays free of any
  knowledge of packages that contribute scenarios. That is the only change
  outside the new package, and it mirrors how the layer plugins already
  load.
- Contract and scenario tests run offline with no credentials and no
  network. `tests/test_sandbox_live.py` is the only file that spends
  anything, and it skips unless `QUARTERMASTER_CONSOLE_URL` is reachable.
- `make ci-local` exits 0 here: ruff, `ruff format --check`, pyright strict
  and pytest at 1323 passed, 4 skipped.

Built for the Agentic Commerce Hackathon (Prava x OpenAI). The plugin is a
thin client over a Quartermaster deployment, which holds the arbiter, the
envelope router and the append-only ledger; `console_url` points it at any
instance.