### PR TITLE
feat(agent-test): add a hardened loopback HTTP driver

### DIFF
--- a/packages/nest-core/nest_core/agent_test/driver.py
+++ b/packages/nest-core/nest_core/agent_test/driver.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Transport-neutral agent driver protocol and safe typed failures."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Protocol, runtime_checkable
+
+from .models import DriverReadiness, DriverRequest, DriverResponse
+from .profiles import ResolvedTestProfile
+
+
+class DriverFailureDisposition(StrEnum):
+    """Policy-relevant meanings without coupling the driver to CLI exit codes."""
+
+    CONFIGURATION = "configuration"
+    COMPATIBILITY = "compatibility"
+    TOWN = "town"
+    CONTRACT = "driver_contract"
+    INCOMPLETE = "incomplete"
+
+
+class AgentDriverError(RuntimeError):
+    """A safe local error containing no remote text or transport exception."""
+
+    disposition: DriverFailureDisposition
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+class DriverConfigurationError(AgentDriverError):
+    disposition = DriverFailureDisposition.CONFIGURATION
+
+
+class DriverCompatibilityError(AgentDriverError):
+    disposition = DriverFailureDisposition.COMPATIBILITY
+
+
+class TownDriverError(AgentDriverError):
+    disposition = DriverFailureDisposition.TOWN
+
+
+class DriverContractError(AgentDriverError):
+    disposition = DriverFailureDisposition.CONTRACT
+
+
+class DriverIncompleteError(AgentDriverError):
+    disposition = DriverFailureDisposition.INCOMPLETE
+
+
+@runtime_checkable
+class AgentDriver(Protocol):
+    """HTTP-free observation-to-intent boundary."""
+
+    async def ready(self, profile: ResolvedTestProfile) -> DriverReadiness:
+        """Validate compatibility and return effective adapter readiness."""
+        ...
+
+    async def decide(self, request: DriverRequest) -> DriverResponse:
+        """Return one validated intent for a validated observation envelope."""
+        ...
+
+    async def close(self) -> None:
+        """Release transport resources on a best-effort basis."""
+        ...

--- a/packages/nest-core/nest_core/agent_test/http_driver.py
+++ b/packages/nest-core/nest_core/agent_test/http_driver.py
@@ -1,0 +1,583 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Strict authenticated HTTP transport for the local AgentDriver boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass
+from typing import Never, cast
+
+import httpx
+from pydantic import Field, ValidationError
+
+from .driver import (
+    AgentDriverError,
+    DriverCompatibilityError,
+    DriverConfigurationError,
+    DriverContractError,
+    DriverIncompleteError,
+    TownDriverError,
+)
+from .models import (
+    AdapterInstanceId,
+    Digest,
+    DriverError,
+    DriverReadiness,
+    DriverReady,
+    DriverRequest,
+    DriverResponse,
+    EffectiveDriverLimits,
+    ProfileId,
+    ProfileReference,
+    ReadyLimits,
+    SafeText128,
+    StrictModel,
+    VersionId,
+)
+from .profile_codecs import BoundProfileCodec
+from .profiles import ResolvedTestProfile, capability_profile_document
+
+_CONTRACT = "town-agent-driver/1"
+_READY_PATH = "/town-driver/1/ready"
+_DECIDE_PATH = "/town-driver/1/decide"
+_TOKEN_RE = re.compile(r"[0-9a-f]{64}\Z")
+_ORIGIN_RE = re.compile(r"http://(?:127\.0\.0\.1|\[::1\]):([0-9]+)\Z")
+
+
+@dataclass(frozen=True, slots=True)
+class _SafeFailure:
+    error_type: type[AgentDriverError]
+    code: str
+
+
+@dataclass(frozen=True, slots=True)
+class _ReadySuccess:
+    readiness: DriverReadiness
+    profile: ProfileReference
+    codec: BoundProfileCodec
+
+
+@dataclass(frozen=True, slots=True)
+class _ReadyOutcome:
+    success: _ReadySuccess | None = None
+    failure: _SafeFailure | None = None
+    cancelled: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _DecideOutcome:
+    success: DriverResponse | None = None
+    failure: _SafeFailure | None = None
+    cancelled: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _Cancelled:
+    pass
+
+
+_CANCELLED = _Cancelled()
+
+
+class _ReadinessProfileIdentity(StrictModel):
+    id: ProfileId
+    version: VersionId
+    digest: Digest
+
+
+class _ReadinessShape(StrictModel):
+    schema_version: SafeText128
+    adapter_instance_id: AdapterInstanceId
+    contracts: list[SafeText128] = Field(min_length=1)
+    profiles: list[_ReadinessProfileIdentity] = Field(min_length=1)
+    accepting_runs: bool
+    limits: ReadyLimits
+
+
+def parse_loopback_origin(origin: str) -> str:
+    """Accept only an exact canonical loopback HTTP origin with a valid port."""
+    matched = _ORIGIN_RE.fullmatch(origin)
+    if matched is None:
+        raise ValueError("endpoint must be a canonical loopback HTTP origin with explicit port")
+    port = int(matched.group(1))
+    if not 1 <= port <= 65535:
+        raise ValueError("endpoint must be a canonical loopback HTTP origin with explicit port")
+    return origin
+
+
+class LoopbackHttpAgentDriver:
+    """One-shot HTTP clients with strict request and response validation."""
+
+    def __init__(self, endpoint_origin: str, token: str, *, timeout_seconds: float = 60.0) -> None:
+        self._endpoint_origin = parse_loopback_origin(endpoint_origin)
+        if _TOKEN_RE.fullmatch(token) is None:
+            raise ValueError("bearer token must be exactly 64 lowercase hexadecimal characters")
+        if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive and finite")
+        self._token = token
+        self._timeout_seconds = timeout_seconds
+        self._profile: ProfileReference | None = None
+        self._profile_codec: BoundProfileCodec | None = None
+        self._readiness: DriverReadiness | None = None
+        self._admitted_run_id: str | None = None
+        self._closed = False
+
+    @property
+    def endpoint_origin(self) -> str:
+        """Return the validated read-only adapter origin."""
+        return self._endpoint_origin
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(endpoint_origin={self.endpoint_origin!r}, "
+            f"timeout_seconds={self._timeout_seconds!r})"
+        )
+
+    async def ready(self, profile: ResolvedTestProfile) -> DriverReadiness:
+        self._require_open()
+        outcome = await self._ready_outcome(profile)
+        if outcome.cancelled:
+            _raise_sanitized_cancellation()
+        if outcome.failure is not None:
+            _raise_sanitized_failure(outcome.failure)
+        success = outcome.success
+        if success is None:
+            raise AssertionError("readiness produced no outcome")
+        self._profile = success.profile
+        self._profile_codec = success.codec
+        self._readiness = success.readiness
+        return success.readiness
+
+    async def _ready_outcome(self, profile: ResolvedTestProfile) -> _ReadyOutcome:
+        try:
+            success = await self._ready_sensitive(profile)
+        except AgentDriverError as error:
+            return _ReadyOutcome(failure=_SafeFailure(type(error), error.code))
+        if isinstance(success, _Cancelled):
+            return _ReadyOutcome(cancelled=True)
+        return _ReadyOutcome(success=success)
+
+    async def _ready_sensitive(self, profile: ResolvedTestProfile) -> _ReadySuccess | _Cancelled:
+        profile_document = capability_profile_document(profile)
+        profile_reference = profile.reference
+        profile_codec = profile.codec
+        if self._profile_codec is not None and self._profile_codec != profile_codec:
+            raise DriverCompatibilityError("PROFILE_CONTEXT_CHANGED")
+        exchange = await self._exchange_with_status(
+            method="GET",
+            path=_READY_PATH,
+            body=None,
+            response_limit=profile_document.driver.max_http_body_bytes,
+        )
+        if isinstance(exchange, _Cancelled):
+            return exchange
+        status, body = exchange
+        if status != 200:
+            self._raise_ready_http_error(status, body)
+            raise AssertionError("typed readiness HTTP error mapper returned")
+        data = _json_object(body, "MALFORMED_RESPONSE")
+        shape = _validate_readiness_shape(data)
+        if self._token in shape.adapter_instance_id:
+            raise DriverContractError("MALFORMED_RESPONSE")
+        self._check_readiness_identity(shape, profile_reference)
+        ready = _validate_ready(data)
+        if (
+            self._admitted_run_id is not None
+            and self._readiness is not None
+            and ready.adapter_instance_id != self._readiness.ready.adapter_instance_id
+        ):
+            raise DriverIncompleteError("ADAPTER_INSTANCE_CHANGED")
+        effective = EffectiveDriverLimits(
+            max_request_bytes=min(
+                profile_document.driver.max_http_body_bytes, ready.limits.max_request_bytes
+            ),
+            max_response_bytes=min(
+                profile_document.driver.max_http_body_bytes, ready.limits.max_response_bytes
+            ),
+        )
+        readiness = DriverReadiness(ready=ready, effective_limits=effective)
+        return _ReadySuccess(
+            readiness=readiness,
+            profile=profile_reference,
+            codec=profile_codec,
+        )
+
+    async def decide(self, request: DriverRequest) -> DriverResponse:
+        self._require_open()
+        outcome = await self._decide_outcome(request)
+        if outcome.cancelled:
+            _raise_sanitized_cancellation()
+        if outcome.failure is not None:
+            _raise_sanitized_failure(outcome.failure)
+        response = outcome.success
+        if response is None:
+            raise AssertionError("decision produced no outcome")
+        if request.observation.kind == "start":
+            self._admitted_run_id = request.run_id
+        return response
+
+    async def _decide_outcome(self, request: DriverRequest) -> _DecideOutcome:
+        try:
+            response = await self._decide_sensitive(request)
+        except AgentDriverError as error:
+            return _DecideOutcome(failure=_SafeFailure(type(error), error.code))
+        if isinstance(response, _Cancelled):
+            return _DecideOutcome(cancelled=True)
+        return _DecideOutcome(success=response)
+
+    async def _decide_sensitive(self, request: DriverRequest) -> DriverResponse | _Cancelled:
+        readiness = self._readiness
+        profile = self._profile
+        profile_codec = self._profile_codec
+        if readiness is None or profile is None or profile_codec is None:
+            raise DriverConfigurationError("NOT_READY")
+        if request.profile.model_dump(mode="json") != profile.model_dump(mode="json"):
+            raise TownDriverError("PROFILE_MISMATCH")
+        try:
+            request = cast(
+                "DriverRequest",
+                profile_codec.validate_request(request.model_dump(mode="json")),
+            )
+        except (AttributeError, ValidationError, ValueError):
+            raise TownDriverError("PROFILE_MISMATCH") from None
+        if self._admitted_run_id is None and request.observation.kind != "start":
+            raise TownDriverError("START_REQUIRED")
+        if self._admitted_run_id is not None and request.run_id != self._admitted_run_id:
+            raise TownDriverError("RUN_MISMATCH")
+
+        body = request.model_dump_json().encode()
+        limits = readiness.effective_limits
+        if len(body) > limits.max_request_bytes:
+            raise TownDriverError("BODY_TOO_LARGE")
+        request_digest = "sha256:" + hashlib.sha256(body).hexdigest()
+        exchange = await self._exchange_with_status(
+            method="POST",
+            path=_DECIDE_PATH,
+            body=body,
+            request_digest=request_digest,
+            response_limit=limits.max_response_bytes,
+        )
+        if isinstance(exchange, _Cancelled):
+            return exchange
+        response_status, response_body = exchange
+        if response_status != 200:
+            self._raise_typed_http_error(
+                response_status, response_body, request, request_digest, readiness
+            )
+            raise AssertionError("typed HTTP error mapper returned")
+
+        data = _json_object(response_body, "MALFORMED_RESPONSE")
+        if _contains_complete_secret(data, self._token):
+            raise DriverContractError("MALFORMED_RESPONSE")
+        response = _validate_response(data, profile_codec)
+        if response.adapter_instance_id != readiness.ready.adapter_instance_id:
+            raise DriverIncompleteError("ADAPTER_INSTANCE_CHANGED")
+        if (
+            response.run_id != request.run_id
+            or response.event_id != request.event_id
+            or response.sequence != request.sequence
+            or response.request_digest != request_digest
+        ):
+            raise DriverContractError("RESPONSE_MISMATCH")
+        if response.intent.kind not in request.observation.allowed_intents:
+            raise DriverContractError("INTENT_NOT_ALLOWED")
+        return response
+
+    async def close(self) -> None:
+        self._closed = True
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise DriverConfigurationError("DRIVER_CLOSED")
+
+    async def _exchange_with_status(
+        self,
+        *,
+        method: str,
+        path: str,
+        body: bytes | None,
+        response_limit: int,
+        request_digest: str | None = None,
+    ) -> tuple[int, bytes] | _Cancelled:
+        try:
+            endpoint_origin = parse_loopback_origin(self._endpoint_origin)
+        except ValueError:
+            raise DriverConfigurationError("INVALID_ENDPOINT") from None
+        headers = {
+            "Authorization": f"Bearer {self._token}",
+            "Town-Driver-Contract": _CONTRACT,
+            "Accept": "application/json",
+            "Accept-Encoding": "identity",
+        }
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+            if request_digest is None:
+                raise AssertionError("decide request digest is required")
+            headers["Town-Request-Digest"] = request_digest
+
+        failure_code: str | None = None
+        result: tuple[int, bytes] | None = None
+        try:
+            transport = httpx.AsyncHTTPTransport(retries=0)
+            async with asyncio.timeout(self._timeout_seconds):
+                async with (
+                    httpx.AsyncClient(
+                        transport=transport,
+                        trust_env=False,
+                        follow_redirects=False,
+                        timeout=self._timeout_seconds,
+                    ) as client,
+                    client.stream(
+                        method,
+                        endpoint_origin + path,
+                        headers=headers,
+                        content=body,
+                    ) as response,
+                ):
+                    response_body = await _bounded_response_body(response, response_limit)
+                    result = (response.status_code, response_body)
+        except asyncio.CancelledError:
+            return _CANCELLED
+        except (TimeoutError, httpx.TimeoutException):
+            failure_code = "TIMEOUT"
+        except httpx.TransportError:
+            failure_code = "TRANSPORT_LOSS"
+        if failure_code is not None:
+            raise DriverIncompleteError(failure_code)
+        if result is None:
+            raise AssertionError("HTTP exchange produced no result")
+        return result
+
+    @staticmethod
+    def _check_readiness_identity(
+        readiness: _ReadinessShape, profile_reference: ProfileReference
+    ) -> None:
+        if readiness.schema_version != "town-agent-driver-ready/1":
+            raise DriverCompatibilityError("UNSUPPORTED_CONTRACT")
+        if _CONTRACT not in readiness.contracts:
+            raise DriverCompatibilityError("UNSUPPORTED_CONTRACT")
+        expected = (profile_reference.id, profile_reference.version, profile_reference.digest)
+        identities = {(item.id, item.version, item.digest) for item in readiness.profiles}
+        if expected not in identities:
+            raise DriverCompatibilityError("UNSUPPORTED_PROFILE")
+
+    def _raise_typed_http_error(
+        self,
+        status: int,
+        body: bytes,
+        request: DriverRequest,
+        request_digest: str,
+        readiness: DriverReadiness,
+    ) -> None:
+        data = _json_object(body, "MALFORMED_ERROR_RESPONSE")
+        error = _validate_error(data)
+        code = error.error.code
+        expected_status = {
+            "AUTHENTICATION_FAILED": 401,
+            "RUN_BUSY": 409,
+            "EVENT_CONFLICT": 409,
+            "OUT_OF_ORDER": 409,
+            "BODY_TOO_LARGE": 413,
+            "UNSUPPORTED_CONTRACT": 422,
+            "UNSUPPORTED_PROFILE": 422,
+            "SCHEMA_INVALID": 422,
+            "ADAPTER_INTERNAL": 500,
+        }[code]
+        if status != expected_status:
+            raise DriverContractError("STATUS_CODE_MISMATCH")
+        if code != "AUTHENTICATION_FAILED":
+            if (
+                error.run_id != request.run_id
+                or error.event_id != request.event_id
+                or error.sequence != request.sequence
+                or error.request_digest != request_digest
+            ):
+                raise DriverContractError("ERROR_RESPONSE_MISMATCH")
+            if error.adapter_instance_id is None:
+                raise DriverContractError("ERROR_RESPONSE_MISMATCH")
+            if error.adapter_instance_id != readiness.ready.adapter_instance_id:
+                raise DriverIncompleteError("ADAPTER_INSTANCE_CHANGED")
+
+        if code == "AUTHENTICATION_FAILED":
+            error_type = (
+                DriverConfigurationError if self._admitted_run_id is None else DriverIncompleteError
+            )
+        elif code in {"RUN_BUSY", "ADAPTER_INTERNAL"}:
+            error_type = DriverIncompleteError
+        elif code in {"EVENT_CONFLICT", "OUT_OF_ORDER", "BODY_TOO_LARGE"}:
+            error_type = DriverContractError
+        elif code in {"UNSUPPORTED_CONTRACT", "UNSUPPORTED_PROFILE"}:
+            error_type = (
+                DriverCompatibilityError if self._admitted_run_id is None else DriverContractError
+            )
+        else:
+            error_type = TownDriverError
+        raise error_type(code)
+
+    def _raise_ready_http_error(self, status: int, body: bytes) -> None:
+        data = _json_object(body, "MALFORMED_ERROR_RESPONSE")
+        error = _validate_error(data)
+        code = error.error.code
+        expected_status = {
+            "AUTHENTICATION_FAILED": 401,
+            "RUN_BUSY": 409,
+            "EVENT_CONFLICT": 409,
+            "OUT_OF_ORDER": 409,
+            "BODY_TOO_LARGE": 413,
+            "UNSUPPORTED_CONTRACT": 422,
+            "UNSUPPORTED_PROFILE": 422,
+            "SCHEMA_INVALID": 422,
+            "ADAPTER_INTERNAL": 500,
+        }[code]
+        if status != expected_status:
+            raise DriverContractError("STATUS_CODE_MISMATCH")
+        if any(
+            value is not None
+            for value in (error.run_id, error.event_id, error.sequence, error.request_digest)
+        ):
+            raise DriverContractError("ERROR_RESPONSE_MISMATCH")
+        if code != "AUTHENTICATION_FAILED":
+            if error.adapter_instance_id is None:
+                raise DriverContractError("ERROR_RESPONSE_MISMATCH")
+            if (
+                self._admitted_run_id is not None
+                and self._readiness is not None
+                and error.adapter_instance_id != self._readiness.ready.adapter_instance_id
+            ):
+                raise DriverIncompleteError("ADAPTER_INSTANCE_CHANGED")
+        if code == "AUTHENTICATION_FAILED":
+            error_type = (
+                DriverConfigurationError if self._admitted_run_id is None else DriverIncompleteError
+            )
+        elif code in {"UNSUPPORTED_CONTRACT", "UNSUPPORTED_PROFILE"}:
+            error_type = (
+                DriverCompatibilityError if self._admitted_run_id is None else DriverContractError
+            )
+        elif code in {"RUN_BUSY", "ADAPTER_INTERNAL"}:
+            error_type = DriverIncompleteError
+        elif code == "SCHEMA_INVALID":
+            error_type = TownDriverError
+        else:
+            error_type = DriverContractError
+        raise error_type(code)
+
+
+async def _bounded_response_body(response: httpx.Response, limit: int) -> bytes:
+    if 300 <= response.status_code <= 399:
+        raise DriverContractError("REDIRECT_RESPONSE")
+    if response.headers.get("content-type") != "application/json":
+        raise DriverContractError("CONTENT_TYPE_RESPONSE")
+    if response.headers.get("town-driver-contract") != _CONTRACT:
+        raise DriverContractError("CONTRACT_HEADER_RESPONSE")
+    if "set-cookie" in response.headers:
+        raise DriverContractError("COOKIE_RESPONSE")
+    content_encoding = response.headers.get("content-encoding")
+    if content_encoding not in {None, "identity"}:
+        raise DriverContractError("COMPRESSED_RESPONSE")
+    length_text = response.headers.get("content-length")
+    if length_text is not None:
+        try:
+            content_length = int(length_text)
+        except ValueError:
+            content_length = -1
+        if content_length < 0:
+            raise DriverContractError("INVALID_CONTENT_LENGTH")
+        if content_length > limit:
+            raise DriverContractError("RESPONSE_TOO_LARGE")
+
+    chunks: list[bytes] = []
+    size = 0
+    async for chunk in response.aiter_raw():
+        size += len(chunk)
+        if size > limit:
+            raise DriverContractError("RESPONSE_TOO_LARGE")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _json_object(body: bytes, error_code: str) -> dict[str, object]:
+    parsed: object | None = None
+    invalid = False
+    try:
+        parsed = json.loads(body)
+    except (ValueError, RecursionError):
+        invalid = True
+    if invalid or not isinstance(parsed, dict):
+        raise DriverContractError(error_code)
+    return cast("dict[str, object]", parsed)
+
+
+def _contains_complete_secret(value: object, secret: str) -> bool:
+    pending: list[object] = [value]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, str):
+            if secret in current:
+                return True
+        elif isinstance(current, dict):
+            mapping = cast("dict[object, object]", current)
+            for key, item in mapping.items():
+                pending.extend((key, item))
+        elif isinstance(current, list):
+            pending.extend(cast("list[object]", current))
+    return False
+
+
+def _raise_sanitized_failure(failure: _SafeFailure) -> Never:
+    raise failure.error_type(failure.code)
+
+
+def _raise_sanitized_cancellation() -> Never:
+    raise asyncio.CancelledError
+
+
+def _validate_ready(data: dict[str, object]) -> DriverReady:
+    value: DriverReady | None = None
+    invalid = False
+    try:
+        value = DriverReady.model_validate(data)
+    except ValidationError:
+        invalid = True
+    if invalid or value is None:
+        raise DriverContractError("MALFORMED_RESPONSE")
+    return value
+
+
+def _validate_readiness_shape(data: dict[str, object]) -> _ReadinessShape:
+    value: _ReadinessShape | None = None
+    invalid = False
+    try:
+        value = _ReadinessShape.model_validate(data)
+    except ValidationError:
+        invalid = True
+    if invalid or value is None:
+        raise DriverContractError("MALFORMED_RESPONSE")
+    return value
+
+
+def _validate_response(data: dict[str, object], profile_codec: BoundProfileCodec) -> DriverResponse:
+    value: DriverResponse | None = None
+    invalid = False
+    try:
+        value = cast("DriverResponse", profile_codec.validate_response(data))
+    except (ValidationError, ValueError):
+        invalid = True
+    if invalid or value is None:
+        raise DriverContractError("MALFORMED_RESPONSE")
+    return value
+
+
+def _validate_error(data: dict[str, object]) -> DriverError:
+    value: DriverError | None = None
+    invalid = False
+    try:
+        value = DriverError.model_validate(data)
+    except ValidationError:
+        invalid = True
+    if invalid or value is None:
+        raise DriverContractError("MALFORMED_ERROR_RESPONSE")
+    return value

--- a/packages/nest-core/pyproject.toml
+++ b/packages/nest-core/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
+    "httpx>=0.28",
     "pydantic>=2.0",
     "pyyaml>=6.0",
     "typer>=0.12",

--- a/packages/nest-core/tests/agent_test/test_http_driver.py
+++ b/packages/nest-core/tests/agent_test/test_http_driver.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Transport-neutral driver protocol and loopback-origin validation tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from nest_core.agent_test.driver import AgentDriver, DriverContractError
+from nest_core.agent_test.http_driver import LoopbackHttpAgentDriver, parse_loopback_origin
+from nest_core.agent_test.models import (
+    DriverError,
+    DriverReadiness,
+    DriverReady,
+    DriverRequest,
+    DriverResponse,
+    ResultDriver,
+)
+from nest_core.agent_test.profiles import ResolvedTestProfile, resolve_test_profile
+from pydantic import ValidationError
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class _ProtocolDriver:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def ready(self, profile: ResolvedTestProfile) -> DriverReadiness:
+        raise DriverContractError("TEST_READY")
+
+    async def decide(self, request: DriverRequest) -> DriverResponse:
+        raise DriverContractError("TEST_DECIDE")
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_agent_driver_protocol_has_http_free_ready_decide_and_best_effort_close() -> None:
+    """Changing the driver seam to expose HTTP concepts breaks transport neutrality."""
+    implementation = _ProtocolDriver()
+    driver = cast("AgentDriver", implementation)
+
+    with pytest.raises(DriverContractError, match="TEST_READY"):
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+    with pytest.raises(DriverContractError, match="TEST_DECIDE"):
+        await driver.decide(cast("DriverRequest", object()))
+    await driver.close()
+
+    assert implementation.closed
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://127.0.0.1:1",
+        "http://127.0.0.1:65535",
+        "http://[::1]:8080",
+    ],
+)
+def test_loopback_origin_accepts_only_canonical_literals_with_explicit_ports(origin: str) -> None:
+    """Rejecting a canonical explicit-port loopback origin would block the approved boundary."""
+    assert parse_loopback_origin(origin) == origin
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "localhost:8000",
+        "http://localhost:8000",
+        "http://example.test:8000",
+        "https://127.0.0.1:8000",
+        "http://user@127.0.0.1:8000",
+        "http://user:pass@127.0.0.1:8000",
+        "http://127.0.0.1",
+        "http://127.0.0.1:0",
+        "http://127.0.0.1:65536",
+        "http://127.0.0.1:notaport",
+        "http://127.0.0.1:8000/",
+        "http://127.0.0.1:8000/path",
+        "http://127.0.0.1:8000?query=yes",
+        "http://127.0.0.1:8000#fragment",
+        "http://127.1:8000",
+        "http://127.0.1:8000",
+        "http://0177.0.0.1:8000",
+        "http://2130706433:8000",
+        "http://0x7f000001:8000",
+        "http://[0:0:0:0:0:0:0:1]:8000",
+        "http://[::1%25lo0]:8000",
+        "http://::1:8000",
+    ],
+)
+def test_loopback_origin_rejects_every_noncanonical_or_nonorigin_form(origin: str) -> None:
+    """Relaxing origin syntax could cross the authenticated local-only boundary."""
+    with pytest.raises(ValueError, match="loopback HTTP origin"):
+        parse_loopback_origin(origin)
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "a" * 63,
+        "a" * 65,
+        "A" * 64,
+        "g" * 64,
+        "0" * 63 + "-",
+    ],
+)
+def test_driver_rejects_tokens_outside_exact_lowercase_hex_grammar(token: str) -> None:
+    """Accepting a weakly shaped bearer value would weaken adapter authentication."""
+    with pytest.raises(ValueError, match="bearer token"):
+        LoopbackHttpAgentDriver("http://127.0.0.1:8000", token)
+
+
+def test_driver_repr_never_contains_bearer_token() -> None:
+    """Adding the secret to repr would leak it through diagnostics and logs."""
+    token = "a1" * 32
+
+    driver = LoopbackHttpAgentDriver("http://127.0.0.1:8000", token)
+
+    assert token not in repr(driver)
+
+
+def test_validated_endpoint_origin_is_read_only_after_construction() -> None:
+    """Ordinary attribute assignment must not retarget an authenticated driver."""
+    driver = LoopbackHttpAgentDriver("http://127.0.0.1:8000", "a1" * 32)
+
+    with pytest.raises(AttributeError):
+        setattr(driver, "endpoint_origin", "http://127.0.0.1:9000")  # noqa: B010
+
+
+@pytest.mark.asyncio
+async def test_bound_driver_accepts_wire_equal_concrete_profile_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A codec-specific reference must remain equal to its generic readiness identity."""
+    driver = LoopbackHttpAgentDriver("http://127.0.0.1:8000", "a1" * 32)
+    profile = resolve_test_profile("capability-fulfillment")
+    request = DriverRequest.model_validate_json(
+        (FIXTURES / "driver-start-request.json").read_bytes()
+    )
+
+    async def exchange(**kwargs: Any) -> tuple[int, bytes]:
+        if kwargs["method"] == "GET":
+            return 200, (FIXTURES / "driver-ready.json").read_bytes()
+        response = json.loads((FIXTURES / "driver-start-response.json").read_text())
+        body = cast("bytes", kwargs["body"])
+        response["request_digest"] = "sha256:" + hashlib.sha256(body).hexdigest()
+        return 200, json.dumps(response, separators=(",", ":")).encode()
+
+    monkeypatch.setattr(driver, "_exchange_with_status", exchange)
+
+    await driver.ready(profile)
+    response = await driver.decide(request)
+
+    assert response.intent.kind == "declare_capability"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("id", "nanda//agent"),
+        ("version", "0/1"),
+        ("digest", "sha256:not-a-digest"),
+    ],
+)
+async def test_malformed_readiness_profile_identity_precedes_unsupported_profile(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: str,
+) -> None:
+    """Malformed authenticated identity is a contract error, never compatibility evidence."""
+    driver = LoopbackHttpAgentDriver("http://127.0.0.1:8000", "a1" * 32)
+    ready = json.loads((FIXTURES / "driver-ready.json").read_text())
+    ready["profiles"][0][field] = value
+
+    async def exchange(**_kwargs: Any) -> tuple[int, bytes]:
+        return 200, json.dumps(ready, separators=(",", ":")).encode()
+
+    monkeypatch.setattr(driver, "_exchange_with_status", exchange)
+
+    with pytest.raises(DriverContractError, match="MALFORMED_RESPONSE"):
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+
+@pytest.mark.parametrize("instance_id", ["", "a" * 257])
+def test_wire_and_result_instance_ids_remain_bounded(instance_id: str) -> None:
+    """The shared published-string boundary remains nonempty and bounded."""
+    ready = json.loads((FIXTURES / "driver-ready.json").read_text())
+    response = json.loads((FIXTURES / "driver-start-response.json").read_text())
+    error = json.loads((FIXTURES / "driver-error.json").read_text())
+    for model, data in (
+        (DriverReady, ready),
+        (DriverResponse, response),
+        (DriverError, error),
+    ):
+        data["adapter_instance_id"] = instance_id
+        with pytest.raises(ValidationError):
+            model.model_validate(data)
+    with pytest.raises(ValidationError):
+        ResultDriver(
+            contract="town-agent-driver/1",
+            kind="loopback-http",
+            adapter_instance_id=instance_id,
+            endpoint_origin="http://127.0.0.1:8787",
+        )

--- a/packages/nest-core/tests/agent_test/test_http_driver_socket.py
+++ b/packages/nest-core/tests/agent_test/test_http_driver_socket.py
@@ -1,0 +1,1103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Real-socket component tests for the authenticated loopback HTTP driver."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import socket
+import threading
+import time
+from collections.abc import Callable, Generator, Iterable, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from nest_core.agent_test.driver import (
+    DriverCompatibilityError,
+    DriverConfigurationError,
+    DriverContractError,
+    DriverIncompleteError,
+    TownDriverError,
+)
+from nest_core.agent_test.http_driver import LoopbackHttpAgentDriver
+from nest_core.agent_test.models import DriverRequest, ResultDriver
+from nest_core.agent_test.profiles import resolve_test_profile
+
+FIXTURES = Path(__file__).parent / "fixtures"
+TOKEN = "0123456789abcdef" * 4
+INSTANCE = "01K00000000000000000000000"
+REMOTE_RESPONSE_CANARY = "REMOTE_RESPONSE_CANARY"
+REMOTE_MODEL_CANARY = "REMOTE_MODEL_CANARY"
+JSON_HEADERS = {
+    "Content-Type": "application/json",
+    "Town-Driver-Contract": "town-agent-driver/1",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _RecordedRequest:
+    method: str
+    path: str
+    headers: Mapping[str, str]
+    body: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class _Response:
+    status: int = 200
+    headers: Mapping[str, str] = field(default_factory=lambda: JSON_HEADERS)
+    chunks: tuple[bytes, ...] = ()
+    include_length: bool = True
+    close_without_response: bool = False
+    delay_seconds: float = 0.0
+    chunk_delay_seconds: float = 0.0
+    first_chunk_sent: threading.Event | None = None
+
+
+Responder = Callable[[_RecordedRequest, int], _Response]
+
+
+class _Server(ThreadingHTTPServer):
+    responder: Responder
+    requests: list[_RecordedRequest]
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._respond()
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._respond()
+
+    def _respond(self) -> None:
+        server = cast("_Server", self.server)
+        content_length = int(self.headers.get("Content-Length", "0"))
+        request = _RecordedRequest(
+            method=self.command,
+            path=self.path,
+            headers={key.lower(): value for key, value in self.headers.items()},
+            body=self.rfile.read(content_length),
+        )
+        server.requests.append(request)
+        response = server.responder(request, len(server.requests))
+        if response.delay_seconds:
+            time.sleep(response.delay_seconds)
+        if response.close_without_response:
+            self.connection.shutdown(socket.SHUT_RDWR)
+            self.connection.close()
+            return
+        self.send_response(response.status)
+        for key, value in response.headers.items():
+            self.send_header(key, value)
+        if response.include_length and "content-length" not in {
+            key.lower() for key in response.headers
+        }:
+            self.send_header("Content-Length", str(sum(map(len, response.chunks))))
+        self.end_headers()
+        try:
+            for index, chunk in enumerate(response.chunks):
+                if response.chunk_delay_seconds:
+                    time.sleep(response.chunk_delay_seconds)
+                self.wfile.write(chunk)
+                self.wfile.flush()
+                if index == 0 and response.first_chunk_sent is not None:
+                    response.first_chunk_sent.set()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+@contextmanager
+def _serve(responder: Responder) -> Generator[_Server]:
+    server = _Server(("127.0.0.1", 0), _Handler)
+    server.responder = responder
+    server.requests = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _json_bytes(value: object) -> bytes:
+    return json.dumps(value, separators=(",", ":")).encode()
+
+
+def _fixture(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _ready_data(**changes: object) -> dict[str, Any]:
+    data = _fixture("driver-ready.json")
+    for key, value in changes.items():
+        data[key] = value
+    return data
+
+
+def _request(name: str = "driver-start-request.json") -> DriverRequest:
+    return DriverRequest.model_validate(_fixture(name))
+
+
+def _success_data(request: _RecordedRequest, *, instance: str = INSTANCE) -> dict[str, Any]:
+    received = json.loads(request.body)
+    intent: dict[str, object]
+    if received["observation"]["kind"] == "start":
+        intent = {"kind": "declare_capability", "capabilities": ["sell"]}
+    elif received["observation"]["kind"] == "message":
+        intent = {
+            "kind": "send_to_sender",
+            "media_type": "text/plain; charset=utf-8",
+            "text": "sold:widget:2",
+        }
+    else:
+        intent = {"kind": "none"}
+    return {
+        "schema_version": "town-agent-driver/1",
+        "run_id": received["run_id"],
+        "event_id": received["event_id"],
+        "sequence": received["sequence"],
+        "adapter_instance_id": instance,
+        "request_digest": "sha256:" + hashlib.sha256(request.body).hexdigest(),
+        "intent": intent,
+    }
+
+
+def _error_data(request: _RecordedRequest, code: str, *, message: str = "safe") -> dict[str, Any]:
+    received = json.loads(request.body)
+    return {
+        "schema_version": "town-agent-driver-error/1",
+        "adapter_instance_id": INSTANCE,
+        "run_id": received["run_id"],
+        "event_id": received["event_id"],
+        "sequence": received["sequence"],
+        "request_digest": "sha256:" + hashlib.sha256(request.body).hexdigest(),
+        "error": {"code": code, "retryable": False, "message": message},
+    }
+
+
+def _ready_error_data(code: str, *, instance: str | None = None) -> dict[str, Any]:
+    return {
+        "schema_version": "town-agent-driver-error/1",
+        "adapter_instance_id": (
+            instance
+            if instance is not None
+            else (None if code == "AUTHENTICATION_FAILED" else INSTANCE)
+        ),
+        "run_id": None,
+        "event_id": None,
+        "sequence": None,
+        "request_digest": None,
+        "error": {"code": code, "retryable": False, "message": "safe"},
+    }
+
+
+def _standard_responder(request: _RecordedRequest, _: int) -> _Response:
+    if request.path == "/town-driver/1/ready":
+        return _Response(chunks=(_json_bytes(_ready_data()),))
+    return _Response(chunks=(_json_bytes(_success_data(request)),))
+
+
+def _origin(server: _Server) -> str:
+    return f"http://127.0.0.1:{server.server_port}"
+
+
+@pytest.mark.asyncio
+async def test_real_socket_uses_fixed_paths_exact_headers_body_digest_and_no_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Changing paths, bytes, digest input, or proxy policy breaks interoperability or isolation."""
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:1")
+    monkeypatch.setenv("NO_PROXY", "")
+    request = _request()
+    expected_body = request.model_dump_json().encode()
+    expected_digest = "sha256:" + hashlib.sha256(expected_body).hexdigest()
+
+    with _serve(_standard_responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        readiness = await driver.ready(resolve_test_profile("capability-fulfillment"))
+        response = await driver.decide(request)
+        await driver.close()
+
+    assert readiness.ready.accepting_runs is True
+    assert response.request_digest == expected_digest
+    assert [(item.method, item.path) for item in server.requests] == [
+        ("GET", "/town-driver/1/ready"),
+        ("POST", "/town-driver/1/decide"),
+    ]
+    ready_headers = server.requests[0].headers
+    decide_headers = server.requests[1].headers
+    for headers in (ready_headers, decide_headers):
+        assert headers["authorization"] == f"Bearer {TOKEN}"
+        assert headers["town-driver-contract"] == "town-agent-driver/1"
+        assert headers["accept"] == "application/json"
+        assert headers["accept-encoding"] == "identity"
+        assert "cookie" not in headers
+    assert "content-type" not in ready_headers
+    assert "town-request-digest" not in ready_headers
+    assert server.requests[0].body == b""
+    assert decide_headers["content-type"] == "application/json"
+    assert decide_headers["town-request-digest"] == expected_digest
+    assert server.requests[1].body == expected_body
+
+
+@pytest.mark.asyncio
+async def test_advisory_accepting_runs_false_does_not_block_start() -> None:
+    """Treating readiness capacity as a reservation would incorrectly skip a valid start."""
+
+    def responder(request: _RecordedRequest, _: int) -> _Response:
+        if request.path.endswith("/ready"):
+            return _Response(chunks=(_json_bytes(_ready_data(accepting_runs=False)),))
+        return _Response(chunks=(_json_bytes(_success_data(request)),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        readiness = await driver.ready(resolve_test_profile("capability-fulfillment"))
+        response = await driver.decide(_request())
+
+    assert readiness.ready.accepting_runs is False
+    assert response.intent.kind == "declare_capability"
+    assert len(server.requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_effective_limits_are_minimum_and_oversized_town_request_is_not_sent() -> None:
+    """Ignoring the adapter's smaller request limit could misattribute a Town defect."""
+
+    def responder(request: _RecordedRequest, _: int) -> _Response:
+        assert request.path.endswith("/ready")
+        data = _ready_data(
+            limits={"max_active_runs": 1, "max_request_bytes": 1, "max_response_bytes": 123}
+        )
+        return _Response(chunks=(_json_bytes(data),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        readiness = await driver.ready(resolve_test_profile("capability-fulfillment"))
+        with pytest.raises(TownDriverError, match="BODY_TOO_LARGE"):
+            await driver.decide(_request())
+
+    assert readiness.effective_limits.max_request_bytes == 1
+    assert readiness.effective_limits.max_response_bytes == 123
+    assert len(server.requests) == 1
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error_code"),
+    [
+        ({"schema_version": "town-agent-driver-ready/0.2"}, "UNSUPPORTED_CONTRACT"),
+        ({"contracts": ["town-agent-driver/0.2"]}, "UNSUPPORTED_CONTRACT"),
+        (
+            {
+                "profiles": [
+                    {
+                        "id": "nanda/agent/capability-fulfillment",
+                        "version": "0.2",
+                        "digest": "sha256:" + "0" * 64,
+                    }
+                ]
+            },
+            "UNSUPPORTED_PROFILE",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_readiness_requires_exact_contract_profile_version_and_digest(
+    mutation: dict[str, object], error_code: str
+) -> None:
+    """Accepting merely similar readiness metadata could run the wrong contract or profile."""
+    data = _ready_data(**mutation)
+
+    with _serve(lambda _request, _count: _Response(chunks=(_json_bytes(data),))) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        with pytest.raises(DriverCompatibilityError, match=error_code):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+
+@pytest.mark.asyncio
+async def test_readiness_rejects_nonpositive_adapter_limits_as_malformed_output() -> None:
+    """Accepting zero limits would make the negotiated boundary undefined."""
+    data = _ready_data(
+        limits={"max_active_runs": 1, "max_request_bytes": 0, "max_response_bytes": 65536}
+    )
+
+    with _serve(lambda _request, _count: _Response(chunks=(_json_bytes(data),))) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        with pytest.raises(DriverContractError, match="MALFORMED_RESPONSE"):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+
+@pytest.mark.asyncio
+async def test_readiness_nested_schema_failure_is_not_mislabeled_as_compatibility() -> None:
+    """Unknown identity fields are malformed adapter output, not an unsupported profile."""
+    data = _ready_data()
+    data["profiles"][0]["unexpected"] = True
+
+    with _serve(lambda _request, _count: _Response(chunks=(_json_bytes(data),))) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        with pytest.raises(DriverContractError, match="MALFORMED_RESPONSE"):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+
+@pytest.mark.parametrize("identity", ["contract", "profile"])
+@pytest.mark.asyncio
+async def test_readiness_validates_full_shape_before_classifying_identity(identity: str) -> None:
+    """A mixed malformed/mismatched readiness body is contract failure, not compatibility."""
+    data = _ready_data(unexpected=True)
+    if identity == "contract":
+        data["contracts"] = ["town-agent-driver/0.2"]
+    else:
+        data["profiles"] = [
+            {
+                "id": "nanda/agent/capability-fulfillment",
+                "version": "0.2",
+                "digest": "sha256:" + "0" * 64,
+            }
+        ]
+
+    with _serve(lambda _request, _count: _Response(chunks=(_json_bytes(data),))) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        with pytest.raises(DriverContractError, match="MALFORMED_RESPONSE"):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+
+@pytest.mark.parametrize(
+    ("status", "code", "expected_type"),
+    [
+        (401, "AUTHENTICATION_FAILED", DriverConfigurationError),
+        (422, "UNSUPPORTED_CONTRACT", DriverCompatibilityError),
+        (422, "UNSUPPORTED_PROFILE", DriverCompatibilityError),
+        (500, "ADAPTER_INTERNAL", DriverIncompleteError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_readiness_non_2xx_uses_the_typed_error_mapping(
+    status: int, code: str, expected_type: type[Exception]
+) -> None:
+    """Collapsing a valid readiness error into generic HTTP failure loses its disposition."""
+    response = _Response(status=status, chunks=(_json_bytes(_ready_error_data(code)),))
+
+    with _serve(lambda _request, _count: response) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        with pytest.raises(expected_type, match=code):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+
+@pytest.mark.parametrize(
+    ("status", "code", "expected_type"),
+    [
+        (401, "AUTHENTICATION_FAILED", DriverIncompleteError),
+        (422, "UNSUPPORTED_CONTRACT", DriverContractError),
+        (422, "UNSUPPORTED_PROFILE", DriverContractError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_readiness_error_mapping_is_admission_aware(
+    status: int, code: str, expected_type: type[Exception]
+) -> None:
+    """Post-admission readiness errors cannot regain pre-admission classifications."""
+    ready_calls = 0
+
+    def responder(request: _RecordedRequest, _: int) -> _Response:
+        nonlocal ready_calls
+        if request.path.endswith("/ready"):
+            ready_calls += 1
+            if ready_calls == 1:
+                return _Response(chunks=(_json_bytes(_ready_data()),))
+            return _Response(status=status, chunks=(_json_bytes(_ready_error_data(code)),))
+        return _Response(chunks=(_json_bytes(_success_data(request)),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        await driver.decide(_request())
+        with pytest.raises(expected_type, match=code):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+
+@pytest.mark.parametrize(
+    ("instance", "expected_type", "code"),
+    [
+        (None, DriverContractError, "ERROR_RESPONSE_MISMATCH"),
+        ("adapter.restarted", DriverIncompleteError, "ADAPTER_INSTANCE_CHANGED"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_authenticated_readiness_error_preserves_bound_instance(
+    instance: str | None, expected_type: type[Exception], code: str
+) -> None:
+    """Authenticated readiness errors must contain the bound adapter instance."""
+    ready_calls = 0
+
+    def responder(request: _RecordedRequest, _: int) -> _Response:
+        nonlocal ready_calls
+        if request.path.endswith("/ready"):
+            ready_calls += 1
+            if ready_calls == 1:
+                return _Response(chunks=(_json_bytes(_ready_data()),))
+            data = _ready_error_data("ADAPTER_INTERNAL", instance=instance)
+            if instance is None:
+                data["adapter_instance_id"] = None
+            return _Response(status=500, chunks=(_json_bytes(data),))
+        return _Response(chunks=(_json_bytes(_success_data(request)),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        await driver.decide(_request())
+        with pytest.raises(expected_type, match=code):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+
+@pytest.mark.asyncio
+async def test_pre_admission_readiness_restart_keeps_valid_compatibility_classification() -> None:
+    """Readiness does not reserve a run, so continuity begins only after start admission."""
+    ready_calls = 0
+
+    def responder(request: _RecordedRequest, _: int) -> _Response:
+        nonlocal ready_calls
+        if request.path.endswith("/ready"):
+            ready_calls += 1
+            if ready_calls == 1:
+                return _Response(chunks=(_json_bytes(_ready_data()),))
+            data = _ready_error_data("UNSUPPORTED_PROFILE", instance="adapter.restarted")
+            return _Response(status=422, chunks=(_json_bytes(data),))
+        raise AssertionError("pre-admission test must not decide")
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        with pytest.raises(DriverCompatibilityError, match="UNSUPPORTED_PROFILE"):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+
+@pytest.mark.asyncio
+async def test_adapter_instance_change_from_readiness_is_incomplete() -> None:
+    """Attributing output across an adapter restart would make evidence identity ambiguous."""
+
+    def responder(request: _RecordedRequest, _: int) -> _Response:
+        if request.path.endswith("/ready"):
+            return _Response(chunks=(_json_bytes(_ready_data()),))
+        body = _json_bytes(_success_data(request, instance="adapter.restarted"))
+        return _Response(chunks=(body,))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        with pytest.raises(DriverIncompleteError, match="ADAPTER_INSTANCE_CHANGED"):
+            await driver.decide(_request())
+
+
+@pytest.mark.parametrize(
+    ("status", "code", "admitted", "expected_type"),
+    [
+        (401, "AUTHENTICATION_FAILED", False, DriverConfigurationError),
+        (401, "AUTHENTICATION_FAILED", True, DriverIncompleteError),
+        (409, "RUN_BUSY", False, DriverIncompleteError),
+        (409, "EVENT_CONFLICT", True, DriverContractError),
+        (409, "OUT_OF_ORDER", True, DriverContractError),
+        (413, "BODY_TOO_LARGE", False, DriverContractError),
+        (422, "UNSUPPORTED_CONTRACT", False, DriverCompatibilityError),
+        (422, "UNSUPPORTED_PROFILE", False, DriverCompatibilityError),
+        (422, "UNSUPPORTED_CONTRACT", True, DriverContractError),
+        (422, "SCHEMA_INVALID", False, TownDriverError),
+        (500, "ADAPTER_INTERNAL", False, DriverIncompleteError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_complete_typed_http_error_mapping(
+    status: int,
+    code: str,
+    admitted: bool,
+    expected_type: type[Exception],
+) -> None:
+    """Mapping a typed adapter status to the wrong disposition corrupts the final verdict."""
+    call = 0
+
+    def responder(request: _RecordedRequest, _: int) -> _Response:
+        nonlocal call
+        if request.path.endswith("/ready"):
+            return _Response(chunks=(_json_bytes(_ready_data()),))
+        call += 1
+        if admitted and call == 1:
+            return _Response(chunks=(_json_bytes(_success_data(request)),))
+        return _Response(status=status, chunks=(_json_bytes(_error_data(request, code)),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        if admitted:
+            await driver.decide(_request())
+        request = _request("driver-message-request.json") if admitted else _request()
+        with pytest.raises(expected_type, match=code):
+            await driver.decide(request)
+
+
+@pytest.mark.asyncio
+async def test_authenticated_error_requires_nonnull_adapter_instance() -> None:
+    """Treating a missing authenticated instance as a restart would hide malformed output."""
+
+    def responder(request: _RecordedRequest, _: int) -> _Response:
+        if request.path.endswith("/ready"):
+            return _Response(chunks=(_json_bytes(_ready_data()),))
+        data = _error_data(request, "RUN_BUSY")
+        data["adapter_instance_id"] = None
+        return _Response(status=409, chunks=(_json_bytes(data),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        with pytest.raises(DriverContractError, match="ERROR_RESPONSE_MISMATCH"):
+            await driver.decide(_request())
+
+
+@pytest.mark.asyncio
+async def test_untyped_non_2xx_is_authenticated_malformed_output() -> None:
+    """Treating an untyped HTTP failure as target behavior would misattribute adapter output."""
+
+    def responder(request: _RecordedRequest, _: int) -> _Response:
+        if request.path.endswith("/ready"):
+            return _Response(chunks=(_json_bytes(_ready_data()),))
+        return _Response(status=503, chunks=(b'{"error":"no typed envelope"}',))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        with pytest.raises(DriverContractError, match="MALFORMED_ERROR_RESPONSE"):
+            await driver.decide(_request())
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        _Response(headers={"Town-Driver-Contract": "town-agent-driver/1"}, chunks=(b"{}",)),
+        _Response(
+            headers={
+                "Content-Type": "text/plain",
+                "Town-Driver-Contract": "town-agent-driver/1",
+            },
+            chunks=(b"{}",),
+        ),
+        _Response(headers={"Content-Type": "application/json"}, chunks=(b"{}",)),
+        _Response(
+            headers={
+                **JSON_HEADERS,
+                "Content-Encoding": "gzip",
+            },
+            chunks=(b"not-gzip",),
+        ),
+        _Response(headers={**JSON_HEADERS, "Set-Cookie": "session=bad"}, chunks=(b"{}",)),
+        _Response(status=307, headers={**JSON_HEADERS, "Location": "/elsewhere"}, chunks=(b"{}",)),
+        _Response(chunks=(b"not json",)),
+        _Response(chunks=(_json_bytes({**_ready_data(), "unexpected": True}),)),
+        _Response(headers={**JSON_HEADERS, "Content-Length": "65537"}, chunks=()),
+        _Response(chunks=(b"x" * 32768, b"y" * 32769), include_length=False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_bounded_read_and_response_metadata_reject_malformed_adapter_output(
+    response: _Response,
+) -> None:
+    """Allocating or accepting an unbounded/non-contract response crosses the strict boundary."""
+    with _serve(lambda _request, _count: response) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        with pytest.raises(DriverContractError):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("run_id", "01K00000000000000000000009"),
+        ("event_id", "01K00000000000000000000009"),
+        ("sequence", 9),
+        ("request_digest", "sha256:" + "f" * 64),
+    ],
+)
+@pytest.mark.asyncio
+async def test_decide_rejects_wrong_echoed_request_identity(field: str, value: object) -> None:
+    """Applying a response to the wrong request would break event attribution."""
+
+    def responder(request: _RecordedRequest, _: int) -> _Response:
+        if request.path.endswith("/ready"):
+            return _Response(chunks=(_json_bytes(_ready_data()),))
+        response = _success_data(request)
+        response[field] = value
+        return _Response(chunks=(_json_bytes(response),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        with pytest.raises(DriverContractError, match="RESPONSE_MISMATCH"):
+            await driver.decide(_request())
+
+
+@pytest.mark.asyncio
+async def test_redirect_is_not_followed_and_transport_failure_is_not_retried() -> None:
+    """Following or retrying can replay an authenticated event without protocol authority."""
+
+    def redirect(request: _RecordedRequest, _: int) -> _Response:
+        return _Response(status=307, headers={**JSON_HEADERS, "Location": "/elsewhere"})
+
+    with _serve(redirect) as redirect_server:
+        driver = LoopbackHttpAgentDriver(_origin(redirect_server), TOKEN)
+        with pytest.raises(DriverContractError, match="REDIRECT_RESPONSE"):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+    assert len(redirect_server.requests) == 1
+
+    def disconnect(_request: _RecordedRequest, _count: int) -> _Response:
+        return _Response(close_without_response=True)
+
+    with _serve(disconnect) as disconnect_server:
+        driver = LoopbackHttpAgentDriver(_origin(disconnect_server), TOKEN)
+        with pytest.raises(DriverIncompleteError, match="TRANSPORT_LOSS"):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+    assert len(disconnect_server.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_incomplete_and_not_retried() -> None:
+    """A wall timeout is absence of evidence, never a target verdict or replay permission."""
+    response = _Response(chunks=(_json_bytes(_ready_data()),), delay_seconds=0.2)
+
+    with _serve(lambda _request, _count: response) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN, timeout_seconds=0.03)
+        with pytest.raises(DriverIncompleteError, match="TIMEOUT"):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+    assert len(server.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_a_wall_deadline_even_when_response_bytes_keep_arriving() -> None:
+    """Slow drip traffic must not extend a decision beyond the configured wall deadline."""
+    body = _json_bytes(_ready_data())
+    response = _Response(
+        chunks=tuple(body[index : index + 16] for index in range(0, len(body), 16)),
+        chunk_delay_seconds=0.02,
+    )
+
+    with _serve(lambda _request, _count: response) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN, timeout_seconds=0.08)
+        started = time.monotonic()
+        with pytest.raises(DriverIncompleteError, match="TIMEOUT"):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+        elapsed = time.monotonic() - started
+
+    assert elapsed < 0.35
+    assert len(server.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_set_cookie_is_rejected_without_persisting_it_to_a_later_request() -> None:
+    """A rejected response must not seed ambient cookie state for later authenticated calls."""
+
+    def responder(_request: _RecordedRequest, count: int) -> _Response:
+        headers = {**JSON_HEADERS, **({"Set-Cookie": "session=secret"} if count == 1 else {})}
+        return _Response(headers=headers, chunks=(_json_bytes(_ready_data()),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        with pytest.raises(DriverContractError, match="COOKIE_RESPONSE"):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+    assert "cookie" not in server.requests[1].headers
+
+
+def _recursive_text(value: object, seen: set[int] | None = None) -> str:
+    seen = seen or set()
+    if id(value) in seen:
+        return ""
+    seen.add(id(value))
+    pieces = [str(value), repr(value)]
+    if isinstance(value, BaseException):
+        pieces.extend(_recursive_text(item, seen) for item in value.args)
+        pieces.append(_recursive_text(value.__context__, seen))
+        pieces.append(_recursive_text(value.__cause__, seen))
+        pieces.append(_recursive_text(vars(value), seen))
+    elif isinstance(value, Mapping):
+        mapping = cast("Mapping[object, object]", value)
+        for key, item in mapping.items():
+            pieces.append(_recursive_text(key, seen))
+            pieces.append(_recursive_text(item, seen))
+    elif isinstance(value, (list, tuple, set)):
+        iterable = cast("Iterable[object]", value)
+        pieces.extend(_recursive_text(item, seen) for item in iterable)
+    return "\n".join(pieces)
+
+
+def _traceback_locals_text(error: BaseException) -> str:
+    pieces: list[str] = []
+    traceback = error.__traceback__
+    while traceback is not None:
+        for name, value in traceback.tb_frame.f_locals.items():
+            pieces.append(f"{name}={value!r}")
+        traceback = traceback.tb_next
+    return "\n".join(pieces)
+
+
+@pytest.mark.asyncio
+async def test_failure_tracebacks_retain_no_bearer_or_remote_response_state() -> None:
+    """Sanitized errors must be raised only after all secret-bearing frames have returned."""
+
+    def responder(_request: _RecordedRequest, count: int) -> _Response:
+        if count == 1:
+            data = _ready_error_data("ADAPTER_INTERNAL")
+            data["adapter_instance_id"] = REMOTE_MODEL_CANARY
+            data["error"]["message"] = f"{TOKEN}-{REMOTE_RESPONSE_CANARY}"
+            return _Response(status=500, chunks=(_json_bytes(data),))
+        return _Response(close_without_response=True)
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        for expected_code in ("ADAPTER_INTERNAL", "TRANSPORT_LOSS"):
+            try:
+                await driver.ready(resolve_test_profile("capability-fulfillment"))
+            except DriverIncompleteError as exc:
+                assert exc.code == expected_code
+                traceback_text = _traceback_locals_text(exc)
+                assert TOKEN not in traceback_text
+                assert REMOTE_RESPONSE_CANARY not in traceback_text
+                assert REMOTE_MODEL_CANARY not in traceback_text
+            else:
+                raise AssertionError("failure response was accepted")
+
+
+@pytest.mark.parametrize("payload_kind", ["huge_integer", "deep_json"])
+@pytest.mark.asyncio
+async def test_pathological_valid_json_is_a_sanitized_malformed_response(
+    payload_kind: str,
+) -> None:
+    """Bounded parser limits cannot bypass the safe driver-contract failure boundary."""
+
+    def responder(request: _RecordedRequest, _count: int) -> _Response:
+        if request.path.endswith("/ready"):
+            return _Response(chunks=(_json_bytes(_ready_data()),))
+        canary = json.dumps(f"{TOKEN}-{REMOTE_RESPONSE_CANARY}").encode()
+        if payload_kind == "huge_integer":
+            body = b'{"canary":' + canary + b',"value":' + (b"9" * 5000) + b"}"
+        else:
+            body = (
+                b'{"canary":'
+                + canary
+                + b',"value":'
+                + (b"[" * 10000)
+                + b"0"
+                + (b"]" * 10000)
+                + b"}"
+            )
+        return _Response(chunks=(body,))
+
+    caught: BaseException | None = None
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        try:
+            await driver.decide(_request())
+        except BaseException as exc:  # cancellation is asserted separately below
+            caught = exc
+
+    if caught is None:
+        raise AssertionError("pathological JSON response was accepted")
+    traceback_text = _traceback_locals_text(caught)
+    diagnostic = (
+        type(caught).__name__,
+        TOKEN in traceback_text,
+        REMOTE_RESPONSE_CANARY in traceback_text,
+        caught.__context__ is not None,
+        caught.__cause__ is not None,
+    )
+    assert diagnostic == (
+        "DriverContractError",
+        False,
+        False,
+        False,
+        False,
+    ), f"safe diagnostic mismatch: {diagnostic!r}"
+    assert isinstance(caught, DriverContractError)
+    assert caught.code == "MALFORMED_RESPONSE"
+    assert TOKEN not in _recursive_text(caught)
+    assert REMOTE_RESPONSE_CANARY not in _recursive_text(caught)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_preserves_native_state_without_sensitive_traceback_locals() -> None:
+    """Cancellation must unwind bearer, raw-response, and parsed-model frames before resurfacing."""
+    first_chunk_sent = threading.Event()
+
+    def responder(request: _RecordedRequest, _: int) -> _Response:
+        if request.path.endswith("/ready"):
+            data = _ready_data(adapter_instance_id=REMOTE_MODEL_CANARY)
+            return _Response(chunks=(_json_bytes(data),))
+        data = _success_data(request, instance=REMOTE_MODEL_CANARY)
+        data["unexpected"] = REMOTE_RESPONSE_CANARY
+        body = _json_bytes(data)
+        split = body.index(REMOTE_RESPONSE_CANARY.encode()) + len(REMOTE_RESPONSE_CANARY)
+        return _Response(
+            chunks=(body[:split], body[split:]),
+            chunk_delay_seconds=0.2,
+            first_chunk_sent=first_chunk_sent,
+        )
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        task = asyncio.create_task(driver.decide(_request()))
+        assert await asyncio.to_thread(first_chunk_sent.wait, 2)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError as exc:
+            traceback_text = _traceback_locals_text(exc)
+            assert TOKEN not in traceback_text
+            assert REMOTE_RESPONSE_CANARY not in traceback_text
+            assert REMOTE_MODEL_CANARY not in traceback_text
+        else:
+            raise AssertionError("cancelled driver task returned normally")
+
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_successful_readiness_rejects_bearer_echo_before_public_model() -> None:
+    """A hostile adapter cannot turn the configured bearer into public readiness metadata."""
+    with _serve(
+        lambda _request, _count: _Response(
+            chunks=(_json_bytes(_ready_data(adapter_instance_id=TOKEN)),)
+        )
+    ) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        with pytest.raises(DriverContractError, match="MALFORMED_RESPONSE") as caught:
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+    assert TOKEN not in _recursive_text(caught.value)
+    assert TOKEN not in _traceback_locals_text(caught.value)
+
+
+@pytest.mark.parametrize("placement", ["prefix", "suffix"])
+@pytest.mark.asyncio
+async def test_successful_readiness_rejects_embedded_bearer_before_public_model(
+    placement: str,
+) -> None:
+    """Adapter metadata cannot wrap the complete bearer in otherwise valid text."""
+
+    def responder(_request: _RecordedRequest, _count: int) -> _Response:
+        instance_id = f"adapter:{TOKEN}" if placement == "prefix" else f"{TOKEN}:adapter"
+        return _Response(chunks=(_json_bytes(_ready_data(adapter_instance_id=instance_id)),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        with pytest.raises(DriverContractError, match="MALFORMED_RESPONSE") as caught:
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+    assert TOKEN not in _recursive_text(caught.value)
+    assert TOKEN not in _traceback_locals_text(caught.value)
+
+
+@pytest.mark.parametrize("placement", ["exact", "prefix", "suffix"])
+@pytest.mark.asyncio
+async def test_successful_decision_rejects_embedded_bearer_before_public_model(
+    placement: str,
+) -> None:
+    """A successful adapter response cannot route the complete bearer into public state."""
+    surfaced: list[object] = []
+    caught: DriverContractError | None = None
+
+    def responder(request: _RecordedRequest, _count: int) -> _Response:
+        if request.path.endswith("/ready"):
+            return _Response(chunks=(_json_bytes(_ready_data()),))
+        data = _success_data(request)
+        received = json.loads(request.body)
+        if received["observation"]["kind"] == "message":
+            data["intent"]["text"] = {
+                "exact": TOKEN,
+                "prefix": f"adapter:{TOKEN}",
+                "suffix": f"{TOKEN}:adapter",
+            }[placement]
+        return _Response(chunks=(_json_bytes(data),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        await driver.decide(_request())
+        try:
+            response = await driver.decide(_request("driver-message-request.json"))
+        except DriverContractError as exc:
+            caught = exc
+        else:
+            surfaced.extend(
+                [
+                    response,
+                    response.model_dump_json(),
+                    {"trace": response.intent.model_dump()},
+                ]
+            )
+
+    assert TOKEN not in _recursive_text(surfaced)
+    assert caught is not None
+    assert caught.code == "MALFORMED_RESPONSE"
+    assert TOKEN not in _recursive_text(caught)
+    assert TOKEN not in _traceback_locals_text(caught)
+
+
+@pytest.mark.asyncio
+async def test_deep_successful_decision_secret_rejection_remains_sanitized() -> None:
+    """Adapter nesting cannot bypass the safe driver-contract failure boundary."""
+
+    def responder(request: _RecordedRequest, _count: int) -> _Response:
+        if request.path.endswith("/ready"):
+            return _Response(chunks=(_json_bytes(_ready_data()),))
+        data = _success_data(request)
+        nested: object = TOKEN
+        for _ in range(600):
+            nested = [nested]
+        data["future"] = nested
+        return _Response(chunks=(_json_bytes(data),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        with pytest.raises(DriverContractError, match="MALFORMED_RESPONSE") as caught:
+            await driver.decide(_request())
+
+    assert TOKEN not in _recursive_text(caught.value)
+    assert TOKEN not in _traceback_locals_text(caught.value)
+
+
+@pytest.mark.parametrize(
+    "response_text",
+    [TOKEN[:-1], TOKEN.upper(), "sold:widget:2"],
+    ids=["partial", "transformed", "unrelated"],
+)
+@pytest.mark.asyncio
+async def test_nonmatching_successful_decision_text_remains_available(response_text: str) -> None:
+    """The secret guard must not broaden to partial, transformed, or unrelated strings."""
+
+    def responder(request: _RecordedRequest, _count: int) -> _Response:
+        if request.path.endswith("/ready"):
+            return _Response(chunks=(_json_bytes(_ready_data()),))
+        data = _success_data(request)
+        received = json.loads(request.body)
+        if received["observation"]["kind"] == "message":
+            data["intent"]["text"] = response_text
+        return _Response(chunks=(_json_bytes(data),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        await driver.ready(resolve_test_profile("capability-fulfillment"))
+        await driver.decide(_request())
+        response = await driver.decide(_request("driver-message-request.json"))
+
+    assert response.intent.kind == "send_to_sender"
+    assert response.intent.text == response_text
+
+
+@pytest.mark.asyncio
+async def test_bearer_echo_cannot_reach_result_driver_path() -> None:
+    """Result metadata must never be constructed from echoed bearer readiness state."""
+    with _serve(
+        lambda _request, _count: _Response(
+            chunks=(_json_bytes(_ready_data(adapter_instance_id=TOKEN)),)
+        )
+    ) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        try:
+            readiness = await driver.ready(resolve_test_profile("capability-fulfillment"))
+            result_driver = ResultDriver(
+                contract="town-agent-driver/1",
+                kind="loopback-http",
+                adapter_instance_id=readiness.ready.adapter_instance_id,
+                endpoint_origin=driver.endpoint_origin,
+            )
+        except DriverContractError as exc:
+            assert exc.code == "MALFORMED_RESPONSE"
+            assert TOKEN not in _recursive_text(exc)
+        else:
+            assert TOKEN not in result_driver.model_dump_json()
+
+
+@pytest.mark.parametrize("placement", ["prefix", "suffix"])
+@pytest.mark.asyncio
+async def test_embedded_bearer_cannot_reach_result_driver_serialization(placement: str) -> None:
+    """Result metadata cannot serialize an adapter instance containing the complete bearer."""
+
+    def responder(_request: _RecordedRequest, _count: int) -> _Response:
+        instance_id = f"adapter:{TOKEN}" if placement == "prefix" else f"{TOKEN}:adapter"
+        return _Response(chunks=(_json_bytes(_ready_data(adapter_instance_id=instance_id)),))
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        try:
+            readiness = await driver.ready(resolve_test_profile("capability-fulfillment"))
+            result_driver = ResultDriver(
+                contract="town-agent-driver/1",
+                kind="loopback-http",
+                adapter_instance_id=readiness.ready.adapter_instance_id,
+                endpoint_origin=driver.endpoint_origin,
+            )
+        except DriverContractError as exc:
+            assert exc.code == "MALFORMED_RESPONSE"
+            assert TOKEN not in _recursive_text(exc)
+            assert TOKEN not in _traceback_locals_text(exc)
+        else:
+            assert TOKEN not in result_driver.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_request_time_origin_revalidation_rejects_private_mutation_without_transport() -> (
+    None
+):
+    """Even adversarial private mutation must fail before the bearer reaches a socket."""
+    with _serve(_standard_responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        object.__setattr__(driver, "_endpoint_origin", f"https://127.0.0.1:{server.server_port}")
+        with pytest.raises(DriverConfigurationError, match="INVALID_ENDPOINT"):
+            await driver.ready(resolve_test_profile("capability-fulfillment"))
+
+    assert server.requests == []
+
+
+@pytest.mark.asyncio
+async def test_secret_canary_never_reaches_errors_diagnostics_digests_or_models() -> None:
+    """Echoing the bearer from a hostile adapter must not leak it through surfaced state."""
+    surfaced: list[object] = ["", ""]  # stdout/stderr surrogates
+
+    def responder(request: _RecordedRequest, _: int) -> _Response:
+        if request.path.endswith("/ready"):
+            return _Response(chunks=(_json_bytes(_ready_data()),))
+        return _Response(
+            status=500,
+            chunks=(_json_bytes(_error_data(request, "ADAPTER_INTERNAL", message=TOKEN)),),
+        )
+
+    with _serve(responder) as server:
+        driver = LoopbackHttpAgentDriver(_origin(server), TOKEN)
+        readiness = await driver.ready(resolve_test_profile("capability-fulfillment"))
+        request = _request()
+        try:
+            await driver.decide(request)
+        except DriverIncompleteError as exc:
+            surfaced.append(exc)
+        else:
+            raise AssertionError("malicious error response was accepted")
+
+    request_digest = "sha256:" + hashlib.sha256(server.requests[-1].body).hexdigest()
+    surfaced.extend(
+        [
+            request_digest,
+            readiness.model_dump_json(),
+            request.model_dump_json(),
+        ]
+    )
+    assert TOKEN not in _recursive_text(surfaced)

--- a/uv.lock
+++ b/uv.lock
@@ -1354,6 +1354,7 @@ version = "0.1.4"
 source = { editable = "packages/nest-core" }
 dependencies = [
     { name = "cryptography" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "typer" },
@@ -1374,6 +1375,7 @@ plugins = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=41.0" },
+    { name = "httpx", specifier = ">=0.28" },
     { name = "nest-core", extras = ["plugins", "llm"], marker = "extra == 'full'", editable = "packages/nest-core" },
     { name = "nest-plugins-reference", marker = "extra == 'plugins'", editable = "packages/nest-plugins-reference" },
     { name = "nest-shell", marker = "extra == 'llm'", editable = "packages/nest-shell" },


### PR DESCRIPTION
## Problem

Town needs a small local adapter transport with strict authentication, bounds, timeouts, and failure attribution before external agents can safely participate in a test run.

## Change

- add an authenticated literal-loopback HTTP driver for the version 1 wire contract
- enforce canonical origins, fixed paths/headers, body limits, digest binding, and no proxy/redirect behavior
- sanitize remote/parser failures and bind responses to the originating profile codec
- add real-socket adversarial and golden-vector coverage

## Verification

- final stack: `make ci-local` — all 5 checks passed; 2,081 passed, 2 skipped, 1 deselected
- socket-level transport, timeout, cancellation, parser-limit, and secret-canary tests pass
- independent security review found no Critical or Important issues

## Stack

**3 of 9. Depends on PR 2.** PR 4 targets this branch. This PR is transport only; orchestration and user commands follow.

**Merge note:** After #221 merges into `main`, retarget this PR to `main`, wait for its CI, and only then merge it.