### PR TITLE
feat(agent-test): add the local-adapter CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 dist/
 build/
 traces/
+.town/
 # Capsule ledger written to cwd by the capsule_emit trust/payments plugins.
 capsule_ledger.jsonl
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ That's the whole "hello world". No clone, no path, no setup.
 - [Hackathon](#hackathon)
 - [Install](#install)
 - [The 60-second tour](#the-60-second-tour)
+- [Test a local agent adapter](#test-a-local-agent-adapter)
 - [Test your own protocol](#test-your-own-protocol)
 - [Built-in scenarios](#built-in-scenarios)
 - [The 12 layers](#the-12-layers)
@@ -131,6 +132,28 @@ Same seed → byte-identical trace, every time.
 > directory isn't installed by pip. Use `nest run marketplace` (a built-in
 > name) or copy a built-in out to edit:
 > `nest scenarios cp marketplace .`
+
+---
+
+## Test a local agent adapter
+
+Bring an agent through a strict loopback adapter, run one frozen
+capability-fulfillment workflow through Town's pinned, run-local Registry
+implementation and simulator, and receive a per-stage evidence report. Town
+translates the adapter's declared capability into a provider card; Town's
+reference requester discovers it. This does not test the external agent's own
+Registry protocol.
+
+Generation 1 is the first frozen agent-test contract/profile generation, not a
+Town or nest-core 1.0 release. The Generation 1 Bring Your Agent preview is
+checkout-only and requires Python 3.12+ plus `uv`. Follow
+[the Generation 1 local-agent adapter guide](docs/bring-your-agent.md) to start
+the reference adapter and set the shared caller credential. After the adapter
+is running:
+
+```bash
+uv run nest test agent --endpoint http://127.0.0.1:8787
+```
 
 ---
 

--- a/docs/bring-your-agent.md
+++ b/docs/bring-your-agent.md
@@ -1,0 +1,287 @@
+# Test a local agent adapter
+
+Nanda Town can exercise one strict boundary between Town and code you control.
+Town sends a separate local adapter three bounded observations—start, one
+synthetic request, and stop—and the adapter returns one permitted intent for
+each observation.
+
+This Bring Your Agent preview slice is intentionally narrower than “test any agent.” It gives
+agent authors a repeatable integration check without a public network, model
+credential, or hosted dependency. The checked-in reference is Python, but the
+HTTP contract is language-neutral.
+
+Generation 1 is the first frozen agent-test contract/profile generation, not a
+Town or nest-core 1.0 release.
+
+> **What a pass means:** Town observed valid, request-bound responses to its
+> bearer-authenticated requests for the frozen capability-fulfillment profile.
+> The responses carried one stable, self-asserted adapter instance ID. Town
+> translated the adapter's declared capability into a card in its pinned,
+> run-local Registry implementation, and Town's reference requester discovered
+> and exercised that card through the simulator.
+>
+> **What it does not mean:** The bearer is a caller credential; it does not
+> authenticate the adapter as a server identity. The adapter instance ID is
+> metadata supplied by the adapter, not a verified identity. This profile does
+> not test an external agent's own Registry protocol or discovery
+> implementation. It also does not establish that a model was used, that the
+> response was not hardcoded, or that the agent is generally compatible, safe,
+> trusted, or reliable.
+
+## Security boundary: trusted local code, not a sandbox
+
+The adapter and any runtime it calls execute with your operating-system user
+privileges. A separate process and a loopback-only endpoint are useful
+boundaries, but **Town does not sandbox the adapter or runtime**. Only run code
+you trust. It can read or modify anything your user account can access.
+
+The reference adapter reads and validates `TOWN_AGENT_TOKEN`, hashes it, and
+removes the raw value from its own process environment before accepting a
+decision. Exporting a variable in a shell still leaves it in that parent shell,
+and other processes under the same OS account may be able to inspect it.
+
+If your adapter starts a child runtime, construct the child's environment from
+an explicit allowlist of only the variables it needs. Do not pass a copy of
+`os.environ`, and never include `TOWN_AGENT_TOKEN` in the child environment.
+Keep model or service credentials in the runtime's own narrowly scoped secret
+configuration, not in Town's bearer variable.
+
+## Run the reference journey
+
+The reference adapter declares `sell`, answers `buy:widget:2` with
+`sold:widget:2`, and stops. Its job is to prove the integration path before you
+connect your own runtime.
+
+This Alpha feature is **checkout-only**. It requires Python 3.12 or newer and
+[uv](https://docs.astral.sh/uv/getting-started/installation/). From the repository
+checkout, install the exact locked workspace:
+
+```bash
+uv sync --frozen
+```
+
+Do not use an older or unpinned package install to evaluate this checkout.
+
+Generate one fresh 64-character local test token:
+
+```bash
+uv run python -c 'import secrets; print(secrets.token_hex(32))'
+```
+
+Copy that value into `TOWN_AGENT_TOKEN` in both terminals. Do not pass it as a
+command-line argument or save it in source, shell history, logs, or a committed
+file.
+
+**Terminal 1 — run the reference adapter**
+
+```bash
+read -r -s TOWN_AGENT_TOKEN && export TOWN_AGENT_TOKEN
+uv run python examples/agent-test/reference_adapter.py
+```
+
+Paste the generated value at the hidden prompt, then press Enter. The adapter
+listens only on `127.0.0.1:8787`.
+
+**Terminal 2 — after the adapter is running, run Town**
+
+```bash
+read -r -s TOWN_AGENT_TOKEN && export TOWN_AGENT_TOKEN
+uv run nest test agent --endpoint http://127.0.0.1:8787 \
+  --target-label my-local-agent
+```
+
+The `read -r -s` snippets are for Bash and zsh. In PowerShell, set the same
+value in each terminal with
+`$env:TOWN_AGENT_TOKEN = Read-Host -MaskInput`, then use the same `uv run`
+commands.
+
+After Town finishes and after you stop the adapter, remove the token from both
+parent shells:
+
+```bash
+unset TOWN_AGENT_TOKEN
+```
+
+```powershell
+Remove-Item Env:TOWN_AGENT_TOKEN
+```
+
+A successful run ends with `RESULT: PASS` and writes a new evidence directory
+under `.town/runs/<run-id>/`. Use `--output-dir <new-or-empty-directory>` to
+choose an exact location. For automation, add `--format json`; advanced callers
+that need the exact frozen reference can add
+`--profile nanda/agent/capability-fulfillment@1`. After an admitted run, stdout
+is byte-for-byte identical to `result.json`, while safe progress and diagnostics
+remain on stderr.
+
+## What Town evaluates
+
+The report separates five questions so that a downstream success cannot hide
+an earlier failure:
+
+1. **Bearer-authenticated driver contract** — did one stable, self-asserted
+   adapter instance return valid, request-bound intents for the required
+   exchanges?
+2. **Provider registered** — did Town translate the adapter's declared `sell`
+   capability into a provider card in the pinned, run-local Registry
+   implementation?
+3. **Provider discovered** — did Town's reference requester find and select that
+   card through the Registry lookup result?
+4. **Request routed** — did Town route the exact synthetic request through its
+   simulator to the selected provider?
+5. **Exact fulfillment returned** — did the expected response travel back
+   through Town and reach the requester?
+
+This is a test of Town's pinned Registry implementation and the adapter's
+declared capability, not the external agent's own Registry protocol.
+
+`Not evaluated` means Town could not produce a sound verdict for a check in this
+run, including when an earlier required stage prevented a dependent check from
+running. `Not tested` is reserved for a property the profile deliberately places
+outside its coverage. Neither means pass.
+
+The evidence directory contains:
+
+- `result.json`: the terminal verdict, per-check outcomes, coverage boundaries,
+  diagnostics, and trace digest.
+- `trace.jsonl`: the simulator trace plus typed `test.*` observations referenced
+  by the report.
+
+These files are mutable local diagnostics, not attestations. On POSIX systems,
+Town creates the default `.town/runs/<run-id>/` hierarchy with mode `0700` and
+artifact files with mode `0600`. If you provide an existing empty
+`--output-dir`, Town preserves that directory's mode; you are responsible for
+securing it. Other operating systems do not share a portable POSIX-mode
+guarantee. `.town/` is ignored by this repository, but ignore rules are not a
+security boundary.
+
+## Connect your own runtime
+
+Start from
+[`examples/agent-test/reference_adapter.py`](../examples/agent-test/reference_adapter.py).
+Preserve its HTTP framing, strict validation, digest binding, replay handling,
+and one-run state machine. Before testing your code:
+
+1. Change `ADAPTER_INSTANCE_ID` from `town-reference-adapter` to a stable
+   value that describes your adapter, such as `my-agent-adapter`. It remains
+   self-asserted metadata, not a verified identity.
+2. Replace only this deterministic decision function with a call to your trusted
+   runtime:
+
+```python
+def decide_intent(observation: dict[str, Any]) -> dict[str, Any]:
+    """Deterministic replace point: map one validated observation to one intent."""
+    kind = observation["kind"]
+    if kind == "start":
+        return {"kind": "declare_capability", "capabilities": ["sell"]}
+    if kind == "message":
+        return {
+            "kind": "send_to_sender",
+            "media_type": "text/plain; charset=utf-8",
+            "text": "sold:widget:2",
+        }
+    return {"kind": "none"}
+```
+
+The mapping is bounded:
+
+| Observation | Allowed result used by the reference adapter |
+|---|---|
+| `start` | declare the `sell` capability |
+| `message` containing `buy:widget:2` | return a plain-text response to the sender |
+| `stop` | return `none` and release the run |
+
+Your bridge may call a state machine, local model, hosted model, or another
+runtime. Town observes only the adapter's response to Town's
+bearer-authenticated request; it cannot infer which implementation produced it.
+
+## HTTP contract and exact resources
+
+The public wire contract is `town-agent-driver/1`:
+
+- `GET /town-driver/1/ready` advertises the exact supported profile and current
+  one-run capacity.
+- `POST /town-driver/1/decide` carries one observation and accepts one intent.
+- Requests use `Authorization: Bearer <token>`,
+  `Town-Driver-Contract: town-agent-driver/1`, and exact SHA-256 body binding.
+  The bearer lets the adapter authenticate its caller; it is not server identity.
+- The endpoint must be a canonical literal-loopback origin with an explicit
+  port. Redirects, proxy environment variables, cookies, compression, remote
+  hosts, and ambiguous URL forms are rejected.
+- Successful events are idempotent. Repeating one event with the same bytes
+  returns the same response bytes; reusing its event ID with changed bytes is a
+  conflict.
+- If a custom start or message decision raises an exception, the adapter returns
+  a fixed retryable `ADAPTER_INTERNAL` error without advancing the run. The same
+  event and exact request bytes may be retried after the runtime recovers. The
+  first schema-valid request still binds its event ID, so changed bytes conflict.
+  Raw exception text is never returned or logged.
+- Legal terminal stops return `none`, release the one-run capacity, and remain
+  byte-idempotent after release. A `run_failed`, `run_incomplete`, or
+  `user_interrupted` stop may account for a missing or failed message decision;
+  `run_complete` cannot skip the required exchange.
+
+The exact frozen Generation 1 profile and schemas are checked-in resources:
+
+- [Generation 1 capability-fulfillment profile](../packages/nest-core/nest_core/agent_test/resources/profiles/capability-fulfillment-1.json)
+- [Generation 1 driver request schema](../packages/nest-core/nest_core/agent_test/resources/schemas/driver-request-1.schema.json)
+- [Generation 1 driver response schema](../packages/nest-core/nest_core/agent_test/resources/schemas/driver-response-1.schema.json)
+- [Generation 1 driver readiness schema](../packages/nest-core/nest_core/agent_test/resources/schemas/driver-ready-1.schema.json)
+- [Generation 1 driver error schema](../packages/nest-core/nest_core/agent_test/resources/schemas/driver-error-1.schema.json)
+- [Generation 1 Test Profile schema](../packages/nest-core/nest_core/agent_test/resources/schemas/test-profile-1.schema.json)
+- [Generation 1 test observation schema](../packages/nest-core/nest_core/agent_test/resources/schemas/test-observation-1.schema.json)
+- [Generation 1 test result schema](../packages/nest-core/nest_core/agent_test/resources/schemas/test-result-1.schema.json)
+
+The standard-library reference is a teaching example, not a production server.
+Its focused notes are in
+[`examples/agent-test/README.md`](../examples/agent-test/README.md).
+
+## Exit codes and artifact admission
+
+| Code | Meaning |
+|---:|---|
+| `0` | Completed with all required checks passing. |
+| `1` | Completed with a conclusive failed check, or the adapter returned an invalid contract response. |
+| `2` | Configuration or compatibility was rejected before admission. |
+| `3` | Town encountered an internal execution error. |
+| `4` | The run was incomplete or evidence was inconclusive. |
+| `130` | The user interrupted the invocation. |
+
+If the invocation stops before Town admits a run, machine JSON stdout is empty
+and Town creates no `result.json`, `trace.jsonl`, or run directory. After
+admission, `result.json` is the authoritative terminal record even when output
+rendering is interrupted.
+
+## Troubleshooting
+
+- **`TOWN_AGENT_TOKEN is not set` or token format error:** enter the same fresh
+  64-character lowercase hexadecimal value in both terminals.
+- **Connection refused or incomplete result:** start the adapter first and
+  verify that no other process owns port 8787.
+- **Unsupported profile or contract:** use the exact command above; the Bring
+  Your Agent preview supports only the Generation 1 `capability-fulfillment`
+  profile.
+- **Pinned reference Registry is unavailable:** from the same checkout, rerun
+  `uv sync --frozen`, then invoke Town through `uv run nest`.
+- **Output directory rejected:** choose a path that does not exist or is an
+  empty, non-symlink directory. Town does not overwrite an earlier run.
+- **Contract failure:** inspect the safe diagnostic in `result.json` when a run
+  was admitted, compare requests and responses with the linked schemas, and
+  retry with a new output path.
+
+For maintainers, the source-tree process journey runs in normal pytest. Before a
+release handoff, also run the explicit clean-package proof:
+
+```bash
+TOWN_RUN_PACKAGE_QUICKSTART=1 \
+  uv run pytest \
+  packages/nest-core/tests/agent_test/test_end_to_end.py::test_clean_archive_wheel_quickstart_checker
+```
+
+## Deliberately deferred
+
+This slice does not include OpenClaw, Docker, A2A, MCP, remote endpoints,
+authentication beyond the local bearer, multi-turn workflows, model scoring,
+signed evidence, public identity or reputation, services, arbitrary SDK
+execution, or hosted testing. Those can be added behind new profiles and
+adapters without changing what this Generation 1 result claims.

--- a/examples/agent-test/README.md
+++ b/examples/agent-test/README.md
@@ -1,0 +1,58 @@
+# Reference local agent adapter
+
+`reference_adapter.py` is the one Python reference for Nanda Town's strict local
+agent-driver boundary. The HTTP contract is language-neutral. This is a
+deterministic teaching bridge, not a hosted service, general agent runtime,
+benchmark agent, or production server.
+
+It uses only Python's standard library, binds literal `127.0.0.1`, reads the
+bearer only from `TOWN_AGENT_TOKEN`, and supports exactly one active
+Generation 1 `capability-fulfillment` run. Generation 1 is the first frozen
+agent-test contract/profile generation, not a Town or nest-core 1.0 release. It
+never accepts the token as a command-line argument or writes it into responses,
+run/decision state, or logs. After
+validating and hashing the token, it removes the raw value from its own process
+environment before serving decisions. The parent shell still retains an
+exported value until you remove it.
+
+**This is not a sandbox.** The adapter and anything it calls run with your user
+privileges. Only connect trusted code. If the adapter starts a child runtime,
+build the child's environment from an explicit allowlist and exclude
+`TOWN_AGENT_TOKEN`; never copy the adapter's full environment.
+
+The Generation 1 Bring Your Agent preview is checkout-only and requires Python
+3.12 or newer. From a clean checkout, install
+[uv](https://docs.astral.sh/uv/getting-started/installation/) using its official
+guide, then install the exact locked workspace and run the adapter:
+
+```bash
+uv sync --frozen
+read -r -s TOWN_AGENT_TOKEN && export TOWN_AGENT_TOKEN
+uv run python examples/agent-test/reference_adapter.py
+```
+
+Paste the same fresh 64-character lowercase hexadecimal token at the hidden
+`read` prompt in both terminals. Then run Town in the second terminal:
+
+```bash
+read -r -s TOWN_AGENT_TOKEN && export TOWN_AGENT_TOKEN
+uv run nest test agent --endpoint http://127.0.0.1:8787
+```
+
+Do not pass the token as an argument or save it in source, shell history, logs,
+or a committed file. The `read -r -s` snippets are for Bash and zsh; the full
+guide gives the PowerShell equivalent and cleanup commands.
+
+To connect a real runtime, preserve the HTTP framing, strict request validation,
+digest binding, replay handling, and one-run state machine. Change
+`ADAPTER_INSTANCE_ID` to a stable value for your adapter; it is self-asserted
+metadata, not a verified identity. Replace only the `decide_intent` function
+with a call to your trusted runtime. The adapter keeps a failed start/message
+decision retryable without advancing state, but still binds that event ID to the
+first schema-valid request bytes. An exact request can retry after recovery;
+changed bytes conflict. The adapter handles terminal stop/release itself. The
+full workflow, claims, limitations, and troubleshooting guide are in
+[`docs/bring-your-agent.md`](../../docs/bring-your-agent.md).
+
+The optional `--port` flag changes only the literal-loopback port; `--port 0` is
+reserved for ephemeral test processes.

--- a/examples/agent-test/reference_adapter.py
+++ b/examples/agent-test/reference_adapter.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal deterministic local adapter for NANDA Town's frozen Generation 1 profile.
+
+Generation 1 is the first frozen agent-test contract/profile generation, not a
+Town or nest-core 1.0 release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import re
+import sys
+import threading
+from collections.abc import Callable
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+CONTRACT = "town-agent-driver/1"
+TOKEN_ENV = "TOWN_AGENT_TOKEN"
+ADAPTER_INSTANCE_ID = "town-reference-adapter"
+PROFILE = {
+    "id": "nanda/agent/capability-fulfillment",
+    "version": "1",
+    "digest": "sha256:436622e70cd84690e39c24f93236c7639adefea2fe9ea72a1dddb25e65609c58",
+}
+MAX_BODY_BYTES = 65536
+_TOKEN_RE = re.compile(r"[0-9a-f]{64}\Z")
+_ULID_RE = re.compile(r"[0-7][0-9A-HJKMNPQRSTVWXYZ]{25}\Z")
+_PROFILE_ID_RE = re.compile(r"[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*\Z")
+_VERSION_RE = re.compile(r"[A-Za-z0-9._-]{1,64}\Z")
+_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+
+
+class _UnsupportedProfileError(ValueError):
+    pass
+
+
+def _json_bytes(value: dict[str, Any]) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def _error_payload(
+    code: str,
+    message: str,
+    *,
+    adapter_instance_id: str | None = ADAPTER_INSTANCE_ID,
+    run_id: str | None = None,
+    event_id: str | None = None,
+    sequence: int | None = None,
+    request_digest: str | None = None,
+    retryable: bool = False,
+) -> bytes:
+    return _json_bytes(
+        {
+            "schema_version": "town-agent-driver-error/1",
+            "adapter_instance_id": adapter_instance_id,
+            "run_id": run_id,
+            "event_id": event_id,
+            "sequence": sequence,
+            "request_digest": request_digest,
+            "error": {"code": code, "retryable": retryable, "message": message},
+        }
+    )
+
+
+class _ReferenceServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, address: tuple[str, int], token_digest: bytes) -> None:
+        super().__init__(address, _ReferenceHandler)
+        self._token_digest = token_digest
+        self._state_lock = threading.Lock()
+        self._active_run_id: str | None = None
+        self._expected_sequence: dict[str, int] = {}
+        self._event_digests: dict[tuple[str, str], str] = {}
+        self._successes: dict[tuple[str, str], tuple[str, bytes]] = {}
+
+    def is_authorized(self, header: str | None) -> bool:
+        if header is None or not header.startswith("Bearer "):
+            return False
+        candidate = header.removeprefix("Bearer ")
+        if _TOKEN_RE.fullmatch(candidate) is None:
+            return False
+        digest = hashlib.sha256(candidate.encode("ascii")).digest()
+        return hmac.compare_digest(digest, self._token_digest)
+
+    def readiness_bytes(self) -> bytes:
+        with self._state_lock:
+            accepting_runs = self._active_run_id is None
+        return _json_bytes(
+            {
+                "schema_version": "town-agent-driver-ready/1",
+                "adapter_instance_id": ADAPTER_INSTANCE_ID,
+                "contracts": [CONTRACT],
+                "profiles": [PROFILE],
+                "accepting_runs": accepting_runs,
+                "limits": {
+                    "max_active_runs": 1,
+                    "max_request_bytes": MAX_BODY_BYTES,
+                    "max_response_bytes": MAX_BODY_BYTES,
+                },
+            }
+        )
+
+    def decide(self, request: dict[str, Any], request_digest: str) -> tuple[int, bytes]:
+        context = _request_context(request, request_digest)
+        if context is None:
+            return 422, _error_payload("SCHEMA_INVALID", "Request schema is invalid")
+        run_id, event_id, sequence = context
+        key = (run_id, event_id)
+        with self._state_lock:
+            bound_digest = self._event_digests.get(key)
+            if bound_digest is not None and bound_digest != request_digest:
+                return 409, self._request_error(
+                    "EVENT_CONFLICT",
+                    "Event ID was reused with different request bytes",
+                    run_id,
+                    event_id,
+                    sequence,
+                    request_digest,
+                )
+            cached = self._successes.get(key)
+            if cached is not None:
+                cached_digest, cached_response = cached
+                if cached_digest == request_digest:
+                    return 200, cached_response
+                return 409, self._request_error(
+                    "EVENT_CONFLICT",
+                    "Event ID was reused with different request bytes",
+                    run_id,
+                    event_id,
+                    sequence,
+                    request_digest,
+                )
+
+            try:
+                kind = _validated_kind(request)
+            except _UnsupportedProfileError:
+                return 422, self._request_error(
+                    "UNSUPPORTED_PROFILE",
+                    "Test Profile is unsupported",
+                    run_id,
+                    event_id,
+                    sequence,
+                    request_digest,
+                )
+            if kind is None:
+                return 422, self._request_error(
+                    "SCHEMA_INVALID",
+                    "Request does not match the frozen profile",
+                    run_id,
+                    event_id,
+                    sequence,
+                    request_digest,
+                )
+            self._event_digests[key] = request_digest
+            observation = request["observation"]
+            assert isinstance(observation, dict)
+            is_sequence_two_abort = (
+                kind == "stop"
+                and self._active_run_id == run_id
+                and self._expected_sequence.get(run_id) == 1
+                and sequence == 2
+                and observation["reason"] in {"run_failed", "run_incomplete", "user_interrupted"}
+            )
+            if kind == "start":
+                if self._active_run_id is not None and self._active_run_id != run_id:
+                    return 409, self._request_error(
+                        "RUN_BUSY",
+                        "The reference adapter already has one active run",
+                        run_id,
+                        event_id,
+                        sequence,
+                        request_digest,
+                        retryable=True,
+                    )
+                if self._active_run_id == run_id or run_id in self._expected_sequence:
+                    return 409, self._request_error(
+                        "OUT_OF_ORDER",
+                        "Expected the next event in the active run",
+                        run_id,
+                        event_id,
+                        sequence,
+                        request_digest,
+                    )
+            elif not is_sequence_two_abort and (
+                self._active_run_id != run_id or self._expected_sequence.get(run_id) != sequence
+            ):
+                return 409, self._request_error(
+                    "OUT_OF_ORDER",
+                    "Expected the next event in the active run",
+                    run_id,
+                    event_id,
+                    sequence,
+                    request_digest,
+                )
+
+            try:
+                intent = {"kind": "none"} if kind == "stop" else decide_intent(observation)
+                response = _json_bytes(
+                    {
+                        "schema_version": CONTRACT,
+                        "run_id": run_id,
+                        "event_id": event_id,
+                        "sequence": sequence,
+                        "adapter_instance_id": ADAPTER_INSTANCE_ID,
+                        "request_digest": request_digest,
+                        "intent": intent,
+                    }
+                )
+            except Exception:
+                return 500, self._request_error(
+                    "ADAPTER_INTERNAL",
+                    "Adapter decision failed",
+                    run_id,
+                    event_id,
+                    sequence,
+                    request_digest,
+                    retryable=True,
+                )
+
+            if kind == "start":
+                self._active_run_id = run_id
+                self._expected_sequence[run_id] = 1
+            elif kind == "message":
+                self._expected_sequence[run_id] = 2
+            else:
+                self._expected_sequence[run_id] = sequence + 1
+                self._active_run_id = None
+            self._successes[key] = (request_digest, response)
+            return 200, response
+
+    @staticmethod
+    def _request_error(
+        code: str,
+        message: str,
+        run_id: str,
+        event_id: str,
+        sequence: int,
+        request_digest: str,
+        *,
+        retryable: bool = False,
+    ) -> bytes:
+        return _error_payload(
+            code,
+            message,
+            run_id=run_id,
+            event_id=event_id,
+            sequence=sequence,
+            request_digest=request_digest,
+            retryable=retryable,
+        )
+
+
+class _ReferenceHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    @property
+    def adapter(self) -> _ReferenceServer:
+        assert isinstance(self.server, _ReferenceServer)
+        return self.server
+
+    def log_message(self, _format: str, *args: object) -> None:
+        del args
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        if not self._authenticate():
+            return
+        if self.path != "/town-driver/1/ready":
+            self._send(404, _error_payload("SCHEMA_INVALID", "Request rejected"))
+            return
+        if not self._common_headers_are_valid():
+            self._send(
+                422,
+                _error_payload("UNSUPPORTED_CONTRACT", "Driver contract is unsupported"),
+            )
+            return
+        self._send(200, self.adapter.readiness_bytes())
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        if not self._authenticate():
+            return
+        if self.path != "/town-driver/1/decide":
+            self._send(404, _error_payload("SCHEMA_INVALID", "Request rejected"))
+            return
+        body = self._read_body()
+        if body is None:
+            return
+        request_digest = "sha256:" + hashlib.sha256(body).hexdigest()
+        if not self._common_headers_are_valid():
+            self._send(
+                422,
+                _error_payload("UNSUPPORTED_CONTRACT", "Driver contract is unsupported"),
+            )
+            return
+        if (
+            self.headers.get("Content-Type") != "application/json"
+            or self.headers.get("Town-Request-Digest") != request_digest
+        ):
+            self._send(422, _error_payload("SCHEMA_INVALID", "Request framing is invalid"))
+            return
+        try:
+            parsed = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            parsed = None
+        if not isinstance(parsed, dict):
+            self._send(422, _error_payload("SCHEMA_INVALID", "Request schema is invalid"))
+            return
+        try:
+            status, response = self.adapter.decide(parsed, request_digest)
+        except Exception:
+            context = _request_context(parsed, request_digest)
+            if context is None:
+                self._send(422, _error_payload("SCHEMA_INVALID", "Request schema is invalid"))
+                return
+            run_id, event_id, sequence = context
+            status = 500
+            response = _error_payload(
+                "ADAPTER_INTERNAL",
+                "Adapter decision failed",
+                run_id=run_id,
+                event_id=event_id,
+                sequence=sequence,
+                request_digest=request_digest,
+                retryable=True,
+            )
+        self._send(status, response)
+
+    def _authenticate(self) -> bool:
+        if not self.adapter.is_authorized(self.headers.get("Authorization")):
+            self._send(
+                401,
+                _error_payload(
+                    "AUTHENTICATION_FAILED",
+                    "Authentication failed",
+                    adapter_instance_id=None,
+                ),
+            )
+            return False
+        return True
+
+    def _common_headers_are_valid(self) -> bool:
+        return (
+            self.headers.get("Town-Driver-Contract") == CONTRACT
+            and self.headers.get("Accept") == "application/json"
+            and self.headers.get("Accept-Encoding") == "identity"
+        )
+
+    def _read_body(self) -> bytes | None:
+        length_text = self.headers.get("Content-Length")
+        if length_text is None or not length_text.isdecimal():
+            self._send(422, _error_payload("SCHEMA_INVALID", "Content length is invalid"))
+            return None
+        length = int(length_text)
+        if length > MAX_BODY_BYTES:
+            self._send(413, _error_payload("BODY_TOO_LARGE", "Request body is too large"))
+            return None
+        return self.rfile.read(length)
+
+    def _send(self, status: int, body: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Town-Driver-Contract", CONTRACT)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _request_context(request: dict[str, Any], request_digest: str) -> tuple[str, str, int] | None:
+    run_id = request.get("run_id")
+    event_id = request.get("event_id")
+    sequence = request.get("sequence")
+    if (
+        not isinstance(run_id, str)
+        or _ULID_RE.fullmatch(run_id) is None
+        or not isinstance(event_id, str)
+        or _ULID_RE.fullmatch(event_id) is None
+        or not isinstance(sequence, int)
+        or isinstance(sequence, bool)
+        or sequence < 0
+        or not re.fullmatch(r"sha256:[0-9a-f]{64}", request_digest)
+    ):
+        return None
+    return run_id, event_id, sequence
+
+
+def _validated_kind(request: dict[str, Any]) -> str | None:
+    if set(request) != {
+        "schema_version",
+        "run_id",
+        "event_id",
+        "sequence",
+        "participant",
+        "profile",
+        "observation",
+    }:
+        return None
+    if request["schema_version"] != CONTRACT:
+        return None
+    profile = request["profile"]
+    if not isinstance(profile, dict) or set(profile) != {"id", "version", "digest"}:
+        return None
+    profile_id = profile.get("id")
+    version = profile.get("version")
+    digest = profile.get("digest")
+    if (
+        not isinstance(profile_id, str)
+        or len(profile_id) > 128
+        or _PROFILE_ID_RE.fullmatch(profile_id) is None
+        or not isinstance(version, str)
+        or _VERSION_RE.fullmatch(version) is None
+        or not isinstance(digest, str)
+        or _DIGEST_RE.fullmatch(digest) is None
+    ):
+        return None
+    try:
+        validator = _PROFILE_CODECS[(profile_id, version)]
+    except KeyError as exc:
+        raise _UnsupportedProfileError from exc
+    if profile != PROFILE:
+        return None
+    return validator(request)
+
+
+def _validated_capability_kind(request: dict[str, Any]) -> str | None:
+    if request["participant"] != {"id": "provider-0", "role": "provider"}:
+        return None
+    observation = request["observation"]
+    if not isinstance(observation, dict):
+        return None
+    logical_time = observation.get("logical_time")
+    if not isinstance(logical_time, int) or isinstance(logical_time, bool) or logical_time < 0:
+        return None
+    sequence = request["sequence"]
+    if (
+        sequence == 0
+        and set(observation) == {"kind", "logical_time", "allowed_intents"}
+        and observation["kind"] == "start"
+        and observation["allowed_intents"] == ["declare_capability", "none"]
+    ):
+        return "start"
+    if (
+        sequence == 1
+        and set(observation) == {"kind", "logical_time", "allowed_intents", "message"}
+        and observation["kind"] == "message"
+        and observation["allowed_intents"] == ["send_to_sender", "none"]
+        and observation["message"]
+        == {
+            "id": "message-001",
+            "sender_id": "requester-0",
+            "media_type": "text/plain; charset=utf-8",
+            "text": "buy:widget:2",
+        }
+    ):
+        return "message"
+    if (
+        sequence in {1, 2}
+        and set(observation) == {"kind", "logical_time", "allowed_intents", "reason"}
+        and observation["kind"] == "stop"
+        and observation["allowed_intents"] == ["none"]
+        and observation["reason"]
+        in {"run_complete", "run_failed", "run_incomplete", "user_interrupted"}
+        and not (sequence == 1 and observation["reason"] == "run_complete")
+    ):
+        return "stop"
+    return None
+
+
+_PROFILE_CODECS: dict[tuple[str, str], Callable[[dict[str, Any]], str | None]] = {
+    ("nanda/agent/capability-fulfillment", "1"): _validated_capability_kind,
+}
+
+
+def decide_intent(observation: dict[str, Any]) -> dict[str, Any]:
+    """Deterministic replace point: map one validated observation to one intent."""
+    kind = observation["kind"]
+    if kind == "start":
+        return {"kind": "declare_capability", "capabilities": ["sell"]}
+    if kind == "message":
+        return {
+            "kind": "send_to_sender",
+            "media_type": "text/plain; charset=utf-8",
+            "text": "sold:widget:2",
+        }
+    return {"kind": "none"}
+
+
+def create_server(*, port: int = 8787) -> ThreadingHTTPServer:
+    """Create a literal-loopback server using only the documented token variable."""
+    if not isinstance(port, int) or not 0 <= port <= 65535:
+        raise ValueError("port must be an integer from 0 through 65535")
+    token = os.environ.get(TOKEN_ENV)
+    if token is None or _TOKEN_RE.fullmatch(token) is None:
+        raise RuntimeError(f"{TOKEN_ENV} must contain exactly 64 lowercase hexadecimal characters")
+    token_digest = hashlib.sha256(token.encode("ascii")).digest()
+    os.environ.pop(TOKEN_ENV)
+    del token
+    return _ReferenceServer(("127.0.0.1", port), token_digest)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the local reference process without accepting credentials in arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8787,
+        help="literal 127.0.0.1 port (default: 8787; use 0 to select a free test port)",
+    )
+    arguments = parser.parse_args(argv)
+    try:
+        server = create_server(port=arguments.port)
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"Reference adapter could not start: {error}", file=sys.stderr)
+        return 2
+    print(
+        f"Reference adapter listening on http://127.0.0.1:{server.server_port}",
+        file=sys.stderr,
+        flush=True,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/nest-cli/tests/test_cli.py
+++ b/packages/nest-cli/tests/test_cli.py
@@ -20,6 +20,18 @@ class TestVersion:
         assert core_version in result.output
 
 
+class TestAgentTestShim:
+    def test_deprecated_shim_reexports_agent_test_help(self) -> None:
+        from nest_core.cli import app as core_app
+
+        shim = runner.invoke(app, ["test", "agent", "--help"], color=False)
+        core = runner.invoke(core_app, ["test", "agent", "--help"], color=False)
+
+        assert app is core_app
+        assert shim.exit_code == 0
+        assert shim.stdout == core.stdout
+
+
 class TestDoctor:
     def test_doctor_passes(self) -> None:
         result = runner.invoke(app, ["doctor"])
@@ -83,6 +95,22 @@ class TestRun:
         )
         assert result.exit_code == 0
         assert "seed: 999" in result.output
+
+    def test_run_capability_fulfillment_builtin_uses_ordinary_interface(
+        self, tmp_path: Path
+    ) -> None:
+        trace_out = tmp_path / "capability.jsonl"
+
+        result = runner.invoke(
+            app,
+            ["run", "capability_fulfillment", "-o", str(trace_out)],
+        )
+
+        assert result.exit_code == 0
+        assert "Running scenario: capability-fulfillment" in result.output
+        assert f"Trace written to: {trace_out}" in result.output
+        assert trace_out.exists()
+        assert '"kind":"test.' not in trace_out.read_text()
 
 
 class TestInit:

--- a/packages/nest-core/nest_core/agent_test/cli.py
+++ b/packages/nest-core/nest_core/agent_test/cli.py
@@ -1,0 +1,496 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused Typer surface for the Generation 1 frozen local agent Test Profile."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import shlex
+import sys
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NoReturn
+
+import typer
+
+if TYPE_CHECKING:
+    from .runner import AgentTestOutcome
+
+_PROFILE_ALIAS = "capability-fulfillment"
+_PROFILE_EXACT = "nanda/agent/capability-fulfillment@1"
+_PROFILE_REFERENCES = frozenset({_PROFILE_ALIAS, _PROFILE_EXACT})
+_TOKEN_RE = re.compile(r"[0-9a-f]{64}\Z")
+_ENVIRONMENT_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,127}\Z")
+_INCOMPLETE_REASON_CODES = frozenset(
+    {
+        "ADAPTER_INSTANCE_CHANGED",
+        "ADAPTER_INTERNAL",
+        "ADAPTER_UNAVAILABLE",
+        "AUTHENTICATION_FAILED",
+        "RUN_BUSY",
+        "TIMEOUT",
+        "TRANSPORT_LOSS",
+    }
+)
+
+
+class _OutputFormat(StrEnum):
+    HUMAN = "human"
+    JSON = "json"
+
+
+def _typer_option(*args: Any, **kwargs: Any) -> Any:
+    return typer.Option(*args, **kwargs)  # pyright: ignore[reportUnknownMemberType]
+
+
+test_app = typer.Typer(
+    help="Run local NANDA Town adapter tests.",
+    no_args_is_help=True,
+)
+
+
+def _configuration_error(message: str) -> NoReturn:
+    typer.echo(f"Configuration error: {message}", err=True)
+    raise typer.Exit(2)
+
+
+def _terminal_error(headline: str, detail: str, exit_code: int) -> NoReturn:
+    typer.echo(headline, err=True)
+    typer.echo(detail, err=True)
+    raise typer.Exit(exit_code)
+
+
+def _interrupted_error() -> NoReturn:
+    _terminal_error(
+        "RESULT: INTERRUPTED",
+        "The local adapter test was interrupted.",
+        130,
+    )
+
+
+def _output_interrupted_error(outcome: AgentTestOutcome) -> NoReturn:
+    final_status = {
+        0: "PASS",
+        1: "FAIL",
+        3: "ERROR",
+        4: "INCOMPLETE",
+        130: "INTERRUPTED",
+    }.get(outcome.exit_code, "UNKNOWN")
+    _terminal_error(
+        "RESULT: OUTPUT INTERRUPTED",
+        (
+            f"Terminal output was interrupted after the test finalized as {final_status}; "
+            "result.json remains authoritative."
+        ),
+        130,
+    )
+
+
+def _pre_admission_incomplete_error(*, code: str, endpoint: str) -> NoReturn:
+    reason = code if code in _INCOMPLETE_REASON_CODES else "ADAPTER_UNAVAILABLE"
+    typer.echo("RESULT: INCOMPLETE", err=True)
+    typer.echo(f"Reason: {reason}", err=True)
+    typer.echo(
+        "Adapter: the local adapter did not complete the requested exchange.",
+        err=True,
+    )
+    typer.echo(
+        f"Next: Start or check the local adapter at {endpoint}, then rerun.",
+        err=True,
+    )
+    raise typer.Exit(4)
+
+
+def _write_stdout_bytes(content: bytes) -> None:
+    """Write the machine result without text transcoding or an implicit newline."""
+    sys.stdout.buffer.write(content)
+    sys.stdout.buffer.flush()
+
+
+def _validate_output_directory(output_dir: Path | None) -> None:
+    if output_dir is None:
+        return
+    try:
+        invalid = output_dir.is_symlink() or (
+            output_dir.exists()
+            and (not output_dir.is_dir() or next(output_dir.iterdir(), None) is not None)
+        )
+    except OSError:
+        invalid = True
+    if invalid:
+        _configuration_error(
+            "output directory must be new or empty and must not be a file or symlink."
+        )
+
+
+async def _execute_agent_test(
+    *,
+    profile: str,
+    endpoint: str,
+    token: str,
+    output_dir: Path | None,
+    target_label: str,
+) -> AgentTestOutcome:
+    """Resolve the pinned profile, then construct the one supported driver lazily."""
+    from .http_driver import LoopbackHttpAgentDriver, parse_loopback_origin
+    from .models import ResultDriver
+    from .profiles import resolve_test_profile
+    from .runner import run_agent_test
+
+    resolve_test_profile(profile)
+    endpoint = parse_loopback_origin(endpoint)
+    driver = LoopbackHttpAgentDriver(endpoint, token)
+    driver_metadata = ResultDriver(
+        contract="town-agent-driver/1",
+        kind="loopback-http",
+        adapter_instance_id=None,
+        endpoint_origin=endpoint,
+    )
+    return await run_agent_test(
+        driver=driver,
+        driver_metadata=driver_metadata,
+        output_dir=output_dir,
+        base_dir=Path.cwd(),
+        target_label=target_label,
+    )
+
+
+def _render_human(outcome: AgentTestOutcome) -> str:
+    result = outcome.result
+    headline = {
+        0: "RESULT: PASS",
+        1: "RESULT: FAIL",
+        3: "RESULT: ERROR",
+        4: "RESULT: INCOMPLETE",
+        130: "RESULT: INTERRUPTED",
+    }.get(outcome.exit_code, "RESULT: ERROR")
+    lines = [
+        headline,
+        f"Run: {result.run_id}",
+        f"Profile: {result.profile.id}@{result.profile.version}",
+        f"Profile digest: {result.profile.digest}",
+        f"Target label: {result.target.label} (local evidence label; not verified identity)",
+        (
+            "Request authentication: Town sent bearer-authenticated requests using the "
+            "caller credential"
+        ),
+        (
+            "Adapter instance (self-asserted): "
+            f"{result.driver.adapter_instance_id or 'not observed'}"
+        ),
+    ]
+
+    checks_by_status = {
+        status: [check for check in result.evaluation.checks if check.status == status]
+        for status in ("pass", "fail", "not_tested", "inconclusive", "error")
+    }
+
+    def add_section(title: str, entries: list[str]) -> None:
+        if entries:
+            lines.extend([title, *(f"  - {entry}" for entry in entries)])
+
+    add_section(
+        "Passed",
+        [f"{check.id}: {check.summary}" for check in checks_by_status["pass"]],
+    )
+    add_section(
+        "Failed",
+        [f"{check.id}: {check.summary}" for check in checks_by_status["fail"]],
+    )
+    incomplete_checks = [
+        check for status in ("inconclusive", "error") for check in checks_by_status[status]
+    ]
+    incomplete_coverage = [item for item in result.coverage if item.status == "unknown"]
+    add_section(
+        "Incomplete",
+        [f"{check.id}: {check.summary}" for check in incomplete_checks]
+        + [
+            f"Coverage {item.claim}: {item.reason_code or 'NOT_OBSERVED'}"
+            for item in incomplete_coverage
+        ],
+    )
+    not_evaluated_entries = [
+        f"{check.id}: {check.summary}" for check in checks_by_status["not_tested"]
+    ]
+    if result.evaluation.verdict == "not_evaluated":
+        not_evaluated_entries.insert(0, "Town did not evaluate this profile.")
+    add_section("Not evaluated", not_evaluated_entries)
+    add_section(
+        "Not tested",
+        [
+            f"{item.claim}: {item.reason_code or 'OUT_OF_PROFILE'}"
+            for item in result.coverage
+            if item.status == "not_tested"
+        ],
+    )
+
+    next_step = {
+        0: "Review the scoped result and trace evidence.",
+        1: "Update the failed adapter behavior, then rerun this profile.",
+        3: "Review Town diagnostics, then rerun this profile.",
+        4: (
+            f"Start or check the local adapter at {result.driver.endpoint_origin}, "
+            "then rerun this profile."
+        ),
+        130: "Rerun this profile when ready.",
+    }.get(outcome.exit_code, "Review Town diagnostics, then rerun this profile.")
+    next_steps = [next_step]
+    trace_artifact = next(
+        (artifact for artifact in result.artifacts if artifact.kind == "trace"),
+        None,
+    )
+    if trace_artifact is not None:
+        trace_path = outcome.output_directory / trace_artifact.path
+        relative_trace = os.path.relpath(trace_path, start=Path.cwd())
+        next_steps.append(f"Inspect the trace: nest inspect {shlex.quote(relative_trace)}")
+    add_section("Next", next_steps)
+    artifacts = [f"result: {outcome.output_directory / 'result.json'}"]
+    artifacts.extend(
+        f"{artifact.kind}: {outcome.output_directory / artifact.path}"
+        for artifact in result.artifacts
+    )
+    add_section("Artifacts", artifacts)
+    return "\n".join(lines) + "\n"
+
+
+def _write_progress(
+    *, profile_reference: str, endpoint: str, output_dir: Path | None, verbose: bool
+) -> None:
+    typer.echo("Running local adapter test...", err=True)
+    if not verbose:
+        return
+    typer.echo(f"Profile: {profile_reference}", err=True)
+    typer.echo(f"Endpoint: {endpoint}", err=True)
+    typer.echo(
+        f"Output: {output_dir if output_dir is not None else '.town/runs/<run-id>'}",
+        err=True,
+    )
+
+
+def _write_diagnostics(outcome: AgentTestOutcome) -> None:
+    for diagnostic in outcome.result.diagnostics:
+        typer.echo(f"Diagnostic {diagnostic.code}: {diagnostic.summary}", err=True)
+        if diagnostic.next is not None:
+            typer.echo(f"Next: {diagnostic.next}", err=True)
+
+
+_OUTPUT_FORMAT_OPTION = _typer_option(
+    _OutputFormat.HUMAN,
+    "--format",
+    help="Final output format.",
+)
+
+
+@test_app.command(
+    "agent",
+    help=(
+        "Test one local agent adapter with bearer-authenticated requests using the "
+        "Generation 1 capability-fulfillment profile. Generation 1 is the first frozen "
+        "agent-test contract/profile generation, not a Town or nest-core 1.0 release."
+    ),
+)
+def agent(
+    profile: str = _typer_option(
+        _PROFILE_ALIAS,
+        "--profile",
+        help="Advanced: built-in profile alias or exact versioned reference.",
+        rich_help_panel="Advanced adapter options",
+    ),
+    endpoint: str = _typer_option(
+        ...,
+        "--endpoint",
+        help="Adapter origin: http://127.0.0.1:<port> or http://[::1]:<port>.",
+    ),
+    target_label: str = _typer_option(
+        "local-agent",
+        "--target-label",
+        help="Local evidence label for this target; not a verified identity.",
+    ),
+    token_env: str = _typer_option(
+        "TOWN_AGENT_TOKEN",
+        "--token-env",
+        help=(
+            "Environment variable containing the bearer caller credential: a 64-character "
+            "lowercase hexadecimal token."
+        ),
+    ),
+    output_format: _OutputFormat = _OUTPUT_FORMAT_OPTION,
+    output_dir: str | None = _typer_option(
+        None,
+        "--output-dir",
+        help="Exact empty or new run-artifact directory. Default: .town/runs/<run-id>.",
+    ),
+    no_color: bool = _typer_option(
+        False,
+        "--no-color",
+        help="Disable ANSI color in human output.",
+    ),
+    verbose: bool = _typer_option(
+        False,
+        "--verbose",
+        help="Write additional safe progress details to stderr.",
+    ),
+) -> None:
+    """Run the frozen local adapter profile."""
+    try:
+        output_path = None if output_dir is None else Path(output_dir)
+        if profile not in _PROFILE_REFERENCES:
+            _configuration_error(f"unknown Test Profile; use {_PROFILE_ALIAS} or {_PROFILE_EXACT}.")
+        if _ENVIRONMENT_NAME_RE.fullmatch(token_env) is None:
+            _configuration_error("--token-env must name a valid environment variable.")
+        token = os.environ.pop(token_env, None)
+        if token is None or not token:
+            _configuration_error(f"{token_env} is not set.")
+        if _TOKEN_RE.fullmatch(token) is None:
+            _configuration_error(
+                f"{token_env} must contain exactly 64 lowercase hexadecimal characters."
+            )
+        _validate_output_directory(output_path)
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        _interrupted_error()
+
+    try:
+        from .driver import (
+            AgentDriverError,
+            DriverCompatibilityError,
+            DriverConfigurationError,
+            DriverContractError,
+            DriverIncompleteError,
+            TownDriverError,
+        )
+        from .http_driver import parse_loopback_origin
+        from .profiles import resolve_test_profile
+        from .runner import AgentTestPreAdmissionError, AgentTestTownError
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        _interrupted_error()
+    except Exception:
+        _terminal_error(
+            "RESULT: ERROR",
+            "Town could not prepare the local adapter test.",
+            3,
+        )
+
+    try:
+        endpoint = parse_loopback_origin(endpoint)
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        _interrupted_error()
+    except ValueError:
+        _configuration_error("endpoint must be http://127.0.0.1:<port> or http://[::1]:<port>.")
+    try:
+        resolved_profile = resolve_test_profile(profile)
+        profile_reference = f"{resolved_profile.reference.id}@{resolved_profile.reference.version}"
+        _write_progress(
+            profile_reference=profile_reference,
+            endpoint=endpoint,
+            output_dir=output_path,
+            verbose=verbose,
+        )
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        _interrupted_error()
+    except KeyError:
+        _configuration_error(f"unknown Test Profile; use {_PROFILE_ALIAS} or {_PROFILE_EXACT}.")
+    except Exception:
+        _terminal_error(
+            "RESULT: ERROR",
+            "Town could not load the frozen Test Profile.",
+            3,
+        )
+
+    try:
+        outcome = asyncio.run(
+            _execute_agent_test(
+                profile=profile,
+                endpoint=endpoint,
+                token=token,
+                output_dir=output_path,
+                target_label=target_label,
+            )
+        )
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        _interrupted_error()
+    except AgentTestPreAdmissionError as error:
+        if error.code == "REFERENCE_REGISTRY_MISSING":
+            typer.echo(
+                "Configuration error: pinned reference Registry is unavailable.",
+                err=True,
+            )
+            typer.echo("Next: pip install 'nest-core[plugins]'", err=True)
+        elif error.code == "OUTPUT_DIR_INVALID":
+            typer.echo(
+                "Configuration error: output directory must be new or empty and must not be a "
+                "file or symlink.",
+                err=True,
+            )
+        elif error.code == "TARGET_LABEL_INVALID":
+            typer.echo(
+                "Configuration error: --target-label must be nonempty, trimmed, control-free, "
+                "and at most 128 UTF-8 bytes.",
+                err=True,
+            )
+        else:
+            typer.echo("Configuration error: Town could not admit this invocation.", err=True)
+        raise typer.Exit(2) from None
+    except (DriverConfigurationError, DriverCompatibilityError) as error:
+        if isinstance(error, DriverCompatibilityError):
+            detail = (
+                "Configuration error: local adapter does not support the frozen profile or "
+                "driver contract."
+            )
+        else:
+            detail = (
+                "Configuration error: local adapter configuration was rejected before admission."
+            )
+        typer.echo(detail, err=True)
+        raise typer.Exit(2) from None
+    except DriverContractError:
+        _terminal_error(
+            "RESULT: FAIL",
+            (
+                "Driver contract: the local adapter returned an invalid response to Town's "
+                "bearer-authenticated request."
+            ),
+            1,
+        )
+    except DriverIncompleteError as error:
+        _pre_admission_incomplete_error(
+            code=error.code,
+            endpoint=endpoint,
+        )
+    except (TownDriverError, AgentTestTownError):
+        _terminal_error(
+            "RESULT: ERROR",
+            "Town could not complete the local adapter test.",
+            3,
+        )
+    except TimeoutError:
+        _pre_admission_incomplete_error(
+            code="TIMEOUT",
+            endpoint=endpoint,
+        )
+    except AgentDriverError:
+        _terminal_error(
+            "RESULT: ERROR",
+            "Town could not classify a local adapter failure.",
+            3,
+        )
+    except Exception:
+        _terminal_error(
+            "RESULT: ERROR",
+            "Town could not complete the local adapter test.",
+            3,
+        )
+
+    try:
+        _write_diagnostics(outcome)
+        if output_format == _OutputFormat.JSON:
+            _write_stdout_bytes(outcome.result_bytes)
+        else:
+            typer.echo(
+                _render_human(outcome),
+                nl=False,
+                color=False if no_color else None,
+            )
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        _output_interrupted_error(outcome)
+    raise typer.Exit(outcome.exit_code)

--- a/packages/nest-core/nest_core/cli.py
+++ b/packages/nest-core/nest_core/cli.py
@@ -19,6 +19,8 @@ from typing import Any
 import typer
 from pydantic import ValidationError
 
+from nest_core.agent_test.cli import test_app
+
 
 def _typer_argument(*args: Any, **kwargs: Any) -> Any:
     return typer.Argument(*args, **kwargs)  # pyright: ignore[reportUnknownMemberType]
@@ -33,6 +35,8 @@ app = typer.Typer(
     help="Nanda Town",
     no_args_is_help=True,
 )
+
+app.add_typer(test_app, name="test")
 
 plugins_app = typer.Typer(help="Manage plugins.")
 app.add_typer(plugins_app, name="plugins")

--- a/packages/nest-core/tests/agent_test/test_cli.py
+++ b/packages/nest-core/tests/agent_test/test_cli.py
@@ -42,6 +42,11 @@ TOKEN = "0123456789abcdef" * 4
 PROFILE_ALIAS = "capability-fulfillment"
 PROFILE_EXACT = "nanda/agent/capability-fulfillment@1"
 ENDPOINT = "http://127.0.0.1:8787"
+PLAIN_HELP_ENV: dict[str, str | None] = {
+    "FORCE_COLOR": None,
+    "GITHUB_ACTIONS": None,
+    "TERM": "dumb",
+}
 
 
 class _InterruptServer(ThreadingHTTPServer):
@@ -234,8 +239,8 @@ def _invoke(
 
 
 def test_test_and_agent_help_freeze_the_additive_command_tree() -> None:
-    test_help = runner.invoke(app, ["test", "--help"], color=False)
-    agent_help = runner.invoke(app, ["test", "agent", "--help"], color=False)
+    test_help = runner.invoke(app, ["test", "--help"], color=False, env=PLAIN_HELP_ENV)
+    agent_help = runner.invoke(app, ["test", "agent", "--help"], color=False, env=PLAIN_HELP_ENV)
 
     assert test_help.exit_code == 0
     assert "Run local NANDA Town adapter tests." in test_help.stdout
@@ -273,7 +278,7 @@ def test_test_and_agent_help_freeze_the_additive_command_tree() -> None:
 
 
 def test_agent_help_is_plain_when_color_is_disabled() -> None:
-    result = runner.invoke(app, ["test", "agent", "--help"], color=False)
+    result = runner.invoke(app, ["test", "agent", "--help"], color=False, env=PLAIN_HELP_ENV)
 
     assert result.exit_code == 0
     assert "\x1b[" not in result.stdout

--- a/packages/nest-core/tests/agent_test/test_cli.py
+++ b/packages/nest-core/tests/agent_test/test_cli.py
@@ -1,0 +1,1150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI contract tests for the frozen local agent-test journey."""
+
+from __future__ import annotations
+
+import builtins
+import io
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import threading
+from collections.abc import Generator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, NoReturn, cast
+
+import pytest
+from nest_core.agent_test.driver import (
+    DriverCompatibilityError,
+    DriverConfigurationError,
+    DriverContractError,
+    DriverIncompleteError,
+    TownDriverError,
+)
+from nest_core.agent_test.models import TestResult
+from nest_core.agent_test.profiles import resolve_test_profile
+from nest_core.agent_test.runner import (
+    AgentTestOutcome,
+    AgentTestPreAdmissionError,
+    AgentTestTownError,
+)
+from nest_core.cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+FIXTURES = Path(__file__).parent / "fixtures"
+TOKEN = "0123456789abcdef" * 4
+PROFILE_ALIAS = "capability-fulfillment"
+PROFILE_EXACT = "nanda/agent/capability-fulfillment@1"
+ENDPOINT = "http://127.0.0.1:8787"
+
+
+class _InterruptServer(ThreadingHTTPServer):
+    daemon_threads = True
+    message_seen: threading.Event
+    release_message: threading.Event
+    observations: list[dict[str, Any]]
+
+
+class _InterruptHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:  # noqa: N802
+        profile = resolve_test_profile(PROFILE_ALIAS)
+        self._send_json(
+            {
+                "schema_version": "town-agent-driver-ready/1",
+                "adapter_instance_id": "adapter:interrupt-test",
+                "contracts": ["town-agent-driver/1"],
+                "profiles": [profile.reference.model_dump(mode="json")],
+                "accepting_runs": True,
+                "limits": {
+                    "max_active_runs": 1,
+                    "max_request_bytes": 65536,
+                    "max_response_bytes": 65536,
+                },
+            }
+        )
+
+    def do_POST(self) -> None:  # noqa: N802
+        import hashlib
+
+        server = cast("_InterruptServer", self.server)
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        request: dict[str, Any] = json.loads(body)
+        observation: dict[str, Any] = request["observation"]
+        server.observations.append(observation)
+        kind = observation["kind"]
+        if kind == "message":
+            server.message_seen.set()
+            server.release_message.wait(timeout=20)
+        if kind == "start":
+            intent: dict[str, object] = {
+                "kind": "declare_capability",
+                "capabilities": ["sell"],
+            }
+        elif kind == "message":
+            intent = {
+                "kind": "send_to_sender",
+                "media_type": "text/plain; charset=utf-8",
+                "text": "sold:widget:2",
+            }
+        else:
+            intent = {"kind": "none"}
+        self._send_json(
+            {
+                "schema_version": "town-agent-driver/1",
+                "run_id": request["run_id"],
+                "event_id": request["event_id"],
+                "sequence": request["sequence"],
+                "adapter_instance_id": "adapter:interrupt-test",
+                "request_digest": "sha256:" + hashlib.sha256(body).hexdigest(),
+                "intent": intent,
+            }
+        )
+
+    def _send_json(self, value: object) -> None:
+        body = json.dumps(value, separators=(",", ":")).encode()
+        try:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Town-Driver-Contract", "town-agent-driver/1")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+@contextmanager
+def _serve_interrupt_adapter() -> Generator[_InterruptServer]:
+    server = _InterruptServer(("127.0.0.1", 0), _InterruptHandler)
+    server.message_seen = threading.Event()
+    server.release_message = threading.Event()
+    server.observations = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.release_message.set()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _result_data(exit_code: int) -> dict[str, Any]:
+    fixture = "result-incomplete.json" if exit_code in {4, 130} else "result-pass.json"
+    data: dict[str, Any] = json.loads((FIXTURES / fixture).read_text(encoding="utf-8"))
+    if exit_code == 1:
+        data["evaluation"]["verdict"] = "fail"
+        data["evaluation"]["checks"][0].update(
+            status="fail", summary="The adapter returned the wrong synthetic response"
+        )
+    elif exit_code == 3:
+        data["execution"]["status"] = "error"
+        data["evaluation"] = {"verdict": "not_evaluated", "checks": []}
+        data["coverage"] = [
+            {
+                "claim": "town.agent-driver.loopback",
+                "status": "unknown",
+                "reason_code": "TOWN_EXECUTION_ERROR",
+                "evidence_refs": [],
+            }
+        ]
+        data["diagnostics"] = [
+            {
+                "code": "TOWN_EXECUTION_ERROR",
+                "stage": "town",
+                "severity": "error",
+                "summary": "Town could not complete the dedicated scenario",
+                "next": None,
+            }
+        ]
+    elif exit_code == 130:
+        data["diagnostics"] = [
+            {
+                "code": "USER_INTERRUPTED",
+                "stage": "driver",
+                "severity": "warning",
+                "summary": "The agent-test run was interrupted by the user",
+                "next": None,
+            }
+        ]
+    return data
+
+
+def _outcome(tmp_path: Path, exit_code: int) -> AgentTestOutcome:
+    result = TestResult.model_validate(_result_data(exit_code))
+    output_directory = tmp_path / f"out-{exit_code}"
+    output_directory.mkdir(exist_ok=True)
+    result_bytes = (
+        json.dumps(result.model_dump(mode="json"), sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode()
+    (output_directory / "result.json").write_bytes(result_bytes)
+    for artifact in result.artifacts:
+        if artifact.kind == "trace":
+            (output_directory / artifact.path).write_text(
+                '{"ts":0.0,"agent":"provider-0","kind":"test.driver.run_admitted"}\n',
+                encoding="utf-8",
+            )
+    return AgentTestOutcome(
+        result=result,
+        exit_code=exit_code,
+        output_directory=output_directory,
+        result_bytes=result_bytes,
+    )
+
+
+def _invoke(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    outcome_exit: int = 0,
+    profile: str = PROFILE_ALIAS,
+    extra: list[str] | None = None,
+) -> tuple[Any, list[dict[str, object]], AgentTestOutcome]:
+    import nest_core.agent_test.cli as agent_cli
+
+    outcome = _outcome(tmp_path, outcome_exit)
+    calls: list[dict[str, object]] = []
+
+    async def fake_execute(**kwargs: object) -> AgentTestOutcome:
+        calls.append(kwargs)
+        return outcome
+
+    monkeypatch.setattr(agent_cli, "_execute_agent_test", fake_execute)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    args = ["test", "agent", "--endpoint", ENDPOINT]
+    if profile != PROFILE_ALIAS:
+        args.extend(["--profile", profile])
+    if extra:
+        args.extend(extra)
+    return runner.invoke(app, args, color=False), calls, outcome
+
+
+def test_test_and_agent_help_freeze_the_additive_command_tree() -> None:
+    test_help = runner.invoke(app, ["test", "--help"], color=False)
+    agent_help = runner.invoke(app, ["test", "agent", "--help"], color=False)
+
+    assert test_help.exit_code == 0
+    assert "Run local NANDA Town adapter tests." in test_help.stdout
+    assert "agent" in test_help.stdout
+    assert agent_help.exit_code == 0
+    normalized = " ".join(agent_help.stdout.replace("│", "").split())
+    assert (
+        "Test one local agent adapter with bearer-authenticated requests using the "
+        "Generation 1 capability-fulfillment profile." in normalized
+    )
+    assert (
+        "Generation 1 is the first frozen agent-test contract/profile generation, not a Town "
+        "or nest-core 1.0 release." in normalized
+    )
+    for expected in (
+        "--profile",
+        "Advanced: built-in profile alias or exact versioned reference.",
+        "--endpoint",
+        "Adapter origin: http://127.0.0.1:<port> or http://[::1]:<port>.",
+        "--target-label",
+        "Local evidence label for this target; not a verified identity.",
+        "local-agent",
+        "--token-env",
+        "TOWN_AGENT_TOKEN",
+        "Environment variable containing the bearer caller credential",
+        "--format",
+        "[human|json]",
+        "--output-dir",
+        ".town/runs/<run-id>",
+        "--no-color",
+        "--verbose",
+    ):
+        assert expected in normalized
+    assert "agent [OPTIONS] PROFILE" not in normalized
+
+
+def test_agent_help_is_plain_when_color_is_disabled() -> None:
+    result = runner.invoke(app, ["test", "agent", "--help"], color=False)
+
+    assert result.exit_code == 0
+    assert "\x1b[" not in result.stdout
+
+
+def test_cli_import_keeps_http_driver_and_runner_lazy() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; import nest_core.cli; "
+                "assert 'nest_core.agent_test.http_driver' not in sys.modules; "
+                "assert 'nest_core.agent_test.runner' not in sys.modules"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_interrupt_during_lazy_import_is_safe_exit_130_without_bundle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    original_import = builtins.__import__
+
+    def interrupt_driver_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if (
+            level == 1
+            and name == "driver"
+            and globals is not None
+            and globals.get("__name__") == "nest_core.agent_test.cli"
+        ):
+            raise KeyboardInterrupt("interrupt-import-canary")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    monkeypatch.setattr(builtins, "__import__", interrupt_driver_import)
+    result = runner.invoke(
+        app,
+        ["test", "agent", "--endpoint", ENDPOINT, "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == 130
+    assert result.stdout_bytes == b""
+    assert "RESULT: INTERRUPTED" in result.stderr
+    assert "interrupt-import-canary" not in result.stderr
+    assert "TOWN_AGENT_TOKEN" not in os.environ
+    assert not (tmp_path / ".town").exists()
+
+
+def test_interrupt_during_profile_resolution_is_safe_exit_130_without_bundle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import nest_core.agent_test.profiles as profiles
+
+    def interrupt_profile(_reference: str) -> NoReturn:
+        raise KeyboardInterrupt("interrupt-profile-canary")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    monkeypatch.setattr(profiles, "resolve_test_profile", interrupt_profile)
+    result = runner.invoke(
+        app,
+        ["test", "agent", "--endpoint", ENDPOINT, "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == 130
+    assert result.stdout_bytes == b""
+    assert "RESULT: INTERRUPTED" in result.stderr
+    assert "interrupt-profile-canary" not in result.stderr
+    assert "TOWN_AGENT_TOKEN" not in os.environ
+    assert not (tmp_path / ".town").exists()
+
+
+def test_interrupt_during_output_directory_validation_is_safe_exit_130_without_bundle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    def interrupt_validation(_output_dir: Path | None) -> NoReturn:
+        raise KeyboardInterrupt("interrupt-validation-canary")
+
+    target = tmp_path / "bundle"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    monkeypatch.setattr(agent_cli, "_validate_output_directory", interrupt_validation)
+    result = runner.invoke(
+        app,
+        [
+            "test",
+            "agent",
+            "--endpoint",
+            ENDPOINT,
+            "--output-dir",
+            str(target),
+            "--format",
+            "json",
+        ],
+        color=False,
+    )
+
+    assert result.exit_code == 130
+    assert result.stdout_bytes == b""
+    assert "RESULT: INTERRUPTED" in result.stderr
+    assert "interrupt-validation-canary" not in result.stderr
+    assert "TOWN_AGENT_TOKEN" not in os.environ
+    assert not target.exists()
+    assert not (tmp_path / ".town").exists()
+
+
+def test_alias_and_exact_profile_reference_reach_the_same_frozen_runner(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    default, default_calls, _ = _invoke(monkeypatch, tmp_path)
+    exact, exact_calls, _ = _invoke(
+        monkeypatch,
+        tmp_path,
+        extra=["--profile", PROFILE_EXACT],
+    )
+
+    assert default.exit_code == exact.exit_code == 0
+    assert default.stdout == exact.stdout
+    assert default_calls[0]["profile"] == PROFILE_ALIAS
+    assert exact_calls[0]["profile"] == PROFILE_EXACT
+
+
+@pytest.mark.parametrize(
+    ("profile", "endpoint", "token_env", "token", "output_format", "expected"),
+    [
+        ("unknown", ENDPOINT, "TOWN_AGENT_TOKEN", TOKEN, "human", "unknown Test Profile"),
+        (
+            PROFILE_ALIAS,
+            "http://localhost:8787",
+            "TOWN_AGENT_TOKEN",
+            TOKEN,
+            "human",
+            "endpoint must be http://127.0.0.1:<port> or http://[::1]:<port>",
+        ),
+        (PROFILE_ALIAS, ENDPOINT, "TOWN_AGENT_TOKEN", None, "human", "is not set"),
+        (
+            PROFILE_ALIAS,
+            ENDPOINT,
+            "TOWN_AGENT_TOKEN",
+            "A" * 64,
+            "human",
+            "exactly 64 lowercase hexadecimal characters",
+        ),
+        (
+            PROFILE_ALIAS,
+            ENDPOINT,
+            "BAD-NAME",
+            TOKEN,
+            "human",
+            "--token-env must name a valid environment variable",
+        ),
+        (
+            PROFILE_ALIAS,
+            ENDPOINT,
+            "TOWN_AGENT_TOKEN",
+            TOKEN,
+            "xml",
+            "one of 'human', 'json'",
+        ),
+    ],
+)
+def test_invalid_invocation_is_exit_2_before_execution_with_empty_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+    profile: str,
+    endpoint: str,
+    token_env: str,
+    token: str | None,
+    output_format: str,
+    expected: str,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    called = False
+
+    async def must_not_execute(**_kwargs: object) -> AgentTestOutcome:
+        nonlocal called
+        called = True
+        raise AssertionError("execution crossed the configuration boundary")
+
+    monkeypatch.setattr(agent_cli, "_execute_agent_test", must_not_execute)
+    if token is None:
+        monkeypatch.delenv(token_env, raising=False)
+    else:
+        monkeypatch.setenv(token_env, token)
+    args = [
+        "test",
+        "agent",
+        "--endpoint",
+        endpoint,
+        "--token-env",
+        token_env,
+        "--format",
+        output_format,
+    ]
+    if profile != PROFILE_ALIAS:
+        args.extend(["--profile", profile])
+    result = runner.invoke(app, args, color=False)
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert expected in result.stderr
+    assert not called
+    if token is not None:
+        assert token not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        ("A" * 64, "exactly 64 lowercase hexadecimal characters"),
+        (None, "TOWN_AGENT_TOKEN is not set"),
+    ],
+)
+def test_invalid_or_missing_caller_credential_is_absent_after_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    token: str | None,
+    expected: str,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    called = False
+
+    async def must_not_execute(**_kwargs: object) -> AgentTestOutcome:
+        nonlocal called
+        called = True
+        raise AssertionError("execution crossed the credential boundary")
+
+    monkeypatch.setattr(agent_cli, "_execute_agent_test", must_not_execute)
+    if token is None:
+        monkeypatch.delenv("TOWN_AGENT_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("TOWN_AGENT_TOKEN", token)
+
+    result = runner.invoke(
+        app,
+        ["test", "agent", "--endpoint", ENDPOINT, "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert expected in result.stderr
+    assert "TOWN_AGENT_TOKEN" not in os.environ
+    assert not called
+    if token is not None:
+        assert token not in result.stderr
+
+
+@pytest.mark.parametrize("kind", ["file", "symlink", "nonempty"])
+def test_unsafe_explicit_output_is_refused_unchanged_before_execution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, kind: str
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    target = tmp_path / "bundle"
+    if kind == "file":
+        target.write_text("caller-data", encoding="utf-8")
+    elif kind == "symlink":
+        source = tmp_path / "source"
+        source.mkdir()
+        target.symlink_to(source, target_is_directory=True)
+    else:
+        target.mkdir()
+        (target / "caller.txt").write_text("caller-data", encoding="utf-8")
+    before = sorted(str(path.relative_to(tmp_path)) for path in tmp_path.rglob("*"))
+    called = False
+
+    async def must_not_execute(**_kwargs: object) -> AgentTestOutcome:
+        nonlocal called
+        called = True
+        raise AssertionError("execution crossed the output boundary")
+
+    monkeypatch.setattr(agent_cli, "_execute_agent_test", must_not_execute)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    result = runner.invoke(
+        app,
+        [
+            "test",
+            "agent",
+            "--endpoint",
+            ENDPOINT,
+            "--output-dir",
+            str(target),
+            "--format",
+            "json",
+        ],
+        color=False,
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert "output directory must be new or empty" in result.stderr
+    assert not called
+    assert sorted(str(path.relative_to(tmp_path)) for path in tmp_path.rglob("*")) == before
+    if kind == "file":
+        assert target.read_text(encoding="utf-8") == "caller-data"
+
+
+def test_default_and_explicit_output_arguments_are_forwarded_without_reinterpretation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    default, default_calls, _ = _invoke(monkeypatch, tmp_path)
+    explicit_path = tmp_path / "explicit"
+    explicit, explicit_calls, _ = _invoke(
+        monkeypatch,
+        tmp_path,
+        extra=["--output-dir", str(explicit_path)],
+    )
+
+    assert default.exit_code == explicit.exit_code == 0
+    assert default_calls[0]["output_dir"] is None
+    assert explicit_calls[0]["output_dir"] == explicit_path
+
+
+def test_target_label_default_and_override_are_forwarded_to_the_runner(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    default, default_calls, _ = _invoke(monkeypatch, tmp_path)
+    named, named_calls, _ = _invoke(
+        monkeypatch,
+        tmp_path,
+        extra=["--target-label", "checkout-agent"],
+    )
+
+    assert default.exit_code == named.exit_code == 0
+    assert default_calls[0]["target_label"] == "local-agent"
+    assert named_calls[0]["target_label"] == "checkout-agent"
+
+
+def test_unsafe_target_label_is_rejected_before_admission_without_bundle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    result = runner.invoke(
+        app,
+        [
+            "test",
+            "agent",
+            "--endpoint",
+            ENDPOINT,
+            "--target-label",
+            "bad\nlabel",
+            "--format",
+            "json",
+        ],
+        color=False,
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert "Configuration error: --target-label must be nonempty, trimmed, control-free" in (
+        result.stderr
+    )
+    assert not (tmp_path / ".town").exists()
+    assert TOKEN not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "headline"),
+    [
+        (0, "RESULT: PASS"),
+        (1, "RESULT: FAIL"),
+        (3, "RESULT: ERROR"),
+        (4, "RESULT: INCOMPLETE"),
+        (130, "RESULT: INTERRUPTED"),
+    ],
+)
+def test_human_terminal_outcomes_have_honest_ordered_sections(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    exit_code: int,
+    headline: str,
+) -> None:
+    result, _, outcome = _invoke(monkeypatch, tmp_path, outcome_exit=exit_code)
+
+    assert result.exit_code == exit_code
+    assert result.stdout.startswith(headline + "\n")
+    assert "Run: 01K00000000000000000000001" in result.stdout
+    assert f"Profile: {PROFILE_EXACT}" in result.stdout
+    assert (
+        "Target label: local-agent (local evidence label; not verified identity)" in result.stdout
+    )
+    expected_instance = outcome.result.driver.adapter_instance_id or "not observed"
+    assert (
+        "Request authentication: Town sent bearer-authenticated requests using the caller "
+        "credential" in result.stdout
+    )
+    assert f"Adapter instance (self-asserted): {expected_instance}" in result.stdout
+    assert "Next\n" in result.stdout
+    assert "Artifacts\n" in result.stdout
+    expected_sections = {
+        0: ["Passed", "Not tested", "Next", "Artifacts"],
+        1: ["Failed", "Not tested", "Next", "Artifacts"],
+        3: ["Not evaluated", "Next", "Artifacts"],
+        4: ["Incomplete", "Next", "Artifacts"],
+        130: ["Incomplete", "Next", "Artifacts"],
+    }[exit_code]
+    positions = [result.stdout.index(section + "\n") for section in expected_sections]
+    assert positions == sorted(positions)
+    lowered = result.stdout.lower()
+    for forbidden in ("compatible", "certified", "safe", "trusted", "reliable", "llm"):
+        assert re.search(rf"\b{forbidden}\b", lowered) is None
+    if exit_code == 4:
+        assert "TRANSPORT_LOSS" in result.stdout
+        assert f"Start or check the local adapter at {ENDPOINT}, then rerun" in result.stdout
+
+
+def test_no_color_explicitly_disables_color_for_human_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    outcome = _outcome(tmp_path, 0)
+
+    async def fake_execute(**_kwargs: object) -> AgentTestOutcome:
+        return outcome
+
+    original_echo = agent_cli.typer.echo
+    final_color_values: list[object] = []
+
+    def recording_echo(message: Any = None, *args: Any, **kwargs: Any) -> None:
+        if isinstance(message, str) and message.startswith("RESULT: PASS"):
+            final_color_values.append(kwargs.get("color"))
+        original_echo(message, *args, **kwargs)
+
+    monkeypatch.setattr(agent_cli, "_execute_agent_test", fake_execute)
+    monkeypatch.setattr(agent_cli.typer, "echo", recording_echo)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    result = runner.invoke(
+        app,
+        ["test", "agent", "--endpoint", ENDPOINT, "--no-color"],
+        color=True,
+    )
+
+    assert result.exit_code == 0
+    assert final_color_values == [False]
+    assert "\x1b[" not in result.stdout
+
+
+def test_json_stdout_is_exact_result_bytes_and_progress_is_only_stderr(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    result, _, outcome = _invoke(monkeypatch, tmp_path, extra=["--format", "json"])
+
+    assert result.exit_code == 0
+    assert result.stdout_bytes == outcome.result_bytes
+    assert result.stdout_bytes == (outcome.output_directory / "result.json").read_bytes()
+    assert str(tmp_path).encode() not in result.stdout_bytes
+    assert b"Running local adapter test" not in result.stdout_bytes
+    assert "Running local adapter test" in result.stderr
+
+
+def test_human_next_offers_a_working_portable_trace_inspect_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result, _, outcome = _invoke(monkeypatch, tmp_path)
+
+    trace = outcome.output_directory / "trace.jsonl"
+    relative_trace = trace.relative_to(tmp_path)
+    command = f"nest inspect {relative_trace}"
+    assert result.exit_code == 0
+    assert f"Inspect the trace: {command}" in result.stdout
+    assert str(tmp_path) not in next(
+        line for line in result.stdout.splitlines() if "nest inspect" in line
+    )
+    inspected = runner.invoke(app, ["inspect", str(relative_trace)], color=False)
+    assert inspected.exit_code == 0
+    assert "Total events:" in inspected.stdout
+
+
+def test_binary_stdout_writer_preserves_exact_bytes_and_flushes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    class _Buffer(io.BytesIO):
+        flushed = False
+
+        def flush(self) -> None:
+            self.flushed = True
+            super().flush()
+
+    class _Stdout:
+        def __init__(self) -> None:
+            self.buffer = _Buffer()
+
+    stdout = _Stdout()
+    monkeypatch.setattr(agent_cli.sys, "stdout", stdout)
+    payload = b'{"unicode":"\\u2603"}\n'
+
+    agent_cli._write_stdout_bytes(payload)  # pyright: ignore[reportPrivateUsage]
+
+    assert stdout.buffer.getvalue() == payload
+    assert stdout.buffer.flushed is True
+
+
+def test_causally_unobserved_check_is_not_merged_with_out_of_profile_coverage(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    data = _result_data(4)
+    data["evaluation"]["checks"][0].update(
+        status="not_tested", summary="The driver exchange did not reach this check"
+    )
+    data["coverage"].append(
+        {
+            "claim": "agent.safety",
+            "status": "not_tested",
+            "reason_code": "OUT_OF_PROFILE",
+            "evidence_refs": [],
+        }
+    )
+    result_model = TestResult.model_validate(data)
+    output_directory = tmp_path / "causal-sections"
+    output_directory.mkdir()
+    result_bytes = (
+        json.dumps(result_model.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
+        + "\n"
+    ).encode()
+    (output_directory / "result.json").write_bytes(result_bytes)
+    outcome = AgentTestOutcome(
+        result=result_model,
+        exit_code=4,
+        output_directory=output_directory,
+        result_bytes=result_bytes,
+    )
+
+    async def fake_execute(**_kwargs: object) -> AgentTestOutcome:
+        return outcome
+
+    monkeypatch.setattr(agent_cli, "_execute_agent_test", fake_execute)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    rendered = runner.invoke(
+        app,
+        ["test", "agent", "--endpoint", ENDPOINT],
+        color=False,
+    )
+
+    assert rendered.exit_code == 4
+    not_evaluated = rendered.stdout.index("Not evaluated\n")
+    causal_check = rendered.stdout.index("driver.contract:")
+    not_tested = rendered.stdout.index("Not tested\n")
+    out_of_profile = rendered.stdout.index("agent.safety:")
+    assert not_evaluated < causal_check < not_tested < out_of_profile
+
+
+def test_verbose_changes_stderr_only_and_never_prints_the_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    normal, _, _ = _invoke(monkeypatch, tmp_path)
+    verbose, _, _ = _invoke(monkeypatch, tmp_path, extra=["--verbose"])
+
+    assert normal.exit_code == verbose.exit_code == 0
+    assert normal.stdout == verbose.stdout
+    assert normal.stderr != verbose.stderr
+    assert PROFILE_EXACT in verbose.stderr
+    assert ENDPOINT in verbose.stderr
+    assert TOKEN not in normal.stdout + normal.stderr + verbose.stdout + verbose.stderr
+
+
+def test_valid_caller_credential_is_removed_from_environment_before_execution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    token_env = "TOWN_TEST_CALLER_CREDENTIAL"
+    outcome = _outcome(tmp_path, 0)
+    observations: list[tuple[str | None, object]] = []
+
+    async def observe_environment(**kwargs: object) -> AgentTestOutcome:
+        observations.append((os.environ.get(token_env), kwargs["token"]))
+        return outcome
+
+    monkeypatch.setattr(agent_cli, "_execute_agent_test", observe_environment)
+    monkeypatch.setenv(token_env, TOKEN)
+
+    result = runner.invoke(
+        app,
+        [
+            "test",
+            "agent",
+            "--endpoint",
+            ENDPOINT,
+            "--token-env",
+            token_env,
+            "--format",
+            "json",
+        ],
+        color=False,
+    )
+
+    assert result.exit_code == 0
+    assert observations == [(None, TOKEN)]
+    assert token_env not in os.environ
+    assert result.stdout_bytes == outcome.result_bytes
+    assert TOKEN not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("outcome_exit", "final_status"),
+    [(0, "PASS"), (1, "FAIL"), (3, "ERROR"), (4, "INCOMPLETE"), (130, "INTERRUPTED")],
+)
+def test_interrupt_during_terminal_diagnostics_distinguishes_finalized_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    outcome_exit: int,
+    final_status: str,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    def interrupt_diagnostics(_outcome: AgentTestOutcome) -> NoReturn:
+        raise KeyboardInterrupt("interrupt-diagnostics-canary")
+
+    monkeypatch.setattr(agent_cli, "_write_diagnostics", interrupt_diagnostics)
+    result, _, outcome = _invoke(
+        monkeypatch,
+        tmp_path,
+        outcome_exit=outcome_exit,
+        extra=["--format", "json"],
+    )
+
+    assert result.exit_code == 130
+    assert result.stdout_bytes == b""
+    assert "RESULT: OUTPUT INTERRUPTED" in result.stderr
+    assert f"test finalized as {final_status}; result.json remains authoritative" in result.stderr
+    assert "The local adapter test was interrupted." not in result.stderr
+    assert "interrupt-diagnostics-canary" not in result.stderr
+    assert (outcome.output_directory / "result.json").read_bytes() == outcome.result_bytes
+    assert outcome.exit_code == outcome_exit
+    assert TOKEN not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("failure", "exit_code", "terminal"),
+    [
+        (
+            AgentTestPreAdmissionError(
+                "REFERENCE_REGISTRY_MISSING", next="pip install 'nest-core[plugins]'"
+            ),
+            2,
+            "Configuration error: pinned reference Registry is unavailable.",
+        ),
+        (
+            DriverConfigurationError("AUTHENTICATION_FAILED"),
+            2,
+            "Configuration error: local adapter configuration was rejected before admission.",
+        ),
+        (
+            DriverCompatibilityError("UNSUPPORTED_PROFILE"),
+            2,
+            "Configuration error: local adapter does not support the frozen profile or driver "
+            "contract.",
+        ),
+        (
+            DriverContractError("MALFORMED_RESPONSE"),
+            1,
+            "Driver contract: the local adapter returned an invalid response to Town's "
+            "bearer-authenticated request.",
+        ),
+        (
+            DriverIncompleteError("TRANSPORT_LOSS"),
+            4,
+            "Reason: TRANSPORT_LOSS",
+        ),
+        (
+            TownDriverError("PROFILE_MISMATCH"),
+            3,
+            "Town could not complete the local adapter test.",
+        ),
+        (
+            AgentTestTownError("TOWN_EXECUTION_ERROR"),
+            3,
+            "Town could not complete the local adapter test.",
+        ),
+        (TimeoutError("secret-timeout-detail"), 4, "RESULT: INCOMPLETE"),
+        (RuntimeError("secret-runtime-detail"), 3, "RESULT: ERROR"),
+        (KeyboardInterrupt(), 130, "RESULT: INTERRUPTED"),
+    ],
+)
+def test_safe_exception_to_exit_mapping_has_no_stdout_or_underlying_text(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: BaseException,
+    exit_code: int,
+    terminal: str,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    async def fail(**_kwargs: object) -> AgentTestOutcome:
+        raise failure
+
+    monkeypatch.setattr(agent_cli, "_execute_agent_test", fail)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    result = runner.invoke(
+        app,
+        ["test", "agent", "--endpoint", ENDPOINT, "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == exit_code
+    assert result.stdout_bytes == b""
+    assert terminal in result.stderr
+    if str(failure) and not isinstance(failure, DriverIncompleteError):
+        assert str(failure) not in result.stderr
+    assert TOKEN not in result.stderr
+    assert "TOWN_AGENT_TOKEN" not in os.environ
+
+
+@pytest.mark.parametrize("reason", ["TRANSPORT_LOSS", "TIMEOUT", "RUN_BUSY"])
+def test_pre_admission_incomplete_names_safe_reason_and_actionable_adapter_next_step(
+    monkeypatch: pytest.MonkeyPatch, reason: str
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    async def fail(**_kwargs: object) -> AgentTestOutcome:
+        raise DriverIncompleteError(reason)
+
+    monkeypatch.setattr(agent_cli, "_execute_agent_test", fail)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    result = runner.invoke(
+        app,
+        ["test", "agent", "--endpoint", ENDPOINT, "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == 4
+    assert result.stdout_bytes == b""
+    assert f"Reason: {reason}" in result.stderr
+    assert f"Next: Start or check the local adapter at {ENDPOINT}, then rerun." in result.stderr
+    assert TOKEN not in result.stderr
+
+
+def test_pre_admission_incomplete_does_not_render_unrecognized_error_text_or_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    unsafe = f"private-{TOKEN}"
+
+    async def fail(**_kwargs: object) -> AgentTestOutcome:
+        raise DriverIncompleteError(unsafe)
+
+    monkeypatch.setattr(agent_cli, "_execute_agent_test", fail)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    result = runner.invoke(
+        app,
+        ["test", "agent", "--endpoint", ENDPOINT, "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == 4
+    assert result.stdout_bytes == b""
+    assert "Reason: ADAPTER_UNAVAILABLE" in result.stderr
+    assert unsafe not in result.stderr
+    assert TOKEN not in result.stderr
+
+
+def test_missing_reference_plugin_prints_exact_remediation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    async def fail(**_kwargs: object) -> AgentTestOutcome:
+        raise AgentTestPreAdmissionError(
+            "REFERENCE_REGISTRY_MISSING", next="pip install 'nest-core[plugins]'"
+        )
+
+    monkeypatch.setattr(agent_cli, "_execute_agent_test", fail)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    result = runner.invoke(
+        app,
+        ["test", "agent", "--endpoint", ENDPOINT],
+        color=False,
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert "Next: pip install 'nest-core[plugins]'" in result.stderr
+
+
+def test_recursive_token_canary_is_absent_from_output_and_artifacts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    async def fail(**_kwargs: object) -> AgentTestOutcome:
+        raise RuntimeError(TOKEN)
+
+    monkeypatch.setattr(agent_cli, "_execute_agent_test", fail)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    result = runner.invoke(
+        app,
+        ["test", "agent", "--endpoint", ENDPOINT, "--verbose"],
+        color=False,
+    )
+
+    corpus = result.stdout_bytes + result.stderr_bytes
+    for path in tmp_path.rglob("*"):
+        if path.is_file():
+            corpus += path.read_bytes()
+    assert TOKEN.encode() not in corpus
+
+
+def test_real_subprocess_sigint_after_admission_writes_terminal_interrupted_bundle(
+    tmp_path: Path,
+) -> None:
+    with _serve_interrupt_adapter() as server:
+        endpoint = f"http://127.0.0.1:{server.server_port}"
+        environment = os.environ.copy()
+        environment["TOWN_AGENT_TOKEN"] = TOKEN
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "nest_core.cli",
+                "test",
+                "agent",
+                "--endpoint",
+                endpoint,
+                "--format",
+                "json",
+            ],
+            cwd=tmp_path,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            assert server.message_seen.wait(timeout=10), "run never reached post-admission message"
+            process.send_signal(signal.SIGINT)
+            stdout, stderr = process.communicate(timeout=15)
+        finally:
+            server.release_message.set()
+            if process.poll() is None:
+                process.kill()
+                process.wait(timeout=5)
+
+    assert process.returncode == 130
+    bundles = list((tmp_path / ".town" / "runs").iterdir())
+    assert len(bundles) == 1
+    result_path = bundles[0] / "result.json"
+    trace_path = bundles[0] / "trace.jsonl"
+    assert stdout == result_path.read_bytes()
+    result = TestResult.model_validate_json(stdout)
+    assert result.execution.status == "incomplete"
+    assert result.evaluation.verdict == "inconclusive"
+    assert trace_path.read_bytes().endswith(b"\n")
+    stop_observations = [item for item in server.observations if item["kind"] == "stop"]
+    assert len(stop_observations) == 1
+    assert stop_observations[0]["reason"] == "user_interrupted"
+    corpus = stdout + stderr
+    for path in bundles[0].rglob("*"):
+        if path.is_file():
+            corpus += path.read_bytes()
+    assert TOKEN.encode() not in corpus

--- a/packages/nest-core/tests/agent_test/test_end_to_end.py
+++ b/packages/nest-core/tests/agent_test/test_end_to_end.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Installed-command proof for the local bring-your-agent journey."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from http.client import HTTPConnection
+from importlib import resources
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import jsonschema
+import pytest
+from nest_core.agent_test.models import TestObservation, TestResult
+
+REPOSITORY_ROOT = Path(__file__).parents[4]
+ADAPTER_PATH = REPOSITORY_ROOT / "examples" / "agent-test" / "reference_adapter.py"
+CHECKER_PATH = REPOSITORY_ROOT / "scripts" / "check_agent_test_quickstart.py"
+TOKEN = "9" * 64
+CONTRACT = "town-agent-driver/1"
+
+
+def _reserve_ephemeral_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def _wait_until_ready(process: subprocess.Popen[bytes], port: int) -> None:
+    deadline = time.monotonic() + 5
+    headers = {
+        "Authorization": f"Bearer {TOKEN}",
+        "Town-Driver-Contract": CONTRACT,
+        "Accept": "application/json",
+        "Accept-Encoding": "identity",
+    }
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise AssertionError(f"reference adapter exited before readiness: {process.returncode}")
+        try:
+            connection = HTTPConnection("127.0.0.1", port, timeout=0.2)
+            connection.request("GET", "/town-driver/1/ready", headers=headers)
+            response = connection.getresponse()
+            body = response.read()
+            connection.close()
+            if response.status == 200 and json.loads(body)["accepting_runs"] is True:
+                return
+        except (ConnectionError, OSError, TimeoutError):
+            pass
+        time.sleep(0.02)
+    raise AssertionError("reference adapter did not become ready")
+
+
+def _installed_nest() -> Path:
+    for name in ("nest", "nest.exe"):
+        command = Path(sys.executable).with_name(name)
+        if command.is_file():
+            return command
+    raise AssertionError("the installed test environment must expose the nest console script")
+
+
+def _schema(name: str) -> dict[str, Any]:
+    package = resources.files("nest_core.agent_test.resources.schemas")
+    return json.loads(package.joinpath(name).read_bytes())
+
+
+def _load_checker() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("town_quickstart_checker", CHECKER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(repository: Path, *arguments: str) -> None:
+    completed = subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_installed_command_runs_reference_adapter_and_emits_verified_evidence(
+    tmp_path: Path,
+) -> None:
+    """Any source shortcut, fake runner, or incomplete evidence chain must fail end to end."""
+    port = _reserve_ephemeral_port()
+    environment = os.environ.copy()
+    environment["TOWN_AGENT_TOKEN"] = TOKEN
+    environment["PYTHONNOUSERSITE"] = "1"
+    environment.pop("PYTHONPATH", None)
+    adapter = subprocess.Popen(
+        [sys.executable, str(ADAPTER_PATH), "--port", str(port)],
+        cwd=tmp_path,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    adapter_stdout = b""
+    adapter_stderr = b""
+    try:
+        _wait_until_ready(adapter, port)
+        output = tmp_path / "evidence"
+        completed = subprocess.run(
+            [
+                str(_installed_nest()),
+                "test",
+                "agent",
+                "--endpoint",
+                f"http://127.0.0.1:{port}",
+                "--format",
+                "json",
+                "--output-dir",
+                str(output),
+                "--no-color",
+            ],
+            cwd=tmp_path,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            check=False,
+            timeout=20,
+        )
+    finally:
+        adapter.terminate()
+        try:
+            adapter_stdout, adapter_stderr = adapter.communicate(timeout=2)
+        except subprocess.TimeoutExpired:
+            adapter.kill()
+            adapter_stdout, adapter_stderr = adapter.communicate(timeout=2)
+
+    assert completed.returncode == 0, completed.stderr.decode("utf-8", errors="replace")
+    result_bytes = (output / "result.json").read_bytes()
+    assert completed.stdout == result_bytes
+    result_data = json.loads(result_bytes)
+    jsonschema.validate(result_data, _schema("test-result-1.schema.json"))
+    result = TestResult.model_validate(result_data)
+    assert result.execution.status == "completed"
+    assert result.evaluation.verdict == "pass"
+    assert [(check.id, check.status) for check in result.evaluation.checks] == [
+        ("driver.contract", "pass"),
+        ("registry.provider-registered", "pass"),
+        ("registry.provider-discovered", "pass"),
+        ("delivery.request-routed", "pass"),
+        ("capability.synthetic-request-fulfilled", "pass"),
+    ]
+
+    trace_bytes = (output / "trace.jsonl").read_bytes()
+    trace_artifact = next(artifact for artifact in result.artifacts if artifact.kind == "trace")
+    assert trace_artifact.path == "trace.jsonl"
+    assert trace_artifact.digest == "sha256:" + hashlib.sha256(trace_bytes).hexdigest()
+    records = [json.loads(line) for line in trace_bytes.splitlines()]
+    test_records = [record for record in records if str(record.get("kind", "")).startswith("test.")]
+    observations: list[TestObservation] = []
+    observation_schema = _schema("test-observation-1.schema.json")
+    for record in test_records:
+        jsonschema.validate(record, observation_schema)
+        observations.append(TestObservation.model_validate(record))
+
+    roots = [observation.root for observation in observations]
+    assert [root.seq for root in roots] == list(range(1, len(roots) + 1))
+    assert len({root.event_id for root in roots}) == len(roots)
+    assert all(root.run_id == result.run_id for root in roots)
+    assert all(root.subject_participant_id == "provider-0" for root in roots)
+    admitted = next(root for root in roots if root.kind == "test.driver.run_admitted")
+    assert admitted.data.profile_digest == result.profile.digest
+    registered = next(root for root in roots if root.kind == "test.registry.provider_registered")
+    assert registered.data.registry_implementation == (
+        "nest_plugins_reference.registry.in_memory.InMemoryRegistry"
+    )
+    discovered = next(root for root in roots if root.kind == "test.registry.lookup_returned")
+    assert discovered.data.card_agent_ids == ["provider-0"]
+    assert any(root.kind == "test.message.request_routed" for root in roots)
+    assert any(root.kind == "test.message.response_routed" for root in roots)
+    referenced_sequences = {
+        int(match.group(1))
+        for check in result.evaluation.checks
+        for reference in check.evidence_refs
+        if (match := re.fullmatch(r"trace\.jsonl#seq=([1-9][0-9]*)", reference))
+    }
+    assert referenced_sequences
+    assert referenced_sequences <= {root.seq for root in roots}
+
+    secret = TOKEN.encode("ascii")
+    scanned = [
+        completed.stdout,
+        completed.stderr,
+        adapter_stdout,
+        adapter_stderr,
+        *(path.read_bytes() for path in output.rglob("*") if path.is_file()),
+    ]
+    assert all(secret not in content for content in scanned)
+
+
+def test_profile_and_public_schemas_resolve_from_installed_wheel(tmp_path: Path) -> None:
+    """Omitting package data or falling back to the checkout must fail this wheel probe."""
+    uv = shutil.which("uv")
+    assert uv is not None
+    distribution = tmp_path / "distribution"
+    environment = os.environ.copy()
+    build = subprocess.run(
+        [
+            uv,
+            "build",
+            "--wheel",
+            "--package",
+            "nest-core",
+            "--out-dir",
+            str(distribution),
+            "--no-create-gitignore",
+        ],
+        cwd=REPOSITORY_ROOT,
+        env=environment,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    assert build.returncode == 0, build.stderr
+    wheels = list(distribution.glob("nest_core-*.whl"))
+    assert len(wheels) == 1
+    installed = tmp_path / "installed"
+    install = subprocess.run(
+        [uv, "pip", "install", "--target", str(installed), "--no-deps", str(wheels[0])],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    assert install.returncode == 0, install.stderr
+    probe = r"""
+import json
+import sys
+from importlib import resources
+from pathlib import Path
+
+site = Path(sys.argv[1]).resolve()
+sys.path.insert(0, str(site))
+import nest_core
+from nest_core.agent_test.profiles import profile_digest, resolve_profile
+
+profile_package = resources.files("nest_core.agent_test.resources.profiles")
+schema_package = resources.files("nest_core.agent_test.resources.schemas")
+schema_names = [
+    "driver-error-1.schema.json",
+    "driver-ready-1.schema.json",
+    "driver-request-1.schema.json",
+    "driver-response-1.schema.json",
+    "test-observation-1.schema.json",
+    "test-profile-1.schema.json",
+    "test-result-1.schema.json",
+]
+for name in schema_names:
+    json.loads(schema_package.joinpath(name).read_bytes())
+profile = json.loads(resolve_profile("capability-fulfillment"))
+assert profile["id"] == "nanda/agent/capability-fulfillment"
+assert profile_digest("capability-fulfillment") == (
+    "sha256:436622e70cd84690e39c24f93236c7639adefea2fe9ea72a1dddb25e65609c58"
+)
+module_path = Path(nest_core.__file__).resolve()
+profile_path = Path(str(profile_package)).resolve()
+schema_path = Path(str(schema_package)).resolve()
+assert module_path.is_relative_to(site)
+assert profile_path.is_relative_to(site)
+assert schema_path.is_relative_to(site)
+print(json.dumps({
+    "module": str(module_path),
+    "profile": str(profile_path),
+    "schema": str(schema_path),
+}))
+"""
+    probe_environment = environment.copy()
+    probe_environment["PYTHONNOUSERSITE"] = "1"
+    probe_environment.pop("PYTHONPATH", None)
+    checked = subprocess.run(
+        [sys.executable, "-I", "-c", probe, str(installed)],
+        cwd=tmp_path,
+        env=probe_environment,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    assert checked.returncode == 0, checked.stderr
+    paths = json.loads(checked.stdout)
+    assert all(str(installed) in path for path in paths.values())
+
+
+def test_checker_archives_committed_head_and_refuses_dirty_or_untracked_inputs(
+    tmp_path: Path,
+) -> None:
+    """Copying working-tree bytes could let uncommitted release files mask a broken HEAD."""
+    checker = _load_checker()
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    _git(repository, "init", "-q")
+    _git(repository, "config", "user.name", "Town Test")
+    _git(repository, "config", "user.email", "town-test@example.invalid")
+    (repository / "required.txt").write_text("committed\n", encoding="utf-8")
+    _git(repository, "add", "required.txt")
+    _git(repository, "commit", "-q", "-m", "fixture")
+    environment = os.environ.copy()
+
+    committed = tmp_path / "committed"
+    checker._copy_committed_source(repository, committed, environment)
+    assert (committed / "required.txt").read_text(encoding="utf-8") == "committed\n"
+    assert not (committed / ".git").exists()
+
+    (repository / "required.txt").write_text("dirty\n", encoding="utf-8")
+    (repository / "untracked.txt").write_text("untracked\n", encoding="utf-8")
+    with pytest.raises(checker._CheckFailureError, match="clean"):
+        checker._copy_committed_source(repository, tmp_path / "rejected", environment)
+
+
+def test_checker_resolves_posix_or_windows_virtual_environment_commands(tmp_path: Path) -> None:
+    """Hard-coding `.venv/bin` would make the clean-package proof fail on Windows."""
+    checker = _load_checker()
+    virtual_environment = tmp_path / "venv"
+    scripts = virtual_environment / "Scripts"
+    scripts.mkdir(parents=True)
+    python = scripts / "python.exe"
+    nest = scripts / "nest.exe"
+    python.touch()
+    nest.touch()
+
+    assert checker._venv_executable(virtual_environment, "python") == python
+    assert checker._venv_executable(virtual_environment, "nest") == nest
+
+
+def test_checker_recursively_enumerates_every_artifact_file(tmp_path: Path) -> None:
+    """A secret in a nested future artifact must remain inside the release scan frontier."""
+    checker = _load_checker()
+    output = tmp_path / "evidence"
+    nested = output / "nested" / "future.bin"
+    nested.parent.mkdir(parents=True)
+    nested.write_bytes(b"future artifact")
+    (output / "result.json").write_bytes(b"{}")
+
+    assert checker._artifact_files(output) == [nested, output / "result.json"]
+
+
+@pytest.mark.skipif(
+    os.environ.get("TOWN_RUN_PACKAGE_QUICKSTART") != "1",
+    reason="explicit clean-package journey; run before release handoff",
+)
+def test_clean_archive_wheel_quickstart_checker() -> None:
+    """Any source fallback or unlocked/source install must fail the release checker."""
+    checker = CHECKER_PATH
+    environment = os.environ.copy()
+    environment["PYTHONNOUSERSITE"] = "1"
+    environment.pop("PYTHONPATH", None)
+    completed = subprocess.run(
+        [sys.executable, str(checker)],
+        cwd=REPOSITORY_ROOT,
+        env=environment,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=180,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == "clean archive/wheel quickstart: PASS\n"

--- a/packages/nest-core/tests/agent_test/test_reference_adapter.py
+++ b/packages/nest-core/tests/agent_test/test_reference_adapter.py
@@ -1,0 +1,670 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Behavior tests for the standard-library reference adapter process."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import threading
+from collections.abc import Generator
+from contextlib import contextmanager
+from http.client import HTTPConnection
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+from nest_core.agent_test.models import DriverError, DriverReady, DriverResponse
+
+REPOSITORY_ROOT = Path(__file__).parents[4]
+ADAPTER_PATH = REPOSITORY_ROOT / "examples" / "agent-test" / "reference_adapter.py"
+TOKEN = "a" * 64
+CONTRACT = "town-agent-driver/1"
+PROFILE_DIGEST = "sha256:436622e70cd84690e39c24f93236c7639adefea2fe9ea72a1dddb25e65609c58"
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_adapter() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("town_reference_adapter", ADAPTER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@contextmanager
+def _running_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[tuple[ModuleType, int, Any], None, None]:
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    module = _load_adapter()
+    server = module.create_server(port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield module, int(server.server_port), server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _request(
+    port: int,
+    method: str,
+    path: str,
+    *,
+    body: bytes | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, str], bytes]:
+    connection = HTTPConnection("127.0.0.1", port, timeout=2)
+    connection.request(method, path, body=body, headers=headers or {})
+    response = connection.getresponse()
+    response_body = response.read()
+    response_headers = {key.lower(): value for key, value in response.getheaders()}
+    connection.close()
+    return response.status, response_headers, response_body
+
+
+def _fixture(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _headers(body: bytes | None = None, *, token: str = TOKEN) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Town-Driver-Contract": CONTRACT,
+        "Accept": "application/json",
+        "Accept-Encoding": "identity",
+    }
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+        headers["Town-Request-Digest"] = "sha256:" + hashlib.sha256(body).hexdigest()
+    return headers
+
+
+def _post_data(port: int, data: dict[str, Any]) -> tuple[int, dict[str, str], bytes, bytes]:
+    body = json.dumps(data, separators=(",", ":")).encode("utf-8")
+    status, headers, response = _request(
+        port,
+        "POST",
+        "/town-driver/1/decide",
+        body=body,
+        headers=_headers(body),
+    )
+    return status, headers, response, body
+
+
+def _error_code(body: bytes) -> str:
+    return DriverError.model_validate_json(body).error.code
+
+
+def _stop_request(*, sequence: int, reason: str) -> dict[str, Any]:
+    request = _fixture("driver-stop-request.json")
+    request["sequence"] = sequence
+    request["observation"]["logical_time"] = 0
+    request["observation"]["reason"] = reason
+    if sequence == 1:
+        request["event_id"] = "01K00000000000000000000003"
+    return request
+
+
+def _second_start() -> dict[str, Any]:
+    request = _fixture("driver-start-request.json")
+    request["run_id"] = "01K00000000000000000000011"
+    request["event_id"] = "01K00000000000000000000012"
+    return request
+
+
+def test_authentication_precedes_body_parsing_and_compatibility_disclosure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing authentication must yield only a generic 401, even for malformed JSON."""
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        status, headers, body = _request(
+            port,
+            "POST",
+            "/town-driver/1/decide",
+            body=b"not-json",
+            headers={
+                "Content-Type": "application/json",
+                "Town-Driver-Contract": CONTRACT,
+                "Town-Request-Digest": "sha256:" + "0" * 64,
+            },
+        )
+
+    assert status == 401
+    assert headers["content-type"] == "application/json"
+    assert headers["town-driver-contract"] == CONTRACT
+    payload = json.loads(body)
+    assert payload["error"] == {
+        "code": "AUTHENTICATION_FAILED",
+        "message": "Authentication failed",
+        "retryable": False,
+    }
+    assert payload["adapter_instance_id"] is None
+    assert payload["run_id"] is None
+    assert payload["event_id"] is None
+    assert payload["sequence"] is None
+    assert payload["request_digest"] is None
+    assert b"town-reference-adapter" not in body
+    assert b"capability-fulfillment" not in body
+
+
+def test_readiness_is_exact_and_capacity_is_honest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Changing readiness identity, limits, or free capacity must fail this contract test."""
+    with _running_adapter(monkeypatch) as (_, port, server):
+        status, headers, body = _request(
+            port,
+            "GET",
+            "/town-driver/1/ready",
+            headers=_headers(),
+        )
+
+    assert status == 200
+    assert headers["content-type"] == "application/json"
+    assert headers["town-driver-contract"] == CONTRACT
+    ready = DriverReady.model_validate_json(body)
+    assert ready.model_dump(mode="json") == {
+        "schema_version": "town-agent-driver-ready/1",
+        "adapter_instance_id": "town-reference-adapter",
+        "contracts": [CONTRACT],
+        "profiles": [
+            {
+                "id": "nanda/agent/capability-fulfillment",
+                "version": "1",
+                "digest": PROFILE_DIGEST,
+            }
+        ],
+        "accepting_runs": True,
+        "limits": {
+            "max_active_runs": 1,
+            "max_request_bytes": 65536,
+            "max_response_bytes": 65536,
+        },
+    }
+    assert TOKEN not in repr(server.__dict__)
+
+
+def test_valid_token_is_removed_from_environment_before_decisions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retaining the raw bearer in the adapter environment must fail this test."""
+    observed_tokens: list[str | None] = []
+    with _running_adapter(monkeypatch) as (module, port, server):
+        original = module.decide_intent
+
+        def observe_environment(observation: dict[str, Any]) -> dict[str, Any]:
+            observed_tokens.append(os.environ.get("TOWN_AGENT_TOKEN"))
+            return original(observation)
+
+        monkeypatch.setattr(module, "decide_intent", observe_environment)
+        status, _, _, _ = _post_data(port, _fixture("driver-start-request.json"))
+
+    assert status == 200
+    assert observed_tokens == [None]
+    assert "TOWN_AGENT_TOKEN" not in os.environ
+    assert TOKEN not in repr(server.__dict__)
+
+
+def test_start_returns_exact_declared_capability_and_request_digest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Changing start intent or digest binding must fail at the adapter boundary."""
+    request = _fixture("driver-start-request.json")
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        status, _headers_out, body, request_body = _post_data(port, request)
+
+    assert status == 200
+    response = DriverResponse.model_validate_json(body)
+    assert response.run_id == request["run_id"]
+    assert response.event_id == request["event_id"]
+    assert response.sequence == 0
+    assert response.adapter_instance_id == "town-reference-adapter"
+    assert response.request_digest == "sha256:" + hashlib.sha256(request_body).hexdigest()
+    assert response.intent.model_dump(mode="json") == {
+        "kind": "declare_capability",
+        "capabilities": ["sell"],
+    }
+
+
+def test_exact_duplicate_returns_byte_identical_cached_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing replay caching must make the byte-identity assertion fail."""
+    request = _fixture("driver-start-request.json")
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        first_status, _, first, _ = _post_data(port, request)
+        second_status, _, second, _ = _post_data(port, request)
+
+    assert first_status == second_status == 200
+    assert first == second
+
+
+def test_same_event_with_changed_body_is_a_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accepting changed bytes under a successful event ID would break replay authority."""
+    request = _fixture("driver-start-request.json")
+    changed = json.loads(json.dumps(request))
+    changed["observation"]["allowed_intents"] = ["none", "declare_capability"]
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        first_status, _, _, _ = _post_data(port, request)
+        conflict_status, _, conflict, _ = _post_data(port, changed)
+
+    assert first_status == 200
+    assert conflict_status == 409
+    assert _error_code(conflict) == "EVENT_CONFLICT"
+
+
+def test_message_before_start_is_rejected_as_out_of_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing sequence admission must allow this skipped start and fail the test."""
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        status, _, body, _ = _post_data(port, _fixture("driver-message-request.json"))
+
+    assert status == 409
+    assert _error_code(body) == "OUT_OF_ORDER"
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("participant", "id"), "another-provider"),
+        (("participant", "role"), "buyer"),
+        (("profile", "digest"), "sha256:" + "0" * 64),
+        (("observation", "allowed_intents"), ["none", "send_to_sender"]),
+        (("observation", "message", "sender_id"), "another-requester"),
+        (("observation", "message", "text"), "buy:other:9"),
+    ],
+)
+def test_message_contract_rejects_wrong_participant_profile_or_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    path: tuple[str, ...],
+    value: object,
+) -> None:
+    """Loosening any frozen message vector must make one mutation unexpectedly pass."""
+    start = _fixture("driver-start-request.json")
+    message = _fixture("driver-message-request.json")
+    cursor: dict[str, Any] = message
+    for part in path[:-1]:
+        cursor = cursor[part]
+    cursor[path[-1]] = value
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        assert _post_data(port, start)[0] == 200
+        status, _, body, _ = _post_data(port, message)
+
+    assert status == 422
+    assert _error_code(body) == "SCHEMA_INVALID"
+
+
+def test_unknown_profile_fails_closed_before_profile_payload_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unregistered safe profile ID is unsupported, never a generic trusted payload."""
+    request = _fixture("driver-start-request.json")
+    request["profile"]["id"] = "example/agent/ping"
+    request["observation"] = {"untrusted": True}
+
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        status, _, body, _ = _post_data(port, request)
+
+    assert status == 422
+    assert _error_code(body) == "UNSUPPORTED_PROFILE"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("id", "nanda//agent"),
+        ("version", "0/1"),
+        ("digest", "sha256:not-a-digest"),
+    ],
+)
+def test_malformed_profile_identity_precedes_unsupported_profile(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: str,
+) -> None:
+    """Only a well-formed unknown identity may receive UNSUPPORTED_PROFILE."""
+    request = _fixture("driver-start-request.json")
+    request["profile"][field] = value
+    request["observation"] = {"untrusted": True}
+
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        status, _, body, _ = _post_data(port, request)
+
+    assert status == 422
+    assert _error_code(body) == "SCHEMA_INVALID"
+
+
+def test_one_active_run_is_enforced_at_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Admitting a second run while the first is active must fail this capacity test."""
+    first = _fixture("driver-start-request.json")
+    second = _fixture("driver-start-request.json")
+    second["run_id"] = "01K00000000000000000000011"
+    second["event_id"] = "01K00000000000000000000012"
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        assert _post_data(port, first)[0] == 200
+        status, _, body, _ = _post_data(port, second)
+
+    assert status == 409
+    assert _error_code(body) == "RUN_BUSY"
+
+
+def test_success_path_is_start_message_stop_and_releases_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wrong transition, semantic response, or capacity release must fail this full sequence."""
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        start_status, _, _, _ = _post_data(port, _fixture("driver-start-request.json"))
+        busy_status, _, busy_body = _request(
+            port, "GET", "/town-driver/1/ready", headers=_headers()
+        )
+        message_status, _, message_body, message_request_body = _post_data(
+            port, _fixture("driver-message-request.json")
+        )
+        stop_status, _, stop_body, stop_request_body = _post_data(
+            port, _fixture("driver-stop-request.json")
+        )
+        free_status, _, free_body = _request(
+            port, "GET", "/town-driver/1/ready", headers=_headers()
+        )
+
+    assert start_status == message_status == stop_status == busy_status == free_status == 200
+    assert DriverReady.model_validate_json(busy_body).accepting_runs is False
+    assert DriverReady.model_validate_json(free_body).accepting_runs is True
+    message = DriverResponse.model_validate_json(message_body)
+    assert message.request_digest == "sha256:" + hashlib.sha256(message_request_body).hexdigest()
+    assert message.intent.model_dump(mode="json") == {
+        "kind": "send_to_sender",
+        "media_type": "text/plain; charset=utf-8",
+        "text": "sold:widget:2",
+    }
+    stop = DriverResponse.model_validate_json(stop_body)
+    assert stop.request_digest == "sha256:" + hashlib.sha256(stop_request_body).hexdigest()
+    assert stop.intent.model_dump(mode="json") == {"kind": "none"}
+
+
+def test_request_digest_header_and_body_bound_are_enforced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ignoring a forged digest or an oversized body must fail this framing test."""
+    request_body = json.dumps(_fixture("driver-start-request.json"), separators=(",", ":")).encode(
+        "utf-8"
+    )
+    bad_headers = _headers(request_body)
+    bad_headers["Town-Request-Digest"] = "sha256:" + "0" * 64
+    oversized = b"{" + b" " * 65536 + b"}"
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        digest_status, _, digest_body = _request(
+            port,
+            "POST",
+            "/town-driver/1/decide",
+            body=request_body,
+            headers=bad_headers,
+        )
+        size_status, _, size_body = _request(
+            port,
+            "POST",
+            "/town-driver/1/decide",
+            body=oversized,
+            headers=_headers(oversized),
+        )
+
+    assert digest_status == 422
+    assert _error_code(digest_body) == "SCHEMA_INVALID"
+    assert size_status == 413
+    assert _error_code(size_body) == "BODY_TOO_LARGE"
+
+
+@pytest.mark.parametrize("reason", ["run_failed", "run_incomplete", "user_interrupted"])
+def test_stop_after_start_accepts_legal_terminal_reasons_and_releases_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+    reason: str,
+) -> None:
+    """Rejecting an early legal terminal stop would strand the one-run adapter capacity."""
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        assert _post_data(port, _fixture("driver-start-request.json"))[0] == 200
+        stop = _stop_request(sequence=1, reason=reason)
+        first_status, _, first_body, _ = _post_data(port, stop)
+        replay_status, _, replay_body, _ = _post_data(port, stop)
+        ready_status, _, ready_body = _request(
+            port, "GET", "/town-driver/1/ready", headers=_headers()
+        )
+        next_status, _, _, _ = _post_data(port, _second_start())
+
+    assert first_status == replay_status == ready_status == next_status == 200
+    assert first_body == replay_body
+    assert DriverResponse.model_validate_json(first_body).intent.kind == "none"
+    assert DriverReady.model_validate_json(ready_body).accepting_runs is True
+
+
+@pytest.mark.parametrize(
+    "reason", ["run_complete", "run_failed", "run_incomplete", "user_interrupted"]
+)
+def test_stop_after_message_accepts_every_legal_terminal_reason_and_releases_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+    reason: str,
+) -> None:
+    """A terminal outcome after the message must release capacity regardless of disposition."""
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        assert _post_data(port, _fixture("driver-start-request.json"))[0] == 200
+        assert _post_data(port, _fixture("driver-message-request.json"))[0] == 200
+        stop = _stop_request(sequence=2, reason=reason)
+        first_status, _, first_body, _ = _post_data(port, stop)
+        replay_status, _, replay_body, _ = _post_data(port, stop)
+        ready_status, _, ready_body = _request(
+            port, "GET", "/town-driver/1/ready", headers=_headers()
+        )
+        next_status, _, _, _ = _post_data(port, _second_start())
+
+    assert first_status == replay_status == ready_status == next_status == 200
+    assert first_body == replay_body
+    assert DriverResponse.model_validate_json(first_body).intent.kind == "none"
+    assert DriverReady.model_validate_json(ready_body).accepting_runs is True
+
+
+def test_run_complete_cannot_skip_the_required_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accepting run_complete at sequence one would certify a skipped required exchange."""
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        assert _post_data(port, _fixture("driver-start-request.json"))[0] == 200
+        status, _, body, _ = _post_data(port, _stop_request(sequence=1, reason="run_complete"))
+
+    assert status == 422
+    assert _error_code(body) == "SCHEMA_INVALID"
+
+
+def test_start_hook_failure_is_safe_retryable_and_transactional(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A failing custom hook must not leak, consume admission, or poison an exact retry."""
+    with _running_adapter(monkeypatch) as (module, port, _server):
+        original = module.decide_intent
+
+        def fail(_observation: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError(f"Traceback: private hook detail {TOKEN}")
+
+        monkeypatch.setattr(module, "decide_intent", fail)
+        request = _fixture("driver-start-request.json")
+        first_status, _, first_body, _ = _post_data(port, request)
+        second_status, _, second_body, _ = _post_data(port, request)
+        changed = json.loads(json.dumps(request))
+        changed["observation"]["logical_time"] = 1
+        conflict_status, _, conflict_body, _ = _post_data(port, changed)
+        ready_status, _, ready_body = _request(
+            port, "GET", "/town-driver/1/ready", headers=_headers()
+        )
+        monkeypatch.setattr(module, "decide_intent", original)
+        recovered_status, _, recovered_body, _ = _post_data(port, request)
+
+    error = DriverError.model_validate_json(first_body)
+    assert first_status == second_status == 500
+    assert first_body == second_body
+    assert error.error.code == "ADAPTER_INTERNAL"
+    assert error.error.retryable is True
+    assert error.error.message == "Adapter decision failed"
+    assert conflict_status == 409
+    assert _error_code(conflict_body) == "EVENT_CONFLICT"
+    assert ready_status == recovered_status == 200
+    assert DriverReady.model_validate_json(ready_body).accepting_runs is True
+    assert DriverResponse.model_validate_json(recovered_body).intent.kind == "declare_capability"
+    captured = capsys.readouterr()
+    combined = (
+        first_body + second_body + conflict_body + captured.out.encode() + captured.err.encode()
+    )
+    assert TOKEN.encode() not in combined
+    assert b"Traceback" not in combined
+    assert b"private hook detail" not in combined
+
+
+def test_message_hook_failure_keeps_active_sequence_for_exact_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Advancing before a failed message hook would make the same event unrecoverable."""
+    with _running_adapter(monkeypatch) as (module, port, _server):
+        original = module.decide_intent
+        assert _post_data(port, _fixture("driver-start-request.json"))[0] == 200
+
+        def fail(_observation: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError(f"private message failure {TOKEN}")
+
+        monkeypatch.setattr(module, "decide_intent", fail)
+        request = _fixture("driver-message-request.json")
+        first_status, _, first_body, _ = _post_data(port, request)
+        second_status, _, second_body, _ = _post_data(port, request)
+        changed = json.loads(json.dumps(request))
+        changed["observation"]["logical_time"] += 1
+        conflict_status, _, conflict_body, _ = _post_data(port, changed)
+        busy_status, _, busy_body = _request(
+            port, "GET", "/town-driver/1/ready", headers=_headers()
+        )
+        monkeypatch.setattr(module, "decide_intent", original)
+        recovered_status, _, recovered_body, _ = _post_data(port, request)
+        stop_status, _, _, _ = _post_data(port, _stop_request(sequence=2, reason="run_complete"))
+        free_status, _, free_body = _request(
+            port, "GET", "/town-driver/1/ready", headers=_headers()
+        )
+
+    assert first_status == second_status == 500
+    assert first_body == second_body
+    assert DriverError.model_validate_json(first_body).error.code == "ADAPTER_INTERNAL"
+    assert conflict_status == 409
+    assert _error_code(conflict_body) == "EVENT_CONFLICT"
+    assert busy_status == recovered_status == stop_status == free_status == 200
+    assert DriverReady.model_validate_json(busy_body).accepting_runs is False
+    assert DriverResponse.model_validate_json(recovered_body).intent.kind == "send_to_sender"
+    assert DriverReady.model_validate_json(free_body).accepting_runs is True
+    captured = capsys.readouterr()
+    combined = (
+        first_body + second_body + conflict_body + captured.out.encode() + captured.err.encode()
+    )
+    assert TOKEN.encode() not in combined
+    assert b"Traceback" not in combined
+
+
+def test_message_hook_failure_can_be_aborted_without_stranding_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Town must be able to terminate a run whose message decision failed internally."""
+    with _running_adapter(monkeypatch) as (module, port, _server):
+        original = module.decide_intent
+        start = _fixture("driver-start-request.json")
+        message = _fixture("driver-message-request.json")
+        assert _post_data(port, start)[0] == 200
+
+        def fail(_observation: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError(f"Traceback: private message failure {TOKEN}")
+
+        monkeypatch.setattr(module, "decide_intent", fail)
+        message_status, _, message_body, _ = _post_data(port, message)
+        stop = _stop_request(sequence=2, reason="run_incomplete")
+        stop_status, _, stop_body, _ = _post_data(port, stop)
+        replay_status, _, replay_body, _ = _post_data(port, stop)
+        changed_stop = json.loads(json.dumps(stop))
+        changed_stop["observation"]["reason"] = "run_failed"
+        conflict_status, _, conflict_body, _ = _post_data(port, changed_stop)
+        ready_status, _, ready_body = _request(
+            port, "GET", "/town-driver/1/ready", headers=_headers()
+        )
+        stale_status, _, stale_body, _ = _post_data(port, message)
+        monkeypatch.setattr(module, "decide_intent", original)
+        next_status, _, _, _ = _post_data(port, _second_start())
+
+    error = DriverError.model_validate_json(message_body)
+    assert message_status == 500
+    assert error.error.model_dump(mode="json") == {
+        "code": "ADAPTER_INTERNAL",
+        "message": "Adapter decision failed",
+        "retryable": True,
+    }
+    assert stop_status == replay_status == ready_status == next_status == 200
+    assert stop_body == replay_body
+    assert DriverResponse.model_validate_json(stop_body).intent.kind == "none"
+    assert conflict_status == 409
+    assert _error_code(conflict_body) == "EVENT_CONFLICT"
+    assert stale_status == 409
+    assert _error_code(stale_body) == "OUT_OF_ORDER"
+    assert DriverReady.model_validate_json(ready_body).accepting_runs is True
+    captured = capsys.readouterr()
+    combined = (
+        message_body
+        + stop_body
+        + replay_body
+        + conflict_body
+        + stale_body
+        + captured.out.encode()
+        + captured.err.encode()
+    )
+    assert TOKEN.encode() not in combined
+    assert b"Traceback" not in combined
+    assert b"private message failure" not in combined
+
+
+@pytest.mark.parametrize("reason", ["run_failed", "run_incomplete", "user_interrupted"])
+def test_sequence_two_abort_can_release_a_run_when_message_never_arrived(
+    monkeypatch: pytest.MonkeyPatch,
+    reason: str,
+) -> None:
+    """A terminal abort may account for a missing message without claiming completion."""
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        assert _post_data(port, _fixture("driver-start-request.json"))[0] == 200
+        status, _, body, _ = _post_data(port, _stop_request(sequence=2, reason=reason))
+        ready_status, _, ready_body = _request(
+            port, "GET", "/town-driver/1/ready", headers=_headers()
+        )
+
+    assert status == ready_status == 200
+    assert DriverResponse.model_validate_json(body).intent.kind == "none"
+    assert DriverReady.model_validate_json(ready_body).accepting_runs is True
+
+
+def test_sequence_two_run_complete_cannot_skip_the_required_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful terminal reason must never jump over the required message exchange."""
+    with _running_adapter(monkeypatch) as (_, port, _server):
+        assert _post_data(port, _fixture("driver-start-request.json"))[0] == 200
+        status, _, body, _ = _post_data(port, _stop_request(sequence=2, reason="run_complete"))
+        ready_status, _, ready_body = _request(
+            port, "GET", "/town-driver/1/ready", headers=_headers()
+        )
+
+    assert status == 409
+    assert _error_code(body) == "OUT_OF_ORDER"
+    assert ready_status == 200
+    assert DriverReady.model_validate_json(ready_body).accepting_runs is False

--- a/scripts/check_agent_test_quickstart.py
+++ b/scripts/check_agent_test_quickstart.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Verify the documented agent-test journey from clean source and installed wheels."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import secrets
+import shutil
+import socket
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from http.client import HTTPConnection
+from pathlib import Path
+
+_CONTRACT = "town-agent-driver/1"
+_PROFILE_DIGEST = "sha256:436622e70cd84690e39c24f93236c7639adefea2fe9ea72a1dddb25e65609c58"
+
+
+class _CheckFailureError(RuntimeError):
+    pass
+
+
+def _safe_environment() -> dict[str, str]:
+    allowed = {
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "NO_PROXY",
+        "PATHEXT",
+        "PATH",
+        "SSL_CERT_FILE",
+        "SYSTEMROOT",
+        "TEMP",
+        "TMPDIR",
+    }
+    environment = {key: value for key, value in os.environ.items() if key in allowed}
+    environment["PYTHONNOUSERSITE"] = "1"
+    return environment
+
+
+def _run(
+    arguments: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    label: str,
+    timeout: int = 120,
+) -> subprocess.CompletedProcess[bytes]:
+    completed = subprocess.run(
+        arguments,
+        cwd=cwd,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        check=False,
+        timeout=timeout,
+    )
+    if completed.returncode != 0:
+        raise _CheckFailureError(f"{label} exited {completed.returncode}")
+    return completed
+
+
+def _copy_committed_source(source: Path, destination: Path, environment: dict[str, str]) -> None:
+    status = _run(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+        cwd=source,
+        environment=environment,
+        label="clean source check",
+    )
+    if status.stdout:
+        raise _CheckFailureError("source tree must be clean before checking committed HEAD")
+    archived = _run(
+        ["git", "archive", "--format=tar", "HEAD"],
+        cwd=source,
+        environment=environment,
+        label="committed source archive",
+    )
+    destination.mkdir(parents=True, exist_ok=False)
+    with tarfile.open(fileobj=io.BytesIO(archived.stdout), mode="r:") as archive:
+        archive.extractall(destination, filter="data")
+
+
+def _venv_executable(virtual_environment: Path, name: str) -> Path:
+    candidates = (
+        virtual_environment / "bin" / name,
+        virtual_environment / "Scripts" / f"{name}.exe",
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise _CheckFailureError(f"virtual environment does not contain {name}")
+
+
+def _artifact_files(output: Path) -> list[Path]:
+    return sorted(path for path in output.rglob("*") if path.is_file())
+
+
+def _reserve_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def _wait_ready(process: subprocess.Popen[bytes], port: int, token: str) -> None:
+    deadline = time.monotonic() + 5
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Town-Driver-Contract": _CONTRACT,
+        "Accept": "application/json",
+        "Accept-Encoding": "identity",
+    }
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise _CheckFailureError("reference adapter exited before readiness")
+        try:
+            connection = HTTPConnection("127.0.0.1", port, timeout=0.2)
+            connection.request("GET", "/town-driver/1/ready", headers=headers)
+            response = connection.getresponse()
+            body = response.read()
+            connection.close()
+            if response.status == 200 and json.loads(body)["accepting_runs"] is True:
+                return
+        except (ConnectionError, OSError, TimeoutError):
+            pass
+        time.sleep(0.02)
+    raise _CheckFailureError("reference adapter did not become ready")
+
+
+def _wheel(distribution: Path, normalized_name: str) -> Path:
+    wheels = list(distribution.glob(f"{normalized_name}-*.whl"))
+    if len(wheels) != 1:
+        raise _CheckFailureError(f"expected one {normalized_name} wheel")
+    return wheels[0]
+
+
+def _verify_installed_resources(
+    python: Path, environment: dict[str, str], runtime: Path, virtual_environment: Path
+) -> None:
+    probe = r"""
+import json
+import sys
+from importlib import resources
+from pathlib import Path
+
+venv = Path(sys.argv[1]).resolve()
+import nest_core
+from nest_core.agent_test.profiles import profile_digest, resolve_profile
+
+module_path = Path(nest_core.__file__).resolve()
+profile_path = Path(str(resources.files("nest_core.agent_test.resources.profiles"))).resolve()
+schema_path = Path(str(resources.files("nest_core.agent_test.resources.schemas"))).resolve()
+assert module_path.is_relative_to(venv)
+assert profile_path.is_relative_to(venv)
+assert schema_path.is_relative_to(venv)
+assert json.loads(resolve_profile("capability-fulfillment"))["version"] == "1"
+assert profile_digest("capability-fulfillment") == sys.argv[2]
+for name in (
+    "driver-error-1.schema.json",
+    "driver-ready-1.schema.json",
+    "driver-request-1.schema.json",
+    "driver-response-1.schema.json",
+    "test-observation-1.schema.json",
+    "test-profile-1.schema.json",
+    "test-result-1.schema.json",
+):
+    json.loads(resources.files("nest_core.agent_test.resources.schemas").joinpath(name).read_bytes())
+"""
+    _run(
+        [str(python), "-I", "-c", probe, str(virtual_environment), _PROFILE_DIGEST],
+        cwd=runtime,
+        environment=environment,
+        label="installed resource probe",
+    )
+
+
+def _check() -> None:
+    source = Path(__file__).resolve().parents[1]
+    uv = shutil.which("uv")
+    if uv is None:
+        raise _CheckFailureError("uv is not installed")
+    base_environment = _safe_environment()
+    with tempfile.TemporaryDirectory(prefix="town-agent-quickstart-") as temporary:
+        temporary_root = Path(temporary)
+        archive = temporary_root / "source"
+        _copy_committed_source(source, archive, base_environment)
+
+        _run(
+            [uv, "--no-config", "sync", "--frozen"],
+            cwd=archive,
+            environment=base_environment,
+            label="locked source install",
+        )
+        distribution = temporary_root / "distribution"
+        distribution.mkdir()
+        for package in ("nest-core", "nest-sdk", "nest-plugins-reference"):
+            _run(
+                [
+                    uv,
+                    "--no-config",
+                    "build",
+                    "--wheel",
+                    "--package",
+                    package,
+                    "--out-dir",
+                    str(distribution),
+                    "--no-create-gitignore",
+                ],
+                cwd=archive,
+                environment=base_environment,
+                label=f"{package} wheel build",
+            )
+        core_wheel = _wheel(distribution, "nest_core")
+        sdk_wheel = _wheel(distribution, "nest_sdk")
+        plugin_wheel = _wheel(distribution, "nest_plugins_reference")
+        virtual_environment = archive / ".venv"
+        python = _venv_executable(virtual_environment, "python")
+        _run(
+            [
+                uv,
+                "--no-config",
+                "pip",
+                "install",
+                "--python",
+                str(python),
+                "--reinstall",
+                "--no-deps",
+                str(core_wheel),
+                str(sdk_wheel),
+                str(plugin_wheel),
+            ],
+            cwd=archive,
+            environment=base_environment,
+            label="wheel replacement install",
+        )
+
+        runtime = temporary_root / "runtime"
+        runtime.mkdir()
+        adapter_path = runtime / "reference_adapter.py"
+        shutil.copy2(archive / "examples" / "agent-test" / "reference_adapter.py", adapter_path)
+        (archive / "packages").rename(archive / "source-packages-disabled")
+        _verify_installed_resources(python, base_environment, runtime, virtual_environment)
+
+        token = secrets.token_hex(32)
+        runtime_environment = base_environment.copy()
+        runtime_environment["TOWN_AGENT_TOKEN"] = token
+        port = _reserve_port()
+        adapter = subprocess.Popen(
+            [str(python), str(adapter_path), "--port", str(port)],
+            cwd=runtime,
+            env=runtime_environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        adapter_stdout = b""
+        adapter_stderr = b""
+        try:
+            _wait_ready(adapter, port, token)
+            output = runtime / "evidence"
+            completed = _run(
+                [
+                    str(_venv_executable(virtual_environment, "nest")),
+                    "test",
+                    "agent",
+                    "--endpoint",
+                    f"http://127.0.0.1:{port}",
+                    "--format",
+                    "json",
+                    "--output-dir",
+                    str(output),
+                    "--no-color",
+                ],
+                cwd=runtime,
+                environment=runtime_environment,
+                label="installed quickstart command",
+            )
+        finally:
+            adapter.terminate()
+            try:
+                adapter_stdout, adapter_stderr = adapter.communicate(timeout=2)
+            except subprocess.TimeoutExpired:
+                adapter.kill()
+                adapter_stdout, adapter_stderr = adapter.communicate(timeout=2)
+
+        result_bytes = (output / "result.json").read_bytes()
+        if completed.stdout != result_bytes:
+            raise _CheckFailureError("JSON stdout did not equal result.json")
+        result = json.loads(result_bytes)
+        if (
+            result["execution"]["status"] != "completed"
+            or result["evaluation"]["verdict"] != "pass"
+        ):
+            raise _CheckFailureError("installed quickstart did not pass")
+        if [check["status"] for check in result["evaluation"]["checks"]] != ["pass"] * 5:
+            raise _CheckFailureError("installed quickstart checks were not all passing")
+        secret = token.encode("ascii")
+        scanned = [
+            completed.stdout,
+            completed.stderr,
+            adapter_stdout,
+            adapter_stderr,
+            *(path.read_bytes() for path in _artifact_files(output)),
+        ]
+        if any(secret in value for value in scanned):
+            raise _CheckFailureError("runtime secret appeared in quickstart output")
+
+
+def main() -> int:
+    try:
+        _check()
+    except (OSError, subprocess.SubprocessError, _CheckFailureError) as error:
+        print(f"clean archive/wheel quickstart: FAIL ({error})", file=sys.stderr)
+        return 1
+    print("clean archive/wheel quickstart: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

Developers need a documented command to attach a strict local adapter, run the Town test, and consume stable human or machine-readable results.

## Change

- add `nest test agent --endpoint` with human and exact-byte JSON output
- ship a strict Python reference adapter and version 1 resources
- document setup, exit codes, trust boundaries, artifacts, and troubleshooting
- add real subprocess and clean installed-wheel journey checks

## Verification

- final stack: `make ci-local` — all 5 checks passed; 2,081 passed, 2 skipped, 1 deselected
- CLI, SIGINT, output-byte, reference-adapter, docs, and package-resource tests pass
- clean committed-archive/installed-wheel quickstart: PASS

## Stack

**5 of 9. Depends on PR 4.** PRs 6–9 add the existing-OpenClaw one-command journey. Custom adapters remain supported through this endpoint mode.

**Merge note:** After #223 merges into `main`, retarget this PR to `main`, wait for its CI, and only then merge it.