### PR TITLE
fix(metrics): don't report zero validators as a passing verdict; guard registry drift

### DIFF
--- a/packages/nest-core/nest_core/metrics.py
+++ b/packages/nest-core/nest_core/metrics.py
@@ -288,12 +288,18 @@ def validate_protocol(
 ) -> dict[str, Any]:
     """Run protocol validators and return results as part of metrics output.
 
-    ``all_passed`` is True only when at least one validator ran and every one
-    of them passed. A scenario type with no entry in ``VALIDATORS`` reports
-    ``all_passed=False`` and ``unknown_scenario_type=True`` rather than
-    silently succeeding: ``all([])`` is ``True``, so without this guard a
-    typo in ``task.type`` -- or a scenario never added to the registry --
-    produced a green verdict having checked nothing.
+    ``all_passed`` is True only when at least one validator was configured for
+    the scenario type and every result it produced passed. A scenario type
+    with no entry in ``VALIDATORS`` reports ``all_passed=False`` and
+    ``unknown_scenario_type=True`` rather than silently succeeding: ``all([])``
+    is ``True``, so without this guard a typo in ``task.type`` -- or a scenario
+    never added to the registry -- produced a green verdict having checked
+    nothing.
+
+    ``validators_run`` counts the validator *functions* executed, which is not
+    the same as ``len(validations)``: a single validator may emit several
+    ``ValidationResult`` entries (``failure_detection``'s two validators
+    return three results between them).
 
     Example::
 
@@ -309,13 +315,13 @@ def validate_protocol(
     from nest_core.validators import VALIDATORS, validate_trace
 
     trace_path = Path(trace_path)
-    known = scenario_type in VALIDATORS
+    validator_fns = VALIDATORS.get(scenario_type, [])
     vresults = validate_trace(trace_path, scenario_type)
     return {
         "validations": [{"name": r.name, "passed": r.passed, "detail": r.detail} for r in vresults],
-        "validators_run": len(vresults),
-        "unknown_scenario_type": not known,
-        "all_passed": known and bool(vresults) and all(r.passed for r in vresults),
+        "validators_run": len(validator_fns),
+        "unknown_scenario_type": scenario_type not in VALIDATORS,
+        "all_passed": bool(validator_fns) and all(r.passed for r in vresults),
     }
 
 

--- a/packages/nest-core/nest_core/metrics.py
+++ b/packages/nest-core/nest_core/metrics.py
@@ -288,19 +288,34 @@ def validate_protocol(
 ) -> dict[str, Any]:
     """Run protocol validators and return results as part of metrics output.
 
+    ``all_passed`` is True only when at least one validator ran and every one
+    of them passed. A scenario type with no entry in ``VALIDATORS`` reports
+    ``all_passed=False`` and ``unknown_scenario_type=True`` rather than
+    silently succeeding: ``all([])`` is ``True``, so without this guard a
+    typo in ``task.type`` -- or a scenario never added to the registry --
+    produced a green verdict having checked nothing.
+
     Example::
 
         results = validate_protocol("trace.jsonl", "marketplace")
         # {"validations": [{"name": ..., "passed": ..., "detail": ...}, ...],
+        #  "validators_run": 3, "unknown_scenario_type": False,
         #  "all_passed": True}
+
+        validate_protocol("trace.jsonl", "typo_here")
+        # {"validations": [], "validators_run": 0,
+        #  "unknown_scenario_type": True, "all_passed": False}
     """
-    from nest_core.validators import validate_trace
+    from nest_core.validators import VALIDATORS, validate_trace
 
     trace_path = Path(trace_path)
+    known = scenario_type in VALIDATORS
     vresults = validate_trace(trace_path, scenario_type)
     return {
         "validations": [{"name": r.name, "passed": r.passed, "detail": r.detail} for r in vresults],
-        "all_passed": all(r.passed for r in vresults),
+        "validators_run": len(vresults),
+        "unknown_scenario_type": not known,
+        "all_passed": known and bool(vresults) and all(r.passed for r in vresults),
     }
 
 

--- a/packages/nest-core/tests/test_registry_conformance.py
+++ b/packages/nest-core/tests/test_registry_conformance.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Guards against drift between the three hand-maintained scenario registries.
+
+Nanda Town keeps three registries in sync by hand, with nothing enforcing that
+they agree:
+
+1. ``scenarios/*.yaml``     -- shipped scenario files, each naming a ``task.type``
+2. ``nest_core.scenarios``  -- ``_try_load_builtin``, an if/elif chain mapping
+                               ``task.type`` -> agent factory
+3. ``nest_core.validators`` -- ``VALIDATORS``, mapping ``task.type`` -> property checks
+
+Drift between them is silent today.
+``test_validators.py::TestValidatorRegistry::test_all_scenario_types_registered``
+asserts only that a *name* is a key in ``VALIDATORS``; it never asks whether a
+scenario of that type can be built, run, or validated. A name can therefore
+satisfy that test while being unreachable end to end.
+
+Known drift present at the time this module was added is marked ``xfail`` with
+the specific reason, so CI stays green while the gap stays visible. The markers
+are ``strict``: fixing one turns its case into an ``XPASS`` failure, which is
+the signal to delete the marker rather than let it rot.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+from nest_core.scenarios import get_scenario_factory
+from nest_core.validators import VALIDATORS
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCENARIO_DIR = _REPO_ROOT / "scenarios"
+
+# --- Known drift, as audited at 675a20b ------------------------------------
+# Each entry is a finding, not an accepted state. See the reason strings.
+
+_NO_FACTORY = {
+    "streaming_payments": (
+        "scenarios/streaming_payments.yaml and streaming_payments_partition.yaml "
+        "ship but no factory is registered for task.type 'streaming_payments' "
+        "(added by PR #21); `nest run` on either raises KeyError"
+    ),
+}
+
+_UNREACHABLE_VALIDATORS = {
+    "streaming_payments": (
+        "3 validators registered against a task.type whose scenarios cannot be "
+        "instantiated, so they have never run against a real trace"
+    ),
+    "receipt_reputation_majority": (
+        "3 validators registered against a task.type no scenario declares -- "
+        "receipt_reputation_majority_ring.yaml declares task.type "
+        "'receipt_reputation'"
+    ),
+}
+
+_MISSING_VALIDATOR_ENTRY = {
+    "capability_spoofing",
+    "delegated_auth",
+    "delegated_auth_partition",
+    "gossip_byzantine_forgery",
+    "gossip_eclipse",
+    "gossip_registry",
+    "gossip_signed_equivocation",
+}
+
+
+def _task_type(path: Path) -> str | None:
+    """Read the declared ``task.type`` from a scenario YAML.
+
+    Example::
+
+        ttype = _task_type(Path("scenarios/marketplace.yaml"))
+    """
+    data = cast("dict[str, Any]", yaml.safe_load(path.read_text()) or {})
+    task = cast("dict[str, Any]", data.get("task") or {})
+    ttype: Any = task.get("type")
+    return str(ttype) if ttype else None
+
+
+def _factory_exists(task_type: str) -> bool:
+    """True when ``nest_core`` can build agents for this task type.
+
+    Example::
+
+        assert _factory_exists("marketplace")
+    """
+    try:
+        get_scenario_factory(task_type)
+    except KeyError:
+        return False
+    return True
+
+
+def _scenario_params() -> list[Any]:
+    """Scenario files as pytest params, xfailing those with no factory.
+
+    Example::
+
+        params = _scenario_params()
+    """
+    params: list[Any] = []
+    for path in sorted(_SCENARIO_DIR.glob("*.yaml")):
+        ttype = _task_type(path)
+        reason = _NO_FACTORY.get(ttype or "")
+        marks = [pytest.mark.xfail(reason=reason, strict=True)] if reason else []
+        params.append(pytest.param(path, marks=marks, id=path.stem))
+    return params
+
+
+def _validator_key_params() -> list[Any]:
+    """VALIDATORS keys as pytest params, xfailing the unreachable ones.
+
+    Example::
+
+        params = _validator_key_params()
+    """
+    params: list[Any] = []
+    for key in sorted(VALIDATORS):
+        reason = _UNREACHABLE_VALIDATORS.get(key)
+        marks = [pytest.mark.xfail(reason=reason, strict=True)] if reason else []
+        params.append(pytest.param(key, marks=marks, id=key))
+    return params
+
+
+def _validator_coverage_params() -> list[Any]:
+    """Scenario files as params, xfailing those absent from VALIDATORS.
+
+    Example::
+
+        params = _validator_coverage_params()
+    """
+    params: list[Any] = []
+    for path in sorted(_SCENARIO_DIR.glob("*.yaml")):
+        marks = (
+            [
+                pytest.mark.xfail(
+                    reason=(
+                        f"task.type {_task_type(path)!r} has no VALIDATORS entry, so "
+                        "validate_protocol reports success having executed zero checks"
+                    ),
+                    strict=True,
+                )
+            ]
+            if path.stem in _MISSING_VALIDATOR_ENTRY
+            else []
+        )
+        params.append(pytest.param(path, marks=marks, id=path.stem))
+    return params
+
+
+@pytest.mark.parametrize("scenario", _scenario_params())
+def test_shipped_scenario_can_be_instantiated(scenario: Path) -> None:
+    """Every shipped scenario YAML must resolve to an agent factory.
+
+    A scenario that ships without a factory raises ``KeyError`` the moment
+    anyone runs ``nest run`` on it. It is dead weight that looks supported.
+
+    Example::
+
+        test_shipped_scenario_can_be_instantiated(Path("scenarios/auction.yaml"))
+    """
+    ttype = _task_type(scenario)
+    assert ttype is not None, f"{scenario.name} declares no task.type"
+    assert _factory_exists(ttype), (
+        f"{scenario.name} declares task.type={ttype!r} but no factory is registered "
+        f"for it in nest_core.scenarios._try_load_builtin, so "
+        f"`nest run {scenario.name}` raises KeyError"
+    )
+
+
+@pytest.mark.parametrize("task_type", _validator_key_params())
+def test_registered_validators_are_reachable(task_type: str) -> None:
+    """Every VALIDATORS entry must belong to a scenario that can actually run.
+
+    Validators registered against a task type that no scenario declares, or
+    that has no factory, can never execute against a real trace. They are
+    unit-tested against hand-built event fixtures and nothing more, which
+    reads as coverage but verifies nothing end to end.
+
+    Example::
+
+        test_registered_validators_are_reachable("marketplace")
+    """
+    declared = {_task_type(p) for p in sorted(_SCENARIO_DIR.glob("*.yaml"))}
+    assert task_type in declared, (
+        f"VALIDATORS registers {len(VALIDATORS[task_type])} validator(s) for "
+        f"task.type={task_type!r}, but no scenario YAML declares that type, so "
+        f"they cannot run against a real trace"
+    )
+    assert _factory_exists(task_type), (
+        f"VALIDATORS registers validators for task.type={task_type!r} but no factory "
+        f"exists, so the scenario cannot be instantiated"
+    )
+
+
+@pytest.mark.parametrize("scenario", _validator_coverage_params())
+def test_runnable_scenario_has_validator_entry(scenario: Path) -> None:
+    """A runnable scenario absent from VALIDATORS yields a vacuous verdict.
+
+    ``validate_events`` does ``VALIDATORS.get(scenario_type, [])``. A scenario
+    missing from that registry reaches ``metrics.validate_protocol`` with an
+    empty validator list and no checks are executed.
+
+    This does not claim such scenarios are unverified -- several are covered by
+    bespoke validators under ``nest_plugins_reference/validators/`` that their
+    own tests call directly. It claims they are unreachable through the
+    registry-driven path.
+
+    Example::
+
+        test_runnable_scenario_has_validator_entry(Path("scenarios/auction.yaml"))
+    """
+    ttype = _task_type(scenario)
+    assert ttype is not None
+    if not _factory_exists(ttype):
+        pytest.skip("covered by test_shipped_scenario_can_be_instantiated")
+    assert VALIDATORS.get(ttype), (
+        f"{scenario.name} (task.type={ttype!r}) runs and emits a trace, but "
+        f"nest_core.VALIDATORS has no entry for it"
+    )
+
+
+def test_unknown_scenario_type_is_not_reported_as_passing(tmp_path: Path) -> None:
+    """An unrecognised scenario type must not produce a passing verdict.
+
+    ``all([])`` is ``True``, so before the accompanying fix a typo in
+    ``task.type`` -- or a scenario never added to the registry -- made
+    ``validate_protocol`` return ``all_passed=True`` having checked nothing.
+
+    Example::
+
+        test_unknown_scenario_type_is_not_reported_as_passing(Path("/tmp/x"))
+    """
+    from nest_core.metrics import validate_protocol
+
+    trace = tmp_path / "trace.jsonl"
+    trace.write_text(json.dumps({"agent": "a-0", "kind": "start", "ts": 0.0}) + "\n")
+
+    result = validate_protocol(trace, "definitely_not_a_real_scenario_type")
+
+    assert result["validators_run"] == 0
+    assert result["unknown_scenario_type"] is True
+    assert result["all_passed"] is False, (
+        "validate_protocol reported success with zero validations for an unknown "
+        "scenario type; absence of checks must not read as a pass"
+    )

--- a/packages/nest-core/tests/test_registry_conformance.py
+++ b/packages/nest-core/tests/test_registry_conformance.py
@@ -58,6 +58,10 @@ _UNREACHABLE_VALIDATORS = {
     ),
 }
 
+# Keyed by task.type, not filename: 10 of the shipped scenarios declare a
+# task.type that differs from their stem (e.g. bft_consensus_partition ->
+# bft_hotstuff, shell_marketplace -> marketplace), so keying on the filename
+# would be fragile to renames and could mis-mark a scenario.
 _MISSING_VALIDATOR_ENTRY = {
     "capability_spoofing",
     "delegated_auth",
@@ -136,17 +140,18 @@ def _validator_coverage_params() -> list[Any]:
     """
     params: list[Any] = []
     for path in sorted(_SCENARIO_DIR.glob("*.yaml")):
+        ttype = _task_type(path)
         marks = (
             [
                 pytest.mark.xfail(
                     reason=(
-                        f"task.type {_task_type(path)!r} has no VALIDATORS entry, so "
-                        "validate_protocol reports success having executed zero checks"
+                        f"task.type {ttype!r} has no VALIDATORS entry, so no property "
+                        "checks run against its traces through the registry-driven path"
                     ),
                     strict=True,
                 )
             ]
-            if path.stem in _MISSING_VALIDATOR_ENTRY
+            if ttype in _MISSING_VALIDATOR_ENTRY
             else []
         )
         params.append(pytest.param(path, marks=marks, id=path.stem))
@@ -249,3 +254,29 @@ def test_unknown_scenario_type_is_not_reported_as_passing(tmp_path: Path) -> Non
         "validate_protocol reported success with zero validations for an unknown "
         "scenario type; absence of checks must not read as a pass"
     )
+
+
+@pytest.mark.parametrize("scenario_type", sorted(VALIDATORS))
+def test_validators_run_counts_functions_not_results(
+    scenario_type: str,
+    tmp_path: Path,
+) -> None:
+    """``validators_run`` counts validator functions, not emitted results.
+
+    A single validator may return several ``ValidationResult`` entries, so
+    ``len(validations)`` overcounts. ``failure_detection``'s two validators
+    return three results between them on a real trace.
+
+    Example::
+
+        test_validators_run_counts_functions_not_results("marketplace", Path("/tmp"))
+    """
+    from nest_core.metrics import validate_protocol
+
+    trace = tmp_path / "trace.jsonl"
+    trace.write_text(json.dumps({"agent": "a-0", "kind": "start", "ts": 0.0}) + "\n")
+
+    result = validate_protocol(trace, scenario_type)
+
+    assert result["validators_run"] == len(VALIDATORS[scenario_type])
+    assert result["unknown_scenario_type"] is False


### PR DESCRIPTION
## The bug

`validate_events` does `VALIDATORS.get(scenario_type, [])`, and `metrics.validate_protocol` reported `all_passed = all(r.passed for r in vresults)`.

`all([])` is `True`. So an unregistered or misspelled scenario type produced a green verdict having executed **zero** checks:

```python
>>> from nest_core.metrics import validate_protocol
>>> validate_protocol("traces/marketplace.jsonl", "definitely_not_a_real_scenario_type")
{'validations': [], 'all_passed': True}
```

`validate_protocol` is the public, documented API a leaderboard or CI would call. As written, a typo in `task.type` is indistinguishable from a clean pass.

Seven shipped scenarios currently reach this path with no registry entry — `gossip_registry`, `gossip_eclipse`, `gossip_byzantine_forgery`, `gossip_signed_equivocation`, `delegated_auth`, `delegated_auth_partition`, `capability_spoofing`.

**To be precise about scope:** several of those *are* covered by bespoke validators under `nest_plugins_reference/validators/` that their own tests call directly. This is **not** a claim that they are unverified. It is a claim that through `validate_protocol` they reported success having run nothing.

## The fix

`all_passed` is now true only when the scenario type is registered **and** at least one validator ran, with a `validators_run` count and an explicit `unknown_scenario_type` flag so callers can distinguish "checked nothing" from "checked everything and passed":

```python
>>> validate_protocol("traces/marketplace.jsonl", "typo_here")
{'validations': [], 'validators_run': 0, 'unknown_scenario_type': True, 'all_passed': False}
```

`validate_protocol` has no in-tree callers besides its own docstring, so the behaviour change is contained.

## Why the existing guard didn't catch it

`test_validators.py::TestValidatorRegistry::test_all_scenario_types_registered` asserts only that a *name* is a key in `VALIDATORS`. It never asks whether a scenario of that type can be built or run — so a name can satisfy that test while being unreachable end to end.

`test_registry_conformance.py` cross-references the three registries that are maintained by hand with nothing enforcing agreement:

1. `scenarios/*.yaml` — shipped scenarios, each naming a `task.type`
2. `nest_core.scenarios` — the `_try_load_builtin` if/elif dispatch chain
3. `nest_core.validators` — the `VALIDATORS` mapping

## What it found at `675a20b`

Marked `xfail(strict=True)` with the specific reason, so **CI stays green** while the gap stays visible. Strict means fixing one turns it into an `XPASS` failure — the signal to delete the marker rather than let it rot.

**Two shipped scenarios cannot run at all.** `scenarios/streaming_payments.yaml` and `scenarios/streaming_payments_partition.yaml` declare `task.type: streaming_payments`, for which no factory exists anywhere in the tree:

```console
$ uv run nest run scenarios/streaming_payments.yaml --seed 42
KeyError: "No scenario factory registered for 'streaming_payments'"
```

Added by #21. The `streaming` payments **plugin** is real and registered — it's the scenarios demonstrating it that are dead.

**Six validators are registered but unreachable:**

| Key | Validators | Why |
|---|---|---|
| `streaming_payments` | `validate_streaming_conservation`, `validate_streaming_no_drain_after_close`, `validate_streaming_no_overbill_on_partition` | scenarios have no factory (above) |
| `receipt_reputation_majority` | `validate_receipt_reputation_honest_confidence`, `validate_receipt_reputation_ring_majority`, `validate_receipt_reputation_ring_severed` | no scenario declares this type — `receipt_reputation_majority_ring.yaml` declares `task.type: receipt_reputation` |

They're unit-tested against hand-built event fixtures (`test_validators.py:773-870`, `2084-2092`) and have never executed against a trace from a running scenario.

I've deliberately **not** silenced these. Resolving them needs maintainer decisions — whether to write the missing `streaming_payments` factory or withdraw the scenarios, and which validators belong to `receipt_reputation_majority` — that aren't mine to make.

## Verification

Per `CONTRIBUTING.md`, all five gates on a pristine checkout:

| | |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 239 files already formatted |
| `uv run pyright` | **0 errors**, 0 warnings |
| `uv run pytest` | **1403 passed, 3 skipped, 11 xfailed** |

Baseline before this PR was 1311 passed; the 11 xfails are the findings above.

## One correction while I'm here

#190's description states `main` has "17 pre-existing failures" in `test_byzantine_gossip*` on a pristine checkout, attributed to `("registry", "byzantine_gossip")` never being registered.

**That doesn't reproduce.** `byzantine_gossip` *is* declared in `packages/nest-plugins-reference/pyproject.toml` under `[project.entry-points."nest.plugins.registry"]`, resolves normally after `uv sync` (it appears in `nest plugins list`), and the full suite is green at 1311 passed on `675a20b`. It looks like a stale editable-install artifact rather than a defect in `main`.

It is worth noting separately that `byzantine_gossip` is absent from `_BUILTINS` in `nest_core/plugins.py` while present in the entry points, so the two registries disagree and resolution depends on install mode — which is the drift #179 proposes a regression test for. Out of scope here.