### PR TITLE
feat(town): add deterministic capability testing support

### DIFF
--- a/packages/nest-core/nest_core/plugins.py
+++ b/packages/nest-core/nest_core/plugins.py
@@ -81,6 +81,7 @@ class PluginRegistry:
 
     def __init__(self) -> None:
         self._cache: dict[tuple[str, str], Any] = {}
+        self._reference_cache: dict[tuple[str, str], Any] = {}
         self._discover_entry_points()
 
     def _discover_entry_points(self) -> None:
@@ -128,6 +129,26 @@ class PluginRegistry:
 
         msg = f"No plugin found for layer={layer!r}, name={name!r}"
         raise KeyError(msg)
+
+    def resolve_reference(self, layer: str, name: str) -> Any:
+        """Resolve a bundled reference plugin without entry-point precedence.
+
+        Example::
+
+            cls = registry.resolve_reference("registry", "in_memory")
+        """
+        key = (layer, name)
+        cached = self._reference_cache.get(key)
+        if cached is not None:
+            return cached
+
+        builtin = _BUILTINS.get(key)
+        if builtin is None:
+            msg = f"No reference plugin found for layer={layer!r}, name={name!r}"
+            raise KeyError(msg)
+        cls = _import_dotted(builtin)
+        self._reference_cache[key] = cls
+        return cls
 
     def list_plugins(self, layer: str | None = None) -> list[tuple[str, str]]:
         """List available plugins, optionally filtered by layer.

--- a/packages/nest-core/nest_core/runner.py
+++ b/packages/nest-core/nest_core/runner.py
@@ -9,11 +9,13 @@ Example::
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 from nest_core.plugins import PluginRegistry
 from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import ScenarioEventSink, StateMachineAgent
 from nest_core.sim.simulator import Simulator
 from nest_core.types import AgentId
 
@@ -28,6 +30,14 @@ def _parse_partition_groups(raw: object) -> list[list[str]] | None:
     return result if result else None
 
 
+class PluginResolver(Protocol):
+    """Generic layer-plugin resolver consumed by ScenarioRunner."""
+
+    def resolve(self, layer: str, name: str) -> Any:
+        """Resolve one configured layer/name pair."""
+        ...
+
+
 class ScenarioRunner:
     """Runs a scenario end-to-end: resolves plugins, creates agents, runs simulation.
 
@@ -38,11 +48,24 @@ class ScenarioRunner:
         await runner.run()
     """
 
-    def __init__(self, config: ScenarioConfig, registry: PluginRegistry | None = None) -> None:
+    def __init__(
+        self,
+        config: ScenarioConfig,
+        registry: PluginRegistry | None = None,
+        *,
+        participant_override: Mapping[AgentId, StateMachineAgent] | None = None,
+        plugin_resolver: PluginResolver | None = None,
+        event_sink: ScenarioEventSink | None = None,
+    ) -> None:
+        if registry is not None and plugin_resolver is not None:
+            raise ValueError("registry and plugin_resolver are mutually exclusive")
         self._config = config
-        self._registry = registry or PluginRegistry()
+        self._plugin_resolver = plugin_resolver or registry or PluginRegistry()
+        self._participant_override = dict(participant_override or {})
+        self._event_sink = event_sink
         self._resolved_plugins: dict[str, Any] = {}
         self._metrics: dict[str, float] = {}
+        self._trace_finalized = False
 
     @property
     def metrics(self) -> dict[str, float]:
@@ -51,6 +74,11 @@ class ScenarioRunner:
     @property
     def resolved_plugins(self) -> dict[str, Any]:
         return self._resolved_plugins
+
+    @property
+    def trace_finalized(self) -> bool:
+        """Whether this run's Simulator trace closed without raising."""
+        return self._trace_finalized
 
     def _resolve_plugins(self) -> dict[str, Any]:
         """Resolve all layer plugins from the config.
@@ -61,18 +89,18 @@ class ScenarioRunner:
         """
         layers = self._config.layers
         return {
-            "transport": self._registry.resolve("transport", layers.transport),
-            "comms": self._registry.resolve("comms", layers.comms),
-            "identity": self._registry.resolve("identity", layers.identity),
-            "registry": self._registry.resolve("registry", layers.registry),
-            "auth": self._registry.resolve("auth", layers.auth),
-            "trust": self._registry.resolve("trust", layers.trust),
-            "payments": self._registry.resolve("payments", layers.payments),
-            "coordination": self._registry.resolve("coordination", layers.coordination),
-            "negotiation": self._registry.resolve("negotiation", layers.negotiation),
-            "memory": self._registry.resolve("memory", layers.memory),
-            "privacy": self._registry.resolve("privacy", layers.privacy),
-            "datafacts": self._registry.resolve("datafacts", layers.datafacts),
+            "transport": self._plugin_resolver.resolve("transport", layers.transport),
+            "comms": self._plugin_resolver.resolve("comms", layers.comms),
+            "identity": self._plugin_resolver.resolve("identity", layers.identity),
+            "registry": self._plugin_resolver.resolve("registry", layers.registry),
+            "auth": self._plugin_resolver.resolve("auth", layers.auth),
+            "trust": self._plugin_resolver.resolve("trust", layers.trust),
+            "payments": self._plugin_resolver.resolve("payments", layers.payments),
+            "coordination": self._plugin_resolver.resolve("coordination", layers.coordination),
+            "negotiation": self._plugin_resolver.resolve("negotiation", layers.negotiation),
+            "memory": self._plugin_resolver.resolve("memory", layers.memory),
+            "privacy": self._plugin_resolver.resolve("privacy", layers.privacy),
+            "datafacts": self._plugin_resolver.resolve("datafacts", layers.datafacts),
         }
 
     def _create_agents(self, plugins: dict[str, Any]) -> dict[AgentId, Any]:
@@ -147,8 +175,18 @@ class ScenarioRunner:
 
             trace_path = await runner.run()
         """
+        self._trace_finalized = False
         plugins = self._resolve_plugins()
         self._resolved_plugins = plugins
+
+        agents = self._create_agents(plugins)
+        missing_overrides = [
+            agent_id for agent_id in self._participant_override if agent_id not in agents
+        ]
+        if missing_overrides:
+            missing = ", ".join(repr(agent_id) for agent_id in missing_overrides)
+            raise KeyError(f"participant override targets are not in the scenario: {missing}")
+        agents.update(self._participant_override)
 
         trace_path = Path(self._config.output.trace)
         trace_path.parent.mkdir(parents=True, exist_ok=True)
@@ -169,19 +207,36 @@ class ScenarioRunner:
             partition_start_at_time=failures.partition_start_at_time,
             partition_heal_at_time=failures.partition_heal_at_time,
             plugins=plugins,
+            event_sink=self._event_sink,
         )
 
-        agents = self._create_agents(plugins)
-        for agent_id, agent in agents.items():
-            sim.add_agent(agent_id, agent)
+        primary_error: BaseException | None = None
+        primary_traceback: Any = None
+        try:
+            for agent_id, agent in agents.items():
+                sim.add_agent(agent_id, agent)
 
-        # Apply per-agent plugin overrides set by scenario factories
-        agent_plugins = cast("dict[AgentId, dict[str, Any]]", plugins.pop("_agent_plugins", {}))
-        for agent_id, overrides in agent_plugins.items():
-            sim.set_agent_plugins(agent_id, overrides)
+            # Apply per-agent plugin overrides set by scenario factories
+            agent_plugins = cast("dict[AgentId, dict[str, Any]]", plugins.pop("_agent_plugins", {}))
+            for agent_id, overrides in agent_plugins.items():
+                sim.set_agent_plugins(agent_id, overrides)
 
-        max_ticks = self._config.get_max_ticks()
-        await sim.run(max_ticks=max_ticks)
+            await sim.run(max_ticks=self._config.get_max_ticks())
+        except BaseException as exc:
+            primary_error = exc
+            primary_traceback = exc.__traceback__
+        finally:
+            cleanup_error: BaseException | None = None
+            try:
+                sim.close_trace()
+            except BaseException as exc:
+                cleanup_error = exc
+            self._trace_finalized = sim.trace_finalized
+
+        if primary_error is not None:
+            raise primary_error.with_traceback(primary_traceback)
+        if cleanup_error is not None:
+            raise cleanup_error
 
         if self._config.metrics:
             from nest_core.metrics import compute_metrics, generate_html_report

--- a/packages/nest-core/nest_core/scenarios.py
+++ b/packages/nest-core/nest_core/scenarios.py
@@ -201,3 +201,9 @@ def _try_load_builtin(name: str) -> None:
         )
 
         register_scenario("capability_spoofing", capability_spoofing_factory)
+    elif name == "capability_fulfillment":
+        from nest_core.scenarios_builtin.capability_fulfillment import (
+            capability_fulfillment_factory,
+        )
+
+        register_scenario("capability_fulfillment", capability_fulfillment_factory)

--- a/packages/nest-core/nest_core/scenarios_builtin/capability_fulfillment.py
+++ b/packages/nest-core/nest_core/scenarios_builtin/capability_fulfillment.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic capability registration, discovery, and fulfillment baseline."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, cast
+
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import AgentContext, ScenarioAgentContext, StateMachineAgent
+from nest_core.types import AgentCard, AgentId, Query
+
+_PROVIDER = AgentId("provider-0")
+_REQUESTER = AgentId("requester-0")
+_LOOKUP = b"lookup:sell"
+_REQUEST = b"buy:widget:2"
+_RESPONSE = b"sold:widget:2"
+_REGISTRY_IMPLEMENTATION = "nest_plugins_reference.registry.in_memory.InMemoryRegistry"
+
+
+def _digest(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+class CapabilityProviderAgent(StateMachineAgent):
+    """Reference provider that registers and fulfills the frozen fixture."""
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        scenario_ctx = cast("ScenarioAgentContext", ctx)
+        registry = ctx.plugins["registry"]
+        await registry.register(
+            AgentCard(agent_id=ctx.agent_id, name="Capability Provider", capabilities=["sell"])
+        )
+        scenario_ctx.record_scenario_event(
+            kind="test.registry.provider_registered",
+            observer="town.capability-requester",
+            subject=str(ctx.agent_id),
+            data={
+                "registry_implementation": _REGISTRY_IMPLEMENTATION,
+                "card_agent_id": "provider-0",
+                "capabilities": ["sell"],
+            },
+        )
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        if sender != _REQUESTER or payload != _REQUEST:
+            return
+        scenario_ctx = cast("ScenarioAgentContext", ctx)
+        correlation_id = await scenario_ctx.send_with_correlation(sender, _RESPONSE)
+        scenario_ctx.record_scenario_event(
+            kind="test.message.response_routed",
+            observer="town.capability-requester",
+            subject=str(ctx.agent_id),
+            attributes={
+                "message_id": "message-002",
+                "correlation_id": str(correlation_id),
+                "request_digest": _digest(_REQUEST),
+                "response_digest": _digest(_RESPONSE),
+            },
+            data={
+                "sender_id": "provider-0",
+                "recipient_id": "requester-0",
+                "media_type": "text/plain; charset=utf-8",
+                "text": "sold:widget:2",
+                "payload_digest": _digest(_RESPONSE),
+            },
+        )
+
+
+class CapabilityRequesterAgent(StateMachineAgent):
+    """Reference requester that sends only after real Registry discovery."""
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        await ctx.schedule(0, _LOOKUP)
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        if sender == ctx.agent_id and payload == _LOOKUP:
+            await self._discover_and_request(ctx)
+            return
+        if sender == _PROVIDER:
+            self._evaluate_response(ctx, payload)
+
+    async def _discover_and_request(self, ctx: AgentContext) -> None:
+        scenario_ctx = cast("ScenarioAgentContext", ctx)
+        registry = ctx.plugins["registry"]
+        cards = await registry.lookup(Query(capabilities=["sell"]))
+        scenario_ctx.record_scenario_event(
+            kind="test.registry.lookup_requested",
+            observer="town.capability-requester",
+            subject="provider-0",
+            data={
+                "registry_implementation": _REGISTRY_IMPLEMENTATION,
+                "capabilities": ["sell"],
+            },
+        )
+        returned = scenario_ctx.record_scenario_event(
+            kind="test.registry.lookup_returned",
+            observer="town.capability-requester",
+            subject="provider-0",
+            data={
+                "registry_implementation": _REGISTRY_IMPLEMENTATION,
+                "card_agent_ids": [str(card.agent_id) for card in cards],
+            },
+        )
+        selected = next((card for card in cards if card.agent_id == _PROVIDER), None)
+        if selected is None:
+            return
+        lookup_event_id = None if returned is None else returned.event_id
+        if lookup_event_id is not None:
+            scenario_ctx.record_scenario_event(
+                kind="test.requester.provider_selected",
+                observer="town.capability-requester",
+                subject="provider-0",
+                data={
+                    "selected_agent_id": "provider-0",
+                    "lookup_event_id": lookup_event_id,
+                },
+            )
+        correlation_id = await scenario_ctx.send_with_correlation(selected.agent_id, _REQUEST)
+        scenario_ctx.record_scenario_event(
+            kind="test.message.request_routed",
+            observer="town.capability-requester",
+            subject="provider-0",
+            attributes={
+                "message_id": "message-001",
+                "correlation_id": str(correlation_id),
+                "request_digest": _digest(_REQUEST),
+            },
+            data={
+                "sender_id": "requester-0",
+                "recipient_id": "provider-0",
+                "media_type": "text/plain; charset=utf-8",
+                "text": "buy:widget:2",
+                "payload_digest": _digest(_REQUEST),
+            },
+        )
+
+    def _evaluate_response(self, ctx: AgentContext, payload: bytes) -> None:
+        scenario_ctx = cast("ScenarioAgentContext", ctx)
+        actual_digest = _digest(payload)
+        expected_digest = _digest(_RESPONSE)
+        scenario_ctx.record_scenario_event(
+            kind="test.capability.result_evaluated",
+            observer="town.profile-evaluator",
+            subject="provider-0",
+            attributes={
+                "message_id": "message-002",
+                "response_digest": actual_digest,
+            },
+            data={
+                "evaluator_id": "nanda.agent.capability-fulfillment",
+                "evaluator_version": "1",
+                "verdict": "pass" if payload == _RESPONSE else "fail",
+                "expected_response_digest": expected_digest,
+                "actual_response_digest": actual_digest,
+            },
+        )
+
+
+def capability_fulfillment_factory(
+    config: ScenarioConfig,
+    plugins: dict[str, Any],
+) -> dict[AgentId, StateMachineAgent]:
+    """Create the exact deterministic requester and provider participants."""
+    registry = plugins.get("registry")
+    if isinstance(registry, type):
+        plugins["registry"] = registry()
+    return {
+        _REQUESTER: CapabilityRequesterAgent(),
+        _PROVIDER: CapabilityProviderAgent(),
+    }

--- a/packages/nest-core/nest_core/scenarios_builtin/yaml/capability_fulfillment.yaml
+++ b/packages/nest-core/nest_core/scenarios_builtin/yaml/capability_fulfillment.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+name: capability-fulfillment
+description: "Deterministic Registry discovery and synthetic capability fulfillment"
+
+tier: 1
+seed: 7
+
+agents:
+  count: 2
+  brain: state-machine
+  roles:
+    - name: requester
+      count: 1
+    - name: provider
+      count: 1
+
+layers:
+  transport: in_memory
+  comms: nest_native
+  identity: did_key
+  registry: in_memory
+  auth: jwt
+  trust: score_average
+  payments: prepaid_credits
+  coordination: contract_net
+  negotiation: alternating_offers
+  memory: blackboard
+  privacy: noop
+  datafacts: datafacts_v1
+
+task:
+  type: capability_fulfillment
+  config:
+    lookup_delay_ticks: 0
+
+failures:
+  message_drop: 0.0
+  byzantine_agents: 0.0
+
+duration: "ticks: 10"
+metrics: []
+
+output:
+  trace: ./traces/capability_fulfillment.jsonl

--- a/packages/nest-core/nest_core/sim/__init__.py
+++ b/packages/nest-core/nest_core/sim/__init__.py
@@ -7,6 +7,10 @@ Example::
 """
 
 from nest_core.sim.agent import AgentContext as AgentContext
+from nest_core.sim.agent import ScenarioAgentContext as ScenarioAgentContext
+from nest_core.sim.agent import ScenarioEventReceipt as ScenarioEventReceipt
+from nest_core.sim.agent import ScenarioEventRequest as ScenarioEventRequest
+from nest_core.sim.agent import ScenarioEventSink as ScenarioEventSink
 from nest_core.sim.agent import StateMachineAgent as StateMachineAgent
 from nest_core.sim.clock import VirtualClock as VirtualClock
 from nest_core.sim.events import Event as Event
@@ -20,6 +24,10 @@ __all__ = [
     "Event",
     "EventQueue",
     "InMemoryTransport",
+    "ScenarioAgentContext",
+    "ScenarioEventReceipt",
+    "ScenarioEventRequest",
+    "ScenarioEventSink",
     "Simulator",
     "StateMachineAgent",
     "TraceWriter",

--- a/packages/nest-core/nest_core/sim/agent.py
+++ b/packages/nest-core/nest_core/sim/agent.py
@@ -14,12 +14,72 @@ Example::
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
-from nest_core.types import AgentId
+from nest_core.types import AgentId, CorrelationId
 
 if TYPE_CHECKING:
     import random as _random
+
+
+def _copied_mapping(value: object, *, field_name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field_name} must be a mapping")
+    mapping = cast("Mapping[object, object]", value)
+    copied: dict[str, object] = {}
+    for key, item in mapping.items():
+        if not isinstance(key, str):
+            raise TypeError(f"{field_name} keys must be strings")
+        copied[key] = deepcopy(item)
+    return MappingProxyType(copied)
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioEventRequest:
+    """Immutable generic event handed from the simulator context to a sink."""
+
+    kind: str
+    logical_time: float
+    observer: str
+    subject: str
+    data: Mapping[str, object]
+    attributes: Mapping[str, object] = field(default_factory=lambda: dict[str, object]())
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "data", _copied_mapping(self.data, field_name="data"))
+        object.__setattr__(
+            self,
+            "attributes",
+            _copied_mapping(self.attributes, field_name="attributes"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioEventReceipt:
+    """Opaque event identifier plus the generic record the simulator may trace."""
+
+    event_id: str
+    trace_record: Mapping[str, object]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "trace_record",
+            _copied_mapping(self.trace_record, field_name="trace_record"),
+        )
+
+
+@runtime_checkable
+class ScenarioEventSink(Protocol):
+    """Optional sink for scenario-owned structured events."""
+
+    def record(self, request: ScenarioEventRequest) -> ScenarioEventReceipt:
+        """Record one generic request and return its traceable receipt."""
+        ...
 
 
 @runtime_checkable
@@ -101,6 +161,32 @@ class AgentContext(Protocol):
 
             await ctx.schedule(5.0, b"timeout")
         """
+        ...
+
+
+@runtime_checkable
+class ScenarioAgentContext(AgentContext, Protocol):
+    """Optional generic extensions used by instrumented simulator scenarios."""
+
+    @property
+    def event_sink(self) -> ScenarioEventSink | None:
+        """Optional run-scoped scenario event sink."""
+        ...
+
+    async def send_with_correlation(self, to: AgentId, payload: bytes) -> CorrelationId:
+        """Send a message and return its simulator correlation identifier."""
+        ...
+
+    def record_scenario_event(
+        self,
+        *,
+        kind: str,
+        observer: str,
+        subject: str,
+        data: Mapping[str, object],
+        attributes: Mapping[str, object] | None = None,
+    ) -> ScenarioEventReceipt | None:
+        """Record one event when a generic sink is injected."""
         ...
 
 

--- a/packages/nest-core/nest_core/sim/simulator.py
+++ b/packages/nest-core/nest_core/sim/simulator.py
@@ -15,11 +15,19 @@ Example::
 from __future__ import annotations
 
 import random
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.sim.agent import (
+    AgentContext,
+    ScenarioAgentContext,
+    ScenarioEventReceipt,
+    ScenarioEventRequest,
+    ScenarioEventSink,
+    StateMachineAgent,
+)
 from nest_core.sim.clock import VirtualClock
 from nest_core.sim.events import Event, EventQueue
 from nest_core.sim.trace import TraceWriter
@@ -59,6 +67,7 @@ class _SimAgentContext:
         trace: TraceWriter | None,
         corr_counter: _CorrelationCounter,
         plugins: dict[str, Any] | None = None,
+        event_sink: ScenarioEventSink | None = None,
     ) -> None:
         self._agent_id = agent_id
         self._clock = clock
@@ -68,6 +77,7 @@ class _SimAgentContext:
         self._trace = trace
         self._corr = corr_counter
         self._plugins: dict[str, Any] = plugins or {}
+        self._event_sink = event_sink
 
     @property
     def agent_id(self) -> AgentId:
@@ -85,7 +95,14 @@ class _SimAgentContext:
     def plugins(self) -> dict[str, Any]:
         return self._plugins
 
+    @property
+    def event_sink(self) -> ScenarioEventSink | None:
+        return self._event_sink
+
     async def send(self, to: AgentId, payload: bytes) -> None:
+        await self.send_with_correlation(to, payload)
+
+    async def send_with_correlation(self, to: AgentId, payload: bytes) -> CorrelationId:
         cid = self._corr.next()
         if self._trace:
             self._trace.record(
@@ -100,6 +117,32 @@ class _SimAgentContext:
                 }
             )
         await self._transport.send(to, payload, correlation_id=cid)
+        return cid
+
+    def record_scenario_event(
+        self,
+        *,
+        kind: str,
+        observer: str,
+        subject: str,
+        data: Mapping[str, object],
+        attributes: Mapping[str, object] | None = None,
+    ) -> ScenarioEventReceipt | None:
+        if self._event_sink is None:
+            return None
+        receipt = self._event_sink.record(
+            ScenarioEventRequest(
+                kind=kind,
+                logical_time=self._clock.now,
+                observer=observer,
+                subject=subject,
+                data=data,
+                attributes={} if attributes is None else attributes,
+            )
+        )
+        if self._trace is not None:
+            self._trace.record(dict(receipt.trace_record))
+        return receipt
 
     async def broadcast(self, payload: bytes) -> None:
         cid = self._corr.next()
@@ -130,6 +173,7 @@ class _SimAgentContext:
 
 # Verify _SimAgentContext satisfies the protocol at import time
 _ctx_check: type[AgentContext] = _SimAgentContext  # noqa: F841
+_scenario_ctx_check: type[ScenarioAgentContext] = _SimAgentContext  # noqa: F841
 
 
 class Simulator:
@@ -153,6 +197,7 @@ class Simulator:
         partition_start_at_time: float | None = None,
         partition_heal_at_time: float | None = None,
         plugins: dict[str, Any] | None = None,
+        event_sink: ScenarioEventSink | None = None,
     ) -> None:
         if not 0.0 <= message_drop_rate <= 1.0:
             msg = f"message_drop_rate must be between 0 and 1: {message_drop_rate}"
@@ -168,6 +213,8 @@ class Simulator:
         self._trace: TraceWriter | None = None
         if trace_path is not None:
             self._trace = TraceWriter(trace_path)
+        self._trace_finalized = False
+        self._trace_close_attempted = False
         self._tick_count = 0
         self._message_count = 0
         self._dropped_count = 0
@@ -188,6 +235,7 @@ class Simulator:
         self._failure_rng = random.Random(self._master_rng.randint(0, 2**63))
         self._plugins: dict[str, Any] = plugins or {}
         self._agent_plugins: dict[AgentId, dict[str, Any]] = {}
+        self._event_sink = event_sink
 
     @property
     def clock(self) -> VirtualClock:
@@ -228,6 +276,19 @@ class Simulator:
             print(sim.dropped_count)
         """
         return self._dropped_count
+
+    @property
+    def trace_finalized(self) -> bool:
+        """Whether the configured trace writer closed without raising."""
+        return self._trace_finalized
+
+    def close_trace(self) -> None:
+        """Close the configured trace at most once and mark only successful closure."""
+        if self._trace is None or self._trace_close_attempted:
+            return
+        self._trace_close_attempted = True
+        self._trace.close()
+        self._trace_finalized = True
 
     def add_agent(self, agent_id: AgentId, agent: StateMachineAgent) -> None:
         """Register an agent for the simulation.
@@ -282,142 +343,166 @@ class Simulator:
 
             await sim.run(max_ticks=5000)
         """
-        all_ids = list(self._agents.keys())
-        for slot in self._agents.values():
-            slot.transport.all_agents = all_ids
+        self._trace_finalized = False
+        primary_error: BaseException | None = None
+        primary_traceback: Any = None
+        lifecycle_started = False
+        try:
+            all_ids = list(self._agents.keys())
+            for slot in self._agents.values():
+                slot.transport.all_agents = all_ids
 
-        self._init_failures()
+            self._init_failures()
 
-        for aid, slot in self._agents.items():
-            ctx = self._make_context(aid, slot)
-            if self._trace:
-                self._trace.record(
-                    {
-                        "ts": self._clock.now,
-                        "agent": str(aid),
-                        "kind": "start",
-                    }
-                )
-            self._queue.push(
-                Event(
-                    time=self._clock.now,
-                    kind="start",
-                    agent_id=aid,
-                )
-            )
-
-        for aid, slot in self._agents.items():
-            ctx = self._make_context(aid, slot)
-            await slot.agent.on_start(ctx)
-
-        while self._queue and self._tick_count < max_ticks:
-            event = self._queue.pop()
-
-            if max_time is not None and event.time > max_time:
-                break
-
-            self._clock.advance_to(event.time)
-            self._tick_count += 1
-
-            if (
-                self._partition_start_at_time is not None
-                and not self._partition_started
-                and not self._partition_healed
-                and self._clock.now >= self._partition_start_at_time
-            ):
-                self._partition_map = dict(self._pending_partition_map)
-                self._partition_started = True
+            for aid, slot in self._agents.items():
+                ctx = self._make_context(aid, slot)
                 if self._trace:
                     self._trace.record(
                         {
                             "ts": self._clock.now,
-                            "agent": "_simulator",
-                            "kind": "partition_started",
+                            "agent": str(aid),
+                            "kind": "start",
                         }
                     )
-
-            if not self._partition_healed and (
-                (
-                    self._partition_heal_at is not None
-                    and self._tick_count >= self._partition_heal_at
-                )
-                or (
-                    self._partition_heal_at_time is not None
-                    and self._clock.now >= self._partition_heal_at_time
-                )
-            ):
-                self._partition_map = {}
-                self._partition_healed = True
-                if self._trace:
-                    self._trace.record(
-                        {
-                            "ts": self._clock.now,
-                            "agent": "_simulator",
-                            "kind": "partition_healed",
-                        }
+                self._queue.push(
+                    Event(
+                        time=self._clock.now,
+                        kind="start",
+                        agent_id=aid,
                     )
+                )
 
-            if event.kind == "start":
-                continue
+            lifecycle_started = True
+            for aid, slot in self._agents.items():
+                ctx = self._make_context(aid, slot)
+                await slot.agent.on_start(ctx)
 
-            if event.kind == "deliver":
-                target_slot = self._agents.get(event.agent_id)
-                if target_slot is None:
+            while self._queue and self._tick_count < max_ticks:
+                event = self._queue.pop()
+
+                if max_time is not None and event.time > max_time:
+                    break
+
+                self._clock.advance_to(event.time)
+                self._tick_count += 1
+
+                if (
+                    self._partition_start_at_time is not None
+                    and not self._partition_started
+                    and not self._partition_healed
+                    and self._clock.now >= self._partition_start_at_time
+                ):
+                    self._partition_map = dict(self._pending_partition_map)
+                    self._partition_started = True
+                    if self._trace:
+                        self._trace.record(
+                            {
+                                "ts": self._clock.now,
+                                "agent": "_simulator",
+                                "kind": "partition_started",
+                            }
+                        )
+
+                if not self._partition_healed and (
+                    (
+                        self._partition_heal_at is not None
+                        and self._tick_count >= self._partition_heal_at
+                    )
+                    or (
+                        self._partition_heal_at_time is not None
+                        and self._clock.now >= self._partition_heal_at_time
+                    )
+                ):
+                    self._partition_map = {}
+                    self._partition_healed = True
+                    if self._trace:
+                        self._trace.record(
+                            {
+                                "ts": self._clock.now,
+                                "agent": "_simulator",
+                                "kind": "partition_healed",
+                            }
+                        )
+
+                if event.kind == "start":
                     continue
 
-                if self._should_drop(event.target_id, event.agent_id):
-                    self._dropped_count += 1
+                if event.kind == "deliver":
+                    target_slot = self._agents.get(event.agent_id)
+                    if target_slot is None:
+                        continue
+
+                    if self._should_drop(event.target_id, event.agent_id):
+                        self._dropped_count += 1
+                        if self._trace:
+                            drop_rec: dict[str, Any] = {
+                                "ts": self._clock.now,
+                                "agent": str(event.agent_id),
+                                "kind": "dropped",
+                                "from": str(event.target_id),
+                                "size": len(event.payload),
+                                "msg": event.payload.decode("utf-8", errors="replace"),
+                            }
+                            if event.correlation_id is not None:
+                                drop_rec["corr"] = str(event.correlation_id)
+                            self._trace.record(drop_rec)
+                        continue
+
+                    delivered_payload = event.payload
+                    if event.target_id in self._byzantine_agents:
+                        delivered_payload = bytes(
+                            (b ^ self._failure_rng.randint(0, 255)) for b in event.payload
+                        )
+
+                    self._message_count += 1
                     if self._trace:
-                        drop_rec: dict[str, Any] = {
+                        rec: dict[str, Any] = {
                             "ts": self._clock.now,
                             "agent": str(event.agent_id),
-                            "kind": "dropped",
+                            "kind": "receive",
                             "from": str(event.target_id),
-                            "size": len(event.payload),
-                            "msg": event.payload.decode("utf-8", errors="replace"),
+                            "size": len(delivered_payload),
+                            "msg": delivered_payload.decode("utf-8", errors="replace"),
                         }
                         if event.correlation_id is not None:
-                            drop_rec["corr"] = str(event.correlation_id)
-                        self._trace.record(drop_rec)
-                    continue
+                            rec["corr"] = str(event.correlation_id)
+                        self._trace.record(rec)
 
-                delivered_payload = event.payload
-                if event.target_id in self._byzantine_agents:
-                    delivered_payload = bytes(
-                        (b ^ self._failure_rng.randint(0, 255)) for b in event.payload
-                    )
+                    ctx = self._make_context(event.agent_id, target_slot)
+                    await target_slot.agent.on_message(ctx, event.target_id, delivered_payload)
+        except BaseException as exc:
+            primary_error = exc
+            primary_traceback = exc.__traceback__
 
-                self._message_count += 1
-                if self._trace:
-                    rec: dict[str, Any] = {
-                        "ts": self._clock.now,
-                        "agent": str(event.agent_id),
-                        "kind": "receive",
-                        "from": str(event.target_id),
-                        "size": len(delivered_payload),
-                        "msg": delivered_payload.decode("utf-8", errors="replace"),
-                    }
-                    if event.correlation_id is not None:
-                        rec["corr"] = str(event.correlation_id)
-                    self._trace.record(rec)
+        cleanup_error: BaseException | None = None
+        try:
+            if lifecycle_started:
+                for aid, slot in self._agents.items():
+                    try:
+                        ctx = self._make_context(aid, slot)
+                        if self._trace:
+                            self._trace.record(
+                                {
+                                    "ts": self._clock.now,
+                                    "agent": str(aid),
+                                    "kind": "stop",
+                                }
+                            )
+                        await slot.agent.on_stop(ctx)
+                    except BaseException as exc:
+                        if cleanup_error is None:
+                            cleanup_error = exc
+        finally:
+            try:
+                self.close_trace()
+            except BaseException as exc:
+                if cleanup_error is None:
+                    cleanup_error = exc
 
-                ctx = self._make_context(event.agent_id, target_slot)
-                await target_slot.agent.on_message(ctx, event.target_id, delivered_payload)
-
-        for aid, slot in self._agents.items():
-            ctx = self._make_context(aid, slot)
-            if self._trace:
-                self._trace.record(
-                    {
-                        "ts": self._clock.now,
-                        "agent": str(aid),
-                        "kind": "stop",
-                    }
-                )
-            await slot.agent.on_stop(ctx)
-
-        if self._trace:
-            self._trace.close()
+        if primary_error is not None:
+            raise primary_error.with_traceback(primary_traceback)
+        if cleanup_error is not None:
+            raise cleanup_error
 
     def set_agent_plugins(self, agent_id: AgentId, overrides: dict[str, Any]) -> None:
         """Set per-agent plugin overrides (merged on top of shared plugins).
@@ -440,4 +525,5 @@ class Simulator:
             trace=self._trace,
             corr_counter=self._corr_counter,
             plugins=merged,
+            event_sink=self._event_sink,
         )

--- a/packages/nest-core/nest_core/sim/trace.py
+++ b/packages/nest-core/nest_core/sim/trace.py
@@ -11,8 +11,13 @@ Example::
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
+
+
+def _private_file_opener(path: str, flags: int) -> int:
+    return os.open(path, flags, 0o600)
 
 
 class TraceWriter:
@@ -29,7 +34,8 @@ class TraceWriter:
         self._path = Path(path)
         self._buffer: list[dict[str, Any]] = []
         self._buffer_size = buffer_size
-        self._file = self._path.open("w")
+        # TraceWriter owns this stream across record() calls and closes it in close().
+        self._file = open(self._path, "w", opener=_private_file_opener)  # noqa: SIM115
 
     def record(self, event: dict[str, Any]) -> None:
         """Record an event to the trace buffer.
@@ -61,8 +67,19 @@ class TraceWriter:
 
             writer.close()
         """
-        self.flush()
-        self._file.close()
+        flush_error: BaseException | None = None
+        try:
+            try:
+                self.flush()
+            except BaseException as exc:
+                flush_error = exc
+                raise
+        finally:
+            try:
+                self._file.close()
+            except BaseException:
+                if flush_error is None:
+                    raise
 
     def __enter__(self) -> TraceWriter:
         return self

--- a/packages/nest-core/tests/agent_test/test_capability_scenario.py
+++ b/packages/nest-core/tests/agent_test/test_capability_scenario.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standalone smoke tests for the deterministic capability workflow."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from nest_core.builtin_scenarios import builtin_path
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import StateMachineAgent
+from nest_core.types import AgentId
+from nest_plugins_reference.registry.in_memory import InMemoryRegistry
+
+
+def _config(tmp_path: Path) -> ScenarioConfig:
+    config = ScenarioConfig.from_yaml(builtin_path("capability_fulfillment"))
+    config.output.trace = str(tmp_path / "capability.jsonl")
+    return config
+
+
+def test_factory_has_exact_participants_and_run_local_registry(tmp_path: Path) -> None:
+    from nest_core.scenarios_builtin.capability_fulfillment import (
+        capability_fulfillment_factory,
+    )
+
+    config = _config(tmp_path)
+    plugins: dict[str, object] = {"registry": InMemoryRegistry}
+
+    agents = capability_fulfillment_factory(config, plugins)
+
+    assert list(agents) == [AgentId("requester-0"), AgentId("provider-0")]
+    assert all(isinstance(agent, StateMachineAgent) for agent in agents.values())
+    assert type(plugins["registry"]) is InMemoryRegistry
+
+
+def test_capability_evaluator_emits_generation_one_revision() -> None:
+    from nest_core.scenarios_builtin.capability_fulfillment import CapabilityRequesterAgent
+
+    class RecordingContext:
+        def __init__(self) -> None:
+            self.events: list[dict[str, object]] = []
+
+        def record_scenario_event(self, **event: object) -> None:
+            self.events.append(event)
+
+    context = RecordingContext()
+    response_digest = "sha256:4929db8434bf7537e497ad88677dcdaf1e8509b6fbf74b69d7a8bb54805cee2a"
+
+    CapabilityRequesterAgent()._evaluate_response(context, b"sold:widget:2")  # type: ignore[arg-type]
+
+    assert context.events[0]["data"] == {
+        "evaluator_id": "nanda.agent.capability-fulfillment",
+        "evaluator_version": "1",
+        "verdict": "pass",
+        "expected_response_digest": response_digest,
+        "actual_response_digest": response_digest,
+    }
+
+
+@pytest.mark.asyncio
+async def test_ordinary_scenario_discovers_and_routes_exact_fixture(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    runner = ScenarioRunner(config)
+
+    await runner.run()
+
+    assert type(runner.resolved_plugins["registry"]) is InMemoryRegistry
+    records = [json.loads(line) for line in Path(config.output.trace).read_text().splitlines()]
+    assert [record["msg"] for record in records if record["kind"] == "send"] == [
+        "buy:widget:2",
+        "sold:widget:2",
+    ]
+    assert not any(record["kind"].startswith("test.") for record in records)

--- a/packages/nest-core/tests/agent_test/test_participant_override.py
+++ b/packages/nest-core/tests/agent_test/test_participant_override.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the generic participant-replacement runner seam."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.scenarios import register_scenario
+from nest_core.sim.agent import AgentContext, StateMachineAgent
+from nest_core.sim.simulator import Simulator
+from nest_core.sim.trace import TraceWriter
+from nest_core.types import AgentId
+
+
+class _ReplacementAgent(StateMachineAgent):
+    def __init__(self, *, fail_on_message: bool = False) -> None:
+        self.started_as: AgentId | None = None
+        self.plugin_marker: object | None = None
+        self.messages: list[bytes] = []
+        self._fail_on_message = fail_on_message
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        self.started_as = ctx.agent_id
+        self.plugin_marker = ctx.plugins["marker"]
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        self.messages.append(payload)
+        if self._fail_on_message:
+            raise RuntimeError("replacement failed")
+
+
+class _ReferenceProvider(StateMachineAgent):
+    def __init__(self) -> None:
+        self.message_calls = 0
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        self.message_calls += 1
+        await ctx.send(sender, b"reference-fallback")
+
+
+class _Requester(StateMachineAgent):
+    async def on_start(self, ctx: AgentContext) -> None:
+        await ctx.send(AgentId("provider-0"), b"request")
+
+
+def _config(tmp_path: Path, task_type: str) -> ScenarioConfig:
+    return ScenarioConfig.from_dict(
+        {
+            "name": task_type,
+            "task": {"type": task_type},
+            "duration": "ticks: 10",
+            "output": {"trace": str(tmp_path / f"{task_type}.jsonl")},
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_override_replaces_exact_participant_and_preserves_its_plugins(
+    tmp_path: Path,
+) -> None:
+    marker = object()
+    original = _ReferenceProvider()
+
+    def factory(
+        config: ScenarioConfig, plugins: dict[str, Any]
+    ) -> dict[AgentId, StateMachineAgent]:
+        plugins["_agent_plugins"] = {AgentId("provider-0"): {"marker": marker}}
+        return {
+            AgentId("requester-0"): _Requester(),
+            AgentId("provider-0"): original,
+        }
+
+    register_scenario("participant_override_exact", factory)
+    replacement = _ReplacementAgent()
+
+    await ScenarioRunner(
+        _config(tmp_path, "participant_override_exact"),
+        participant_override={AgentId("provider-0"): replacement},
+    ).run()
+
+    assert replacement.started_as == AgentId("provider-0")
+    assert replacement.plugin_marker is marker
+    assert replacement.messages == [b"request"]
+    assert original.message_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_override_accepts_multiple_existing_targets_without_event_sink(
+    tmp_path: Path,
+) -> None:
+    requester = _ReplacementAgent()
+    provider = _ReplacementAgent()
+
+    def factory(
+        config: ScenarioConfig, plugins: dict[str, Any]
+    ) -> dict[AgentId, StateMachineAgent]:
+        marker = object()
+        plugins["_agent_plugins"] = {
+            AgentId("requester-0"): {"marker": marker},
+            AgentId("provider-0"): {"marker": marker},
+        }
+        return {
+            AgentId("requester-0"): _Requester(),
+            AgentId("provider-0"): _ReferenceProvider(),
+        }
+
+    register_scenario("participant_override_multiple", factory)
+
+    await ScenarioRunner(
+        _config(tmp_path, "participant_override_multiple"),
+        participant_override={
+            AgentId("requester-0"): requester,
+            AgentId("provider-0"): provider,
+        },
+    ).run()
+
+    assert requester.started_as == AgentId("requester-0")
+    assert provider.started_as == AgentId("provider-0")
+
+
+@pytest.mark.asyncio
+async def test_override_rejects_only_absent_targets(tmp_path: Path) -> None:
+    def factory(
+        config: ScenarioConfig, plugins: dict[str, Any]
+    ) -> dict[AgentId, StateMachineAgent]:
+        return {AgentId("provider-0"): _ReferenceProvider()}
+
+    register_scenario("participant_override_absent", factory)
+
+    with pytest.raises(KeyError, match="absent-0"):
+        await ScenarioRunner(
+            _config(tmp_path, "participant_override_absent"),
+            participant_override={AgentId("absent-0"): _ReferenceProvider()},
+        ).run()
+
+
+@pytest.mark.asyncio
+async def test_generic_runner_allows_requester_replacement(tmp_path: Path) -> None:
+    replacement = _ReplacementAgent()
+
+    def factory(
+        config: ScenarioConfig, plugins: dict[str, Any]
+    ) -> dict[AgentId, StateMachineAgent]:
+        plugins["_agent_plugins"] = {AgentId("requester-0"): {"marker": object()}}
+        return {
+            AgentId("requester-0"): _Requester(),
+            AgentId("provider-0"): _ReferenceProvider(),
+        }
+
+    register_scenario("participant_override_requester", factory)
+
+    await ScenarioRunner(
+        _config(tmp_path, "participant_override_requester"),
+        participant_override={AgentId("requester-0"): replacement},
+    ).run()
+
+    assert replacement.started_as == AgentId("requester-0")
+
+
+@pytest.mark.asyncio
+async def test_failed_replacement_never_falls_back_to_reference_provider(tmp_path: Path) -> None:
+    original = _ReferenceProvider()
+
+    def factory(
+        config: ScenarioConfig, plugins: dict[str, Any]
+    ) -> dict[AgentId, StateMachineAgent]:
+        plugins["_agent_plugins"] = {AgentId("provider-0"): {"marker": object()}}
+        return {
+            AgentId("requester-0"): _Requester(),
+            AgentId("provider-0"): original,
+        }
+
+    register_scenario("participant_override_failure", factory)
+    config = _config(tmp_path, "participant_override_failure")
+
+    with pytest.raises(RuntimeError, match="replacement failed"):
+        await ScenarioRunner(
+            config,
+            participant_override={AgentId("provider-0"): _ReplacementAgent(fail_on_message=True)},
+        ).run()
+
+    assert original.message_calls == 0
+    records = [json.loads(line) for line in Path(config.output.trace).read_text().splitlines()]
+    assert all(record.get("msg") != "reference-fallback" for record in records)
+
+
+@pytest.mark.asyncio
+async def test_ordinary_calls_are_identical_when_optional_seams_are_absent(tmp_path: Path) -> None:
+    def factory(
+        config: ScenarioConfig, plugins: dict[str, Any]
+    ) -> dict[AgentId, StateMachineAgent]:
+        return {
+            AgentId("requester-0"): _Requester(),
+            AgentId("provider-0"): _ReferenceProvider(),
+        }
+
+    register_scenario("ordinary_runner_compatibility", factory)
+    first = _config(tmp_path, "ordinary_runner_compatibility")
+    first.output.trace = str(tmp_path / "first.jsonl")
+    second = _config(tmp_path, "ordinary_runner_compatibility")
+    second.output.trace = str(tmp_path / "second.jsonl")
+
+    await ScenarioRunner(first).run()
+    await ScenarioRunner(second, participant_override=None).run()
+
+    assert Path(first.output.trace).read_bytes() == Path(second.output.trace).read_bytes()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_stage", ["add_agent", "set_agent_plugins"])
+async def test_runner_closes_trace_when_agent_setup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+) -> None:
+    primary = RuntimeError(f"{failure_stage} failed")
+    close_calls = 0
+    original_close = TraceWriter.close
+
+    def factory(
+        config: ScenarioConfig, plugins: dict[str, Any]
+    ) -> dict[AgentId, StateMachineAgent]:
+        plugins["_agent_plugins"] = {AgentId("provider-0"): {"marker": object()}}
+        return {AgentId("provider-0"): _ReferenceProvider()}
+
+    def fail_add_agent(simulator: Simulator, agent_id: AgentId, agent: StateMachineAgent) -> None:
+        raise primary
+
+    def fail_set_agent_plugins(
+        simulator: Simulator, agent_id: AgentId, overrides: dict[str, Any]
+    ) -> None:
+        raise primary
+
+    def record_close(writer: TraceWriter) -> None:
+        nonlocal close_calls
+        close_calls += 1
+        original_close(writer)
+
+    register_scenario("participant_setup_failure", factory)
+    if failure_stage == "add_agent":
+        monkeypatch.setattr(Simulator, "add_agent", fail_add_agent)
+    else:
+        monkeypatch.setattr(Simulator, "set_agent_plugins", fail_set_agent_plugins)
+    monkeypatch.setattr(TraceWriter, "close", record_close)
+    runner = ScenarioRunner(_config(tmp_path, "participant_setup_failure"))
+
+    with pytest.raises(RuntimeError) as caught:
+        await runner.run()
+
+    assert caught.value is primary
+    assert close_calls == 1
+    assert runner.trace_finalized is True

--- a/packages/nest-core/tests/agent_test/test_reference_plugin_resolution.py
+++ b/packages/nest-core/tests/agent_test/test_reference_plugin_resolution.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for profile-pinned reference plugin resolution."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from nest_core.builtin_scenarios import builtin_path
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_plugins_reference.registry.gossip import GossipRegistry
+from nest_plugins_reference.registry.in_memory import InMemoryRegistry
+
+
+class _CollidingRegistry:
+    async def register(self, card: object) -> None:
+        return None
+
+    async def lookup(self, query: object) -> list[object]:
+        return []
+
+
+class _EntryPoint:
+    name = "in_memory"
+
+    def load(self) -> type[_CollidingRegistry]:
+        return _CollidingRegistry
+
+
+def test_reference_resolution_bypasses_colliding_entry_point(monkeypatch: Any) -> None:
+    def entry_points(*, group: str) -> list[_EntryPoint]:
+        if group == "nest.plugins.registry":
+            return [_EntryPoint()]
+        return []
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", entry_points)
+    registry = PluginRegistry()
+
+    assert registry.resolve("registry", "in_memory") is _CollidingRegistry
+    assert registry.resolve_reference("registry", "in_memory") is InMemoryRegistry
+    assert (
+        f"{registry.resolve_reference('registry', 'in_memory').__module__}."
+        f"{registry.resolve_reference('registry', 'in_memory').__name__}"
+        == "nest_plugins_reference.registry.in_memory.InMemoryRegistry"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generic_scenario_runner_honors_entry_point_precedence(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    def entry_points(*, group: str) -> list[_EntryPoint]:
+        if group == "nest.plugins.registry":
+            return [_EntryPoint()]
+        return []
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", entry_points)
+    config = ScenarioConfig.from_yaml(builtin_path("capability_fulfillment"))
+    config.output.trace = str(tmp_path / "collision.jsonl")
+    runner = ScenarioRunner(config)
+
+    await runner.run()
+
+    assert type(runner.resolved_plugins["registry"]) is _CollidingRegistry
+
+
+@pytest.mark.asyncio
+async def test_generic_runner_resolves_configured_registry_without_profile_policy(
+    tmp_path: Path,
+) -> None:
+    config = ScenarioConfig.from_yaml(builtin_path("capability_fulfillment"))
+    config.layers.registry = "gossip"
+    config.output.trace = str(tmp_path / "mutated-registry.jsonl")
+    runner = ScenarioRunner(config)
+
+    plugins = cast("Any", runner)._resolve_plugins()
+
+    assert plugins["registry"] is GossipRegistry
+    assert not Path(config.output.trace).exists()
+
+
+def test_reference_resolution_rejects_unknown_reference() -> None:
+    registry = PluginRegistry()
+
+    try:
+        registry.resolve_reference("registry", "third_party_only")
+    except KeyError as exc:
+        assert "No reference plugin found" in str(exc)
+    else:
+        raise AssertionError("unknown reference plugin unexpectedly resolved")

--- a/packages/nest-core/tests/test_sim.py
+++ b/packages/nest-core/tests/test_sim.py
@@ -6,9 +6,12 @@ Covers: clock, event queue, agent lifecycle, determinism, and performance.
 
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
+from typing import Any, cast
 
+import nest_core.sim.agent as sim_agent
 import pytest
 from nest_core.sim import (
     EventQueue,
@@ -16,8 +19,9 @@ from nest_core.sim import (
     StateMachineAgent,
     VirtualClock,
 )
-from nest_core.sim.agent import AgentContext
+from nest_core.sim.agent import AgentContext, ScenarioAgentContext
 from nest_core.sim.events import Event
+from nest_core.sim.trace import TraceWriter
 from nest_core.types import AgentId
 
 # ---------------------------------------------------------------------------
@@ -145,6 +149,69 @@ class TestSimulator:
             assert "kind" in event
 
     @pytest.mark.asyncio
+    async def test_generic_event_sink_returns_trace_record_for_context_to_write(
+        self, tmp_path: Path
+    ) -> None:
+        """Passing TraceWriter or feature kwargs to the sink would break this boundary."""
+        requests: list[Any] = []
+        caller_data = {"values": ["before"]}
+        caller_attributes = {"link": {"value": "before"}}
+        trace_file = tmp_path / "scenario-event.jsonl"
+
+        class RecordingSink:
+            def record(self, request: Any) -> Any:
+                requests.append(request)
+                return sim_agent.ScenarioEventReceipt(
+                    event_id="event-1",
+                    trace_record={
+                        "kind": request.kind,
+                        "logical_time": request.logical_time,
+                        "observer": request.observer,
+                        "subject": request.subject,
+                        "data": dict(request.data),
+                        "attributes": dict(request.attributes),
+                    },
+                )
+
+        class EventAgent(StateMachineAgent):
+            async def on_start(self, ctx: AgentContext) -> None:
+                scenario_ctx = cast("ScenarioAgentContext", ctx)
+                receipt = scenario_ctx.record_scenario_event(
+                    kind="scenario.fixture.observed",
+                    observer="fixture-agent",
+                    subject="fixture-subject",
+                    data=caller_data,
+                    attributes=caller_attributes,
+                )
+                assert receipt is not None
+                assert receipt.event_id == "event-1"
+                caller_data["values"].append("after")
+                caller_attributes["link"]["value"] = "after"
+
+        sim = Simulator(seed=7, trace_path=trace_file, event_sink=RecordingSink())
+        sim.add_agent(AgentId("fixture-agent"), EventAgent())
+
+        await sim.run(max_ticks=10)
+
+        request_type = getattr(sim_agent, "ScenarioEventRequest", None)
+        assert request_type is not None
+        assert len(requests) == 1
+        assert isinstance(requests[0], request_type)
+        assert requests[0].data == {"values": ["before"]}
+        assert requests[0].attributes == {"link": {"value": "before"}}
+        records = [json.loads(line) for line in trace_file.read_text().splitlines()]
+        assert [record for record in records if record["kind"] == "scenario.fixture.observed"] == [
+            {
+                "kind": "scenario.fixture.observed",
+                "logical_time": 0.0,
+                "observer": "fixture-agent",
+                "subject": "fixture-subject",
+                "data": {"values": ["before"]},
+                "attributes": {"link": {"value": "before"}},
+            }
+        ]
+
+    @pytest.mark.asyncio
     async def test_deterministic_traces(self, tmp_path: Path) -> None:
         """Two runs with the same seed produce byte-identical traces."""
         traces: list[str] = []
@@ -234,3 +301,186 @@ class TestSimulator:
 
         assert len(received) == 1
         assert received[0] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_setup_failure_closes_trace_without_starting_agent_lifecycle(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Failure initialization is protected by trace cleanup but not agent stop hooks."""
+        stopped: list[str] = []
+        trace_close_calls = 0
+        original_close = TraceWriter.close
+
+        class StopWitness(StateMachineAgent):
+            async def on_stop(self, ctx: AgentContext) -> None:
+                stopped.append(str(ctx.agent_id))
+
+        def fail_initialization() -> None:
+            raise RuntimeError("setup failed")
+
+        def record_trace_close(writer: TraceWriter) -> None:
+            nonlocal trace_close_calls
+            original_close(writer)
+            trace_close_calls += 1
+
+        trace = tmp_path / "setup-failure.jsonl"
+        sim = Simulator(trace_path=trace)
+        sim.add_agent(AgentId("witness"), StopWitness())
+        monkeypatch.setattr(sim, "_init_failures", fail_initialization)
+        monkeypatch.setattr(TraceWriter, "close", record_trace_close)
+
+        with pytest.raises(RuntimeError, match="setup failed"):
+            await sim.run()
+
+        assert trace_close_calls == 1
+        assert stopped == []
+        assert trace.read_bytes() == b""
+
+    @pytest.mark.asyncio
+    async def test_setup_failure_remains_primary_when_trace_close_also_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cleanup failure cannot mask the earlier Simulator setup failure."""
+        stopped: list[str] = []
+        trace_close_calls = 0
+        original_close = TraceWriter.close
+
+        class StopWitness(StateMachineAgent):
+            async def on_stop(self, ctx: AgentContext) -> None:
+                stopped.append(str(ctx.agent_id))
+
+        def fail_initialization() -> None:
+            raise RuntimeError("setup failed")
+
+        def fail_after_trace_close(writer: TraceWriter) -> None:
+            nonlocal trace_close_calls
+            original_close(writer)
+            trace_close_calls += 1
+            raise RuntimeError("trace close failed")
+
+        sim = Simulator(trace_path=tmp_path / "setup-and-close-failure.jsonl")
+        sim.add_agent(AgentId("witness"), StopWitness())
+        monkeypatch.setattr(sim, "_init_failures", fail_initialization)
+        monkeypatch.setattr(TraceWriter, "close", fail_after_trace_close)
+
+        with pytest.raises(RuntimeError, match="setup failed"):
+            await sim.run()
+
+        assert trace_close_calls == 1
+        assert stopped == []
+
+    @pytest.mark.asyncio
+    async def test_primary_error_survives_cleanup_context_failure_and_trace_still_closes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stop-context failure cannot mask the primary error or bypass trace closure."""
+        trace_close_calls = 0
+        original_close = TraceWriter.close
+        sim = Simulator(trace_path=tmp_path / "cleanup-context-failure.jsonl")
+
+        def fail_cleanup_context(_agent_id: AgentId, _slot: object) -> None:
+            raise RuntimeError("cleanup context failed")
+
+        class PrimaryFailure(StateMachineAgent):
+            async def on_start(self, ctx: AgentContext) -> None:
+                monkeypatch.setattr(sim, "_make_context", fail_cleanup_context)
+                raise RuntimeError("primary start failed")
+
+        def record_trace_close(writer: TraceWriter) -> None:
+            nonlocal trace_close_calls
+            original_close(writer)
+            trace_close_calls += 1
+
+        sim.add_agent(AgentId("failing"), PrimaryFailure())
+        monkeypatch.setattr(TraceWriter, "close", record_trace_close)
+
+        with pytest.raises(RuntimeError, match="primary start failed"):
+            await sim.run()
+
+        assert trace_close_calls == 1
+        assert sim.trace_finalized is True
+
+    @pytest.mark.asyncio
+    async def test_start_failure_attempts_all_stops_and_flushes_without_masking(
+        self, tmp_path: Path
+    ) -> None:
+        stopped: list[str] = []
+
+        class FailingStart(StateMachineAgent):
+            async def on_start(self, ctx: AgentContext) -> None:
+                raise RuntimeError("start failed")
+
+            async def on_stop(self, ctx: AgentContext) -> None:
+                stopped.append(str(ctx.agent_id))
+                raise RuntimeError("stop failed")
+
+        class StopWitness(StateMachineAgent):
+            async def on_stop(self, ctx: AgentContext) -> None:
+                stopped.append(str(ctx.agent_id))
+
+        trace = tmp_path / "start-failure.jsonl"
+        sim = Simulator(trace_path=trace)
+        sim.add_agent(AgentId("failing"), FailingStart())
+        sim.add_agent(AgentId("witness"), StopWitness())
+
+        with pytest.raises(RuntimeError, match="start failed"):
+            await sim.run()
+
+        assert stopped == ["failing", "witness"]
+        assert [json.loads(line)["kind"] for line in trace.read_text().splitlines()][-2:] == [
+            "stop",
+            "stop",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_message_failure_attempts_stop_and_flushes_without_masking(
+        self, tmp_path: Path
+    ) -> None:
+        stopped: list[str] = []
+
+        class Sender(StateMachineAgent):
+            async def on_start(self, ctx: AgentContext) -> None:
+                await ctx.send(AgentId("failing"), b"boom")
+
+            async def on_stop(self, ctx: AgentContext) -> None:
+                stopped.append(str(ctx.agent_id))
+
+        class FailingMessage(StateMachineAgent):
+            async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+                raise RuntimeError("message failed")
+
+            async def on_stop(self, ctx: AgentContext) -> None:
+                stopped.append(str(ctx.agent_id))
+                raise RuntimeError("stop failed")
+
+        trace = tmp_path / "message-failure.jsonl"
+        sim = Simulator(trace_path=trace)
+        sim.add_agent(AgentId("sender"), Sender())
+        sim.add_agent(AgentId("failing"), FailingMessage())
+
+        with pytest.raises(RuntimeError, match="message failed"):
+            await sim.run()
+
+        assert stopped == ["sender", "failing"]
+        assert any(json.loads(line)["kind"] == "receive" for line in trace.read_text().splitlines())
+
+    @pytest.mark.asyncio
+    async def test_stop_failure_attempts_remaining_stops_and_flushes(self, tmp_path: Path) -> None:
+        stopped: list[str] = []
+
+        class FailingStop(StateMachineAgent):
+            async def on_stop(self, ctx: AgentContext) -> None:
+                stopped.append(str(ctx.agent_id))
+                if ctx.agent_id == AgentId("first"):
+                    raise RuntimeError("first stop failed")
+
+        trace = tmp_path / "stop-failure.jsonl"
+        sim = Simulator(trace_path=trace)
+        sim.add_agent(AgentId("first"), FailingStop())
+        sim.add_agent(AgentId("second"), FailingStop())
+
+        with pytest.raises(RuntimeError, match="first stop failed"):
+            await sim.run()
+
+        assert stopped == ["first", "second"]
+        assert len(trace.read_text().splitlines()) == 4

--- a/packages/nest-core/tests/test_trace.py
+++ b/packages/nest-core/tests/test_trace.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Trace writer lifecycle tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from nest_core.sim.trace import TraceWriter
+
+
+class _InspectableTraceWriter(TraceWriter):
+    @property
+    def underlying_file_closed(self) -> bool:
+        return self._file.closed
+
+    def close_underlying_file(self) -> None:
+        self._file.close()
+
+
+def test_close_attempts_file_close_when_flush_fails_and_preserves_flush_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A flush failure remains primary without leaking the underlying file handle."""
+    writer = _InspectableTraceWriter(tmp_path / "flush-failure.jsonl")
+    flush_failure = RuntimeError("flush failed")
+
+    def fail_flush() -> None:
+        raise flush_failure
+
+    monkeypatch.setattr(writer, "flush", fail_flush)
+    try:
+        with pytest.raises(RuntimeError) as caught:
+            writer.close()
+
+        assert caught.value is flush_failure
+        assert writer.underlying_file_closed
+    finally:
+        if not writer.underlying_file_closed:
+            writer.close_underlying_file()


### PR DESCRIPTION
## Problem

Town needs a deterministic, real execution seam before an external agent can be evaluated through the simulator without coupling generic scenario code to the agent-test feature.

## Change

- add the pinned capability workflow used by the test profile
- resolve the reference Registry explicitly for the run
- support per-run participant injection through the generic scenario boundary
- keep ordinary `nest run capability_fulfillment` behavior unchanged

## Verification

- final stack: `make ci-local` — all 5 checks passed; 2,081 passed, 2 skipped, 1 deselected
- generic ScenarioRunner compatibility and ordinary capability workflow smoke are covered
- independent architecture review found no Critical or Important issues

## Stack

**1 of 9 — review this PR first.** Each PR targets the preceding branch.

1. #220 — deterministic Town seam
2. #221 — version 1 contracts and profile
3. #222 — hardened loopback driver
4. #223 — evaluation engine and artifacts
5. #224 — local-adapter CLI and reference journey
6. #225 — shared local adapter server
7. #226 — bounded OpenClaw connector
8. #227 — managed-runtime Town bridge
9. #228 — one-command OpenClaw CLI and docs

**Merge note:** Merge this PR into `main` first. Then retarget #221 to `main`, wait for its CI, and continue one PR at a time.