### PR TITLE
trust(parc): anchor behavioral_merkle_root into a capsule, closing the equivocation gap.  

### DIFF
--- a/docs/layers/trust.md
+++ b/docs/layers/trust.md
@@ -92,6 +92,20 @@ edge), so the signed score stands — re-deriving it from a hand-picked
 subset is exactly the cherry-picking this split forbids. Full-ledger
 recomputation remains `admit`'s job.
 
+**Root anchoring.** The issuer's signature only proves *an* issuer
+signed *some* root — an issuer that regenerates its receipt tree (drops
+a receipt, adds a fabricated one) can produce a different, still
+self-consistently-signed root for the same nominal credential, and
+nothing in the proof check alone catches it. With `anchor=True`,
+`build_credential` seals each credential's `behavioral_merkle_root` and
+`receipt_count` into a capsule — same opt-in, soft-dependent-on-
+`capsule-emit` posture as `aae_permit_gate`'s `anchor` (below): absent
+the package, anchoring degrades to a one-time debug log and a no-op,
+never a hard dependency. `verify_presentation`'s `anchor_capsule` option
+then checks a presented root against that sealed capsule, so a
+regenerated-tree equivocation surfaces as `anchor_mismatch` instead of
+verifying clean.
+
 Source: [`nest_plugins_reference/trust/parc.py`](../../packages/nest-plugins-reference/nest_plugins_reference/trust/parc.py).
 Scenario: `parc_migration` (two trust domains in one run; forged,
 replayed, stale-key, inflated, and wash-ring credentials each denied

--- a/packages/nest-plugins-reference/nest_plugins_reference/trust/parc.py
+++ b/packages/nest-plugins-reference/nest_plugins_reference/trust/parc.py
@@ -36,6 +36,17 @@ gates, collusion-ring severance) with three new capabilities:
    every edge), so the signed score stands — recomputing it from a
    hand-picked subset is exactly the cherry-picking attack this split
    forbids. Full-ledger recomputation remains :meth:`ParcTrust.admit`'s job.
+4. **Root anchoring** — the issuer's signature alone only proves *an* issuer
+   signed *some* root; an issuer that regenerates its receipt tree can
+   produce a different, still self-consistently-signed root for the same
+   nominal credential, and the signature check alone never catches it. With
+   ``anchor=True``, :meth:`ParcTrust.build_credential` seals each credential's
+   ``behavioral_merkle_root`` and ``receipt_count`` into a capsule
+   (:meth:`ParcTrust._anchor_root`, the same optional,
+   soft-dependent-on-``capsule_emit`` posture as ``aae_permit_gate``'s
+   ``anchor``), and :meth:`ParcTrust.verify_presentation`'s
+   ``anchor_capsule`` option checks a presented root against that sealed
+   capsule, surfacing a regenerated-tree equivocation as ``anchor_mismatch``.
 
 An inline credential carries only the subject's own receipts — a star graph —
 so it cannot reveal an N-party collusion ring (each ring member's credential
@@ -78,6 +89,8 @@ Example::
 from __future__ import annotations
 
 import hashlib
+import importlib
+import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any, cast
@@ -91,6 +104,8 @@ from nest_core.types import AgentId
 # whole-graph collusion severance MUST stay in exactly one place so a
 # credential's recomputed score can never drift from the exporter's.
 from nest_plugins_reference.trust import agent_receipts as ar
+
+logger = logging.getLogger(__name__)
 
 SCORING_METHOD = "nanda-rep/0.2"
 CREDENTIAL_TYPE = "ParcReputationCredential"
@@ -423,8 +438,9 @@ class DisclosureResult:
     receipt checked out. ``reasons`` is empty on success, else the ordered,
     de-duplicated snake_case failures (``malformed_presentation``,
     ``issuer_mismatch``, ``bad_credential_proof``, ``malformed_proof``,
-    ``count_mismatch``, ``not_included``). Frozen — a verification verdict is
-    evidence, not a scratchpad.
+    ``count_mismatch``, ``not_included``, ``anchor_mismatch``,
+    ``anchor_unavailable``). Frozen — a verification verdict is evidence,
+    not a scratchpad.
 
     Example::
 
@@ -473,6 +489,36 @@ def _disclosed_entry_reasons(entry: Any, *, root: str, receipt_count: int) -> li
     return reasons
 
 
+def _anchor_reason(anchor_capsule: dict[str, Any], *, root: str, receipt_count: int) -> str | None:
+    """``None`` iff ``anchor_capsule`` was sealed for exactly this ``(root, receipt_count)``.
+
+    Uses ``capsule_emit.verify_input_digest`` against the same
+    ``{"behavioral_merkle_root", "receipt_count"}`` shape
+    :meth:`ParcTrust._anchor_root` sealed as the capsule's digest-committed
+    ``agent_input`` — the capsule never stores the plaintext root (digest-only
+    commitment), so this recomputes the digest and compares rather than
+    reading a stored value back out. ``"anchor_unavailable"`` when
+    ``capsule_emit`` cannot be imported — a capsule cannot be interpreted
+    without the package that produced it, so this fails closed rather than
+    silently skipping the check. ``"anchor_mismatch"`` when the digest
+    disagrees: the credential's presented root was not the one this capsule
+    sealed — the regenerated-tree equivocation case this check exists to
+    catch.
+
+    Example::
+
+        reason = _anchor_reason(capsule, root=root, receipt_count=2)
+    """
+    try:
+        capsule_emit = importlib.import_module("capsule_emit")
+    except ImportError:
+        return "anchor_unavailable"
+    candidate = {"behavioral_merkle_root": root, "receipt_count": receipt_count}
+    if not capsule_emit.verify_input_digest(anchor_capsule, candidate):
+        return "anchor_mismatch"
+    return None
+
+
 # ---------------------------------------------------------------------------
 # The trust plugin
 # ---------------------------------------------------------------------------
@@ -491,13 +537,33 @@ class ParcTrust(ar.AgentReceiptsTrust):
 
         trust = ParcTrust()
         vc = await trust.build_credential(subject, identity=ident, valid_from=6.0)
+
+    ``anchor=True`` opts into sealing each built credential's
+    ``behavioral_merkle_root`` into a capsule (:meth:`_anchor_root`), the
+    same optional, soft-dependent-on-``capsule_emit`` posture as
+    ``AAEPermitGate``'s ``anchor`` — never a hard requirement.
     """
 
-    def __init__(self, identity: Any = None) -> None:
+    def __init__(
+        self,
+        identity: Any = None,
+        *,
+        anchor: bool = False,
+        ledger: str = "capsule_ledger.jsonl",
+    ) -> None:
         super().__init__(identity)
         # The originating domain's community ledger, if one was published to
         # this gate. Whole-graph severance for admissions runs over this.
         self._published_ledger: list[dict[str, Any]] = []
+        self._anchor = anchor
+        # Deliberately NOT named ``_ledger`` — the base class already owns
+        # that name for the receipt ledger (``AgentReceiptsTrust._ledger``);
+        # this is the on-disk path capsule_emit appends its JSONL to.
+        self._capsule_ledger = ledger
+        self._anchor_unavailable_logged = False
+        # (subject_did, valid_from) -> the capsule this instance sealed for
+        # that credential's root, if anchoring is on and available.
+        self._anchor_capsules: dict[tuple[str, float], dict[str, Any]] = {}
 
     # -- export ------------------------------------------------------------
 
@@ -549,7 +615,71 @@ class ParcTrust(ar.AgentReceiptsTrust):
                 "receipts": receipts,
             },
         }
-        return attach_proof(credential, identity=identity, key_id=key_id)
+        credential = attach_proof(credential, identity=identity, key_id=key_id)
+        self._anchor_root(
+            did=did,
+            valid_from=valid_from,
+            root=str(credential["credentialSubject"]["behavioral_merkle_root"]),
+            receipt_count=len(receipts),
+            issuer=str(credential["issuer"]),
+        )
+        return credential
+
+    def _anchor_root(
+        self, *, did: str, valid_from: float, root: str, receipt_count: int, issuer: str
+    ) -> None:
+        """Optionally seal ``(behavioral_merkle_root, receipt_count)`` into a capsule.
+
+        Mirrors ``AAEPermitGate._anchor_envelope``: opt-in (``anchor=True``
+        at construction) and soft-dependent on the optional ``capsule_emit``
+        package — absent, this degrades to a one-time debug log and a no-op,
+        never a hard dependency. Namespaced ``"parc.root_sealed"`` so a
+        sealed root never reads as an executed action. The capsule is a
+        second, independent witness of the root the issuer already signed —
+        it does not replace that signature, it gives
+        :meth:`verify_presentation`'s ``anchor_capsule`` option something
+        outside the issuer's own proof to check a presented root against.
+
+        Example::
+
+            trust._anchor_root(did=did, valid_from=6.0, root=root,
+                               receipt_count=2, issuer="did:nest:issuer-a")
+        """
+        if not self._anchor:
+            return
+        try:
+            capsule_emit = importlib.import_module("capsule_emit")
+        except ImportError:
+            if not self._anchor_unavailable_logged:
+                logger.debug("anchor=True but capsule_emit is not installed; anchoring disabled")
+                self._anchor_unavailable_logged = True
+            return
+        result = capsule_emit.emit(
+            action="parc.root_sealed",
+            operator=did,
+            developer=str(self._SYSTEM_AGENT),
+            agent_input={"behavioral_merkle_root": root, "receipt_count": receipt_count},
+            agent_output={"issuer": issuer, "valid_from": valid_from},
+            anchor=True,
+            ledger=self._capsule_ledger,
+        )
+        self._anchor_capsules[(did, valid_from)] = result.capsule
+
+    def anchored_capsule(self, subject_did: str, valid_from: float) -> dict[str, Any] | None:
+        """The capsule this instance sealed for ``(subject_did, valid_from)``, if any.
+
+        ``None`` when anchoring is off, ``capsule_emit`` was unavailable at
+        build time, or no credential has been built for that key yet. A real
+        deployment fetches the equivalent capsule from the transparency
+        ledger by capsule id; same-process tests and demos read it straight
+        from here and pass it to :meth:`verify_presentation`'s
+        ``anchor_capsule`` option.
+
+        Example::
+
+            capsule = trust.anchored_capsule(did, 6.0)
+        """
+        return self._anchor_capsules.get((subject_did, valid_from))
 
     # -- published-ledger ingestion -----------------------------------------
 
@@ -779,6 +909,7 @@ class ParcTrust(ar.AgentReceiptsTrust):
         *,
         identity: Any,
         expected_issuer: str | None = None,
+        anchor_capsule: dict[str, Any] | None = None,
     ) -> DisclosureResult:
         """Verify a selective-disclosure presentation; no score is recomputed.
 
@@ -796,6 +927,19 @@ class ParcTrust(ar.AgentReceiptsTrust):
         remainder (``count_mismatch``) — and the receipt folds to the signed
         ``behavioral_merkle_root`` (``not_included``).
 
+        ``anchor_capsule``, when supplied, is checked against the presented
+        ``(behavioral_merkle_root, receipt_count)`` (``_anchor_reason``): a
+        signature alone only proves the issuer signed *some* root for this
+        subject — an issuer that regenerates its receipt tree can produce a
+        different, still self-consistently-signed root for the same nominal
+        credential, and nothing in the proof check catches that. A capsule
+        sealed for the credential's ORIGINAL root at issuance (see
+        :meth:`_anchor_root` / :meth:`anchored_capsule`) gives this check
+        something outside the issuer's own signature to compare against, so
+        that equivocation surfaces as ``anchor_mismatch`` instead of passing
+        silently. Omitting ``anchor_capsule`` (the default) skips this check
+        entirely — same opt-in posture as ``anchor=True`` at construction.
+
         Deliberately absent: score recomputation. Disclosure proves *which
         receipts happened* under the signed commitment; the reputation
         aggregate is a whole-graph property, so the signed score stands and a
@@ -804,7 +948,8 @@ class ParcTrust(ar.AgentReceiptsTrust):
 
         Example::
 
-            result = await gate.verify_presentation(pres, identity=gate_ident)
+            result = await gate.verify_presentation(pres, identity=gate_ident,
+                                                     anchor_capsule=capsule)
         """
         credential = presentation.get("credential")
         disclosed = presentation.get("disclosed")
@@ -835,6 +980,10 @@ class ParcTrust(ar.AgentReceiptsTrust):
             for reason in _disclosed_entry_reasons(entry, root=root, receipt_count=receipt_count):
                 if reason not in reasons:
                     reasons.append(reason)
+        if anchor_capsule is not None:
+            anchor_fail = _anchor_reason(anchor_capsule, root=root, receipt_count=receipt_count)
+            if anchor_fail is not None and anchor_fail not in reasons:
+                reasons.append(anchor_fail)
         if reasons:
             return DisclosureResult(False, tuple(reasons))
         return DisclosureResult(True)

--- a/packages/nest-plugins-reference/tests/test_parc.py
+++ b/packages/nest-plugins-reference/tests/test_parc.py
@@ -28,7 +28,10 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import importlib
 import json
+import sys
+import types
 from typing import Any
 
 import pytest
@@ -116,6 +119,77 @@ def _identities() -> tuple[Ed25519RotatingIdentity, Ed25519RotatingIdentity, str
     assert gate.apply_rotation(rotation)
     issuer.set_clock(_ISSUE_AT)
     return issuer, gate, old_key_id
+
+
+# ---------------------------------------------------------------------------
+# A minimal in-memory stand-in for the optional ``capsule_emit`` package.
+#
+# ``ParcTrust``'s anchoring is soft-dependent on the real package (never
+# installed in this repo — see ``aae_permit_gate.py``'s identical posture),
+# so these tests install a fake module under ``sys.modules["capsule_emit"]``
+# that mimics just the two entry points ``parc.py`` calls: ``emit()`` (returns
+# an object with ``.capsule_id`` / ``.capsule``) and ``verify_input_digest()``
+# (digest-only, matching the real package's "content stays local" contract —
+# the capsule stores a digest of ``agent_input``, never the plaintext).
+# ---------------------------------------------------------------------------
+
+
+def _fake_capsule_digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+class _FakeEmitResult:
+    def __init__(self, capsule_id: str, capsule: dict[str, Any]) -> None:
+        self.capsule_id = capsule_id
+        self.capsule = capsule
+        self.anchored = True
+
+
+def _install_fake_capsule_emit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a fake ``capsule_emit`` module for the duration of one test."""
+    counter = {"n": 0}
+
+    def _emit(
+        action: str,
+        operator: str = "",
+        developer: str = "",
+        *,
+        agent_input: Any = None,
+        agent_output: Any = None,
+        anchor: bool = True,
+        ledger: Any = "ledger.jsonl",
+        **_kwargs: Any,
+    ) -> _FakeEmitResult:
+        counter["n"] += 1
+        capsule_id = f"fake-capsule-{counter['n']}"
+        capsule = {
+            "capsule_id": capsule_id,
+            "action": action,
+            "model_attestation": {
+                "compute_attestation": {
+                    "agent_input_digest": (
+                        _fake_capsule_digest(agent_input) if agent_input is not None else None
+                    ),
+                },
+            },
+        }
+        return _FakeEmitResult(capsule_id, capsule)
+
+    def _verify_input_digest(capsule: dict[str, Any], candidate_input: Any) -> bool:
+        stored = (
+            capsule.get("model_attestation", {})
+            .get("compute_attestation", {})
+            .get("agent_input_digest")
+        )
+        if stored is None:
+            return False
+        return bool(stored == _fake_capsule_digest(candidate_input))
+
+    fake_module = types.ModuleType("capsule_emit")
+    fake_module.emit = _emit  # type: ignore[attr-defined]
+    fake_module.verify_input_digest = _verify_input_digest  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "capsule_emit", fake_module)
 
 
 def _policy(**overrides: Any) -> AdmissionPolicy:
@@ -770,3 +844,187 @@ class TestPresentation:
         pres1, _, _ = await _presentation()
         pres2, _, _ = await _presentation()
         assert json.dumps(pres1, sort_keys=True) == json.dumps(pres2, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# Root anchoring — sealing behavioral_merkle_root into a capsule, and the
+# verify_presentation check against it.
+# ---------------------------------------------------------------------------
+
+
+class TestAnchor:
+    @pytest.mark.asyncio
+    async def test_anchor_off_by_default_no_capsule(self) -> None:
+        # anchor=False (the default) never touches capsule_emit, installed
+        # or not — same opt-in posture as AAEPermitGate's anchor=False.
+        _vc, trust = await _alice_credential()
+        assert trust.anchored_capsule(_did("alice"), _ISSUE_AT) is None
+
+    @pytest.mark.asyncio
+    async def test_anchor_unavailable_degrades_to_noop(self) -> None:
+        # anchor=True but capsule_emit genuinely not installed in this repo's
+        # env (no fake module patched in this test): no crash, no capsule
+        # sealed — the credential itself is unaffected.
+        receipts = _alice_receipts()
+        trust = ParcTrust(anchor=True)
+        for r in receipts:
+            await trust.report(
+                AgentId("reporter"),
+                Evidence(
+                    reporter=AgentId("reporter"),
+                    subject=AgentId("reporter"),
+                    kind="positive",
+                    detail=json.dumps(r),
+                ),
+            )
+        issuer_ident, _, _ = _identities()
+        vc = await trust.build_credential(
+            AgentId("alice"), identity=issuer_ident, valid_from=_ISSUE_AT
+        )
+        assert trust.anchored_capsule(_did("alice"), _ISSUE_AT) is None
+        assert vc["credentialSubject"]["behavioral_merkle_root"] == merkle_root(receipts)
+
+    @pytest.mark.asyncio
+    async def test_root_sealed_into_capsule(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_capsule_emit(monkeypatch)
+        receipts = _alice_receipts()
+        trust = ParcTrust(anchor=True)
+        for r in receipts:
+            await trust.report(
+                AgentId("reporter"),
+                Evidence(
+                    reporter=AgentId("reporter"),
+                    subject=AgentId("reporter"),
+                    kind="positive",
+                    detail=json.dumps(r),
+                ),
+            )
+        issuer_ident, _, _ = _identities()
+        vc = await trust.build_credential(
+            AgentId("alice"), identity=issuer_ident, valid_from=_ISSUE_AT
+        )
+        capsule = trust.anchored_capsule(_did("alice"), _ISSUE_AT)
+        assert capsule is not None
+        assert capsule["action"] == "parc.root_sealed"
+
+        capsule_emit = importlib.import_module("capsule_emit")  # the fake installed above
+
+        root = vc["credentialSubject"]["behavioral_merkle_root"]
+        count = vc["credentialSubject"]["receipt_count"]
+        assert capsule_emit.verify_input_digest(
+            capsule, {"behavioral_merkle_root": root, "receipt_count": count}
+        )
+        # A tampered candidate root does not match the sealed digest.
+        assert not capsule_emit.verify_input_digest(
+            capsule, {"behavioral_merkle_root": "0" * 64, "receipt_count": count}
+        )
+
+    @pytest.mark.asyncio
+    async def test_verify_presentation_accepts_matching_anchor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_fake_capsule_emit(monkeypatch)
+        receipts = _ledger(20)
+        trust = ParcTrust(anchor=True)
+        for r in receipts:
+            await trust.report(
+                AgentId("reporter"),
+                Evidence(
+                    reporter=AgentId("reporter"),
+                    subject=AgentId("reporter"),
+                    kind="positive",
+                    detail=json.dumps(r),
+                ),
+            )
+        issuer_ident, gate_ident, _ = _identities()
+        vc = await trust.build_credential(
+            AgentId("alice"), identity=issuer_ident, valid_from=_ISSUE_AT
+        )
+        capsule = trust.anchored_capsule(_did("alice"), _ISSUE_AT)
+        assert capsule is not None
+        pres = trust.build_presentation(vc, receipts, disclose=("r03", "r07"))
+
+        result = await trust.verify_presentation(pres, identity=gate_ident, anchor_capsule=capsule)
+        assert (result.ok, result.reasons) == (True, ())
+
+    @pytest.mark.asyncio
+    async def test_equivocation_after_anchor_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The gap this feature closes: an issuer regenerates its receipt
+        tree (here: reports one more corroborated receipt) and re-exports a
+        different, still self-consistently-signed root for the SAME nominal
+        (issuer, subject, validFrom). Without the anchor, the equivocated
+        credential's presentation verifies clean. With the ORIGINAL sealed
+        root supplied as ``anchor_capsule``, it is caught.
+        """
+        _install_fake_capsule_emit(monkeypatch)
+        receipts = _alice_receipts()  # 2 receipts: r1, r2
+        trust = ParcTrust(anchor=True)
+        for r in receipts:
+            await trust.report(
+                AgentId("reporter"),
+                Evidence(
+                    reporter=AgentId("reporter"),
+                    subject=AgentId("reporter"),
+                    kind="positive",
+                    detail=json.dumps(r),
+                ),
+            )
+        issuer_ident, gate_ident, _ = _identities()
+        vc1 = await trust.build_credential(
+            AgentId("alice"), identity=issuer_ident, valid_from=_ISSUE_AT
+        )
+        original_capsule = trust.anchored_capsule(_did("alice"), _ISSUE_AT)
+        assert original_capsule is not None
+
+        # Equivocate: the issuer's own ledger grows a THIRD corroborated
+        # receipt for alice, and the issuer re-exports for the same
+        # (subject, validFrom) — a different, self-consistent root.
+        extra = _receipt("alice", "dave", rid="r3")
+        await trust.report(
+            AgentId("reporter"),
+            Evidence(
+                reporter=AgentId("reporter"),
+                subject=AgentId("reporter"),
+                kind="positive",
+                detail=json.dumps(extra),
+            ),
+        )
+        vc2 = await trust.build_credential(
+            AgentId("alice"), identity=issuer_ident, valid_from=_ISSUE_AT
+        )
+        assert (
+            vc2["credentialSubject"]["behavioral_merkle_root"]
+            != vc1["credentialSubject"]["behavioral_merkle_root"]
+        )
+
+        all_receipts = [*receipts, extra]
+        pres2 = trust.build_presentation(vc2, all_receipts, disclose=("r1",))
+
+        # THE GAP: without the anchor, the equivocated credential's
+        # presentation is entirely self-consistent and verifies clean.
+        unchecked = await trust.verify_presentation(pres2, identity=gate_ident)
+        assert (unchecked.ok, unchecked.reasons) == (True, ())
+
+        # THE CLOSE: the ORIGINAL anchored root catches the swap.
+        checked = await trust.verify_presentation(
+            pres2, identity=gate_ident, anchor_capsule=original_capsule
+        )
+        assert checked.ok is False
+        assert "anchor_mismatch" in checked.reasons
+
+    @pytest.mark.asyncio
+    async def test_anchor_capsule_without_package_fails_closed(self) -> None:
+        # anchor_capsule supplied, but capsule_emit is NOT installed (no fake
+        # module patched in this test): fails closed, distinctly from a
+        # digest mismatch.
+        pres, trust, _ = await _presentation()
+        _, gate_ident, _ = _identities()
+        result = await trust.verify_presentation(
+            pres,
+            identity=gate_ident,
+            anchor_capsule={"model_attestation": {}},
+        )
+        assert result.ok is False
+        assert "anchor_unavailable" in result.reasons


### PR DESCRIPTION
cc @Skyrider3 @dhve @Sharathvc23 — wiring PARC (#63, #66) to the capsule/anchor machinery (#197, #200) that docs/layers/trust.md already named as the next step.

**The gap**

ParcTrust.build_credential (#63) computes behavioral_merkle_root = merkle_root(receipts) and signs the whole credential through the identity layer (#66 layers selective disclosure on top). That signature proves an issuer signed some root for a subject — it does not stop the SAME issuer from regenerating its own receipt tree (drop a receipt, add a fabricated one) and re-exporting a different, still self-consistently-signed root for the identical nominal (issuer, subject, validFrom). Nothing outside the issuer's own signature catches that today.

docs/layers/trust.md already named the target shape, in its closing line under bonded_trust's pluggable-scarcity-anchor section: "an anchored PARC reputation standing... fits the same seam; both are planned." This PR builds the anchoring primitive that line points at — not the full NotaryBackedLedger integration (PARC standing as a bonded_trust scarcity source), which stays open. Just the sealed-root witness such an integration would sit on top of.

**What this does**
Seal at issuance. build_credential, with anchor=True, seals {behavioral_merkle_root, receipt_count} into a capsule right after signing (ParcTrust._anchor_root) — a second, independent witness of the root the issuer already committed to, not a replacement for that signature.
Check at verification. verify_presentation gains an anchor_capsule option: when supplied, it checks the presented (root, receipt_count) against the sealed capsule (capsule_emit.verify_input_digest) and surfaces a mismatch as the typed reason anchor_mismatch — same typed-reason contract every other gate in this file already uses.
Same optional posture as aae_permit_gate's anchor, exactly. Soft dependency: importlib.import_module("capsule_emit") inside a try/except ImportError; absent ⇒ one-time debug log + no-op, never a hard requirement. Namespaced action "parc.root_sealed" (mirrors permit.granted / permit.denied) so a sealed root never reads as an executed action. anchor=False is the default — this PR does not change build_credential's or verify_presentation's behavior for any existing caller.
Anchor URL

Deliberately unset in this PR — capsule_emit.emit() reads AAC_ANCHOR_URL from the environment on its own. Nothing here hard-pins an endpoint or an ACL instance.

Discrimination test — the equivocation case

TestAnchor::test_equivocation_after_anchor_rejected (packages/nest-plugins-reference/tests/test_parc.py): issuer builds and anchors a genuine credential (root₁), then reports one more corroborated receipt and re-exports for the SAME (subject, validFrom) — a different, self-consistent root₂, signed and internally valid on its own. The presentation over root₂ verifies clean under the CURRENT (pre-this-PR) checks:

python
unchecked = await trust.verify_presentation(pres2, identity=gate_ident)
assert (unchecked.ok, unchecked.reasons) == (True, ())   # passes — the gap

Supplying the ORIGINAL sealed capsule catches it:

python
checked = await trust.verify_presentation(
    pres2, identity=gate_ident, anchor_capsule=original_capsule
)
assert checked.ok is False
assert "anchor_mismatch" in checked.reasons              # passes — the close

Mutant check (condition-removed): temporarily deleted the anchor_capsule branch in verify_presentation (the 4 lines that call _anchor_reason and append its result to reasons) and re-ran this one test:

FAILED test_parc.py::TestAnchor::test_equivocation_after_anchor_rejected
AssertionError: assert True is False
 +  where True = DisclosureResult(ok=True, reasons=(), detail='').ok

The test flips to incorrectly passing exactly as expected — it depends on the check, not on incidental setup. Restored the code, re-ran:

test_anchor_off_by_default_no_capsule PASSED
test_anchor_unavailable_degrades_to_noop PASSED
test_root_sealed_into_capsule PASSED
test_verify_presentation_accepts_matching_anchor PASSED
test_equivocation_after_anchor_rejected PASSED
test_anchor_capsule_without_package_fails_closed PASSED
6 passed in 0.40s

Also covered: anchor=False (default) never touches capsule_emit (test_anchor_off_by_default_no_capsule); anchor=True with the package genuinely absent from this repo's own uv sync degrades to a no-op, no crash (test_anchor_unavailable_degrades_to_noop); the sealed capsule round-trips through capsule_emit.verify_input_digest (test_root_sealed_into_capsule); a genuine, un-equivocated presentation with a matching anchor still verifies clean (test_verify_presentation_accepts_matching_anchor); an anchor_capsule supplied without the package installed fails closed as anchor_unavailable, distinct from anchor_mismatch (test_anchor_capsule_without_package_fails_closed).

capsule_emit is not installed in this repo's own uv sync (confirmed: ModuleNotFoundError: No module named 'capsule_emit') — same posture as aae_permit_gate's existing, untested-by-necessity anchor=True path. The new tests install a small in-memory fake under sys.modules["capsule_emit"] exposing just the two entry points production code calls (emit, verify_input_digest), digest-only, mirroring the real package's "content stays local" contract.

CI (clean-room mirror of ci.yml)

uv sync ✓ · ruff check . ✓ · ruff format --check . ✓ · pyright 0 errors ✓ · pytest 1317 passed, 1 skipped, 1 deselected (full suite; skip/deselect pre-existing and unrelated to this branch) ✓

Scope

Small and additive: build_credential, verify_presentation, and ParcTrust.__init__ gain new optional parameters with unchanged defaults; no existing test's assertions changed. Does not touch bonded_trust/NotaryBackedLedger — that integration (PARC standing as a StakeLedger scarcity source) is still open; this is the sealed-root primitive it would sit on top of.

Normative references

Agent Action Capsule I-D / agentactioncapsule.org (the neutral standard capsule_emit implements) — no other references.