### PR TITLE
feat(agent-test): evaluate external agents in Town

### DIFF
--- a/packages/nest-core/nest_core/agent_test/artifacts.py
+++ b/packages/nest-core/nest_core/agent_test/artifacts.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exclusive artifact-directory ownership and deterministic terminal writers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Sequence
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import TypeAdapter, ValidationError
+
+from .models import ULID, ResultArtifact, TestObservation, TestResult
+
+LOCAL_ARTIFACT_BOUNDARY = (
+    "Artifact output must be on a local filesystem in a directory controlled by the invoking "
+    "user. Town is not a privilege boundary and does not defend against another process running "
+    "as the same OS user, hostile filesystem behavior, or path replacement during a run. It "
+    "refuses files, direct symlinks, non-empty directories, and existing artifact names, and "
+    "never intentionally overwrites caller data. On POSIX, Town-created run directories and "
+    "artifact files use modes 0700 and 0600. Existing caller-owned directories keep their "
+    "modes; Town does not recursively chmod them. Do not run Town elevated. Local artifacts "
+    "are mutable diagnostic files, not attestations. If adapter/model is untrusted, sandbox "
+    "without artifact output mount."
+)
+
+_TRACE_LINE_ADAPTER = TypeAdapter(dict[str, object])
+
+
+def _private_file_opener(path: str, flags: int) -> int:
+    return os.open(path, flags, 0o600)
+
+
+def _create_missing_private_directories(path: Path) -> None:
+    """Create only missing POSIX hierarchy components with mode 0700."""
+    missing: list[Path] = []
+    current = path
+    while not current.exists():
+        missing.append(current)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    for directory in reversed(missing):
+        directory.mkdir(mode=0o700, exist_ok=True)
+
+
+class ArtifactDirectoryError(ValueError):
+    """The requested output target is not safe for exclusive run ownership."""
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactStaging:
+    """Invocation-owned trace staging that leaves the requested target untouched."""
+
+    path: Path
+    target: Path
+    generated: bool
+    target_identity: tuple[int, int] | None
+
+    @property
+    def trace_path(self) -> Path:
+        return self.path / "trace.jsonl"
+
+    def promote(self, *, run_id: ULID) -> ArtifactDirectory:
+        """Publish the closed trace into the validated final directory."""
+        validate_artifact_target(
+            run_id=run_id,
+            output_dir=None if self.generated else self.target,
+            base_dir=self.target.parents[2] if self.generated else None,
+        )
+        target_created = False
+        if self.target_identity is not None:
+            current = self.target.stat(follow_symlinks=False)
+            if (current.st_dev, current.st_ino) != self.target_identity:
+                raise ArtifactDirectoryError("output target identity changed before admission")
+        else:
+            try:
+                self.target.mkdir(mode=0o700, exist_ok=False)
+                target_created = True
+            except OSError as exc:
+                raise ArtifactDirectoryError("output target could not be claimed") from exc
+        try:
+            os.link(self.trace_path, self.target / "trace.jsonl")
+        except OSError as exc:
+            if target_created:
+                with suppress(OSError):
+                    self.target.rmdir()
+            raise ArtifactDirectoryError("closed trace could not be published") from exc
+        self.trace_path.unlink()
+        self.path.rmdir()
+        return ArtifactDirectory(path=self.target, generated=self.generated)
+
+    def discard(self) -> None:
+        """Best-effort removal of only this invocation's private staged bytes."""
+        with suppress(OSError):
+            self.trace_path.unlink()
+        with suppress(OSError):
+            self.path.rmdir()
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactDirectory:
+    """A validated directory owned exclusively by one admitted agent-test run."""
+
+    path: Path
+    generated: bool
+
+    @property
+    def trace_path(self) -> Path:
+        return self.path / "trace.jsonl"
+
+    @property
+    def result_path(self) -> Path:
+        return self.path / "result.json"
+
+    def finalize_trace(self, observations: Sequence[TestObservation]) -> ResultArtifact:
+        """Verify closed exact trace/runtime parity, then digest the terminal bytes."""
+        try:
+            content = self.trace_path.read_bytes()
+        except OSError as exc:
+            raise ArtifactDirectoryError("trace is not available for finalization") from exc
+        if not content.endswith(b"\n"):
+            raise ArtifactDirectoryError("trace must be terminally flushed with a final LF")
+        parsed_observations: list[TestObservation] = []
+        try:
+            for line in content.splitlines():
+                value = _TRACE_LINE_ADAPTER.validate_json(line)
+                if str(value.get("kind", "")).startswith("test."):
+                    parsed_observations.append(TestObservation.model_validate(value))
+        except (UnicodeDecodeError, ValidationError) as exc:
+            raise ArtifactDirectoryError("trace contains invalid test observation bytes") from exc
+        actual = [item.model_dump(mode="json") for item in parsed_observations]
+        expected = [item.model_dump(mode="json") for item in observations]
+        if actual != expected:
+            raise ArtifactDirectoryError("trace and runtime observations must match exactly")
+        return ResultArtifact(
+            kind="trace",
+            path="trace.jsonl",
+            media_type="application/x-ndjson",
+            digest="sha256:" + hashlib.sha256(content).hexdigest(),
+        )
+
+    def write_result(self, result: TestResult) -> bytes:
+        """Atomically publish deterministic result bytes once, after all other artifacts."""
+        if self.generated and self.path.name != result.run_id:
+            raise ArtifactDirectoryError("generated output directory must match the result run ID")
+        if self.result_path.exists() or self.result_path.is_symlink():
+            raise ArtifactDirectoryError("result.json is already present")
+        content = (
+            json.dumps(result.model_dump(mode="json"), sort_keys=True, separators=(",", ":")) + "\n"
+        ).encode()
+        temporary = self.path / f".result-{result.run_id}.tmp"
+        try:
+            with open(temporary, "xb", opener=_private_file_opener) as stream:
+                stream.write(content)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.link(temporary, self.result_path)
+        except FileExistsError as exc:
+            raise ArtifactDirectoryError("result.json is already present") from exc
+        finally:
+            with suppress(FileNotFoundError):
+                temporary.unlink()
+        return content
+
+
+def prepare_artifact_directory(
+    *,
+    run_id: ULID,
+    output_dir: Path | None,
+    base_dir: Path | None = None,
+) -> ArtifactDirectory:
+    """Validate the complete target first, then claim it without opening writers."""
+    generated = output_dir is None
+    target = validate_artifact_target(run_id=run_id, output_dir=output_dir, base_dir=base_dir)
+    if not target.exists():
+        try:
+            if generated:
+                _create_missing_private_directories(target.parent)
+                target.mkdir(mode=0o700, exist_ok=False)
+            else:
+                target.mkdir(mode=0o700, parents=True, exist_ok=False)
+        except OSError as exc:
+            raise ArtifactDirectoryError("output target could not be claimed") from exc
+    return ArtifactDirectory(path=target, generated=generated)
+
+
+def prepare_artifact_staging(
+    *,
+    run_id: ULID,
+    output_dir: Path | None,
+    base_dir: Path | None = None,
+) -> ArtifactStaging:
+    """Create private same-filesystem trace staging without claiming the final target."""
+    generated = output_dir is None
+    target = validate_artifact_target(run_id=run_id, output_dir=output_dir, base_dir=base_dir)
+    target_identity: tuple[int, int] | None = None
+    if target.exists():
+        current = target.stat(follow_symlinks=False)
+        target_identity = (current.st_dev, current.st_ino)
+    try:
+        if generated:
+            _create_missing_private_directories(target.parent)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+        staging = Path(tempfile.mkdtemp(prefix=f".{target.name}.staging-", dir=target.parent))
+    except OSError as exc:
+        raise ArtifactDirectoryError("artifact staging could not be created") from exc
+    return ArtifactStaging(
+        path=staging,
+        target=target,
+        generated=generated,
+        target_identity=target_identity,
+    )
+
+
+def validate_artifact_target(
+    *,
+    run_id: ULID,
+    output_dir: Path | None,
+    base_dir: Path | None = None,
+) -> Path:
+    """Validate an output target without creating, opening, or mutating it."""
+    generated = output_dir is None
+    root = Path.cwd() if base_dir is None else base_dir
+    target = root / ".town" / "runs" / run_id if output_dir is None else output_dir
+    if target.is_symlink() or (target.exists() and not target.is_dir()):
+        raise ArtifactDirectoryError("output target must be a non-symlink directory")
+    if target.exists() and (generated or any(target.iterdir())):
+        raise ArtifactDirectoryError("output target must not already contain entries")
+    return target

--- a/packages/nest-core/nest_core/agent_test/driven_agent.py
+++ b/packages/nest-core/nest_core/agent_test/driven_agent.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Transport-neutral simulator participant controlled by one AgentDriver."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Callable
+from typing import Literal, cast
+
+from pydantic import ValidationError
+
+from nest_core.sim.agent import AgentContext, ScenarioAgentContext, StateMachineAgent
+from nest_core.types import AgentCard, AgentId
+
+from .capability_profile import CapabilityParticipant
+from .driver import (
+    AgentDriver,
+    AgentDriverError,
+    DriverCompatibilityError,
+    DriverConfigurationError,
+    DriverContractError,
+    DriverFailureDisposition,
+    DriverIncompleteError,
+    TownDriverError,
+)
+from .ids import new_ulid
+from .models import (
+    ULID,
+    DeclareCapabilityIntent,
+    DriverMessage,
+    DriverReadiness,
+    DriverRequest,
+    DriverResponse,
+    MessageDriverObservation,
+    SendToSenderIntent,
+    StartDriverObservation,
+    StopDriverObservation,
+)
+from .profile_codecs import BoundProfileCodec
+from .profiles import (
+    ResolvedTestProfile,
+    capability_profile_document,
+    capability_profile_reference,
+)
+
+
+def _logical_time(value: float) -> int:
+    if not math.isfinite(value) or value < 0 or not value.is_integer():
+        raise TownDriverError("INVALID_LOGICAL_TIME")
+    return int(value)
+
+
+def _request_digest(request: DriverRequest) -> str:
+    return "sha256:" + hashlib.sha256(request.model_dump_json().encode()).hexdigest()
+
+
+def _payload_digest(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _validate_response(
+    request: DriverRequest,
+    response: DriverResponse,
+    adapter_instance_id: str,
+    profile_codec: BoundProfileCodec,
+) -> DriverResponse:
+    try:
+        validated = cast(
+            "DriverResponse",
+            profile_codec.validate_response(response.model_dump(mode="json")),
+        )
+    except (AttributeError, ValidationError, ValueError):
+        raise DriverContractError("MALFORMED_RESPONSE") from None
+    if validated.adapter_instance_id != adapter_instance_id:
+        raise DriverIncompleteError("ADAPTER_INSTANCE_CHANGED")
+    if (
+        validated.run_id != request.run_id
+        or validated.event_id != request.event_id
+        or validated.sequence != request.sequence
+        or validated.request_digest != _request_digest(request)
+    ):
+        raise DriverContractError("RESPONSE_MISMATCH")
+    if validated.intent.kind not in request.observation.allowed_intents:
+        raise DriverContractError("INTENT_NOT_ALLOWED")
+    return validated
+
+
+def _failure_disposition(error: AgentDriverError) -> str:
+    if error.disposition == DriverFailureDisposition.CONTRACT:
+        return "driver_contract"
+    if error.disposition == DriverFailureDisposition.INCOMPLETE:
+        return "incomplete"
+    return "town"
+
+
+class DrivenAgent(StateMachineAgent):
+    """One profile-bound provider whose permitted actions come from an AgentDriver."""
+
+    def __init__(
+        self,
+        *,
+        driver: AgentDriver,
+        run_id: ULID,
+        resolved_profile: ResolvedTestProfile,
+        readiness: DriverReadiness,
+        event_id_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self._driver = driver
+        self._run_id = run_id
+        self._resolved_profile = resolved_profile
+        self._readiness = readiness
+        self._event_id_factory = event_id_factory or new_ulid
+        self._start_request: DriverRequest | None = None
+        self._start_response: DriverResponse | None = None
+        self._start_applied = False
+        self._capability_declared = False
+        self._message_request: DriverRequest | None = None
+        self._message_response: DriverResponse | None = None
+        self._message_applied = False
+        self._admitted = False
+        self._last_logical_time = 0
+        self._stop_attempted = False
+        self._driver_event_ids: set[str] = set()
+
+    @property
+    def admitted(self) -> bool:
+        """Whether a valid start response bound the adapter to this run."""
+        return self._admitted
+
+    @property
+    def logical_time_end(self) -> int:
+        """Last validated integral Town logical time observed by this participant."""
+        return self._last_logical_time
+
+    def _new_driver_event_id(self) -> str:
+        event_id = self._event_id_factory()
+        if event_id in self._driver_event_ids:
+            raise TownDriverError("EVENT_CONFLICT")
+        self._driver_event_ids.add(event_id)
+        return event_id
+
+    async def on_start(self, ctx: AgentContext) -> None:
+        """Admit the run and register only a capability declared by the driver."""
+        profile = capability_profile_document(self._resolved_profile)
+        if str(ctx.agent_id) != profile.scenario.subject_participant_id:
+            raise TownDriverError("PARTICIPANT_MISMATCH")
+        self._last_logical_time = _logical_time(ctx.time)
+        request = self._start_request
+        if request is None:
+            request = DriverRequest(
+                schema_version="town-agent-driver/1",
+                run_id=self._run_id,
+                event_id=self._new_driver_event_id(),
+                sequence=0,
+                participant=CapabilityParticipant(id="provider-0", role="provider"),
+                profile=capability_profile_reference(self._resolved_profile),
+                observation=StartDriverObservation(
+                    kind="start",
+                    logical_time=self._last_logical_time,
+                    allowed_intents=["declare_capability", "none"],
+                ),
+            )
+            self._start_request = request
+        elif (
+            request.observation.kind != "start"
+            or request.observation.logical_time != self._last_logical_time
+        ):
+            raise TownDriverError("EVENT_CONFLICT")
+        try:
+            response = _validate_response(
+                request,
+                await self._driver.decide(request),
+                self._readiness.ready.adapter_instance_id,
+                self._resolved_profile.codec,
+            )
+            self._require_same_response(self._start_response, response)
+        except (DriverConfigurationError, DriverCompatibilityError):
+            raise
+        except AgentDriverError as error:
+            self._record_exchange_failure(ctx, stage="start", request=request, error=error)
+            raise
+        if self._start_applied:
+            return
+        self._start_response = response
+        self._admitted = True
+        scenario_ctx = cast("ScenarioAgentContext", ctx)
+        scenario_ctx.record_scenario_event(
+            kind="test.driver.run_admitted",
+            observer="town.driven-agent",
+            subject=str(ctx.agent_id),
+            attributes={"request_digest": _request_digest(request)},
+            data={
+                "adapter_instance_id": self._readiness.ready.adapter_instance_id,
+                "profile_digest": self._resolved_profile.reference.digest,
+                "driver_sequence": 0,
+                "intent_kind": response.intent.kind,
+            },
+        )
+        if not isinstance(response.intent, DeclareCapabilityIntent):
+            self._start_applied = True
+            return
+        registry = ctx.plugins["registry"]
+        await registry.register(
+            AgentCard(
+                agent_id=ctx.agent_id,
+                name="Driven Capability Provider",
+                capabilities=["sell"],
+            )
+        )
+        scenario_ctx.record_scenario_event(
+            kind="test.registry.provider_registered",
+            observer="town.driven-agent",
+            subject=str(ctx.agent_id),
+            data={
+                "registry_implementation": (
+                    "nest_plugins_reference.registry.in_memory.InMemoryRegistry"
+                ),
+                "card_agent_id": "provider-0",
+                "capabilities": ["sell"],
+            },
+        )
+        self._capability_declared = True
+        self._start_applied = True
+
+    async def on_message(self, ctx: AgentContext, sender: AgentId, payload: bytes) -> None:
+        """Ask the driver for one intent, then apply it through simulator routing."""
+        if not self._start_applied or not self._capability_declared:
+            raise TownDriverError("START_REQUIRED")
+        self._last_logical_time = _logical_time(ctx.time)
+        if str(sender) != "requester-0" or payload != b"buy:widget:2":
+            raise TownDriverError("MESSAGE_MISMATCH")
+        request = self._message_request
+        if request is None:
+            request = DriverRequest(
+                schema_version="town-agent-driver/1",
+                run_id=self._run_id,
+                event_id=self._new_driver_event_id(),
+                sequence=1,
+                participant=CapabilityParticipant(id="provider-0", role="provider"),
+                profile=capability_profile_reference(self._resolved_profile),
+                observation=MessageDriverObservation(
+                    kind="message",
+                    logical_time=self._last_logical_time,
+                    allowed_intents=["send_to_sender", "none"],
+                    message=DriverMessage(
+                        id="message-001",
+                        sender_id="requester-0",
+                        media_type="text/plain; charset=utf-8",
+                        text="buy:widget:2",
+                    ),
+                ),
+            )
+            self._message_request = request
+        elif (
+            request.observation.kind != "message"
+            or request.observation.logical_time != self._last_logical_time
+            or request.observation.message.sender_id != str(sender)
+            or request.observation.message.text.encode("utf-8") != payload
+        ):
+            raise TownDriverError("EVENT_CONFLICT")
+        try:
+            response = _validate_response(
+                request,
+                await self._driver.decide(request),
+                self._readiness.ready.adapter_instance_id,
+                self._resolved_profile.codec,
+            )
+            self._require_same_response(self._message_response, response)
+        except AgentDriverError as error:
+            self._record_exchange_failure(ctx, stage="message", request=request, error=error)
+            raise
+        if self._message_applied:
+            return
+        self._message_response = response
+        scenario_ctx = cast("ScenarioAgentContext", ctx)
+        scenario_ctx.record_scenario_event(
+            kind="test.driver.intent_returned",
+            observer="town.driven-agent",
+            subject=str(ctx.agent_id),
+            attributes={
+                "message_id": "message-001",
+                "request_digest": _request_digest(request),
+            },
+            data={
+                "adapter_instance_id": self._readiness.ready.adapter_instance_id,
+                "driver_event_id": request.event_id,
+                "driver_sequence": 1,
+                "intent_kind": response.intent.kind,
+            },
+        )
+        if not isinstance(response.intent, SendToSenderIntent):
+            self._message_applied = True
+            return
+        routed = response.intent.text.encode("utf-8")
+        correlation_id = await scenario_ctx.send_with_correlation(sender, routed)
+        scenario_ctx.record_scenario_event(
+            kind="test.message.response_routed",
+            observer="town.driven-agent",
+            subject=str(ctx.agent_id),
+            attributes={
+                "message_id": "message-002",
+                "correlation_id": str(correlation_id),
+                "request_digest": _payload_digest(payload),
+                "response_digest": _payload_digest(routed),
+            },
+            data={
+                "sender_id": "provider-0",
+                "recipient_id": "requester-0",
+                "media_type": "text/plain; charset=utf-8",
+                "text": response.intent.text,
+                "payload_digest": _payload_digest(routed),
+            },
+        )
+        self._message_applied = True
+
+    async def on_stop(self, ctx: AgentContext) -> None:
+        """Capture terminal Town time without performing driver or transport I/O."""
+        self._last_logical_time = _logical_time(ctx.time)
+
+    async def best_effort_stop(
+        self,
+        reason: Literal["run_complete", "run_failed", "run_incomplete", "user_interrupted"],
+    ) -> None:
+        """Send the outer-owned stop observation once after successful admission."""
+        if not self._admitted or self._stop_attempted:
+            return
+        self._stop_attempted = True
+        sequence = 2 if self._message_request is not None else 1
+        try:
+            request = DriverRequest(
+                schema_version="town-agent-driver/1",
+                run_id=self._run_id,
+                event_id=self._new_driver_event_id(),
+                sequence=sequence,
+                participant=CapabilityParticipant(id="provider-0", role="provider"),
+                profile=capability_profile_reference(self._resolved_profile),
+                observation=StopDriverObservation(
+                    kind="stop",
+                    logical_time=self._last_logical_time,
+                    allowed_intents=["none"],
+                    reason=reason,
+                ),
+            )
+            _validate_response(
+                request,
+                await self._driver.decide(request),
+                self._readiness.ready.adapter_instance_id,
+                self._resolved_profile.codec,
+            )
+        except BaseException:
+            return
+
+    @staticmethod
+    def _require_same_response(previous: DriverResponse | None, response: DriverResponse) -> None:
+        if previous is not None and previous != response:
+            raise DriverContractError("EVENT_CONFLICT")
+
+    @staticmethod
+    def _record_exchange_failure(
+        ctx: AgentContext,
+        *,
+        stage: str,
+        request: DriverRequest,
+        error: AgentDriverError,
+    ) -> None:
+        scenario_ctx = cast("ScenarioAgentContext", ctx)
+        scenario_ctx.record_scenario_event(
+            kind="test.driver.exchange_failed",
+            observer="town.driven-agent",
+            subject=str(ctx.agent_id),
+            attributes={"request_digest": _request_digest(request)},
+            data={
+                "stage": stage,
+                "disposition": _failure_disposition(error),
+                "error_code": error.code,
+                "driver_event_id": request.event_id,
+                "driver_sequence": request.sequence,
+            },
+        )

--- a/packages/nest-core/nest_core/agent_test/evaluator.py
+++ b/packages/nest-core/nest_core/agent_test/evaluator.py
@@ -1,0 +1,390 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure evidence evaluation for the frozen capability-fulfillment profile."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+
+from .capability_evidence import CapabilityObservationBase
+from .capability_profile import CAPABILITY_REQUIRED_CHECKS
+from .models import (
+    ULID,
+    CheckResult,
+    DriverExchangeFailedObservation,
+    IntentReturnedObservation,
+    LookupRequestedObservation,
+    LookupReturnedObservation,
+    ProviderRegisteredObservation,
+    ProviderSelectedObservation,
+    RequestRoutedObservation,
+    ResponseRoutedObservation,
+    ResultEvaluatedObservation,
+    RunAdmittedObservation,
+    TestObservation,
+)
+from .profiles import ResolvedTestProfile, capability_profile_document
+
+_REQUIRED_CHECKS = CAPABILITY_REQUIRED_CHECKS
+_OBSERVER_BY_KIND = {
+    "test.driver.run_admitted": "town.driven-agent",
+    "test.driver.exchange_failed": "town.driven-agent",
+    "test.registry.provider_registered": "town.driven-agent",
+    "test.driver.intent_returned": "town.driven-agent",
+    "test.message.response_routed": "town.driven-agent",
+    "test.registry.lookup_requested": "town.capability-requester",
+    "test.registry.lookup_returned": "town.capability-requester",
+    "test.requester.provider_selected": "town.capability-requester",
+    "test.message.request_routed": "town.capability-requester",
+    "test.capability.result_evaluated": "town.profile-evaluator",
+}
+
+
+def _single[TEvent: CapabilityObservationBase](
+    observations: Sequence[TestObservation], event_type: type[TEvent]
+) -> TEvent | None:
+    matches = [event for item in observations if isinstance((event := item.root), event_type)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _result(
+    check_id: str,
+    status: str,
+    summary: str,
+    evidence: Sequence[CapabilityObservationBase] = (),
+) -> CheckResult:
+    return CheckResult.model_validate(
+        {
+            "id": check_id,
+            "required": True,
+            "status": status,
+            "summary": summary,
+            "evidence_refs": [f"trace.jsonl#seq={event.seq}" for event in evidence],
+        }
+    )
+
+
+def _trace_is_integral(
+    observations: Sequence[TestObservation], run_id: ULID, profile_digest: str
+) -> bool:
+    events = [observation.root for observation in observations]
+    sequences = [event.seq for event in events]
+    event_ids = [event.event_id for event in events]
+    kinds = [event.kind for event in events]
+    return (
+        sequences == list(range(1, len(events) + 1))
+        and len(event_ids) == len(set(event_ids))
+        and len(kinds) == len(set(kinds))
+        and all(event.run_id == run_id for event in events)
+        and all(event.subject_participant_id == "provider-0" for event in events)
+        and all(event.observer == _OBSERVER_BY_KIND[event.kind] for event in events)
+        and all(
+            not isinstance(event, RunAdmittedObservation)
+            or event.data.profile_digest == profile_digest
+            for event in events
+        )
+    )
+
+
+def _all_inconclusive() -> list[CheckResult]:
+    return [
+        _result(
+            check_id,
+            "inconclusive",
+            (
+                "Trace evidence is duplicate, missing, out of order, misattributed, "
+                "or bound to another run/profile"
+            ),
+        )
+        for check_id in _REQUIRED_CHECKS
+    ]
+
+
+def evaluate_capability_fulfillment(
+    observations: Sequence[TestObservation],
+    *,
+    run_id: ULID,
+    resolved_profile: ResolvedTestProfile,
+) -> list[CheckResult]:
+    """Return the five frozen required checks from validated trace observations."""
+    profile = capability_profile_document(resolved_profile)
+    if tuple(profile.evaluator.required_checks) != _REQUIRED_CHECKS:
+        raise ValueError("profile required-check table is not the frozen evaluator table")
+    if not _trace_is_integral(observations, run_id, resolved_profile.reference.digest):
+        return _all_inconclusive()
+
+    admitted = _single(observations, RunAdmittedObservation)
+    failed = _single(observations, DriverExchangeFailedObservation)
+    registered = _single(observations, ProviderRegisteredObservation)
+    lookup_requested = _single(observations, LookupRequestedObservation)
+    lookup_returned = _single(observations, LookupReturnedObservation)
+    selected = _single(observations, ProviderSelectedObservation)
+    request_routed = _single(observations, RequestRoutedObservation)
+    intent_returned = _single(observations, IntentReturnedObservation)
+    response_routed = _single(observations, ResponseRoutedObservation)
+    evaluated = _single(observations, ResultEvaluatedObservation)
+
+    driver = _driver_check(admitted, failed, request_routed, intent_returned)
+    provider = _provider_check(admitted, failed, registered)
+    discovery = _discovery_check(
+        provider, lookup_requested, lookup_returned, selected, request_routed
+    )
+    request = _request_check(discovery, selected, request_routed)
+    fulfillment = _fulfillment_check(
+        request,
+        failed,
+        request_routed,
+        intent_returned,
+        response_routed,
+        evaluated,
+        expected_text=profile.fixture.expected_response.text,
+    )
+    return [driver, provider, discovery, request, fulfillment]
+
+
+def _driver_check(
+    admitted: RunAdmittedObservation | None,
+    failed: DriverExchangeFailedObservation | None,
+    request_routed: RequestRoutedObservation | None,
+    intent_returned: IntentReturnedObservation | None,
+) -> CheckResult:
+    if failed is not None:
+        status = {
+            "driver_contract": "fail",
+            "incomplete": "inconclusive",
+            "town": "error",
+        }[failed.data.disposition]
+        return _result(
+            _REQUIRED_CHECKS[0],
+            status,
+            "Driver exchange ended with a closed local failure classification",
+            [failed],
+        )
+    if admitted is None:
+        return _result(
+            _REQUIRED_CHECKS[0], "inconclusive", "No driver admission evidence was observed"
+        )
+    if admitted.data.intent_kind == "none":
+        return _result(
+            _REQUIRED_CHECKS[0], "pass", "Driver returned one allowed start intent", [admitted]
+        )
+    if request_routed is None and intent_returned is None:
+        return _result(
+            _REQUIRED_CHECKS[0],
+            "inconclusive",
+            "Start passed but the required message exchange was not observed",
+        )
+    if intent_returned is None:
+        return _result(
+            _REQUIRED_CHECKS[0],
+            "inconclusive",
+            "The routed request has no bounded driver intent evidence",
+        )
+    if (
+        admitted.data.adapter_instance_id != intent_returned.data.adapter_instance_id
+        or intent_returned.data.driver_sequence != 1
+        or admitted.seq >= intent_returned.seq
+    ):
+        return _result(
+            _REQUIRED_CHECKS[0],
+            "fail",
+            "Driver instance or sequence continuity was violated",
+            [admitted, intent_returned],
+        )
+    return _result(
+        _REQUIRED_CHECKS[0],
+        "pass",
+        "Driver returned one allowed intent for each required exchange",
+        [admitted, intent_returned],
+    )
+
+
+def _provider_check(
+    admitted: RunAdmittedObservation | None,
+    failed: DriverExchangeFailedObservation | None,
+    registered: ProviderRegisteredObservation | None,
+) -> CheckResult:
+    if failed is not None and failed.data.stage == "start":
+        return _result(
+            _REQUIRED_CHECKS[1], "not_tested", "Registration depends on successful admission"
+        )
+    if admitted is None:
+        return _result(
+            _REQUIRED_CHECKS[1], "not_tested", "Registration was not reached without admission"
+        )
+    if admitted.data.intent_kind == "none":
+        return _result(
+            _REQUIRED_CHECKS[1],
+            "fail",
+            "The adapter declined to declare the required sell capability",
+            [admitted],
+        )
+    if registered is None:
+        return _result(
+            _REQUIRED_CHECKS[1], "inconclusive", "Provider registration evidence is missing"
+        )
+    if admitted.seq >= registered.seq:
+        return _result(
+            _REQUIRED_CHECKS[1],
+            "inconclusive",
+            "Provider registration is not ordered after admission",
+        )
+    return _result(
+        _REQUIRED_CHECKS[1],
+        "pass",
+        "The driven provider registered sell through the pinned Registry",
+        [admitted, registered],
+    )
+
+
+def _discovery_check(
+    provider: CheckResult,
+    lookup_requested: LookupRequestedObservation | None,
+    lookup_returned: LookupReturnedObservation | None,
+    selected: ProviderSelectedObservation | None,
+    request_routed: RequestRoutedObservation | None,
+) -> CheckResult:
+    if provider.status != "pass":
+        return _result(
+            _REQUIRED_CHECKS[2], "not_tested", "Discovery depends on provider registration"
+        )
+    evidence = [
+        event for event in (lookup_requested, lookup_returned, selected) if event is not None
+    ]
+    if lookup_returned is not None and "provider-0" not in lookup_returned.data.card_agent_ids:
+        return _result(
+            _REQUIRED_CHECKS[2],
+            "fail",
+            "The pinned Registry lookup did not return provider-0",
+            evidence,
+        )
+    complete = lookup_requested is not None and lookup_returned is not None and selected is not None
+    if complete:
+        assert lookup_requested is not None
+        assert lookup_returned is not None
+        assert selected is not None
+        if (
+            lookup_requested.seq < lookup_returned.seq < selected.seq
+            and selected.data.lookup_event_id == lookup_returned.event_id
+            and "provider-0" in lookup_returned.data.card_agent_ids
+        ):
+            return _result(
+                _REQUIRED_CHECKS[2],
+                "pass",
+                "Requester selected provider-0 from the exact Registry lookup result",
+                evidence,
+            )
+        return _result(
+            _REQUIRED_CHECKS[2],
+            "fail",
+            "Discovery evidence is not causally linked to the selected provider",
+            evidence,
+        )
+    if request_routed is not None:
+        return _result(
+            _REQUIRED_CHECKS[2],
+            "fail",
+            "A routed request cannot substitute for Registry discovery evidence",
+            [request_routed],
+        )
+    return _result(_REQUIRED_CHECKS[2], "inconclusive", "Registry discovery evidence is incomplete")
+
+
+def _request_check(
+    discovery: CheckResult,
+    selected: ProviderSelectedObservation | None,
+    request_routed: RequestRoutedObservation | None,
+) -> CheckResult:
+    if discovery.status != "pass":
+        return _result(
+            _REQUIRED_CHECKS[3], "not_tested", "Request routing depends on proven discovery"
+        )
+    if selected is None or request_routed is None:
+        return _result(_REQUIRED_CHECKS[3], "inconclusive", "Request routing evidence is missing")
+    if selected.seq >= request_routed.seq:
+        return _result(
+            _REQUIRED_CHECKS[3],
+            "inconclusive",
+            "Request routing is not ordered after provider selection",
+        )
+    return _result(
+        _REQUIRED_CHECKS[3],
+        "pass",
+        "The exact synthetic request used current simulator routing",
+        [selected, request_routed],
+    )
+
+
+def _fulfillment_check(
+    request: CheckResult,
+    failed: DriverExchangeFailedObservation | None,
+    request_routed: RequestRoutedObservation | None,
+    intent_returned: IntentReturnedObservation | None,
+    response_routed: ResponseRoutedObservation | None,
+    evaluated: ResultEvaluatedObservation | None,
+    *,
+    expected_text: str,
+) -> CheckResult:
+    if failed is not None and failed.data.stage == "message":
+        return _result(
+            _REQUIRED_CHECKS[4],
+            "not_tested",
+            "Capability semantics were not evaluated after a driver exchange failure",
+        )
+    if request.status != "pass":
+        return _result(
+            _REQUIRED_CHECKS[4], "not_tested", "Fulfillment depends on proven request routing"
+        )
+    if request_routed is None or intent_returned is None:
+        return _result(
+            _REQUIRED_CHECKS[4], "inconclusive", "No bounded message intent was observed"
+        )
+    if intent_returned.data.intent_kind == "none":
+        return _result(
+            _REQUIRED_CHECKS[4],
+            "fail",
+            "The adapter returned none for the synthetic request",
+            [intent_returned],
+        )
+    if response_routed is None or evaluated is None:
+        return _result(_REQUIRED_CHECKS[4], "inconclusive", "Fulfillment evidence is incomplete")
+    expected_digest = "sha256:" + hashlib.sha256(expected_text.encode()).hexdigest()
+    evidence: list[CapabilityObservationBase] = [
+        request_routed,
+        intent_returned,
+        response_routed,
+        evaluated,
+    ]
+    if not (
+        request_routed.seq < intent_returned.seq < response_routed.seq < evaluated.seq
+        and request_routed.message_id == "message-001"
+        and intent_returned.message_id == request_routed.message_id
+        and request_routed.correlation_id is not None
+        and request_routed.request_digest == request_routed.data.payload_digest
+        and response_routed.message_id == "message-002"
+        and response_routed.correlation_id is not None
+        and response_routed.request_digest == request_routed.data.payload_digest
+        and response_routed.response_digest == response_routed.data.payload_digest
+        and evaluated.message_id == response_routed.message_id
+        and evaluated.response_digest == evaluated.data.actual_response_digest
+        and evaluated.data.expected_response_digest == expected_digest
+        and evaluated.data.actual_response_digest == response_routed.data.payload_digest
+    ):
+        return _result(
+            _REQUIRED_CHECKS[4],
+            "inconclusive",
+            "Response and evaluation evidence are not causally or digest linked",
+        )
+    if response_routed.data.text != expected_text or evaluated.data.verdict != "pass":
+        return _result(
+            _REQUIRED_CHECKS[4],
+            "fail",
+            "The routed response did not equal the exact synthetic fulfillment",
+            evidence,
+        )
+    return _result(
+        _REQUIRED_CHECKS[4],
+        "pass",
+        "Requester observed the exact synthetic fulfillment",
+        evidence,
+    )

--- a/packages/nest-core/nest_core/agent_test/runner.py
+++ b/packages/nest-core/nest_core/agent_test/runner.py
@@ -1,0 +1,516 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Outer transport-neutral orchestration for one admitted external participant."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from importlib import metadata
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Literal, cast
+
+from pydantic import TypeAdapter, ValidationError
+
+from nest_core.builtin_scenarios import builtin_path
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import PluginResolver, ScenarioRunner
+from nest_core.scenario import ScenarioConfig
+from nest_core.sim.agent import ScenarioEventSink, StateMachineAgent
+from nest_core.types import AgentId
+
+from .aggregation import AggregationCondition, aggregate
+from .artifacts import (
+    ArtifactDirectory,
+    ArtifactDirectoryError,
+    ArtifactStaging,
+    prepare_artifact_staging,
+    validate_artifact_target,
+)
+from .driven_agent import DrivenAgent
+from .driver import (
+    AgentDriver,
+    AgentDriverError,
+    DriverCompatibilityError,
+    DriverConfigurationError,
+    DriverFailureDisposition,
+)
+from .evaluator import evaluate_capability_fulfillment
+from .ids import new_ulid
+from .models import (
+    ULID,
+    CheckResult,
+    CoverageResult,
+    Diagnostic,
+    Evaluation,
+    Execution,
+    ResultDriver,
+    ResultTarget,
+    SafeText128,
+    TestResult,
+    ToolMetadata,
+)
+from .profiles import (
+    ResolvedTestProfile,
+    capability_profile_document,
+    resolve_test_profile,
+)
+from .runtime import AgentTestRuntime
+
+_REGISTRY_IMPLEMENTATION = "nest_plugins_reference.registry.in_memory.InMemoryRegistry"
+_ULID_ADAPTER: TypeAdapter[str] = TypeAdapter(ULID)
+_TARGET_LABEL_ADAPTER: TypeAdapter[str] = TypeAdapter(SafeText128)
+_CAPABILITY_PROFILE_LAYERS = MappingProxyType(
+    {
+        "transport": "in_memory",
+        "comms": "nest_native",
+        "identity": "did_key",
+        "registry": "in_memory",
+        "auth": "jwt",
+        "trust": "score_average",
+        "payments": "prepaid_credits",
+        "coordination": "contract_net",
+        "negotiation": "alternating_offers",
+        "memory": "blackboard",
+        "privacy": "noop",
+        "datafacts": "datafacts_v1",
+    }
+)
+type StopReason = Literal["run_complete", "run_failed", "run_incomplete", "user_interrupted"]
+_STOP_REASON_BY_EXIT: dict[int, StopReason] = {
+    0: "run_complete",
+    1: "run_failed",
+    3: "run_failed",
+    4: "run_incomplete",
+    130: "user_interrupted",
+}
+
+
+class AgentTestPreAdmissionError(RuntimeError):
+    """Safe configuration failure raised before a run bundle can be authoritative."""
+
+    exit_code: Literal[2] = 2
+
+    def __init__(self, code: str, *, next: str | None = None) -> None:
+        self.code = code
+        self.next = next
+        super().__init__(code)
+
+
+class AgentTestTownError(RuntimeError):
+    """Safe Town failure raised before an evidence bundle can be authoritative."""
+
+    exit_code: Literal[3] = 3
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentTestOutcome:
+    """Terminal machine-readable result plus process and artifact metadata."""
+
+    result: TestResult
+    exit_code: int
+    output_directory: Path
+    result_bytes: bytes
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _timestamp(value: datetime) -> str:
+    if value.tzinfo is None:
+        raise ValueError("agent-test timestamps must be timezone-aware")
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _tool_version() -> str:
+    try:
+        return metadata.version("nest-core")
+    except metadata.PackageNotFoundError:
+        return "0.1.4"
+
+
+def _preflight_registry(registry: PluginRegistry) -> None:
+    try:
+        implementation = registry.resolve_reference("registry", "in_memory")
+    except (ImportError, KeyError):
+        raise AgentTestPreAdmissionError(
+            "REFERENCE_REGISTRY_MISSING", next="pip install 'nest-core[plugins]'"
+        ) from None
+    identity = f"{implementation.__module__}.{implementation.__qualname__}"
+    if identity != _REGISTRY_IMPLEMENTATION:
+        raise AgentTestPreAdmissionError(
+            "REFERENCE_REGISTRY_MISSING", next="pip install 'nest-core[plugins]'"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _ProfilePluginResolver(PluginResolver):
+    registry: PluginRegistry
+
+    def resolve(self, layer: str, name: str) -> Any:
+        expected_name = _CAPABILITY_PROFILE_LAYERS.get(layer)
+        if expected_name is None or name != expected_name:
+            raise AgentTestTownError("PROFILE_SCENARIO_INVALID")
+        return self.registry.resolve_reference(layer, expected_name)
+
+
+def _validate_profile_scenario(
+    config: ScenarioConfig, resolved_profile: ResolvedTestProfile
+) -> None:
+    scenario = capability_profile_document(resolved_profile).scenario
+    if (
+        config.task.type != scenario.id
+        or config.seed != scenario.seed
+        or config.layers.model_dump() != dict(_CAPABILITY_PROFILE_LAYERS)
+        or config.layers.registry != scenario.registry_plugin
+        or config.task.config.get("lookup_delay_ticks") != scenario.lookup_delay_ticks
+    ):
+        raise AgentTestTownError("PROFILE_SCENARIO_INVALID")
+
+
+def _build_profile_scenario_runner(
+    *,
+    config: ScenarioConfig,
+    resolved_profile: ResolvedTestProfile,
+    registry: PluginRegistry,
+    participant_override: Mapping[AgentId, StateMachineAgent],
+    event_sink: ScenarioEventSink,
+) -> ScenarioRunner:
+    """Apply exact profile policy before entering the generic runner."""
+    _validate_profile_scenario(config, resolved_profile)
+    subject_id = AgentId(
+        capability_profile_document(resolved_profile).scenario.subject_participant_id
+    )
+    if len(participant_override) != 1 or set(participant_override) != {subject_id}:
+        raise AgentTestTownError("PROFILE_SCENARIO_INVALID")
+    return ScenarioRunner(
+        config,
+        participant_override=participant_override,
+        plugin_resolver=_ProfilePluginResolver(registry=registry),
+        event_sink=event_sink,
+    )
+
+
+def _coverage(
+    checks: list[CheckResult], resolved_profile: ResolvedTestProfile
+) -> list[CoverageResult]:
+    profile = capability_profile_document(resolved_profile)
+    by_id = {check.id: check for check in checks}
+    check_for_claim = {
+        "town.agent-driver.loopback": "driver.contract",
+        "nanda.registry.run-local-discovery": "registry.provider-discovered",
+        "town.simulator.in-memory-routing": "delivery.request-routed",
+        "nanda.agent.synthetic-capability-fulfillment": ("capability.synthetic-request-fulfilled"),
+    }
+    results: list[CoverageResult] = []
+    for claim in profile.coverage.exercised:
+        check = by_id.get(check_for_claim[claim])
+        conclusive = check is not None and check.status in {"pass", "fail"}
+        results.append(
+            CoverageResult(
+                claim=claim,
+                status="exercised" if conclusive else "unknown",
+                reason_code=None if conclusive else "NOT_OBSERVED",
+                evidence_refs=check.evidence_refs if check is not None and conclusive else [],
+            )
+        )
+    results.extend(
+        CoverageResult(
+            claim=claim,
+            status="not_tested",
+            reason_code="OUT_OF_PROFILE",
+            evidence_refs=[],
+        )
+        for claim in profile.coverage.not_tested
+    )
+    return results
+
+
+async def run_agent_test(
+    *,
+    driver: AgentDriver,
+    driver_metadata: ResultDriver,
+    output_dir: Path | None = None,
+    base_dir: Path | None = None,
+    target_label: str = "local-agent",
+    plugin_registry: PluginRegistry | None = None,
+    run_id_factory: Callable[[], str] = new_ulid,
+) -> AgentTestOutcome:
+    """Run the frozen scenario with one driver-backed provider and write terminal artifacts."""
+    artifacts: ArtifactDirectory | None = None
+    staging: ArtifactStaging | None = None
+    runtime: AgentTestRuntime | None = None
+    driven: DrivenAgent | None = None
+    scenario_runner: ScenarioRunner | None = None
+    driver_closed = False
+    stop_attempted = False
+    stop_reason: StopReason = "run_failed"
+
+    async def close_driver_once() -> str | None:
+        nonlocal driver_closed
+        if driver_closed:
+            return None
+        driver_closed = True
+        try:
+            await driver.close()
+        except BaseException:
+            return "DRIVER_CLOSE_FAILED"
+        return None
+
+    async def stop_driven_once() -> None:
+        nonlocal stop_attempted
+        if stop_attempted or driven is None:
+            return
+        stop_attempted = True
+        try:
+            await driven.best_effort_stop(stop_reason)
+        except BaseException:
+            return
+
+    try:
+        try:
+            target_label = _TARGET_LABEL_ADAPTER.validate_python(target_label, strict=True)
+        except ValidationError:
+            raise AgentTestPreAdmissionError("TARGET_LABEL_INVALID") from None
+        try:
+            run_id = _ULID_ADAPTER.validate_python(run_id_factory(), strict=True)
+        except ValidationError:
+            raise AgentTestPreAdmissionError("RUN_ID_INVALID") from None
+        resolved_profile = resolve_test_profile("capability-fulfillment")
+        profile_document = capability_profile_document(resolved_profile)
+        try:
+            validate_artifact_target(run_id=run_id, output_dir=output_dir, base_dir=base_dir)
+        except ArtifactDirectoryError:
+            raise AgentTestPreAdmissionError("OUTPUT_DIR_INVALID") from None
+        registry = plugin_registry or PluginRegistry()
+        _preflight_registry(registry)
+        config: ScenarioConfig | None = None
+        try:
+            config = ScenarioConfig.from_yaml(builtin_path("capability_fulfillment"))
+            _validate_profile_scenario(config, resolved_profile)
+        except AgentTestTownError:
+            raise
+        except asyncio.CancelledError:
+            raise
+        except BaseException:
+            config = None
+        if config is None:
+            raise AgentTestTownError("TOWN_EXECUTION_ERROR") from None
+        started_wall = _utc_now()
+        started_ns = time.monotonic_ns()
+        readiness = await driver.ready(resolved_profile)
+        try:
+            staging = prepare_artifact_staging(
+                run_id=run_id, output_dir=output_dir, base_dir=base_dir
+            )
+        except ArtifactDirectoryError:
+            raise AgentTestPreAdmissionError("OUTPUT_DIR_INVALID") from None
+        condition: AggregationCondition | None = None
+        diagnostics: list[Diagnostic] = []
+        try:
+            runtime = AgentTestRuntime(run_id=run_id, resolved_profile=resolved_profile)
+            driven = DrivenAgent(
+                driver=driver,
+                run_id=run_id,
+                resolved_profile=resolved_profile,
+                readiness=readiness,
+            )
+            config.output.trace = str(staging.trace_path)
+            scenario_runner = _build_profile_scenario_runner(
+                config=config,
+                resolved_profile=resolved_profile,
+                registry=registry,
+                participant_override={AgentId(runtime.subject_participant_id): driven},
+                event_sink=runtime,
+            )
+            await scenario_runner.run()
+        except AgentTestTownError:
+            raise
+        except (DriverConfigurationError, DriverCompatibilityError) as error:
+            if driven is None or not driven.admitted:
+                raise
+            diagnostics.append(
+                Diagnostic(
+                    code=error.code,
+                    stage="driver",
+                    severity="error",
+                    summary="The driver exchange ended with a closed local failure",
+                    next=None,
+                )
+            )
+        except asyncio.CancelledError:
+            if runtime is None or not runtime.observations:
+                raise
+            condition = "user_interrupted"
+            stop_reason = "user_interrupted"
+            diagnostics.append(
+                Diagnostic(
+                    code="USER_INTERRUPTED",
+                    stage="driver",
+                    severity="warning",
+                    summary="The agent-test run was interrupted by the user",
+                    next=None,
+                )
+            )
+        except AgentDriverError as error:
+            if error.disposition == DriverFailureDisposition.TOWN:
+                condition = "town_defect"
+            elif error.disposition == DriverFailureDisposition.INCOMPLETE:
+                stop_reason = "run_incomplete"
+            diagnostics.append(
+                Diagnostic(
+                    code=error.code,
+                    stage="town" if condition == "town_defect" else "driver",
+                    severity=(
+                        "warning"
+                        if error.disposition == DriverFailureDisposition.INCOMPLETE
+                        else "error"
+                    ),
+                    summary="The driver exchange ended with a closed local failure",
+                    next=None,
+                )
+            )
+        except BaseException:
+            if runtime is not None and runtime.observations:
+                condition = "town_defect"
+                diagnostics.append(
+                    Diagnostic(
+                        code="TOWN_EXECUTION_ERROR",
+                        stage="town",
+                        severity="error",
+                        summary="Town could not complete the dedicated scenario",
+                        next=None,
+                    )
+                )
+
+        if (
+            runtime is None
+            or driven is None
+            or scenario_runner is None
+            or not runtime.observations
+            or not scenario_runner.trace_finalized
+        ):
+            raise AgentTestTownError("TOWN_EXECUTION_ERROR") from None
+
+        artifacts = staging.promote(run_id=run_id)
+
+        checks: list[CheckResult]
+        if condition == "town_defect":
+            checks = []
+        else:
+            try:
+                checks = evaluate_capability_fulfillment(
+                    runtime.observations,
+                    run_id=run_id,
+                    resolved_profile=resolved_profile,
+                )
+            except BaseException:
+                condition = "town_defect"
+                checks = []
+                diagnostics.append(
+                    Diagnostic(
+                        code="EVALUATOR_ERROR",
+                        stage="evaluation",
+                        severity="error",
+                        summary="Town could not evaluate the closed observation trace",
+                        next=None,
+                    )
+                )
+        aggregated = aggregate(
+            checks,
+            observations=runtime.observations,
+            run_id=run_id,
+            condition=condition,
+        )
+
+        trace_artifact = None
+        try:
+            trace_artifact = artifacts.finalize_trace(runtime.observations)
+        except ArtifactDirectoryError:
+            condition = "town_defect"
+            checks = []
+            aggregated = aggregate(
+                checks,
+                observations=runtime.observations,
+                run_id=run_id,
+                condition=condition,
+            )
+            diagnostics.append(
+                Diagnostic(
+                    code="TRACE_FINALIZATION_FAILED",
+                    stage="artifacts",
+                    severity="error",
+                    summary="Town could not verify the terminal trace artifact",
+                    next=None,
+                )
+            )
+
+        stop_reason = _STOP_REASON_BY_EXIT.get(aggregated.exit_code, "run_failed")
+        await stop_driven_once()
+        close_error = await close_driver_once()
+        if close_error is not None:
+            diagnostics.append(
+                Diagnostic(
+                    code=close_error,
+                    stage="cleanup",
+                    severity="warning",
+                    summary="The driver transport did not close cleanly",
+                    next=None,
+                )
+            )
+        finished_wall = _utc_now()
+        duration_ms = max(0, (time.monotonic_ns() - started_ns) // 1_000_000)
+        result = TestResult(
+            schema_version="town.test-result/1",
+            run_id=run_id,
+            tool=ToolMetadata(name="nest-core", version=_tool_version(), commit=None),
+            target=ResultTarget(
+                kind="agent",
+                label=target_label,
+                attribution="self_asserted_loopback_adapter_instance",
+            ),
+            driver=ResultDriver.model_validate(
+                {
+                    **driver_metadata.model_dump(mode="json"),
+                    "adapter_instance_id": readiness.ready.adapter_instance_id,
+                }
+            ),
+            profile=resolved_profile.reference,
+            execution=Execution(
+                status=aggregated.execution_status,
+                started_at=_timestamp(started_wall),
+                finished_at=_timestamp(finished_wall),
+                duration_ms=duration_ms,
+                scenario="capability_fulfillment",
+                seed=profile_document.scenario.seed,
+                logical_time_end=driven.logical_time_end,
+                decision_timeout_ms=profile_document.driver.decision_timeout_ms,
+            ),
+            evaluation=Evaluation(verdict=aggregated.verdict, checks=checks),
+            coverage=_coverage(checks, resolved_profile),
+            artifacts=[] if trace_artifact is None else [trace_artifact],
+            diagnostics=diagnostics,
+        )
+        result = cast("TestResult", resolved_profile.codec.validate_result(result))
+        result_bytes = artifacts.write_result(result)
+        return AgentTestOutcome(
+            result=result,
+            exit_code=aggregated.exit_code,
+            output_directory=artifacts.path,
+            result_bytes=result_bytes,
+        )
+    finally:
+        if staging is not None:
+            staging.discard()
+        try:
+            await stop_driven_once()
+        finally:
+            await close_driver_once()

--- a/packages/nest-core/nest_core/agent_test/runtime.py
+++ b/packages/nest-core/nest_core/agent_test/runtime.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Profile-owned construction and serialization of agent-test observations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import cast
+
+from nest_core.sim.agent import ScenarioEventReceipt, ScenarioEventRequest
+
+from .ids import new_ulid
+from .models import ULID, ProfileReference, SafeId, TestObservation
+from .profiles import ResolvedTestProfile, capability_profile_document
+
+_OBSERVATION_ATTRIBUTES = frozenset(
+    {
+        "duration_ms",
+        "message_id",
+        "correlation_id",
+        "request_digest",
+        "response_digest",
+    }
+)
+
+
+class AgentTestRuntime:
+    """Run-scoped recorder for closed, profile-owned test observations."""
+
+    def __init__(
+        self,
+        *,
+        run_id: ULID,
+        resolved_profile: ResolvedTestProfile,
+        event_id_factory: Callable[[], str] | None = None,
+        observed_at: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.run_id = run_id
+        profile_document = capability_profile_document(resolved_profile)
+        self.subject_participant_id: SafeId = profile_document.scenario.subject_participant_id
+        self.profile: ProfileReference = resolved_profile.reference
+        self._codec = resolved_profile.codec
+        self._event_id_factory = event_id_factory or new_ulid
+        self._observed_at = observed_at or (lambda: datetime.now(UTC))
+        self._observations: list[TestObservation] = []
+
+    @property
+    def observations(self) -> tuple[TestObservation, ...]:
+        """Return validated observations in their global sequence order."""
+        return tuple(self._observations)
+
+    def record(self, request: ScenarioEventRequest) -> ScenarioEventReceipt:
+        """Validate and sequence one generic request into a traceable observation."""
+        attributes = dict(request.attributes)
+        unknown_attributes = set(attributes) - _OBSERVATION_ATTRIBUTES
+        if unknown_attributes:
+            names = ", ".join(sorted(unknown_attributes))
+            raise ValueError(f"unsupported agent-test observation attributes: {names}")
+        observed_at = self._observed_at()
+        if observed_at.tzinfo is None:
+            raise ValueError("observed_at must be timezone-aware")
+        timestamp = observed_at.astimezone(UTC).isoformat().replace("+00:00", "Z")
+        observation = cast(
+            "TestObservation",
+            self._codec.validate_observation(
+                {
+                    "schema_version": "town.test-observation/1",
+                    "seq": len(self._observations) + 1,
+                    "event_id": self._event_id_factory(),
+                    "run_id": self.run_id,
+                    "kind": request.kind,
+                    "logical_time": request.logical_time,
+                    "observed_at": timestamp,
+                    "duration_ms": attributes.get("duration_ms"),
+                    "observer": request.observer,
+                    "subject_participant_id": request.subject,
+                    "message_id": attributes.get("message_id"),
+                    "correlation_id": attributes.get("correlation_id"),
+                    "request_digest": attributes.get("request_digest"),
+                    "response_digest": attributes.get("response_digest"),
+                    "data": dict(request.data),
+                }
+            ),
+        )
+        self._observations.append(observation)
+        trace_record = observation.model_dump(mode="json")
+        return ScenarioEventReceipt(
+            event_id=observation.root.event_id,
+            trace_record=trace_record,
+        )

--- a/packages/nest-core/tests/agent_test/test_agent_test_runner.py
+++ b/packages/nest-core/tests/agent_test/test_agent_test_runner.py
@@ -1,0 +1,1169 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Outer orchestration tests over the real ScenarioRunner/Registry/simulator path."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib.metadata
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import nest_core.agent_test.runner as agent_test_runner_module
+import pytest
+from nest_core.agent_test.artifacts import ArtifactDirectory, ArtifactStaging
+from nest_core.agent_test.driver import (
+    DriverCompatibilityError,
+    DriverConfigurationError,
+    DriverIncompleteError,
+    TownDriverError,
+)
+from nest_core.agent_test.models import (
+    ULID,
+    DeclareCapabilityIntent,
+    DriverReadiness,
+    DriverReady,
+    DriverRequest,
+    DriverResponse,
+    EffectiveDriverLimits,
+    NoneIntent,
+    ReadyLimits,
+    ResultDriver,
+    SendToSenderIntent,
+    StopDriverObservation,
+    TestResult,
+)
+from nest_core.agent_test.profile_codecs import BoundProfileCodec
+from nest_core.agent_test.profiles import ResolvedTestProfile, resolve_test_profile
+from nest_core.agent_test.runner import (
+    AgentTestPreAdmissionError,
+    AgentTestTownError,
+    run_agent_test,
+)
+from nest_core.plugins import PluginRegistry
+from nest_core.runner import ScenarioRunner
+from nest_core.scenario import OutputConfig, ScenarioConfig
+from nest_core.sim.simulator import Simulator
+from nest_core.sim.trace import TraceWriter
+
+RUN_ID = "01K00000000000000000000001"
+type DriverIntent = DeclareCapabilityIntent | SendToSenderIntent | NoneIntent
+_FROZEN_LAYER_NAMES = {
+    "transport": "in_memory",
+    "comms": "nest_native",
+    "identity": "did_key",
+    "registry": "in_memory",
+    "auth": "jwt",
+    "trust": "score_average",
+    "payments": "prepaid_credits",
+    "coordination": "contract_net",
+    "negotiation": "alternating_offers",
+    "memory": "blackboard",
+    "privacy": "noop",
+    "datafacts": "datafacts_v1",
+}
+
+
+class _CollidingRegistry:
+    pass
+
+
+class _RegistryEntryPoint:
+    name = "in_memory"
+
+    def load(self) -> type[_CollidingRegistry]:
+        return _CollidingRegistry
+
+
+class _ForeignPlugin:
+    pass
+
+
+class _ForeignEntryPoint:
+    def __init__(self, *, layer: str, name: str, loads: list[tuple[str, str]]) -> None:
+        self.name = name
+        self._layer = layer
+        self._loads = loads
+
+    def load(self) -> type[_ForeignPlugin]:
+        self._loads.append((self._layer, self.name))
+        return _ForeignPlugin
+
+
+def _digest_request(request: DriverRequest) -> str:
+    return "sha256:" + hashlib.sha256(request.model_dump_json().encode()).hexdigest()
+
+
+def _readiness() -> DriverReadiness:
+    return DriverReadiness(
+        ready=DriverReady(
+            schema_version="town-agent-driver-ready/1",
+            adapter_instance_id="adapter:dev",
+            contracts=["town-agent-driver/1"],
+            profiles=[resolve_test_profile("capability-fulfillment").reference],
+            accepting_runs=True,
+            limits=ReadyLimits(
+                max_active_runs=1,
+                max_request_bytes=65536,
+                max_response_bytes=65536,
+            ),
+        ),
+        effective_limits=EffectiveDriverLimits(
+            max_request_bytes=65536,
+            max_response_bytes=65536,
+        ),
+    )
+
+
+class _Driver:
+    def __init__(self, intent_for: Callable[[DriverRequest], DriverIntent]) -> None:
+        self.intent_for = intent_for
+        self.requests: list[DriverRequest] = []
+        self.lifecycle: list[str] = []
+        self.ready_calls = 0
+        self.close_calls = 0
+
+    async def ready(self, profile: ResolvedTestProfile) -> DriverReadiness:
+        self.ready_calls += 1
+        self.lifecycle.append("ready")
+        return _readiness()
+
+    async def decide(self, request: DriverRequest) -> DriverResponse:
+        self.requests.append(request)
+        self.lifecycle.append(request.observation.kind)
+        return DriverResponse(
+            schema_version="town-agent-driver/1",
+            run_id=request.run_id,
+            event_id=request.event_id,
+            sequence=request.sequence,
+            adapter_instance_id="adapter:dev",
+            request_digest=_digest_request(request),
+            intent=self.intent_for(request),
+        )
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.lifecycle.append("close")
+
+
+class _FailingDriver(_Driver):
+    def __init__(self, failure: BaseException) -> None:
+        super().__init__(
+            lambda request: (
+                DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+                if request.observation.kind == "start"
+                else NoneIntent(kind="none")
+            )
+        )
+        self.failure = failure
+
+    async def decide(self, request: DriverRequest) -> DriverResponse:
+        if request.observation.kind == "message":
+            self.requests.append(request)
+            self.lifecycle.append(request.observation.kind)
+            raise self.failure
+        return await super().decide(request)
+
+
+class _CleanupFailingDriver(_Driver):
+    async def decide(self, request: DriverRequest) -> DriverResponse:
+        if request.observation.kind == "stop":
+            self.requests.append(request)
+            self.lifecycle.append(request.observation.kind)
+            raise RuntimeError("Bearer secret-cleanup-canary")
+        return await super().decide(request)
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.lifecycle.append("close")
+        raise RuntimeError("Bearer secret-close-canary")
+
+
+class _StartContractFailingDriver(_Driver):
+    async def decide(self, request: DriverRequest) -> DriverResponse:
+        response = await super().decide(request)
+        return response.model_copy(update={"sequence": request.sequence + 1})
+
+
+class _StartPreAdmissionFailingDriver(_Driver):
+    def __init__(self, failure: DriverConfigurationError | DriverCompatibilityError) -> None:
+        super().__init__(lambda request: NoneIntent(kind="none"))
+        self.failure = failure
+
+    async def decide(self, request: DriverRequest) -> DriverResponse:
+        self.requests.append(request)
+        self.lifecycle.append(request.observation.kind)
+        raise self.failure
+
+
+class _StartAttemptFailingDriver(_Driver):
+    def __init__(self, failure: DriverIncompleteError | TownDriverError) -> None:
+        super().__init__(lambda request: NoneIntent(kind="none"))
+        self.failure = failure
+
+    async def decide(self, request: DriverRequest) -> DriverResponse:
+        self.requests.append(request)
+        self.lifecycle.append(request.observation.kind)
+        raise self.failure
+
+
+def _metadata() -> ResultDriver:
+    return ResultDriver(
+        contract="town-agent-driver/1",
+        kind="loopback-http",
+        adapter_instance_id=None,
+        endpoint_origin="http://127.0.0.1:8787",
+    )
+
+
+@pytest.mark.asyncio
+async def test_pass_runs_real_registry_discovery_and_simulator_routing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing Registry lookup or current simulator routing prevents the terminal PASS."""
+    validated_results: list[object] = []
+    validate_result = BoundProfileCodec.validate_result
+
+    def track_result_validation(self: BoundProfileCodec, value: object) -> object:
+        validated_results.append(value)
+        return validate_result(self, value)
+
+    monkeypatch.setattr(BoundProfileCodec, "validate_result", track_result_validation)
+
+    def intent_for(request: DriverRequest) -> DriverIntent:
+        if request.observation.kind == "start":
+            return DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+        if request.observation.kind == "message":
+            return SendToSenderIntent(
+                kind="send_to_sender",
+                media_type="text/plain; charset=utf-8",
+                text="sold:widget:2",
+            )
+        return NoneIntent(kind="none")
+
+    driver = _Driver(intent_for)
+    output = tmp_path / "run"
+
+    outcome = await run_agent_test(
+        driver=driver,
+        driver_metadata=_metadata(),
+        output_dir=output,
+        base_dir=tmp_path,
+        run_id_factory=lambda: RUN_ID,
+    )
+
+    assert outcome.exit_code == 0
+    assert outcome.result.run_id == RUN_ID
+    assert outcome.result.execution.status == "completed"
+    assert outcome.result.evaluation.verdict == "pass"
+    assert len(validated_results) == 1
+    assert [check.status for check in outcome.result.evaluation.checks] == ["pass"] * 5
+    assert [request.observation.kind for request in driver.requests] == [
+        "start",
+        "message",
+        "stop",
+    ]
+    assert [request.sequence for request in driver.requests] == [0, 1, 2]
+    stop = driver.requests[-1].observation
+    assert isinstance(stop, StopDriverObservation)
+    assert stop.reason == "run_complete"
+    assert driver.ready_calls == 1
+    assert driver.close_calls == 1
+
+    records = [json.loads(line) for line in (output / "trace.jsonl").read_text().splitlines()]
+    assert [record["msg"] for record in records if record["kind"] == "send"] == [
+        "buy:widget:2",
+        "sold:widget:2",
+    ]
+    observations = [record for record in records if record["kind"].startswith("test.")]
+    assert [record["kind"] for record in observations] == [
+        "test.driver.run_admitted",
+        "test.registry.provider_registered",
+        "test.registry.lookup_requested",
+        "test.registry.lookup_returned",
+        "test.requester.provider_selected",
+        "test.message.request_routed",
+        "test.driver.intent_returned",
+        "test.message.response_routed",
+        "test.capability.result_evaluated",
+    ]
+    assert observations[1]["data"]["registry_implementation"] == (
+        "nest_plugins_reference.registry.in_memory.InMemoryRegistry"
+    )
+    assert observations[3]["data"]["card_agent_ids"] == ["provider-0"]
+    assert (output / "result.json").read_bytes() == outcome.result_bytes
+    assert [item.status for item in outcome.result.coverage[:4]] == ["exercised"] * 4
+    assert all(
+        item.status == "not_tested" and item.reason_code == "OUT_OF_PROFILE"
+        for item in outcome.result.coverage[4:]
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_test_injects_reference_registry_under_entry_point_collision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The profile path, rather than generic runner policy, pins the bundled Registry."""
+
+    def entry_points(*, group: str) -> list[_RegistryEntryPoint]:
+        if group == "nest.plugins.registry":
+            return [_RegistryEntryPoint()]
+        return []
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", entry_points)
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+
+    outcome = await run_agent_test(
+        driver=driver,
+        driver_metadata=_metadata(),
+        base_dir=tmp_path,
+        plugin_registry=PluginRegistry(),
+        run_id_factory=lambda: RUN_ID,
+    )
+
+    records = [
+        json.loads(line)
+        for line in (outcome.output_directory / "trace.jsonl").read_text().splitlines()
+    ]
+    registry_records = [record for record in records if record["kind"].startswith("test.registry.")]
+    assert registry_records
+    assert all(
+        record["data"]["registry_implementation"]
+        == "nest_plugins_reference.registry.in_memory.InMemoryRegistry"
+        for record in registry_records
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_test_never_loads_colliding_entry_points_for_any_profile_layer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resolving any frozen layer through entry-point precedence executes foreign code."""
+    loads: list[tuple[str, str]] = []
+
+    def entry_points(*, group: str) -> list[_ForeignEntryPoint]:
+        prefix = "nest.plugins."
+        if not group.startswith(prefix):
+            return []
+        layer = group.removeprefix(prefix)
+        name = _FROZEN_LAYER_NAMES.get(layer)
+        if name is None:
+            return []
+        return [_ForeignEntryPoint(layer=layer, name=name, loads=loads)]
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", entry_points)
+
+    outcome = await run_agent_test(
+        driver=_Driver(lambda request: NoneIntent(kind="none")),
+        driver_metadata=_metadata(),
+        base_dir=tmp_path,
+        plugin_registry=PluginRegistry(),
+        run_id_factory=lambda: RUN_ID,
+    )
+
+    assert outcome.exit_code == 1
+    assert loads == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("layer_name", list(_FROZEN_LAYER_NAMES))
+async def test_mutated_profile_scenario_config_is_rejected_before_admission(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, layer_name: str
+) -> None:
+    """A packaged scenario that drifts from its profile cannot reach driver readiness."""
+    config = ScenarioConfig.from_yaml(
+        agent_test_runner_module.builtin_path("capability_fulfillment")
+    )
+    setattr(config.layers, layer_name, "foreign")
+
+    def return_mutated_config(_path: str | Path) -> ScenarioConfig:
+        return config
+
+    monkeypatch.setattr(ScenarioConfig, "from_yaml", return_mutated_config)
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+
+    with pytest.raises(AgentTestTownError) as caught:
+        await run_agent_test(
+            driver=driver,
+            driver_metadata=_metadata(),
+            base_dir=tmp_path,
+            run_id_factory=lambda: RUN_ID,
+        )
+
+    assert caught.value.code == "PROFILE_SCENARIO_INVALID"
+    assert driver.ready_calls == 0
+    assert driver.requests == []
+    assert driver.close_calls == 1
+    assert not (tmp_path / ".town" / "runs" / RUN_ID).exists()
+
+
+@pytest.mark.asyncio
+async def test_start_none_writes_terminal_semantic_failure(tmp_path: Path) -> None:
+    """A valid start refusal fails registration without direct-address fallback."""
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+    output = tmp_path / "run"
+
+    outcome = await run_agent_test(
+        driver=driver,
+        driver_metadata=_metadata(),
+        output_dir=output,
+        base_dir=tmp_path,
+        run_id_factory=lambda: RUN_ID,
+    )
+
+    assert outcome.exit_code == 1
+    assert outcome.result.execution.status == "completed"
+    assert outcome.result.evaluation.verdict == "fail"
+    assert [check.status for check in outcome.result.evaluation.checks] == [
+        "pass",
+        "fail",
+        "not_tested",
+        "not_tested",
+        "not_tested",
+    ]
+    assert [request.observation.kind for request in driver.requests] == ["start", "stop"]
+    stop = driver.requests[-1].observation
+    assert isinstance(stop, StopDriverObservation)
+    assert stop.reason == "run_failed"
+    assert driver.close_calls == 1
+    records = [json.loads(line) for line in (output / "trace.jsonl").read_text().splitlines()]
+    assert not any(record.get("msg") == "buy:widget:2" for record in records)
+    assert (output / "result.json").is_file()
+
+
+@pytest.mark.asyncio
+async def test_start_contract_failure_writes_failure_without_stop_before_admission(
+    tmp_path: Path,
+) -> None:
+    """Malformed start output fails the driver while dependent checks remain untested."""
+    driver = _StartContractFailingDriver(
+        lambda request: DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+    )
+    output = tmp_path / "run"
+
+    outcome = await run_agent_test(
+        driver=driver,
+        driver_metadata=_metadata(),
+        output_dir=output,
+        base_dir=tmp_path,
+        run_id_factory=lambda: RUN_ID,
+    )
+
+    assert outcome.exit_code == 1
+    assert outcome.result.execution.status == "completed"
+    assert outcome.result.evaluation.verdict == "fail"
+    assert [check.status for check in outcome.result.evaluation.checks] == [
+        "fail",
+        "not_tested",
+        "not_tested",
+        "not_tested",
+        "not_tested",
+    ]
+    assert [request.observation.kind for request in driver.requests] == ["start"]
+    assert driver.close_calls == 1
+    assert (output / "result.json").read_bytes() == outcome.result_bytes
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("preexisting_explicit", [False, True])
+async def test_pre_trace_town_failure_raises_safe_typed_error_without_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    preexisting_explicit: bool,
+) -> None:
+    """A Town setup failure cannot be converted into a missing-trace artifact failure."""
+
+    async def fail_before_trace(_runner: ScenarioRunner) -> Path:
+        raise RuntimeError("remote Town exception text must not escape")
+
+    monkeypatch.setattr(ScenarioRunner, "run", fail_before_trace)
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+    output = tmp_path / "explicit" if preexisting_explicit else None
+    before_identity: tuple[int, int] | None = None
+    if output is not None:
+        output.mkdir()
+        before = output.stat()
+        before_identity = (before.st_ino, before.st_mode)
+    with pytest.raises(AgentTestTownError) as caught:
+        await run_agent_test(
+            driver=driver,
+            driver_metadata=_metadata(),
+            output_dir=output,
+            base_dir=tmp_path,
+            run_id_factory=lambda: RUN_ID,
+        )
+
+    assert str(caught.value) == "TOWN_EXECUTION_ERROR"
+    assert caught.value.code == "TOWN_EXECUTION_ERROR"
+    assert caught.value.exit_code == 3
+    assert caught.value.__context__ is None
+    assert driver.ready_calls == 1
+    assert driver.requests == []
+    assert driver.close_calls == 1
+    if output is None:
+        assert not (tmp_path / ".town" / "runs" / RUN_ID).exists()
+    else:
+        assert output.is_dir()
+        assert list(output.iterdir()) == []
+        after = output.stat()
+        assert (after.st_ino, after.st_mode) == before_identity
+    assert not any("staging" in path.name for path in tmp_path.rglob("*"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure_stage",
+    [
+        "runtime_construction",
+        "driven_agent_construction",
+        "scenario_config_loading",
+        "scenario_config_mutation",
+        "scenario_runner_construction",
+    ],
+)
+async def test_every_town_setup_failure_uses_safe_town_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+) -> None:
+    """No internal setup exception may escape after Town has created staging."""
+
+    def fail_setup(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("remote post-staging setup text must not escape")
+
+    if failure_stage == "runtime_construction":
+        monkeypatch.setattr(agent_test_runner_module, "AgentTestRuntime", fail_setup)
+    elif failure_stage == "driven_agent_construction":
+        monkeypatch.setattr(agent_test_runner_module, "DrivenAgent", fail_setup)
+    elif failure_stage == "scenario_config_loading":
+        monkeypatch.setattr(ScenarioConfig, "from_yaml", fail_setup)
+    elif failure_stage == "scenario_config_mutation":
+        original_setattr = OutputConfig.__setattr__
+
+        def fail_trace_assignment(output: OutputConfig, name: str, value: object) -> None:
+            if name == "trace":
+                fail_setup()
+            original_setattr(output, name, value)
+
+        monkeypatch.setattr(OutputConfig, "__setattr__", fail_trace_assignment)
+    else:
+        monkeypatch.setattr(agent_test_runner_module, "ScenarioRunner", fail_setup)
+
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+    output = tmp_path / "explicit"
+    output.mkdir()
+    before = output.stat()
+
+    with pytest.raises(AgentTestTownError) as caught:
+        await run_agent_test(
+            driver=driver,
+            driver_metadata=_metadata(),
+            output_dir=output,
+            base_dir=tmp_path,
+            run_id_factory=lambda: RUN_ID,
+        )
+
+    after = output.stat()
+    assert caught.value.code == "TOWN_EXECUTION_ERROR"
+    assert str(caught.value) == "TOWN_EXECUTION_ERROR"
+    assert caught.value.__context__ is None
+    assert "remote post-staging" not in repr(caught.value)
+    assert (after.st_ino, after.st_mode) == (before.st_ino, before.st_mode)
+    assert list(output.iterdir()) == []
+    assert driver.ready_calls == (0 if failure_stage == "scenario_config_loading" else 1)
+    assert driver.requests == []
+    assert driver.close_calls == 1
+    assert not any("staging" in path.name for path in tmp_path.rglob("*"))
+
+
+@pytest.mark.asyncio
+async def test_post_staging_setup_cancellation_remains_native_without_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Moving setup under Town classification cannot consume native cancellation."""
+
+    def cancel_setup(*_args: object, **_kwargs: object) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(agent_test_runner_module, "DrivenAgent", cancel_setup)
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+    output = tmp_path / "explicit"
+    output.mkdir()
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_agent_test(
+            driver=driver,
+            driver_metadata=_metadata(),
+            output_dir=output,
+            base_dir=tmp_path,
+            run_id_factory=lambda: RUN_ID,
+        )
+
+    assert list(output.iterdir()) == []
+    assert driver.ready_calls == 1
+    assert driver.requests == []
+    assert driver.close_calls == 1
+    assert not any("staging" in path.name for path in tmp_path.rglob("*"))
+
+
+@pytest.mark.asyncio
+async def test_pre_observation_cancellation_propagates_without_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cancellation remains native until a meaningful test observation exists."""
+
+    async def cancel_before_trace(_runner: ScenarioRunner) -> Path:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(ScenarioRunner, "run", cancel_before_trace)
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+    output = tmp_path / "explicit"
+    output.mkdir()
+    before = output.stat()
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_agent_test(
+            driver=driver,
+            driver_metadata=_metadata(),
+            output_dir=output,
+            base_dir=tmp_path,
+            run_id_factory=lambda: RUN_ID,
+        )
+
+    after = output.stat()
+    assert (after.st_ino, after.st_mode) == (before.st_ino, before.st_mode)
+    assert list(output.iterdir()) == []
+    assert driver.ready_calls == 1
+    assert driver.requests == []
+    assert driver.close_calls == 1
+    assert not any("staging" in path.name for path in tmp_path.rglob("*"))
+
+
+@pytest.mark.asyncio
+async def test_unexpected_town_failure_after_observation_writes_terminal_exit_three_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Once test evidence exists, an unexpected Town failure remains an honest outcome."""
+    original_run = ScenarioRunner.run
+
+    async def fail_after_scenario(runner: ScenarioRunner) -> Path:
+        await original_run(runner)
+        raise RuntimeError("remote Town exception text must not escape")
+
+    monkeypatch.setattr(ScenarioRunner, "run", fail_after_scenario)
+
+    def intent_for(request: DriverRequest) -> DriverIntent:
+        if request.observation.kind == "start":
+            return DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+        if request.observation.kind == "message":
+            return SendToSenderIntent(
+                kind="send_to_sender",
+                media_type="text/plain; charset=utf-8",
+                text="sold:widget:2",
+            )
+        return NoneIntent(kind="none")
+
+    driver = _Driver(intent_for)
+    output = tmp_path / "run"
+
+    outcome = await run_agent_test(
+        driver=driver,
+        driver_metadata=_metadata(),
+        output_dir=output,
+        base_dir=tmp_path,
+        run_id_factory=lambda: RUN_ID,
+    )
+
+    assert outcome.exit_code == 3
+    assert outcome.result.execution.status == "error"
+    assert outcome.result.evaluation.verdict == "not_evaluated"
+    assert outcome.result.evaluation.checks == []
+    assert [item.code for item in outcome.result.diagnostics] == ["TOWN_EXECUTION_ERROR"]
+    assert (output / "trace.jsonl").read_bytes().endswith(b"\n")
+    assert (output / "result.json").read_bytes() == outcome.result_bytes
+    assert driver.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_trace_close_after_observation_discards_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A present trace file is not publishable unless its close returned successfully."""
+    original_close = TraceWriter.close
+    trace_close_calls = 0
+
+    def fail_after_trace_close(writer: TraceWriter) -> None:
+        nonlocal trace_close_calls
+        original_close(writer)
+        trace_close_calls += 1
+        raise RuntimeError("remote trace-close text must not escape")
+
+    def intent_for(request: DriverRequest) -> DriverIntent:
+        if request.observation.kind == "start":
+            return DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+        if request.observation.kind == "message":
+            return SendToSenderIntent(
+                kind="send_to_sender",
+                media_type="text/plain; charset=utf-8",
+                text="sold:widget:2",
+            )
+        return NoneIntent(kind="none")
+
+    monkeypatch.setattr(TraceWriter, "close", fail_after_trace_close)
+    driver = _Driver(intent_for)
+    output = tmp_path / "explicit"
+    output.mkdir()
+
+    with pytest.raises(AgentTestTownError) as caught:
+        await run_agent_test(
+            driver=driver,
+            driver_metadata=_metadata(),
+            output_dir=output,
+            base_dir=tmp_path,
+            run_id_factory=lambda: RUN_ID,
+        )
+
+    assert caught.value.code == "TOWN_EXECUTION_ERROR"
+    assert caught.value.__context__ is None
+    assert "remote trace-close" not in repr(caught.value)
+    assert trace_close_calls == 1
+    assert list(output.iterdir()) == []
+    assert [request.observation.kind for request in driver.requests] == [
+        "start",
+        "message",
+        "stop",
+    ]
+    stop = driver.requests[-1].observation
+    assert isinstance(stop, StopDriverObservation)
+    assert stop.reason == "run_failed"
+    assert driver.lifecycle[-2:] == ["stop", "close"]
+    assert driver.close_calls == 1
+    assert not any("staging" in path.name for path in tmp_path.rglob("*"))
+
+
+@pytest.mark.asyncio
+async def test_artifact_promotion_failure_stops_before_close_without_masking(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Post-admission publication failure still sends one safe terminal stop."""
+    primary = RuntimeError("artifact promotion failed")
+
+    def fail_promotion(staging: ArtifactStaging, *, run_id: ULID) -> ArtifactDirectory:
+        raise primary
+
+    monkeypatch.setattr(ArtifactStaging, "promote", fail_promotion)
+    driver = _CleanupFailingDriver(lambda request: NoneIntent(kind="none"))
+
+    with pytest.raises(RuntimeError) as caught:
+        await run_agent_test(
+            driver=driver,
+            driver_metadata=_metadata(),
+            base_dir=tmp_path,
+            run_id_factory=lambda: RUN_ID,
+        )
+
+    assert caught.value is primary
+    assert [request.observation.kind for request in driver.requests] == ["start", "stop"]
+    stop = driver.requests[-1].observation
+    assert isinstance(stop, StopDriverObservation)
+    assert stop.reason == "run_failed"
+    assert driver.lifecycle == ["ready", "start", "stop", "close"]
+    assert driver.close_calls == 1
+    assert not (tmp_path / ".town" / "runs" / RUN_ID).exists()
+    assert not any("staging" in path.name for path in tmp_path.rglob("*"))
+
+
+@pytest.mark.asyncio
+async def test_simulator_setup_failure_closes_trace_and_leaves_no_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A post-writer Simulator setup failure closes before staging is discarded."""
+    trace_close_calls = 0
+    original_close = TraceWriter.close
+
+    def fail_initialization(_simulator: Simulator) -> None:
+        raise RuntimeError("remote Simulator setup text must not escape")
+
+    def record_trace_close(writer: TraceWriter) -> None:
+        nonlocal trace_close_calls
+        original_close(writer)
+        trace_close_calls += 1
+
+    monkeypatch.setattr(Simulator, "_init_failures", fail_initialization)
+    monkeypatch.setattr(TraceWriter, "close", record_trace_close)
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+
+    with pytest.raises(AgentTestTownError) as caught:
+        await run_agent_test(
+            driver=driver,
+            driver_metadata=_metadata(),
+            base_dir=tmp_path,
+            run_id_factory=lambda: RUN_ID,
+        )
+
+    assert caught.value.code == "TOWN_EXECUTION_ERROR"
+    assert caught.value.__context__ is None
+    assert trace_close_calls == 1
+    assert driver.ready_calls == 1
+    assert driver.requests == []
+    assert driver.close_calls == 1
+    assert not (tmp_path / ".town" / "runs" / RUN_ID).exists()
+    assert not any("staging" in path.name for path in tmp_path.rglob("*"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_type", "code"),
+    [
+        (DriverConfigurationError, "AUTHENTICATION_FAILED"),
+        (DriverCompatibilityError, "UNSUPPORTED_PROFILE"),
+    ],
+)
+@pytest.mark.parametrize("preexisting_explicit", [False, True])
+async def test_start_configuration_or_compatibility_failure_leaves_no_run_bundle(
+    tmp_path: Path,
+    error_type: type[DriverConfigurationError] | type[DriverCompatibilityError],
+    code: str,
+    preexisting_explicit: bool,
+) -> None:
+    """Pre-admission start failures preserve their type without claiming output."""
+    failure = error_type(code)
+    driver = _StartPreAdmissionFailingDriver(failure)
+    output = tmp_path / "explicit" if preexisting_explicit else None
+    before_identity: tuple[int, int] | None = None
+    if output is not None:
+        output.mkdir()
+        before = output.stat()
+        before_identity = (before.st_ino, before.st_mode)
+
+    with pytest.raises(error_type) as caught:
+        await run_agent_test(
+            driver=driver,
+            driver_metadata=_metadata(),
+            output_dir=output,
+            base_dir=tmp_path,
+            run_id_factory=lambda: RUN_ID,
+        )
+
+    assert caught.value is failure
+    assert caught.value.code == code
+    assert driver.ready_calls == 1
+    assert [request.observation.kind for request in driver.requests] == ["start"]
+    assert driver.close_calls == 1
+    if output is None:
+        assert not (tmp_path / ".town" / "runs" / RUN_ID).exists()
+    else:
+        assert output.is_dir()
+        assert list(output.iterdir()) == []
+        after = output.stat()
+        assert (after.st_ino, after.st_mode) == before_identity
+    assert not any("staging" in path.name for path in tmp_path.rglob("*"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "execution", "verdict", "exit_code", "disposition"),
+    [
+        (
+            DriverIncompleteError("TIMEOUT"),
+            "incomplete",
+            "inconclusive",
+            4,
+            "incomplete",
+        ),
+        (TownDriverError("TOWN_BROKEN"), "error", "not_evaluated", 3, "town"),
+    ],
+)
+async def test_start_attempt_failures_keep_evidence_and_terminal_bundle(
+    tmp_path: Path,
+    failure: DriverIncompleteError | TownDriverError,
+    execution: str,
+    verdict: str,
+    exit_code: int,
+    disposition: str,
+) -> None:
+    """Incomplete and Town start failures remain evidenced attempted-run outcomes."""
+    driver = _StartAttemptFailingDriver(failure)
+
+    outcome = await run_agent_test(
+        driver=driver,
+        driver_metadata=_metadata(),
+        base_dir=tmp_path,
+        run_id_factory=lambda: RUN_ID,
+    )
+
+    assert outcome.exit_code == exit_code
+    assert outcome.result.execution.status == execution
+    assert outcome.result.evaluation.verdict == verdict
+    assert [request.observation.kind for request in driver.requests] == ["start"]
+    assert driver.close_calls == 1
+    records = [
+        json.loads(line)
+        for line in (outcome.output_directory / "trace.jsonl").read_text().splitlines()
+    ]
+    failed = [record for record in records if record["kind"] == "test.driver.exchange_failed"]
+    assert len(failed) == 1
+    assert failed[0]["data"]["disposition"] == disposition
+    assert (outcome.output_directory / "result.json").is_file()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "execution", "verdict", "exit_code", "stop_reason"),
+    [
+        (DriverIncompleteError("TIMEOUT"), "incomplete", "inconclusive", 4, "run_incomplete"),
+        (TownDriverError("TOWN_BROKEN"), "error", "not_evaluated", 3, "run_failed"),
+        (asyncio.CancelledError(), "incomplete", "inconclusive", 130, "user_interrupted"),
+    ],
+)
+async def test_post_admission_attempts_always_write_terminal_result_and_close_once(
+    tmp_path: Path,
+    failure: BaseException,
+    execution: str,
+    verdict: str,
+    exit_code: int,
+    stop_reason: str,
+) -> None:
+    """Incomplete, Town-error, and interrupted attempts retain honest terminal artifacts."""
+    driver = _FailingDriver(failure)
+    output = tmp_path / "run"
+
+    outcome = await run_agent_test(
+        driver=driver,
+        driver_metadata=_metadata(),
+        output_dir=output,
+        base_dir=tmp_path,
+        run_id_factory=lambda: RUN_ID,
+    )
+
+    assert outcome.exit_code == exit_code
+    assert outcome.result.execution.status == execution
+    assert outcome.result.evaluation.verdict == verdict
+    if verdict == "not_evaluated":
+        assert outcome.result.evaluation.checks == []
+    else:
+        assert len(outcome.result.evaluation.checks) == 5
+    assert [request.observation.kind for request in driver.requests] == [
+        "start",
+        "message",
+        "stop",
+    ]
+    stop = driver.requests[-1].observation
+    assert isinstance(stop, StopDriverObservation)
+    assert stop.reason == stop_reason
+    assert driver.close_calls == 1
+    assert (output / "trace.jsonl").read_bytes().endswith(b"\n")
+    assert (output / "result.json").read_bytes() == outcome.result_bytes
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["file", "symlink", "nonempty_directory"])
+async def test_output_configuration_is_rejected_before_readiness_without_mutation(
+    tmp_path: Path, kind: str
+) -> None:
+    """A caller-owned unsafe target cannot trigger driver I/O or a misleading bundle."""
+    output = tmp_path / "owned"
+    if kind == "file":
+        output.write_bytes(b"caller bytes")
+    elif kind == "symlink":
+        destination = tmp_path / "destination"
+        destination.mkdir()
+        (destination / "marker.txt").write_bytes(b"caller bytes")
+        output.symlink_to(destination, target_is_directory=True)
+    else:
+        output.mkdir()
+        (output / "marker.txt").write_bytes(b"caller bytes")
+    before = sorted(
+        (path.relative_to(tmp_path), path.read_bytes())
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    )
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+
+    with pytest.raises(AgentTestPreAdmissionError) as caught:
+        await run_agent_test(
+            driver=driver,
+            driver_metadata=_metadata(),
+            output_dir=output,
+            base_dir=tmp_path,
+            run_id_factory=lambda: RUN_ID,
+        )
+
+    assert caught.value.code == "OUTPUT_DIR_INVALID"
+    after = sorted(
+        (path.relative_to(tmp_path), path.read_bytes())
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    )
+    assert after == before
+    if kind == "symlink":
+        assert output.is_symlink()
+    assert driver.ready_calls == 0
+    assert driver.requests == []
+    assert driver.close_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target_label", ["", " untrimmed", "bad\nlabel", "é" * 129])
+async def test_invalid_target_label_is_rejected_before_admission_or_artifacts(
+    tmp_path: Path, target_label: str
+) -> None:
+    """Unsafe public result labels cannot reach the adapter or mutate caller output."""
+    output = tmp_path / "owned"
+    output.mkdir()
+    marker = output / "marker.txt"
+    marker.write_bytes(b"caller bytes")
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+
+    with pytest.raises(AgentTestPreAdmissionError) as caught:
+        await run_agent_test(
+            driver=driver,
+            driver_metadata=_metadata(),
+            output_dir=output,
+            base_dir=tmp_path,
+            target_label=target_label,
+            run_id_factory=lambda: RUN_ID,
+        )
+
+    assert caught.value.code == "TARGET_LABEL_INVALID"
+    assert str(caught.value) == "TARGET_LABEL_INVALID"
+    assert marker.read_bytes() == b"caller bytes"
+    assert list(output.iterdir()) == [marker]
+    assert driver.ready_calls == 0
+    assert driver.requests == []
+    assert driver.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_publication_follows_trace_writer_close_and_writes_result_last(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ordinary ScenarioRunner closure precedes trace promotion and result publication."""
+    trace_closed = False
+    original_close = TraceWriter.close
+    original_promote = ArtifactStaging.promote
+    original_write_result = ArtifactDirectory.write_result
+
+    def record_trace_close(writer: TraceWriter) -> None:
+        nonlocal trace_closed
+        original_close(writer)
+        trace_closed = True
+
+    def assert_closed_before_promotion(
+        staging: ArtifactStaging, *, run_id: ULID
+    ) -> ArtifactDirectory:
+        assert trace_closed
+        return original_promote(staging, run_id=run_id)
+
+    def assert_result_is_last(artifacts: ArtifactDirectory, result: TestResult) -> bytes:
+        assert artifacts.trace_path.is_file()
+        assert artifacts.trace_path.read_bytes().endswith(b"\n")
+        assert not artifacts.result_path.exists()
+        assert sorted(path.name for path in artifacts.path.iterdir()) == ["trace.jsonl"]
+        return original_write_result(artifacts, result)
+
+    monkeypatch.setattr(TraceWriter, "close", record_trace_close)
+    monkeypatch.setattr(ArtifactStaging, "promote", assert_closed_before_promotion)
+    monkeypatch.setattr(ArtifactDirectory, "write_result", assert_result_is_last)
+    output = tmp_path / "run"
+
+    outcome = await run_agent_test(
+        driver=_Driver(lambda request: NoneIntent(kind="none")),
+        driver_metadata=_metadata(),
+        output_dir=output,
+        base_dir=tmp_path,
+        run_id_factory=lambda: RUN_ID,
+    )
+
+    assert outcome.exit_code == 1
+    assert trace_closed
+    assert sorted(path.name for path in output.iterdir()) == ["result.json", "trace.jsonl"]
+
+
+class _MissingRegistry:
+    def resolve_reference(self, layer: str, name: str):
+        raise ModuleNotFoundError("remote package text must not surface")
+
+
+@pytest.mark.asyncio
+async def test_missing_pinned_registry_has_exact_guidance_before_admission(tmp_path: Path) -> None:
+    """A core-only install fails closed with the one supported optional-extra remediation."""
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+    output = tmp_path / "run"
+
+    with pytest.raises(AgentTestPreAdmissionError) as caught:
+        await run_agent_test(
+            driver=driver,
+            driver_metadata=_metadata(),
+            output_dir=output,
+            base_dir=tmp_path,
+            plugin_registry=_MissingRegistry(),  # type: ignore[arg-type]
+            run_id_factory=lambda: RUN_ID,
+        )
+
+    assert caught.value.code == "REFERENCE_REGISTRY_MISSING"
+    assert caught.value.next == "pip install 'nest-core[plugins]'"
+    assert str(caught.value) == "REFERENCE_REGISTRY_MISSING"
+    assert not output.exists()
+    assert driver.ready_calls == 0
+    assert driver.requests == []
+    assert driver.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_default_output_path_is_exact_run_id_directory(tmp_path: Path) -> None:
+    """Generated output uses exactly .town/runs/<result run ID> and remains unique."""
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+
+    outcome = await run_agent_test(
+        driver=driver,
+        driver_metadata=_metadata(),
+        base_dir=tmp_path,
+        run_id_factory=lambda: RUN_ID,
+    )
+
+    assert outcome.output_directory == tmp_path / ".town" / "runs" / RUN_ID
+    assert outcome.output_directory.name == outcome.result.run_id
+    assert (outcome.output_directory / "result.json").is_file()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failures_do_not_change_pass_or_leak_secrets(tmp_path: Path) -> None:
+    """Best-effort stop and close failures preserve verdict while emitting only local codes."""
+
+    def intent_for(request: DriverRequest) -> DriverIntent:
+        if request.observation.kind == "start":
+            return DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+        if request.observation.kind == "message":
+            return SendToSenderIntent(
+                kind="send_to_sender",
+                media_type="text/plain; charset=utf-8",
+                text="sold:widget:2",
+            )
+        return NoneIntent(kind="none")
+
+    driver = _CleanupFailingDriver(intent_for)
+    output = tmp_path / "run"
+
+    outcome = await run_agent_test(
+        driver=driver,
+        driver_metadata=_metadata(),
+        output_dir=output,
+        base_dir=tmp_path,
+        run_id_factory=lambda: RUN_ID,
+    )
+
+    assert outcome.exit_code == 0
+    assert outcome.result.evaluation.verdict == "pass"
+    assert [request.observation.kind for request in driver.requests] == [
+        "start",
+        "message",
+        "stop",
+    ]
+    assert driver.close_calls == 1
+    assert [diagnostic.code for diagnostic in outcome.result.diagnostics] == ["DRIVER_CLOSE_FAILED"]
+    artifact_bytes = (output / "trace.jsonl").read_bytes() + (output / "result.json").read_bytes()
+    assert b"secret-cleanup-canary" not in artifact_bytes
+    assert b"secret-close-canary" not in artifact_bytes

--- a/packages/nest-core/tests/agent_test/test_artifacts.py
+++ b/packages/nest-core/tests/agent_test/test_artifacts.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ownership, closure, and exact-byte tests for agent-test run artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from nest_core.agent_test import artifacts as artifact_module
+from nest_core.agent_test.artifacts import (
+    ArtifactDirectoryError,
+    prepare_artifact_directory,
+    prepare_artifact_staging,
+)
+from nest_core.agent_test.models import TestResult
+from nest_core.agent_test.profiles import resolve_test_profile
+from nest_core.agent_test.runtime import AgentTestRuntime
+from nest_core.sim.agent import ScenarioEventRequest
+from nest_core.sim.trace import TraceWriter
+
+RUN_ID = "01K00000000000000000000001"
+
+
+def test_local_artifact_boundary_is_explicit_and_complete() -> None:
+    """The API must carry the exact local-storage trust boundary for later surfaces."""
+    assert artifact_module.LOCAL_ARTIFACT_BOUNDARY == (
+        "Artifact output must be on a local filesystem in a directory controlled by the "
+        "invoking user. Town is not a privilege boundary and does not defend against another "
+        "process running as the same OS user, hostile filesystem behavior, or path replacement "
+        "during a run. It refuses files, direct symlinks, non-empty directories, and existing "
+        "artifact names, and never intentionally overwrites caller data. On POSIX, Town-created "
+        "run directories and artifact files use modes 0700 and 0600. Existing caller-owned "
+        "directories keep their modes; Town does not recursively chmod them. Do not run Town "
+        "elevated. Local artifacts are mutable diagnostic files, not attestations. If "
+        "adapter/model is untrusted, sandbox without artifact output mount."
+    )
+
+
+@contextmanager
+def _umask(mask: int) -> Generator[None]:
+    previous = os.umask(mask)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+def _write_artifacts(*, tmp_path: Path, output_dir: Path | None) -> tuple[Path, Path, Path]:
+    staging = prepare_artifact_staging(
+        run_id=RUN_ID,
+        output_dir=output_dir,
+        base_dir=tmp_path,
+    )
+    writer = TraceWriter(staging.trace_path)
+    writer.record({"kind": "test.permissions"})
+    writer.close()
+    artifacts = staging.promote(run_id=RUN_ID)
+    fixture = json.loads(
+        (Path(__file__).parent / "fixtures" / "result-pass.json").read_text(encoding="utf-8")
+    )
+    artifacts.write_result(TestResult.model_validate(fixture))
+    return artifacts.path, artifacts.trace_path, artifacts.result_path
+
+
+@pytest.mark.parametrize("process_umask", [0o022, 0o000])
+@pytest.mark.parametrize("explicit", [False, True])
+def test_town_created_artifact_directories_and_files_are_private(
+    tmp_path: Path,
+    process_umask: int,
+    explicit: bool,
+) -> None:
+    """Default and absent explicit targets must not inherit permissive process modes."""
+    output_dir = tmp_path / "new-explicit-output" if explicit else None
+
+    with _umask(process_umask):
+        directory, trace_path, result_path = _write_artifacts(
+            tmp_path=tmp_path,
+            output_dir=output_dir,
+        )
+
+    assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+    assert stat.S_IMODE(trace_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(result_path.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize("process_umask", [0o022, 0o000])
+def test_missing_generated_hierarchy_parents_are_private(
+    tmp_path: Path,
+    process_umask: int,
+) -> None:
+    """Every generated hierarchy component created by Town must exclude group and other."""
+    with _umask(process_umask):
+        directory, _, _ = _write_artifacts(tmp_path=tmp_path, output_dir=None)
+
+    assert stat.S_IMODE((tmp_path / ".town").stat().st_mode) == 0o700
+    assert stat.S_IMODE((tmp_path / ".town" / "runs").stat().st_mode) == 0o700
+    assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+
+
+@pytest.mark.parametrize("preexisting_runs", [False, True])
+def test_generated_hierarchy_preserves_preexisting_parent_mode(
+    tmp_path: Path,
+    preexisting_runs: bool,
+) -> None:
+    """Securing missing descendants must not chmod a caller-owned hierarchy component."""
+    town = tmp_path / ".town"
+    town.mkdir()
+    town.chmod(0o751)
+    runs = town / "runs"
+    if preexisting_runs:
+        runs.mkdir()
+        runs.chmod(0o753)
+
+    with _umask(0o000):
+        directory, _, _ = _write_artifacts(tmp_path=tmp_path, output_dir=None)
+
+    assert stat.S_IMODE(town.stat().st_mode) == 0o751
+    assert stat.S_IMODE(runs.stat().st_mode) == (0o753 if preexisting_runs else 0o700)
+    assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+
+
+@pytest.mark.parametrize("process_umask", [0o022, 0o000])
+def test_existing_explicit_directory_keeps_its_mode_while_new_files_are_private(
+    tmp_path: Path,
+    process_umask: int,
+) -> None:
+    """Town secures its files without recursively chmodding a caller-owned directory."""
+    output_dir = tmp_path / "existing-explicit-output"
+    output_dir.mkdir(mode=0o751)
+    output_dir.chmod(0o751)
+
+    with _umask(process_umask):
+        directory, trace_path, result_path = _write_artifacts(
+            tmp_path=tmp_path,
+            output_dir=output_dir,
+        )
+
+    assert directory == output_dir
+    assert stat.S_IMODE(directory.stat().st_mode) == 0o751
+    assert stat.S_IMODE(trace_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(result_path.stat().st_mode) == 0o600
+
+
+def test_staging_is_unique_same_parent_and_discard_removes_only_its_own_entries(
+    tmp_path: Path,
+) -> None:
+    """Separate invocations stage beside the target and clean up only their own directory."""
+    target = tmp_path / "explicit-absent"
+    unrelated = tmp_path / "caller-marker.txt"
+    unrelated.write_bytes(b"caller bytes")
+    first = prepare_artifact_staging(run_id=RUN_ID, output_dir=target, base_dir=tmp_path)
+    second = prepare_artifact_staging(run_id=RUN_ID, output_dir=target, base_dir=tmp_path)
+
+    assert first.path.parent == target.parent
+    assert second.path.parent == target.parent
+    assert first.path != second.path
+    first.trace_path.write_bytes(b"first trace\n")
+    second.trace_path.write_bytes(b"second trace\n")
+
+    first.discard()
+
+    assert not first.path.exists()
+    assert second.trace_path.read_bytes() == b"second trace\n"
+    assert unrelated.read_bytes() == b"caller bytes"
+    assert not target.exists()
+    second.discard()
+    assert unrelated.read_bytes() == b"caller bytes"
+
+
+def test_absent_explicit_target_is_published_without_run_id_child(tmp_path: Path) -> None:
+    """An absent explicit target is claimed directly only after its trace is complete."""
+    target = tmp_path / "explicit-absent"
+    staging = prepare_artifact_staging(run_id=RUN_ID, output_dir=target, base_dir=tmp_path)
+    staging.trace_path.write_bytes(b"closed trace\n")
+
+    artifacts = staging.promote(run_id=RUN_ID)
+
+    assert artifacts.path == target
+    assert artifacts.trace_path.read_bytes() == b"closed trace\n"
+    assert not (target / RUN_ID).exists()
+    assert not any("staging" in path.name for path in tmp_path.iterdir())
+
+
+def test_trace_publication_collision_preserves_caller_entry_and_staging(tmp_path: Path) -> None:
+    """A late artifact-name collision fails closed without overwriting either copy."""
+    target = tmp_path / "explicit-empty"
+    target.mkdir()
+    staging = prepare_artifact_staging(run_id=RUN_ID, output_dir=target, base_dir=tmp_path)
+    staging.trace_path.write_bytes(b"invocation trace\n")
+    caller_trace = target / "trace.jsonl"
+    caller_trace.write_bytes(b"caller trace\n")
+
+    with pytest.raises(ArtifactDirectoryError):
+        staging.promote(run_id=RUN_ID)
+
+    assert caller_trace.read_bytes() == b"caller trace\n"
+    assert staging.trace_path.read_bytes() == b"invocation trace\n"
+    staging.discard()
+    assert caller_trace.read_bytes() == b"caller trace\n"
+
+
+@pytest.mark.parametrize("kind", ["file", "symlink", "nonempty_directory"])
+def test_explicit_unsafe_output_is_refused_without_mutation(tmp_path: Path, kind: str) -> None:
+    """Validation must fail before opening writers or changing caller-owned output."""
+    target = tmp_path / "owned-output"
+    if kind == "file":
+        target.write_bytes(b"caller bytes")
+    elif kind == "symlink":
+        destination = tmp_path / "destination"
+        destination.mkdir()
+        target.symlink_to(destination, target_is_directory=True)
+    else:
+        target.mkdir()
+        (target / "caller.txt").write_bytes(b"caller bytes")
+    before = sorted(
+        (path.name, path.read_bytes()) for path in tmp_path.rglob("*") if path.is_file()
+    )
+
+    with pytest.raises(ArtifactDirectoryError):
+        prepare_artifact_directory(run_id=RUN_ID, output_dir=target, base_dir=tmp_path)
+
+    after = sorted((path.name, path.read_bytes()) for path in tmp_path.rglob("*") if path.is_file())
+    assert after == before
+    assert not (target / "trace.jsonl").exists()
+    assert not (target / "result.json").exists()
+
+
+def test_generated_and_explicit_directories_have_exact_distinct_shapes(tmp_path: Path) -> None:
+    """Generated output owns the run-ID child; an explicit directory never gains one."""
+    generated = prepare_artifact_directory(run_id=RUN_ID, output_dir=None, base_dir=tmp_path)
+    assert generated.path == tmp_path / ".town" / "runs" / RUN_ID
+    assert generated.path.is_dir()
+
+    explicit_path = tmp_path / "explicit"
+    explicit_path.mkdir()
+    explicit = prepare_artifact_directory(
+        run_id=RUN_ID, output_dir=explicit_path, base_dir=tmp_path
+    )
+    assert explicit.path == explicit_path
+    assert not (explicit_path / RUN_ID).exists()
+
+    with pytest.raises(ArtifactDirectoryError):
+        prepare_artifact_directory(run_id=RUN_ID, output_dir=None, base_dir=tmp_path)
+
+
+def _runtime() -> AgentTestRuntime:
+    event_ids = iter(["01K00000000000000000000002"])
+    return AgentTestRuntime(
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+        event_id_factory=lambda: next(event_ids),
+        observed_at=lambda: datetime(2026, 8, 13, 12, 0, tzinfo=UTC),
+    )
+
+
+def test_trace_finalization_requires_closed_exact_runtime_parity(tmp_path: Path) -> None:
+    """Digesting a buffered/open or runtime-divergent trace must fail before result writing."""
+    artifacts = prepare_artifact_directory(
+        run_id=RUN_ID, output_dir=tmp_path / "run", base_dir=tmp_path
+    )
+    runtime = _runtime()
+    runtime.record(
+        ScenarioEventRequest(
+            kind="test.driver.run_admitted",
+            logical_time=0,
+            observer="town.driven-agent",
+            subject="provider-0",
+            data={
+                "adapter_instance_id": "adapter:dev",
+                "profile_digest": resolve_test_profile("capability-fulfillment").reference.digest,
+                "driver_sequence": 0,
+                "intent_kind": "declare_capability",
+            },
+        )
+    )
+    writer = TraceWriter(artifacts.trace_path)
+    writer.record(runtime.observations[-1].model_dump(mode="json"))
+
+    with pytest.raises(ArtifactDirectoryError):
+        artifacts.finalize_trace(runtime.observations)
+
+    writer.close()
+    trace_artifact = artifacts.finalize_trace(runtime.observations)
+    exact_bytes = artifacts.trace_path.read_bytes()
+    assert exact_bytes.endswith(b"\n")
+    assert trace_artifact.model_dump(mode="json") == {
+        "kind": "trace",
+        "path": "trace.jsonl",
+        "media_type": "application/x-ndjson",
+        "digest": "sha256:" + hashlib.sha256(exact_bytes).hexdigest(),
+    }
+
+
+def test_result_is_deterministic_final_lf_and_atomic_last(tmp_path: Path) -> None:
+    """A terminal result is closed, stable, and cannot be silently overwritten."""
+    artifacts = prepare_artifact_directory(
+        run_id=RUN_ID, output_dir=tmp_path / "run", base_dir=tmp_path
+    )
+    fixture = (Path(__file__).parent / "fixtures" / "result-pass.json").read_text(encoding="utf-8")
+    result = TestResult.model_validate_json(fixture)
+
+    written = artifacts.write_result(result)
+
+    exact_bytes = artifacts.result_path.read_bytes()
+    assert written == exact_bytes
+    assert exact_bytes.endswith(b"\n")
+    assert json.loads(exact_bytes) == result.model_dump(mode="json")
+    assert sorted(path.name for path in artifacts.path.iterdir()) == ["result.json"]
+    with pytest.raises(ArtifactDirectoryError):
+        artifacts.write_result(result)

--- a/packages/nest-core/tests/agent_test/test_capability_scenario.py
+++ b/packages/nest-core/tests/agent_test/test_capability_scenario.py
@@ -1,18 +1,42 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Standalone smoke tests for the deterministic capability workflow."""
+"""Behavior tests for the deterministic capability-fulfillment baseline."""
 
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
+from nest_core.agent_test.models import (
+    LookupReturnedObservation,
+    ProviderSelectedObservation,
+    TestObservation,
+)
+from nest_core.agent_test.profiles import capability_profile_document, resolve_test_profile
 from nest_core.builtin_scenarios import builtin_path
 from nest_core.runner import ScenarioRunner
 from nest_core.scenario import ScenarioConfig
-from nest_core.sim.agent import StateMachineAgent
+from nest_core.sim.agent import ScenarioEventRequest, StateMachineAgent
 from nest_core.types import AgentId
 from nest_plugins_reference.registry.in_memory import InMemoryRegistry
+from pydantic import ValidationError
+
+RUN_ID = "01K00000000000000000000001"
+EVENT_IDS = [f"01K0000000000000000000000{value}" for value in range(2, 9)]
+
+
+def _runtime(event_ids: Iterator[str] | None = None) -> Any:
+    from nest_core.agent_test.runtime import AgentTestRuntime
+
+    return AgentTestRuntime(
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+        event_id_factory=(lambda: next(event_ids)) if event_ids is not None else None,
+        observed_at=lambda: datetime(2026, 8, 13, 12, 0, tzinfo=UTC),
+    )
 
 
 def _config(tmp_path: Path) -> ScenarioConfig:
@@ -21,7 +45,7 @@ def _config(tmp_path: Path) -> ScenarioConfig:
     return config
 
 
-def test_factory_has_exact_participants_and_run_local_registry(tmp_path: Path) -> None:
+def test_factory_has_exact_participants_and_pinned_registry(tmp_path: Path) -> None:
     from nest_core.scenarios_builtin.capability_fulfillment import (
         capability_fulfillment_factory,
     )
@@ -61,16 +85,114 @@ def test_capability_evaluator_emits_generation_one_revision() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ordinary_scenario_discovers_and_routes_exact_fixture(tmp_path: Path) -> None:
+async def test_scenario_discovers_then_routes_exact_fixture_with_typed_observations(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime(iter(EVENT_IDS))
     config = _config(tmp_path)
-    runner = ScenarioRunner(config)
+    runner = ScenarioRunner(config, event_sink=runtime)
 
     await runner.run()
 
     assert type(runner.resolved_plugins["registry"]) is InMemoryRegistry
     records = [json.loads(line) for line in Path(config.output.trace).read_text().splitlines()]
-    assert [record["msg"] for record in records if record["kind"] == "send"] == [
+    ordinary = [record for record in records if not record["kind"].startswith("test.")]
+    assert [(r["agent"], r["kind"]) for r in ordinary[:2]] == [
+        ("requester-0", "start"),
+        ("provider-0", "start"),
+    ]
+    assert [r["msg"] for r in ordinary if r["kind"] == "send"] == [
         "buy:widget:2",
         "sold:widget:2",
     ]
-    assert not any(record["kind"].startswith("test.") for record in records)
+
+    observations = [
+        TestObservation.model_validate(record)
+        for record in records
+        if record["kind"].startswith("test.")
+    ]
+    assert [observation.root.seq for observation in observations] == list(range(1, 8))
+    assert [observation.root.event_id for observation in observations] == EVENT_IDS
+    assert [observation.root.run_id for observation in observations] == [RUN_ID] * 7
+    assert [observation.root.kind for observation in observations] == [
+        "test.registry.provider_registered",
+        "test.registry.lookup_requested",
+        "test.registry.lookup_returned",
+        "test.requester.provider_selected",
+        "test.message.request_routed",
+        "test.message.response_routed",
+        "test.capability.result_evaluated",
+    ]
+    lookup_returned = observations[2].root
+    provider_selected = observations[3].root
+    assert isinstance(lookup_returned, LookupReturnedObservation)
+    assert isinstance(provider_selected, ProviderSelectedObservation)
+    assert lookup_returned.data.card_agent_ids == ["provider-0"]
+    assert provider_selected.data.lookup_event_id == EVENT_IDS[2]
+
+
+@pytest.mark.asyncio
+async def test_direct_address_without_successful_lookup_emits_no_discovery_evidence(
+    tmp_path: Path,
+) -> None:
+    class _UnregisteredProvider(StateMachineAgent):
+        async def on_message(self, ctx: object, sender: AgentId, payload: bytes) -> None:
+            raise AssertionError("requester bypassed registry lookup")
+
+    runtime = _runtime(iter(EVENT_IDS))
+    config = _config(tmp_path)
+    await ScenarioRunner(
+        config,
+        participant_override={AgentId("provider-0"): _UnregisteredProvider()},
+        event_sink=runtime,
+    ).run()
+
+    records = [json.loads(line) for line in Path(config.output.trace).read_text().splitlines()]
+    observations = [record for record in records if record["kind"].startswith("test.")]
+    assert [record["kind"] for record in observations] == [
+        "test.registry.lookup_requested",
+        "test.registry.lookup_returned",
+    ]
+    assert observations[-1]["data"]["card_agent_ids"] == []
+    assert not any(record.get("msg") == "buy:widget:2" for record in records)
+
+
+def test_runtime_rejects_observations_outside_closed_model() -> None:
+    runtime = _runtime(iter(EVENT_IDS))
+
+    with pytest.raises(ValidationError):
+        runtime.record(
+            ScenarioEventRequest(
+                kind="test.registry.lookup_requested",
+                logical_time=0,
+                observer="town.capability-requester",
+                subject="provider-0",
+                data={
+                    "registry_implementation": (
+                        "nest_plugins_reference.registry.in_memory.InMemoryRegistry"
+                    ),
+                    "capabilities": ["sell"],
+                    "unexpected": True,
+                },
+            )
+        )
+
+
+def test_capability_runtime_subject_is_profile_provider() -> None:
+    runtime = _runtime(iter(EVENT_IDS))
+    resolved = resolve_test_profile("capability-fulfillment")
+
+    assert runtime.subject_participant_id == "provider-0"
+    assert runtime.profile == resolved.reference
+
+
+def test_runtime_rederives_subject_from_canonical_packaged_resource() -> None:
+    from nest_core.agent_test.runtime import AgentTestRuntime
+
+    resolved = resolve_test_profile("capability-fulfillment")
+    returned_document = capability_profile_document(resolved)
+    cast("Any", returned_document.scenario).subject_participant_id = "requester-0"
+
+    runtime = AgentTestRuntime(run_id=RUN_ID, resolved_profile=resolved)
+
+    assert runtime.subject_participant_id == "provider-0"

--- a/packages/nest-core/tests/agent_test/test_driven_agent.py
+++ b/packages/nest-core/tests/agent_test/test_driven_agent.py
@@ -1,0 +1,591 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Behavior tests for the transport-neutral externally driven participant."""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from nest_core.agent_test.driven_agent import DrivenAgent
+from nest_core.agent_test.driver import (
+    DriverContractError,
+    DriverIncompleteError,
+    TownDriverError,
+)
+from nest_core.agent_test.models import (
+    DeclareCapabilityIntent,
+    DriverExchangeFailedObservation,
+    DriverReadiness,
+    DriverRequest,
+    DriverResponse,
+    EffectiveDriverLimits,
+    NoneIntent,
+    ReadyLimits,
+    SendToSenderIntent,
+)
+from nest_core.agent_test.profiles import ResolvedTestProfile, resolve_test_profile
+from nest_core.agent_test.runtime import AgentTestRuntime
+from nest_core.sim.agent import ScenarioEventRequest
+from nest_core.types import AgentId, CorrelationId, Query
+from nest_plugins_reference.registry.in_memory import InMemoryRegistry
+
+RUN_ID = "01K00000000000000000000001"
+type DriverIntent = DeclareCapabilityIntent | SendToSenderIntent | NoneIntent
+
+
+def _identity_response(response: DriverResponse) -> DriverResponse:
+    return response
+
+
+def _event_id_factory(start: int) -> Callable[[], str]:
+    event_ids = iter(f"01K000000000000000000000{value:02d}" for value in range(start, start + 20))
+    return lambda: next(event_ids)
+
+
+def _digest_request(request: DriverRequest) -> str:
+    return "sha256:" + hashlib.sha256(request.model_dump_json().encode()).hexdigest()
+
+
+def _readiness(instance_id: str = "adapter:dev") -> DriverReadiness:
+    profile = resolve_test_profile("capability-fulfillment").reference
+    from nest_core.agent_test.models import DriverReady
+
+    return DriverReadiness(
+        ready=DriverReady(
+            schema_version="town-agent-driver-ready/1",
+            adapter_instance_id=instance_id,
+            contracts=["town-agent-driver/1"],
+            profiles=[profile],
+            accepting_runs=True,
+            limits=ReadyLimits(
+                max_active_runs=1,
+                max_request_bytes=65536,
+                max_response_bytes=65536,
+            ),
+        ),
+        effective_limits=EffectiveDriverLimits(
+            max_request_bytes=65536,
+            max_response_bytes=65536,
+        ),
+    )
+
+
+class _Driver:
+    def __init__(
+        self,
+        intent_for: Callable[[DriverRequest], DriverIntent],
+        response_mutator: Callable[[DriverResponse], DriverResponse] | None = None,
+    ) -> None:
+        self._intent_for = intent_for
+        self._response_mutator: Callable[[DriverResponse], DriverResponse] = (
+            response_mutator or _identity_response
+        )
+        self.requests: list[DriverRequest] = []
+        self.close_calls = 0
+
+    async def ready(self, profile: ResolvedTestProfile) -> DriverReadiness:
+        return _readiness()
+
+    async def decide(self, request: DriverRequest) -> DriverResponse:
+        self.requests.append(request)
+        response = DriverResponse(
+            schema_version="town-agent-driver/1",
+            run_id=request.run_id,
+            event_id=request.event_id,
+            sequence=request.sequence,
+            adapter_instance_id="adapter:dev",
+            request_digest=_digest_request(request),
+            intent=self._intent_for(request),
+        )
+        return self._response_mutator(response)
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+class _Context:
+    def __init__(self, registry: InMemoryRegistry, runtime: AgentTestRuntime) -> None:
+        self.agent_id = AgentId("provider-0")
+        self.time = 0.0
+        self.rng = random.Random(7)
+        self.plugins: dict[str, Any] = {"registry": registry}
+        self.test_runtime = runtime
+        self.event_sink = runtime
+        self.sent: list[tuple[AgentId, bytes]] = []
+
+    async def send(self, to: AgentId, payload: bytes) -> None:
+        await self.send_with_correlation(to, payload)
+
+    async def send_with_correlation(self, to: AgentId, payload: bytes) -> CorrelationId:
+        self.sent.append((to, payload))
+        return CorrelationId(f"corr-{len(self.sent)}")
+
+    async def broadcast(self, payload: bytes) -> None:
+        raise AssertionError("DrivenAgent must not broadcast")
+
+    async def schedule(self, delay: float, payload: bytes) -> None:
+        raise AssertionError("DrivenAgent must not schedule")
+
+    def record_scenario_event(
+        self,
+        *,
+        kind: str,
+        observer: str,
+        subject: str,
+        data: Mapping[str, object],
+        attributes: Mapping[str, object] | None = None,
+    ):
+        return self.test_runtime.record(
+            ScenarioEventRequest(
+                kind=kind,
+                logical_time=self.time,
+                observer=observer,
+                subject=subject,
+                data=data,
+                attributes={} if attributes is None else attributes,
+            )
+        )
+
+
+def _runtime() -> AgentTestRuntime:
+    return AgentTestRuntime(
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+        event_id_factory=_event_id_factory(10),
+        observed_at=lambda: datetime(2026, 8, 13, 12, 0, tzinfo=UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_binds_driver_and_registers_declared_capability() -> None:
+    """Changing run/profile/participant/instance binding or bypassing Registry breaks admission."""
+    profile = resolve_test_profile("capability-fulfillment")
+    registry = InMemoryRegistry()
+    runtime = _runtime()
+    ctx = _Context(registry, runtime)
+    driver = _Driver(
+        lambda request: DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+    )
+    agent = DrivenAgent(
+        driver=driver,
+        run_id=RUN_ID,
+        resolved_profile=profile,
+        readiness=_readiness(),
+        event_id_factory=_event_id_factory(2),
+    )
+
+    await agent.on_start(ctx)
+
+    request = driver.requests[0]
+    assert request.model_dump(mode="json") == {
+        "schema_version": "town-agent-driver/1",
+        "run_id": RUN_ID,
+        "event_id": "01K00000000000000000000002",
+        "sequence": 0,
+        "participant": {"id": "provider-0", "role": "provider"},
+        "profile": profile.reference.model_dump(mode="json"),
+        "observation": {
+            "kind": "start",
+            "logical_time": 0,
+            "allowed_intents": ["declare_capability", "none"],
+        },
+    }
+    cards = await registry.lookup(Query(capabilities=["sell"]))
+    assert [str(card.agent_id) for card in cards] == ["provider-0"]
+    assert [observation.root.kind for observation in runtime.observations] == [
+        "test.driver.run_admitted",
+        "test.registry.provider_registered",
+    ]
+    admitted = runtime.observations[0].root
+    assert admitted.data.model_dump(mode="json") == {
+        "adapter_instance_id": "adapter:dev",
+        "profile_digest": profile.reference.digest,
+        "driver_sequence": 0,
+        "intent_kind": "declare_capability",
+    }
+
+
+@pytest.mark.asyncio
+async def test_message_observes_exact_request_and_routes_one_bounded_intent() -> None:
+    """Changing the sender/payload envelope or replacing Town routing breaks fulfillment."""
+    profile = resolve_test_profile("capability-fulfillment")
+    registry = InMemoryRegistry()
+    runtime = _runtime()
+    ctx = _Context(registry, runtime)
+
+    def intent_for(request: DriverRequest) -> DriverIntent:
+        if request.observation.kind == "start":
+            return DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+        return SendToSenderIntent(
+            kind="send_to_sender",
+            media_type="text/plain; charset=utf-8",
+            text="bounded but semantically wrong",
+        )
+
+    driver = _Driver(intent_for)
+    agent = DrivenAgent(
+        driver=driver,
+        run_id=RUN_ID,
+        resolved_profile=profile,
+        readiness=_readiness(),
+        event_id_factory=_event_id_factory(2),
+    )
+    await agent.on_start(ctx)
+
+    await agent.on_message(ctx, AgentId("requester-0"), b"buy:widget:2")
+
+    request = driver.requests[1]
+    assert request.model_dump(mode="json") == {
+        "schema_version": "town-agent-driver/1",
+        "run_id": RUN_ID,
+        "event_id": "01K00000000000000000000003",
+        "sequence": 1,
+        "participant": {"id": "provider-0", "role": "provider"},
+        "profile": profile.reference.model_dump(mode="json"),
+        "observation": {
+            "kind": "message",
+            "logical_time": 0,
+            "allowed_intents": ["send_to_sender", "none"],
+            "message": {
+                "id": "message-001",
+                "sender_id": "requester-0",
+                "media_type": "text/plain; charset=utf-8",
+                "text": "buy:widget:2",
+            },
+        },
+    }
+    assert ctx.sent == [(AgentId("requester-0"), b"bounded but semantically wrong")]
+    assert [observation.root.kind for observation in runtime.observations] == [
+        "test.driver.run_admitted",
+        "test.registry.provider_registered",
+        "test.driver.intent_returned",
+        "test.message.response_routed",
+    ]
+    returned = runtime.observations[2].root
+    assert returned.data.model_dump(mode="json") == {
+        "adapter_instance_id": "adapter:dev",
+        "driver_event_id": "01K00000000000000000000003",
+        "driver_sequence": 1,
+        "intent_kind": "send_to_sender",
+    }
+
+
+@pytest.mark.asyncio
+async def test_mismatched_start_response_aborts_and_records_closed_failure() -> None:
+    """A wrong response sequence cannot admit/register or fall back to reference behavior."""
+    registry = InMemoryRegistry()
+    runtime = _runtime()
+    ctx = _Context(registry, runtime)
+    driver = _Driver(
+        lambda request: DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"]),
+        response_mutator=lambda response: response.model_copy(update={"sequence": 1}),
+    )
+    agent = DrivenAgent(
+        driver=driver,
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+        readiness=_readiness(),
+        event_id_factory=_event_id_factory(2),
+    )
+
+    with pytest.raises(DriverContractError, match="RESPONSE_MISMATCH"):
+        await agent.on_start(ctx)
+
+    assert await registry.lookup(Query(capabilities=["sell"])) == []
+    assert len(runtime.observations) == 1
+    failed = runtime.observations[0].root
+    assert failed.kind == "test.driver.exchange_failed"
+    assert failed.data.model_dump(mode="json") == {
+        "stage": "start",
+        "disposition": "driver_contract",
+        "error_code": "RESPONSE_MISMATCH",
+        "driver_event_id": "01K00000000000000000000002",
+        "driver_sequence": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_duplicate_lifecycle_callbacks_reuse_event_and_apply_intent_once() -> None:
+    """A same-event retry is stable while registration and response routing happen once."""
+    runtime = _runtime()
+    ctx = _Context(InMemoryRegistry(), runtime)
+
+    def intent_for(request: DriverRequest) -> DriverIntent:
+        if request.observation.kind == "start":
+            return DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+        return SendToSenderIntent(
+            kind="send_to_sender",
+            media_type="text/plain; charset=utf-8",
+            text="sold:widget:2",
+        )
+
+    driver = _Driver(intent_for)
+    agent = DrivenAgent(
+        driver=driver,
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+        readiness=_readiness(),
+        event_id_factory=_event_id_factory(2),
+    )
+
+    await agent.on_start(ctx)
+    await agent.on_start(ctx)
+    await agent.on_message(ctx, AgentId("requester-0"), b"buy:widget:2")
+    await agent.on_message(ctx, AgentId("requester-0"), b"buy:widget:2")
+
+    assert [(request.sequence, request.event_id) for request in driver.requests] == [
+        (0, "01K00000000000000000000002"),
+        (0, "01K00000000000000000000002"),
+        (1, "01K00000000000000000000003"),
+        (1, "01K00000000000000000000003"),
+    ]
+    assert ctx.sent == [(AgentId("requester-0"), b"sold:widget:2")]
+    assert [observation.root.kind for observation in runtime.observations] == [
+        "test.driver.run_admitted",
+        "test.registry.provider_registered",
+        "test.driver.intent_returned",
+        "test.message.response_routed",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stop_is_outer_owned_best_effort_and_idempotent() -> None:
+    """Simulator on_stop performs no I/O; the outer cleanup sends one stop decision only."""
+    ctx = _Context(InMemoryRegistry(), _runtime())
+
+    def intent_for(request: DriverRequest) -> DriverIntent:
+        if request.observation.kind == "start":
+            return DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+        return NoneIntent(kind="none")
+
+    driver = _Driver(intent_for)
+    agent = DrivenAgent(
+        driver=driver,
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+        readiness=_readiness(),
+        event_id_factory=_event_id_factory(2),
+    )
+    await agent.on_start(ctx)
+
+    await agent.on_stop(ctx)
+    assert len(driver.requests) == 1
+
+    await agent.best_effort_stop("run_failed")
+    await agent.best_effort_stop("run_complete")
+
+    assert len(driver.requests) == 2
+    stop = driver.requests[1]
+    assert stop.sequence == 1
+    assert stop.event_id == "01K00000000000000000000003"
+    assert stop.observation.model_dump(mode="json") == {
+        "kind": "stop",
+        "logical_time": 0,
+        "allowed_intents": ["none"],
+        "reason": "run_failed",
+    }
+    assert driver.close_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_driver_event_ids_must_be_unique_across_lifecycle_requests() -> None:
+    """A colliding generated event ID aborts before a second exchange or routed fallback."""
+    ctx = _Context(InMemoryRegistry(), _runtime())
+
+    def intent_for(request: DriverRequest) -> DriverIntent:
+        if request.observation.kind == "start":
+            return DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+        return SendToSenderIntent(
+            kind="send_to_sender",
+            media_type="text/plain; charset=utf-8",
+            text="sold:widget:2",
+        )
+
+    driver = _Driver(intent_for)
+    agent = DrivenAgent(
+        driver=driver,
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+        readiness=_readiness(),
+        event_id_factory=lambda: "01K00000000000000000000002",
+    )
+    await agent.on_start(ctx)
+
+    with pytest.raises(TownDriverError, match="EVENT_CONFLICT"):
+        await agent.on_message(ctx, AgentId("requester-0"), b"buy:widget:2")
+
+    assert len(driver.requests) == 1
+    assert ctx.sent == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("logical_time", [float("nan"), float("inf"), -1.0, 0.5])
+async def test_invalid_town_logical_time_aborts_before_driver_exchange(
+    logical_time: float,
+) -> None:
+    """Driver requests never coerce non-finite, negative, or fractional Town time."""
+    ctx = _Context(InMemoryRegistry(), _runtime())
+    ctx.time = logical_time
+    driver = _Driver(lambda request: NoneIntent(kind="none"))
+    agent = DrivenAgent(
+        driver=driver,
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+        readiness=_readiness(),
+    )
+
+    with pytest.raises(TownDriverError, match="INVALID_LOGICAL_TIME"):
+        await agent.on_start(ctx)
+
+    assert driver.requests == []
+
+
+@pytest.mark.asyncio
+async def test_oversized_message_intent_is_revalidated_before_town_routing() -> None:
+    """A constructed response cannot bypass the profile's 4096-byte routing bound."""
+    ctx = _Context(InMemoryRegistry(), _runtime())
+
+    def intent_for(request: DriverRequest) -> DriverIntent:
+        if request.observation.kind == "start":
+            return DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+        return SendToSenderIntent(
+            kind="send_to_sender",
+            media_type="text/plain; charset=utf-8",
+            text="sold:widget:2",
+        )
+
+    def mutate_message(response: DriverResponse) -> DriverResponse:
+        if response.sequence != 1:
+            return response
+        oversized = SendToSenderIntent.model_construct(
+            kind="send_to_sender",
+            media_type="text/plain; charset=utf-8",
+            text="é" * 2049,
+        )
+        return response.model_copy(update={"intent": oversized})
+
+    driver = _Driver(intent_for, response_mutator=mutate_message)
+    agent = DrivenAgent(
+        driver=driver,
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+        readiness=_readiness(),
+    )
+    await agent.on_start(ctx)
+
+    with pytest.raises(DriverContractError, match="MALFORMED_RESPONSE"):
+        await agent.on_message(ctx, AgentId("requester-0"), b"buy:widget:2")
+
+    assert ctx.sent == []
+    failed = ctx.test_runtime.observations[-1].root
+    assert isinstance(failed, DriverExchangeFailedObservation)
+    assert failed.data.disposition == "driver_contract"
+
+
+@pytest.mark.asyncio
+async def test_adapter_instance_drift_aborts_message_without_routing() -> None:
+    """One run cannot continue after the ready-bound adapter instance changes."""
+    ctx = _Context(InMemoryRegistry(), _runtime())
+
+    def intent_for(request: DriverRequest) -> DriverIntent:
+        if request.observation.kind == "start":
+            return DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+        return SendToSenderIntent(
+            kind="send_to_sender",
+            media_type="text/plain; charset=utf-8",
+            text="sold:widget:2",
+        )
+
+    def mutate_message(response: DriverResponse) -> DriverResponse:
+        if response.sequence == 1:
+            return response.model_copy(update={"adapter_instance_id": "adapter:other"})
+        return response
+
+    driver = _Driver(intent_for, response_mutator=mutate_message)
+    agent = DrivenAgent(
+        driver=driver,
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+        readiness=_readiness(),
+    )
+    await agent.on_start(ctx)
+
+    with pytest.raises(DriverIncompleteError, match="ADAPTER_INSTANCE_CHANGED"):
+        await agent.on_message(ctx, AgentId("requester-0"), b"buy:widget:2")
+
+    assert ctx.sent == []
+    failed = ctx.test_runtime.observations[-1].root
+    assert isinstance(failed, DriverExchangeFailedObservation)
+    assert failed.data.disposition == "incomplete"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sender", "payload"),
+    [
+        (AgentId("provider-0"), b"buy:widget:2"),
+        (AgentId("requester-0"), b"buy:widget:1"),
+    ],
+)
+async def test_wrong_synthetic_message_envelope_aborts_before_driver_exchange(
+    sender: AgentId,
+    payload: bytes,
+) -> None:
+    """Only the frozen requester and request bytes may enter the driver contract."""
+    ctx = _Context(InMemoryRegistry(), _runtime())
+
+    def intent_for(request: DriverRequest) -> DriverIntent:
+        if request.observation.kind == "start":
+            return DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+        return NoneIntent(kind="none")
+
+    driver = _Driver(intent_for)
+    agent = DrivenAgent(
+        driver=driver,
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+        readiness=_readiness(),
+    )
+    await agent.on_start(ctx)
+
+    with pytest.raises(TownDriverError, match="MESSAGE_MISMATCH"):
+        await agent.on_message(ctx, sender, payload)
+
+    assert len(driver.requests) == 1
+    assert ctx.sent == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_message_with_changed_logical_time_is_an_event_conflict() -> None:
+    """A retry is idempotent only when the complete driver event body is unchanged."""
+    ctx = _Context(InMemoryRegistry(), _runtime())
+
+    def intent_for(request: DriverRequest) -> DriverIntent:
+        if request.observation.kind == "start":
+            return DeclareCapabilityIntent(kind="declare_capability", capabilities=["sell"])
+        return SendToSenderIntent(
+            kind="send_to_sender",
+            media_type="text/plain; charset=utf-8",
+            text="sold:widget:2",
+        )
+
+    driver = _Driver(intent_for)
+    agent = DrivenAgent(
+        driver=driver,
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+        readiness=_readiness(),
+    )
+    await agent.on_start(ctx)
+    await agent.on_message(ctx, AgentId("requester-0"), b"buy:widget:2")
+    ctx.time = 1.0
+
+    with pytest.raises(TownDriverError, match="EVENT_CONFLICT"):
+        await agent.on_message(ctx, AgentId("requester-0"), b"buy:widget:2")
+
+    assert len(driver.requests) == 2
+    assert ctx.sent == [(AgentId("requester-0"), b"sold:widget:2")]

--- a/packages/nest-core/tests/agent_test/test_evaluator.py
+++ b/packages/nest-core/tests/agent_test/test_evaluator.py
@@ -1,0 +1,474 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure evidence-table tests for capability-fulfillment evaluation."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import pytest
+from nest_core.agent_test.evaluator import evaluate_capability_fulfillment
+from nest_core.agent_test.models import TestObservation
+from nest_core.agent_test.profiles import resolve_test_profile
+
+RUN_ID = "01K00000000000000000000001"
+REGISTRY = "nest_plugins_reference.registry.in_memory.InMemoryRegistry"
+OBSERVER_BY_KIND = {
+    "test.driver.run_admitted": "town.driven-agent",
+    "test.driver.exchange_failed": "town.driven-agent",
+    "test.registry.provider_registered": "town.driven-agent",
+    "test.driver.intent_returned": "town.driven-agent",
+    "test.message.response_routed": "town.driven-agent",
+    "test.registry.lookup_requested": "town.capability-requester",
+    "test.registry.lookup_returned": "town.capability-requester",
+    "test.requester.provider_selected": "town.capability-requester",
+    "test.message.request_routed": "town.capability-requester",
+    "test.capability.result_evaluated": "town.profile-evaluator",
+}
+
+
+def _digest(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode()).hexdigest()
+
+
+def _event_id(sequence: int) -> str:
+    return f"01K000000000000000000000{sequence + 1:02d}"
+
+
+def _observation(sequence: int, kind: str, data: dict[str, Any]) -> TestObservation:
+    return TestObservation.model_validate(
+        {
+            "schema_version": "town.test-observation/1",
+            "seq": sequence,
+            "event_id": _event_id(sequence),
+            "run_id": RUN_ID,
+            "kind": kind,
+            "logical_time": 0.0,
+            "observed_at": "2026-08-13T12:00:00Z",
+            "duration_ms": None,
+            "observer": OBSERVER_BY_KIND[kind],
+            "subject_participant_id": "provider-0",
+            "message_id": {
+                "test.message.request_routed": "message-001",
+                "test.driver.intent_returned": "message-001",
+                "test.message.response_routed": "message-002",
+                "test.capability.result_evaluated": "message-002",
+            }.get(kind),
+            "correlation_id": (
+                "corr-1"
+                if kind in {"test.message.request_routed", "test.message.response_routed"}
+                else None
+            ),
+            "request_digest": (
+                _digest("buy:widget:2")
+                if kind in {"test.message.request_routed", "test.message.response_routed"}
+                else None
+            ),
+            "response_digest": (
+                _digest("sold:widget:2")
+                if kind in {"test.message.response_routed", "test.capability.result_evaluated"}
+                else None
+            ),
+            "data": data,
+        }
+    )
+
+
+def _passing_observations() -> list[TestObservation]:
+    return [
+        _observation(
+            1,
+            "test.driver.run_admitted",
+            {
+                "adapter_instance_id": "adapter:dev",
+                "profile_digest": resolve_test_profile("capability-fulfillment").reference.digest,
+                "driver_sequence": 0,
+                "intent_kind": "declare_capability",
+            },
+        ),
+        _observation(
+            2,
+            "test.registry.provider_registered",
+            {
+                "registry_implementation": REGISTRY,
+                "card_agent_id": "provider-0",
+                "capabilities": ["sell"],
+            },
+        ),
+        _observation(
+            3,
+            "test.registry.lookup_requested",
+            {"registry_implementation": REGISTRY, "capabilities": ["sell"]},
+        ),
+        _observation(
+            4,
+            "test.registry.lookup_returned",
+            {"registry_implementation": REGISTRY, "card_agent_ids": ["provider-0"]},
+        ),
+        _observation(
+            5,
+            "test.requester.provider_selected",
+            {"selected_agent_id": "provider-0", "lookup_event_id": _event_id(4)},
+        ),
+        _observation(
+            6,
+            "test.message.request_routed",
+            {
+                "sender_id": "requester-0",
+                "recipient_id": "provider-0",
+                "media_type": "text/plain; charset=utf-8",
+                "text": "buy:widget:2",
+                "payload_digest": _digest("buy:widget:2"),
+            },
+        ),
+        _observation(
+            7,
+            "test.driver.intent_returned",
+            {
+                "adapter_instance_id": "adapter:dev",
+                "driver_event_id": "01K00000000000000000000021",
+                "driver_sequence": 1,
+                "intent_kind": "send_to_sender",
+            },
+        ),
+        _observation(
+            8,
+            "test.message.response_routed",
+            {
+                "sender_id": "provider-0",
+                "recipient_id": "requester-0",
+                "media_type": "text/plain; charset=utf-8",
+                "text": "sold:widget:2",
+                "payload_digest": _digest("sold:widget:2"),
+            },
+        ),
+        _observation(
+            9,
+            "test.capability.result_evaluated",
+            {
+                "evaluator_id": "nanda.agent.capability-fulfillment",
+                "evaluator_version": "1",
+                "verdict": "pass",
+                "expected_response_digest": _digest("sold:widget:2"),
+                "actual_response_digest": _digest("sold:widget:2"),
+            },
+        ),
+    ]
+
+
+def test_five_required_checks_pass_only_from_ordered_real_path_evidence() -> None:
+    """Removing or reordering any real-path stage prevents the five-check PASS table."""
+    checks = evaluate_capability_fulfillment(
+        _passing_observations(),
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+    )
+
+    assert [(check.id, check.required, check.status) for check in checks] == [
+        ("driver.contract", True, "pass"),
+        ("registry.provider-registered", True, "pass"),
+        ("registry.provider-discovered", True, "pass"),
+        ("delivery.request-routed", True, "pass"),
+        ("capability.synthetic-request-fulfilled", True, "pass"),
+    ]
+    assert [check.evidence_refs for check in checks] == [
+        ["trace.jsonl#seq=1", "trace.jsonl#seq=7"],
+        ["trace.jsonl#seq=1", "trace.jsonl#seq=2"],
+        ["trace.jsonl#seq=3", "trace.jsonl#seq=4", "trace.jsonl#seq=5"],
+        ["trace.jsonl#seq=5", "trace.jsonl#seq=6"],
+        [
+            "trace.jsonl#seq=6",
+            "trace.jsonl#seq=7",
+            "trace.jsonl#seq=8",
+            "trace.jsonl#seq=9",
+        ],
+    ]
+
+
+def _statuses(observations: list[TestObservation]) -> list[str]:
+    return [
+        check.status
+        for check in evaluate_capability_fulfillment(
+            observations,
+            run_id=RUN_ID,
+            resolved_profile=resolve_test_profile("capability-fulfillment"),
+        )
+    ]
+
+
+def _driver_failure(
+    *, stage: str, disposition: str, error_code: str = "MALFORMED_RESPONSE"
+) -> TestObservation:
+    return _observation(
+        1,
+        "test.driver.exchange_failed",
+        {
+            "stage": stage,
+            "disposition": disposition,
+            "error_code": error_code,
+            "driver_event_id": "01K00000000000000000000021",
+            "driver_sequence": 0 if stage == "start" else 1,
+        },
+    )
+
+
+def test_start_none_is_semantic_registration_failure_with_downstream_not_tested() -> None:
+    """A valid refusal is conclusive without pretending discovery or delivery ran."""
+    observations = _passing_observations()[:1]
+    admitted = observations[0].root
+    observations[0] = TestObservation.model_validate(
+        {
+            **admitted.model_dump(mode="json"),
+            "data": {**admitted.data.model_dump(mode="json"), "intent_kind": "none"},
+        }
+    )
+
+    assert _statuses(observations) == [
+        "pass",
+        "fail",
+        "not_tested",
+        "not_tested",
+        "not_tested",
+    ]
+
+
+def test_start_driver_contract_failure_is_conclusive_and_stops_causal_checks() -> None:
+    """Malformed authenticated adapter output fails its check, not the synthetic task."""
+    assert _statuses([_driver_failure(stage="start", disposition="driver_contract")]) == [
+        "fail",
+        "not_tested",
+        "not_tested",
+        "not_tested",
+        "not_tested",
+    ]
+
+
+def test_transport_loss_is_inconclusive_and_stops_causal_checks() -> None:
+    """Timeout/loss cannot become a semantic failure or a false downstream pass."""
+    assert _statuses(
+        [_driver_failure(stage="start", disposition="incomplete", error_code="TIMEOUT")]
+    ) == [
+        "inconclusive",
+        "not_tested",
+        "not_tested",
+        "not_tested",
+        "not_tested",
+    ]
+
+
+def test_direct_addressing_without_linked_lookup_cannot_pass_discovery() -> None:
+    """A routed request is evidence of delivery, never retroactive Registry discovery."""
+    retained = [
+        observation
+        for observation in _passing_observations()
+        if observation.root.kind
+        not in {
+            "test.registry.lookup_requested",
+            "test.registry.lookup_returned",
+            "test.requester.provider_selected",
+        }
+    ]
+    observations = [
+        observation.model_copy(
+            update={
+                "root": observation.root.model_copy(
+                    update={"seq": sequence, "event_id": _event_id(sequence)}
+                )
+            }
+        )
+        for sequence, observation in enumerate(retained, start=1)
+    ]
+
+    assert _statuses(observations) == [
+        "pass",
+        "pass",
+        "fail",
+        "not_tested",
+        "not_tested",
+    ]
+
+
+def test_message_none_is_a_semantic_fulfillment_failure() -> None:
+    """A valid no-op response proves the capability request was not fulfilled."""
+    observations = _passing_observations()[:7]
+    returned = observations[-1].root
+    observations[-1] = TestObservation.model_validate(
+        {
+            **returned.model_dump(mode="json"),
+            "data": {**returned.data.model_dump(mode="json"), "intent_kind": "none"},
+        }
+    )
+
+    assert _statuses(observations) == ["pass", "pass", "pass", "pass", "fail"]
+
+
+def test_wrong_bounded_response_is_a_semantic_fulfillment_failure() -> None:
+    """Town routes bounded arbitrary text but evaluates only the exact frozen response as pass."""
+    observations = _passing_observations()
+    observations[7] = _observation(
+        8,
+        "test.message.response_routed",
+        {
+            "sender_id": "provider-0",
+            "recipient_id": "requester-0",
+            "media_type": "text/plain; charset=utf-8",
+            "text": "wrong but bounded",
+            "payload_digest": _digest("wrong but bounded"),
+        },
+    )
+    response = observations[7].root
+    observations[7] = observations[7].model_copy(
+        update={
+            "root": response.model_copy(update={"response_digest": _digest("wrong but bounded")})
+        }
+    )
+    observations[8] = _observation(
+        9,
+        "test.capability.result_evaluated",
+        {
+            "evaluator_id": "nanda.agent.capability-fulfillment",
+            "evaluator_version": "1",
+            "verdict": "fail",
+            "expected_response_digest": _digest("sold:widget:2"),
+            "actual_response_digest": _digest("wrong but bounded"),
+        },
+    )
+    evaluated = observations[8].root
+    observations[8] = observations[8].model_copy(
+        update={
+            "root": evaluated.model_copy(update={"response_digest": _digest("wrong but bounded")})
+        }
+    )
+
+    assert _statuses(observations) == ["pass", "pass", "pass", "pass", "fail"]
+
+
+def test_unlinked_response_envelope_cannot_pass_fulfillment() -> None:
+    """Payload data alone cannot replace the simulator's request/response digest chain."""
+    observations = _passing_observations()
+    response = observations[7].root
+    observations[7] = observations[7].model_copy(
+        update={
+            "root": response.model_copy(update={"request_digest": _digest("unrelated-request")})
+        }
+    )
+
+    assert _statuses(observations) == [
+        "pass",
+        "pass",
+        "pass",
+        "pass",
+        "inconclusive",
+    ]
+
+
+def test_message_driver_contract_failure_leaves_fulfillment_not_tested() -> None:
+    """Malformed adapter output after routing fails the driver, not the capability result."""
+    observations = _passing_observations()[:6]
+    observations.append(
+        _observation(
+            7,
+            "test.driver.exchange_failed",
+            {
+                "stage": "message",
+                "disposition": "driver_contract",
+                "error_code": "MALFORMED_RESPONSE",
+                "driver_event_id": "01K00000000000000000000021",
+                "driver_sequence": 1,
+            },
+        )
+    )
+
+    assert _statuses(observations) == ["fail", "pass", "pass", "pass", "not_tested"]
+
+
+def test_duplicate_or_out_of_order_evidence_makes_every_check_inconclusive() -> None:
+    """Trace integrity failure cannot yield even a partial conclusive result."""
+    passing = _passing_observations()
+    duplicate = passing.copy()
+    duplicate[1] = duplicate[1].model_copy(
+        update={
+            "root": duplicate[1].root.model_copy(update={"event_id": duplicate[0].root.event_id})
+        }
+    )
+    out_of_order = passing.copy()
+    out_of_order[4], out_of_order[5] = out_of_order[5], out_of_order[4]
+
+    assert _statuses(duplicate) == ["inconclusive"] * 5
+    assert _statuses(out_of_order) == ["inconclusive"] * 5
+
+
+def _replace_event_fields(observation: TestObservation, **changes: object) -> TestObservation:
+    return TestObservation.model_validate({**observation.root.model_dump(mode="json"), **changes})
+
+
+def test_wrong_admitted_profile_digest_makes_every_check_inconclusive() -> None:
+    """A valid but different profile digest cannot authorize this evaluator table."""
+    observations = _passing_observations()
+    admitted = observations[0].root
+    observations[0] = TestObservation.model_validate(
+        {
+            **admitted.model_dump(mode="json"),
+            "data": {
+                **admitted.data.model_dump(mode="json"),
+                "profile_digest": "sha256:" + "f" * 64,
+            },
+        }
+    )
+
+    assert _statuses(observations) == ["inconclusive"] * 5
+
+
+@pytest.mark.parametrize("event_index", range(9))
+def test_wrong_observer_for_each_scoped_event_makes_every_check_inconclusive(
+    event_index: int,
+) -> None:
+    """No event kind may borrow authority from another valid Town observer role."""
+    observations = _passing_observations()
+    observations[event_index] = _replace_event_fields(
+        observations[event_index], observer="town.agent-test-runner"
+    )
+
+    assert _statuses(observations) == ["inconclusive"] * 5
+
+
+@pytest.mark.parametrize("event_index", range(9))
+def test_wrong_subject_for_each_scoped_event_makes_every_check_inconclusive(
+    event_index: int,
+) -> None:
+    """Every event in this external-provider slice must remain bound to provider-0."""
+    observations = _passing_observations()
+    observations[event_index] = _replace_event_fields(
+        observations[event_index], subject_participant_id="requester-0"
+    )
+
+    assert _statuses(observations) == ["inconclusive"] * 5
+
+
+def test_exchange_failure_with_wrong_authority_is_inconclusive() -> None:
+    """A failure classification is evidence only when emitted by the driven agent."""
+    failed = _replace_event_fields(
+        _driver_failure(stage="start", disposition="driver_contract"),
+        observer="town.capability-requester",
+    )
+
+    assert _statuses([failed]) == ["inconclusive"] * 5
+
+
+def test_combined_profile_observer_and_subject_misattribution_cannot_pass() -> None:
+    """Several individually valid-looking provenance substitutions never compose to PASS."""
+    observations = _passing_observations()
+    admitted = observations[0].root
+    observations[0] = TestObservation.model_validate(
+        {
+            **admitted.model_dump(mode="json"),
+            "data": {
+                **admitted.data.model_dump(mode="json"),
+                "profile_digest": "sha256:" + "e" * 64,
+            },
+        }
+    )
+    observations[1] = _replace_event_fields(observations[1], observer="town.capability-requester")
+    observations[2] = _replace_event_fields(observations[2], subject_participant_id="requester-0")
+
+    assert _statuses(observations) == ["inconclusive"] * 5

--- a/packages/nest-core/tests/agent_test/test_participant_override.py
+++ b/packages/nest-core/tests/agent_test/test_participant_override.py
@@ -1,13 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Regression tests for the generic participant-replacement runner seam."""
+"""Regression tests for the exact participant-replacement runner seam."""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+import nest_core.agent_test.runner as agent_test_runner_module
 import pytest
+from nest_core.agent_test.profiles import resolve_test_profile
+from nest_core.builtin_scenarios import builtin_path
+from nest_core.plugins import PluginRegistry
 from nest_core.runner import ScenarioRunner
 from nest_core.scenario import ScenarioConfig
 from nest_core.scenarios import register_scenario
@@ -15,6 +19,17 @@ from nest_core.sim.agent import AgentContext, StateMachineAgent
 from nest_core.sim.simulator import Simulator
 from nest_core.sim.trace import TraceWriter
 from nest_core.types import AgentId
+
+RUN_ID = "01K00000000000000000000001"
+
+
+def _runtime() -> Any:
+    from nest_core.agent_test.runtime import AgentTestRuntime
+
+    return AgentTestRuntime(
+        run_id=RUN_ID,
+        resolved_profile=resolve_test_profile("capability-fulfillment"),
+    )
 
 
 class _ReplacementAgent(StateMachineAgent):
@@ -162,6 +177,49 @@ async def test_generic_runner_allows_requester_replacement(tmp_path: Path) -> No
     assert replacement.started_as == AgentId("requester-0")
 
 
+def test_runtime_rejects_independent_subject_authority() -> None:
+    from nest_core.agent_test.runtime import AgentTestRuntime
+
+    forged_kwargs: dict[str, object] = {
+        "run_id": RUN_ID,
+        "resolved_profile": resolve_test_profile("capability-fulfillment"),
+        "subject_participant_id": "requester-0",
+    }
+
+    with pytest.raises(TypeError, match="subject_participant_id"):
+        AgentTestRuntime(**forged_kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {AgentId("requester-0"): _ReferenceProvider()},
+        {
+            AgentId("requester-0"): _Requester(),
+            AgentId("provider-0"): _ReferenceProvider(),
+        },
+    ],
+)
+def test_agent_test_builder_rejects_non_subject_or_multiple_overrides(
+    override: dict[AgentId, StateMachineAgent],
+) -> None:
+    """Exact profile replacement policy remains in the agent-test boundary."""
+    resolved = resolve_test_profile("capability-fulfillment")
+    config = ScenarioConfig.from_yaml(builtin_path("capability_fulfillment"))
+
+    with pytest.raises(
+        agent_test_runner_module.AgentTestTownError,
+        match="PROFILE_SCENARIO_INVALID",
+    ):
+        cast("Any", agent_test_runner_module)._build_profile_scenario_runner(
+            config=config,
+            resolved_profile=resolved,
+            registry=PluginRegistry(),
+            participant_override=override,
+            event_sink=_runtime(),
+        )
+
+
 @pytest.mark.asyncio
 async def test_failed_replacement_never_falls_back_to_reference_provider(tmp_path: Path) -> None:
     original = _ReferenceProvider()
@@ -218,6 +276,7 @@ async def test_runner_closes_trace_when_agent_setup_fails(
     monkeypatch: pytest.MonkeyPatch,
     failure_stage: str,
 ) -> None:
+    """A failure after Simulator construction cannot leave its trace writer open."""
     primary = RuntimeError(f"{failure_stage} failed")
     close_calls = 0
     original_close = TraceWriter.close


### PR DESCRIPTION
## Problem

A successful adapter exchange is not enough: Town must drive the participant through a real deterministic workflow and emit honest, stage-specific evidence instead of a single opaque score.

## Change

- run one external participant through the pinned Town scenario and run-local Registry
- evaluate five ordered stages with pass/fail/incomplete/not-evaluated distinctions
- emit private, no-overwrite `result.json` and `trace.jsonl` artifacts
- close admitted runs and artifacts across success, failure, interruption, and Town defects

## Verification

- final stack: `make ci-local` — all 5 checks passed; 2,081 passed, 2 skipped, 1 deselected
- runner, evaluator, lifecycle, artifact-permission, collision, cancellation, and exact-byte tests pass
- independent lifecycle/security review found no Critical or Important issues

## Stack

**4 of 9. Depends on PR 3.** PR 5 adds the first user journey; this PR is the evaluation engine.

**Merge note:** After #222 merges into `main`, retarget this PR to `main`, wait for its CI, and only then merge it.