### PR TITLE
feat(agent-test): add a bounded OpenClaw connector

### DIFF
--- a/packages/nest-core/nest_core/agent_test/openclaw_runtime.py
+++ b/packages/nest-core/nest_core/agent_test/openclaw_runtime.py
@@ -1,0 +1,1384 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exact-version, same-host OpenClaw connector for Town's managed runtime seam."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import tempfile
+import uuid
+from collections.abc import Mapping
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, NoReturn, cast
+from urllib.parse import urlsplit
+
+from .runtime_connectors import (
+    RuntimeConfigurationError,
+    RuntimeDisplay,
+    RuntimeExecutionError,
+    RuntimeIncompleteError,
+    RuntimeIssuePolicy,
+    RuntimeProbe,
+    RuntimeTarget,
+    RuntimeTurn,
+)
+from .runtime_subprocess import (
+    DEFAULT_OUTPUT_LIMIT_BYTES,
+    KILL_REAP_SECONDS,
+    PROBE_DEADLINE_SECONDS,
+    TERMINATE_GRACE_SECONDS,
+    TURN_DEADLINE_SECONDS,
+    ProcessError,
+    run_bounded,
+)
+
+_SAFE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}\Z")
+_MAX_JSON_DEPTH = 16
+_MAX_JSON_NODES = 4096
+_MAX_STRING_BYTES = 16 * 1024
+_MAX_SUMMARY_BYTES = 1024
+_MAX_INTENT_TEXT_BYTES = 4096
+_AGENT_INVENTORY_DEADLINE_SECONDS = 30
+_ECMASCRIPT_TRIM_CHARACTERS = (
+    "\u0009\u000a\u000b\u000c\u000d\u0020\u00a0\u1680"
+    "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a"
+    "\u2028\u2029\u202f\u205f\u3000\ufeff"
+)
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1"})
+_ACTIVITY_KEYS = frozenset(
+    {
+        "channel",
+        "channels",
+        "acceptedsessionspawns",
+        "automation",
+        "automations",
+        "cron",
+        "cronjobs",
+        "delivered",
+        "deliveries",
+        "delivery",
+        "didsendviamessagingtool",
+        "messages",
+        "pendingtoolcalls",
+        "spawn",
+        "spawnedsession",
+        "spawnedsessions",
+        "spawns",
+        "successfulcronadds",
+        "tool",
+        "toolcalls",
+        "toolresults",
+        "toolsummary",
+        "tools",
+    }
+)
+_ERROR_KEYS = frozenset({"error", "failuresignal"})
+_CLI_VERSION_BANNER = re.compile(r"OpenClaw (2026\.7\.1-2)(?: \([0-9a-f]{7}\))?\Z")
+_OPENCLAW_ENVIRONMENT_KEYS = frozenset(
+    {"OPENCLAW_CONFIG_PATH", "OPENCLAW_GATEWAY_URL", "OPENCLAW_STATE_DIR"}
+)
+_OPENCLAW_ENVIRONMENT = {"OPENCLAW_GATEWAY_URL": ""}
+_OPENCLAW_DISPLAY = RuntimeDisplay("OpenClaw", "openclaw gateway status")
+_OPENCLAW_ISSUE_POLICY = RuntimeIssuePolicy(
+    configuration=frozenset(
+        {
+            "OPENCLAW_CONFIG_DRIFT",
+            "OPENCLAW_MODEL_INVALID",
+            "OPENCLAW_PLATFORM_UNSUPPORTED",
+            "OPENCLAW_PROBE_MISMATCH",
+            "OPENCLAW_REMOTE_DISPATCH",
+            "OPENCLAW_RPC_UNHEALTHY",
+            "OPENCLAW_RUN_DUPLICATE",
+            "OPENCLAW_RUN_ID_INVALID",
+            "OPENCLAW_VERSION_MISMATCH",
+            "OPENCLAW_VERSION_UNSUPPORTED",
+            "TARGET_AMBIGUOUS",
+            "TARGET_NOT_FOUND",
+        }
+    ),
+    incomplete=frozenset(
+        {
+            "OPENCLAW_ABORTED",
+            "OPENCLAW_ACTIVITY_REPORTED",
+            "OPENCLAW_FALLBACK_REPORTED",
+            "OPENCLAW_GATEWAY_UNAVAILABLE",
+            "OPENCLAW_REPLAY_INVALID",
+            "OPENCLAW_RUN_ERROR",
+            "OPENCLAW_TRANSPORT_AMBIGUOUS",
+        }
+    ),
+    execution=frozenset(
+        {
+            "OPENCLAW_AGENTS_INVALID",
+            "OPENCLAW_AGENTS_UNAVAILABLE",
+            "OPENCLAW_ENVELOPE_INVALID",
+            "OPENCLAW_EXECUTION_FAILED",
+            "OPENCLAW_CONFIG_MODE_INVALID",
+            "OPENCLAW_CONFIG_MODE_UNAVAILABLE",
+            "OPENCLAW_CONFIG_ENV_INVALID",
+            "OPENCLAW_CONFIG_ENV_UNAVAILABLE",
+            "OPENCLAW_GATEWAY_INVALID",
+            "OPENCLAW_INTENT_FORBIDDEN",
+            "OPENCLAW_INTENT_INVALID",
+            "OPENCLAW_INTENT_NONCANONICAL",
+            "OPENCLAW_MESSAGE_FILE_CLEANUP_FAILED",
+            "OPENCLAW_MESSAGE_FILE_FAILED",
+            "OPENCLAW_MODEL_MISMATCH",
+            "OPENCLAW_OBSERVATION_INVALID",
+            "OPENCLAW_OUTPUT_LIMIT",
+            "OPENCLAW_PROBE_FAILED",
+            "OPENCLAW_RUN_CLOSED",
+            "OPENCLAW_SESSION_MISMATCH",
+            "OPENCLAW_TIMEOUT",
+            "OPENCLAW_TRANSPORT_LOSS",
+        }
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OpenClawCompatibility:
+    cli_version: str
+    gateway_version: str
+    rpc_version: str
+    envelope_version: str
+
+
+SUPPORTED_OPENCLAW = OpenClawCompatibility(
+    cli_version="2026.7.1-2",
+    gateway_version="2026.7.1-2",
+    rpc_version="2026.7.1-2",
+    envelope_version="2026.7.1-2",
+)
+
+
+class _DuplicateKeyError(ValueError):
+    pass
+
+
+def _object_without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateKeyError
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(_value: str) -> NoReturn:
+    raise ValueError
+
+
+def _validate_tree(value: object, *, depth: int = 0, counter: list[int] | None = None) -> None:
+    if depth > _MAX_JSON_DEPTH:
+        raise ValueError
+    if counter is None:
+        counter = [0]
+    counter[0] += 1
+    if counter[0] > _MAX_JSON_NODES:
+        raise ValueError
+    if value is None or type(value) is bool:
+        return
+    if type(value) is int:
+        if abs(value) > 2**63 - 1:
+            raise ValueError
+        return
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ValueError
+        return
+    if type(value) is str:
+        if len(value.encode("utf-8")) > _MAX_STRING_BYTES:
+            raise ValueError
+        return
+    if type(value) is list:
+        for item in cast("list[object]", value):
+            _validate_tree(item, depth=depth + 1, counter=counter)
+        return
+    if type(value) is dict:
+        for key, item in cast("dict[object, object]", value).items():
+            if type(key) is not str or len(key.encode("utf-8")) > 128:
+                raise ValueError
+            _validate_tree(item, depth=depth + 1, counter=counter)
+        return
+    raise ValueError
+
+
+def _parse_json(raw: bytes, *, code: str, error_type: type[RuntimeError]) -> object:
+    invalid = False
+    text = ""
+    value: object = None
+    try:
+        if not raw or len(raw) > DEFAULT_OUTPUT_LIMIT_BYTES:
+            raise ValueError
+        text = raw.decode("utf-8")
+        value = json.loads(
+            text,
+            object_pairs_hook=_object_without_duplicates,
+            parse_constant=_reject_json_constant,
+        )
+        _validate_tree(value)
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        invalid = True
+    if invalid:
+        raw = b""
+        text = ""
+        value = None
+        raise error_type(code)
+    return value
+
+
+def _dictionary(value: object, *, code: str, error_type: type[RuntimeError]) -> dict[str, object]:
+    if type(value) is not dict:
+        raise error_type(code)
+    return cast("dict[str, object]", value)
+
+
+def _list(value: object, *, code: str, error_type: type[RuntimeError]) -> list[object]:
+    if type(value) is not list:
+        raise error_type(code)
+    return cast("list[object]", value)
+
+
+def _string(
+    value: object,
+    *,
+    code: str,
+    error_type: type[RuntimeError],
+    maximum: int = 128,
+) -> str:
+    if type(value) is not str:
+        raise error_type(code)
+    result = value
+    if (
+        not result
+        or result != result.strip()
+        or len(result.encode("utf-8")) > maximum
+        or any(ord(character) < 32 or ord(character) == 127 for character in result)
+    ):
+        raise error_type(code)
+    return result
+
+
+def _safe_id(value: object, *, code: str, error_type: type[RuntimeError]) -> str:
+    result = _string(value, code=code, error_type=error_type)
+    if _SAFE_ID.fullmatch(result) is None:
+        raise error_type(code)
+    return result
+
+
+def _bounded_text(value: object, *, maximum: int, code: str) -> str:
+    if type(value) is not str:
+        raise RuntimeExecutionError(code)
+    result = value
+    if not result or len(result.encode("utf-8")) > maximum or "\x00" in result:
+        raise RuntimeExecutionError(code)
+    return result
+
+
+def _process(
+    argv: list[str],
+    *,
+    deadline_seconds: float,
+    unavailable_code: str,
+    error_type: type[RuntimeError],
+) -> bytes:
+    failed = False
+    output = b""
+    try:
+        output = run_bounded(
+            argv,
+            deadline_seconds=deadline_seconds,
+            environment=_OPENCLAW_ENVIRONMENT,
+            allowed_environment_keys=_OPENCLAW_ENVIRONMENT_KEYS,
+        ).stdout
+    except ProcessError:
+        failed = True
+    if failed:
+        del argv
+        raise error_type(unavailable_code)
+    return output
+
+
+def _version_string(raw: bytes) -> str:
+    invalid = False
+    version = ""
+    try:
+        version = raw.decode("utf-8").strip("\n")
+    except UnicodeDecodeError:
+        invalid = True
+    match = None if invalid else _CLI_VERSION_BANNER.fullmatch(version)
+    if match is None or match.group(1) != SUPPORTED_OPENCLAW.cli_version:
+        raw = b""
+        version = ""
+        raise RuntimeConfigurationError("OPENCLAW_VERSION_UNSUPPORTED")
+    return SUPPORTED_OPENCLAW.cli_version
+
+
+def _require_local_gateway_mode(raw: bytes) -> None:
+    invalid_code: str | None = None
+    mode: object = None
+    try:
+        mode = _parse_json(
+            raw,
+            code="OPENCLAW_CONFIG_MODE_INVALID",
+            error_type=RuntimeExecutionError,
+        )
+    except RuntimeExecutionError as error:
+        invalid_code = error.code
+    raw = b""
+    if invalid_code is not None:
+        mode = None
+        raise RuntimeExecutionError(invalid_code)
+    if mode != "local":
+        mode = None
+        raise RuntimeConfigurationError("OPENCLAW_REMOTE_DISPATCH")
+
+
+def _gateway_url_config_issue(raw: bytes) -> str | None:
+    invalid = False
+    value: object = None
+    try:
+        value = _parse_json(
+            raw,
+            code="OPENCLAW_CONFIG_ENV_INVALID",
+            error_type=RuntimeExecutionError,
+        )
+    except RuntimeExecutionError:
+        invalid = True
+    raw = b""
+    if invalid:
+        value = None
+        return "OPENCLAW_CONFIG_ENV_INVALID"
+    if type(value) is not dict:
+        value = None
+        return "OPENCLAW_CONFIG_ENV_INVALID"
+
+    configured = False
+    env = cast("dict[object, object]", value)
+    for key in env:
+        if type(key) is str and key.strip(_ECMASCRIPT_TRIM_CHARACTERS) == "OPENCLAW_GATEWAY_URL":
+            configured = True
+            break
+    variables = env.get("vars")
+    if not configured and type(variables) is dict:
+        for key in cast("dict[object, object]", variables):
+            if (
+                type(key) is str
+                and key.strip(_ECMASCRIPT_TRIM_CHARACTERS) == "OPENCLAW_GATEWAY_URL"
+            ):
+                configured = True
+                break
+    variables = None
+    value = None
+    env = {}
+    if configured:
+        return "OPENCLAW_REMOTE_DISPATCH"
+    return None
+
+
+def _require_no_gateway_url_config(executable: Path) -> None:
+    failed = False
+    result = None
+    try:
+        result = run_bounded(
+            [os.fspath(executable), "config", "get", "env", "--json"],
+            deadline_seconds=PROBE_DEADLINE_SECONDS,
+            environment=_OPENCLAW_ENVIRONMENT,
+            allowed_environment_keys=_OPENCLAW_ENVIRONMENT_KEYS,
+            accept_empty_exit_one=True,
+        )
+    except ProcessError:
+        failed = True
+    if failed:
+        result = None
+        raise RuntimeExecutionError("OPENCLAW_CONFIG_ENV_UNAVAILABLE")
+    assert result is not None
+    if result.returncode == 1:
+        result = None
+        return
+    raw = result.stdout
+    result = None
+    issue = _gateway_url_config_issue(raw)
+    raw = b""
+    if issue == "OPENCLAW_REMOTE_DISPATCH":
+        raise RuntimeConfigurationError(issue)
+    if issue is not None:
+        raise RuntimeExecutionError(issue)
+
+
+def _targets_from_output_unchecked(raw: bytes) -> tuple[RuntimeTarget, ...]:
+    values = _list(
+        _parse_json(
+            raw,
+            code="OPENCLAW_AGENTS_INVALID",
+            error_type=RuntimeExecutionError,
+        ),
+        code="OPENCLAW_AGENTS_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    targets: list[RuntimeTarget] = []
+    seen: set[str] = set()
+    for value in values:
+        agent = _dictionary(
+            value,
+            code="OPENCLAW_AGENTS_INVALID",
+            error_type=RuntimeExecutionError,
+        )
+        target_id = _safe_id(
+            agent.get("id"),
+            code="OPENCLAW_AGENTS_INVALID",
+            error_type=RuntimeExecutionError,
+        )
+        if target_id in seen:
+            raise RuntimeConfigurationError("TARGET_AMBIGUOUS")
+        seen.add(target_id)
+        configured_model = agent.get("model")
+        if configured_model is not None:
+            configured_model = _string(
+                configured_model,
+                code="OPENCLAW_AGENTS_INVALID",
+                error_type=RuntimeExecutionError,
+            )
+            _model_pair(configured_model)
+        targets.append(RuntimeTarget(target_id, configured_model))
+    return tuple(targets)
+
+
+def _targets_from_output(raw: bytes) -> tuple[RuntimeTarget, ...]:
+    targets: tuple[RuntimeTarget, ...] | None = None
+    configuration_code: str | None = None
+    execution_code: str | None = None
+    try:
+        targets = _targets_from_output_unchecked(raw)
+    except RuntimeConfigurationError as error:
+        configuration_code = error.code
+    except RuntimeExecutionError as error:
+        execution_code = error.code
+    raw = b""
+    if configuration_code is not None:
+        raise RuntimeConfigurationError(configuration_code)
+    if execution_code is not None:
+        raise RuntimeExecutionError(execution_code)
+    assert targets is not None
+    return targets
+
+
+def _require_probe(probe: RuntimeProbe, executable: Path) -> None:
+    if (
+        probe.runtime_id != "openclaw"
+        or probe.executable != executable
+        or probe.version != SUPPORTED_OPENCLAW.cli_version
+        or probe.display != _OPENCLAW_DISPLAY
+    ):
+        raise RuntimeConfigurationError("OPENCLAW_PROBE_MISMATCH")
+
+
+def _model_pair(value: str | None) -> tuple[str, str] | None:
+    if value is None:
+        return None
+    if value.count("/") != 1:
+        raise RuntimeConfigurationError("OPENCLAW_MODEL_INVALID")
+    provider, model = value.split("/", 1)
+    return (
+        _safe_id(provider, code="OPENCLAW_MODEL_INVALID", error_type=RuntimeConfigurationError),
+        _safe_id(model, code="OPENCLAW_MODEL_INVALID", error_type=RuntimeConfigurationError),
+    )
+
+
+def _is_loopback_url(value: object) -> bool:
+    if type(value) is not str or len(value) > 2048:
+        return False
+    try:
+        parsed = urlsplit(value)
+        return (
+            parsed.scheme in {"ws", "wss"}
+            and parsed.hostname in _LOOPBACK_HOSTS
+            and parsed.port is not None
+            and parsed.username is None
+            and parsed.password is None
+            and not parsed.query
+            and not parsed.fragment
+        )
+    except ValueError:
+        return False
+
+
+def _walk_key_paths(value: object, *, prefix: tuple[str, ...] = ()) -> set[tuple[str, ...]]:
+    paths: set[tuple[str, ...]] = set()
+    if type(value) is dict:
+        for key, item in cast("dict[str, object]", value).items():
+            path = (*prefix, key)
+            paths.add(path)
+            paths.update(_walk_key_paths(item, prefix=path))
+    elif type(value) is list:
+        for item in cast("list[object]", value):
+            paths.update(_walk_key_paths(item, prefix=prefix))
+    return paths
+
+
+def _raise_envelope_condition(value: dict[str, object]) -> None:
+    allowed_fallback_path = ("result", "meta", "executionTrace", "fallbackUsed")
+    opaque_report_prefixes = (
+        ("result", "meta", "systemPromptReport"),
+        ("result", "meta", "requestShaping"),
+        ("result", "meta", "agentMeta", "usage"),
+        ("result", "meta", "agentMeta", "lastCallUsage"),
+    )
+    activity_reported = False
+    error_reported = False
+    fallback_reported = False
+    transport_reported = False
+    for path in _walk_key_paths(value):
+        if any(path[: len(prefix)] == prefix for prefix in opaque_report_prefixes):
+            continue
+        key = path[-1].lower()
+        if key in _ACTIVITY_KEYS:
+            activity_reported = True
+        if key in _ERROR_KEYS:
+            error_reported = True
+        if "transport" in key:
+            transport_reported = True
+        if "fallback" in key and path != allowed_fallback_path:
+            fallback_reported = True
+    if fallback_reported:
+        raise RuntimeIncompleteError("OPENCLAW_FALLBACK_REPORTED")
+    if transport_reported:
+        raise RuntimeIncompleteError("OPENCLAW_TRANSPORT_AMBIGUOUS")
+    if activity_reported:
+        raise RuntimeIncompleteError("OPENCLAW_ACTIVITY_REPORTED")
+    if error_reported:
+        raise RuntimeIncompleteError("OPENCLAW_RUN_ERROR")
+
+
+def _canonical_intent(text: str) -> dict[str, object]:
+    try:
+        raw = text.encode("utf-8")
+        if len(raw) > _MAX_INTENT_TEXT_BYTES:
+            raise ValueError
+        value = json.loads(
+            text,
+            object_pairs_hook=_object_without_duplicates,
+            parse_constant=_reject_json_constant,
+        )
+        _validate_tree(value)
+    except (UnicodeError, ValueError, json.JSONDecodeError):
+        raise RuntimeExecutionError("OPENCLAW_INTENT_INVALID") from None
+    intent = _dictionary(
+        value,
+        code="OPENCLAW_INTENT_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    if json.dumps(intent, ensure_ascii=False, sort_keys=True, separators=(",", ":")) != text:
+        raise RuntimeExecutionError("OPENCLAW_INTENT_NONCANONICAL")
+    kind = intent.get("kind")
+    if kind == "none":
+        if set(intent) != {"kind"}:
+            raise RuntimeExecutionError("OPENCLAW_INTENT_FORBIDDEN")
+    elif kind == "declare_capability":
+        if set(intent) != {"kind", "capabilities"}:
+            raise RuntimeExecutionError("OPENCLAW_INTENT_FORBIDDEN")
+        capabilities = _list(
+            intent.get("capabilities"),
+            code="OPENCLAW_INTENT_FORBIDDEN",
+            error_type=RuntimeExecutionError,
+        )
+        if not capabilities or len(capabilities) > 64:
+            raise RuntimeExecutionError("OPENCLAW_INTENT_FORBIDDEN")
+        for capability in capabilities:
+            _safe_id(
+                capability,
+                code="OPENCLAW_INTENT_FORBIDDEN",
+                error_type=RuntimeExecutionError,
+            )
+    elif kind == "send_to_sender":
+        if set(intent) != {"kind", "media_type", "text"}:
+            raise RuntimeExecutionError("OPENCLAW_INTENT_FORBIDDEN")
+        if intent.get("media_type") != "text/plain; charset=utf-8":
+            raise RuntimeExecutionError("OPENCLAW_INTENT_FORBIDDEN")
+        message = intent.get("text")
+        if type(message) is not str or not message:
+            raise RuntimeExecutionError("OPENCLAW_INTENT_FORBIDDEN")
+        if len(message.encode("utf-8")) > _MAX_INTENT_TEXT_BYTES:
+            raise RuntimeExecutionError("OPENCLAW_INTENT_FORBIDDEN")
+    else:
+        raise RuntimeExecutionError("OPENCLAW_INTENT_FORBIDDEN")
+    return intent
+
+
+def _prompt_bytes(observation: Mapping[str, object]) -> bytes:
+    value = dict(observation)
+    kind = value.get("kind")
+    logical_time = value.get("logical_time")
+    allowed_intents = value.get("allowed_intents")
+    if type(logical_time) is not int or logical_time < 0 or type(allowed_intents) is not list:
+        raise ValueError
+
+    common = (
+        "You are completing one basic local NANDA Town agent test.\n"
+        "Return exactly one minified JSON object and no other characters.\n"
+        "Do not return prose, Markdown, or code fences.\n"
+        "Do not invoke tools, access files, memory, messages, channels, or perform any "
+        "other action.\n"
+    )
+    if kind == "start":
+        if set(value) != {"kind", "logical_time", "allowed_intents"} or allowed_intents != [
+            "declare_capability",
+            "none",
+        ]:
+            raise ValueError
+        prompt = (
+            common
+            + "This is the start event. Declare the sell capability by returning exactly "
+            + '{"capabilities":["sell"],"kind":"declare_capability"}.\n'
+            + 'If you cannot do that, return exactly {"kind":"none"}.\n'
+        )
+    elif kind == "message":
+        if set(value) != {"kind", "logical_time", "allowed_intents", "message"} or (
+            allowed_intents != ["send_to_sender", "none"]
+        ):
+            raise ValueError
+        message = value.get("message")
+        if type(message) is not dict:
+            raise ValueError
+        message = cast("dict[str, object]", message)
+        if set(message) != {"id", "sender_id", "media_type", "text"}:
+            raise ValueError
+        if (
+            type(message.get("id")) is not str
+            or _SAFE_ID.fullmatch(cast("str", message["id"])) is None
+            or message.get("sender_id") != "requester-0"
+            or message.get("media_type") != "text/plain; charset=utf-8"
+        ):
+            raise ValueError
+        text = message.get("text")
+        if (
+            text != "buy:widget:2"
+            or type(text) is not str
+            or len(text.encode("utf-8")) > _MAX_INTENT_TEXT_BYTES
+        ):
+            raise ValueError
+        encoded_text = json.dumps(text, ensure_ascii=False)
+        prompt = (
+            common
+            + "This is the message event.\n"
+            + f"Input text: {encoded_text}\n"
+            + "If the text matches buy:<item>:<quantity>, return one canonical object shaped as "
+            + '{"kind":"send_to_sender","media_type":"text/plain; charset=utf-8",'
+            + '"text":"sold:<item>:<quantity>"}, replacing <item> and <quantity> with the '
+            + "input values.\n"
+            + 'If you cannot do that, return exactly {"kind":"none"}.\n'
+        )
+    else:
+        raise ValueError
+    raw = prompt.encode("utf-8")
+    if not raw or len(raw) > 64 * 1024:
+        raise ValueError
+    return raw
+
+
+def _envelope_turn(
+    raw: bytes,
+    *,
+    session_key: str,
+    expected_model: tuple[str, str] | None,
+    expected_session_id_digest: str | None,
+) -> tuple[RuntimeTurn, tuple[str, str], str]:
+    value = _parse_json(
+        raw,
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    envelope = _dictionary(
+        value,
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    _raise_envelope_condition(envelope)
+    if set(envelope) != {"runId", "status", "summary", "result"}:
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    _safe_id(
+        envelope.get("runId"),
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    if envelope.get("status") != "ok":
+        raise RuntimeIncompleteError("OPENCLAW_RUN_ERROR")
+    if envelope.get("summary") != "completed":
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    if len(cast("str", envelope["summary"]).encode("utf-8")) > _MAX_SUMMARY_BYTES:
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    result = _dictionary(
+        envelope.get("result"),
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    if set(result) != {"payloads", "meta"}:
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    payloads = _list(
+        result.get("payloads"),
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    if len(payloads) != 1:
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    payload = _dictionary(
+        payloads[0],
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    if set(payload) != {"text", "mediaUrl"} or payload.get("mediaUrl") is not None:
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    text = _bounded_text(
+        payload.get("text"),
+        maximum=_MAX_INTENT_TEXT_BYTES,
+        code="OPENCLAW_ENVELOPE_INVALID",
+    )
+    meta = _dictionary(
+        result.get("meta"),
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    required_meta = {
+        "durationMs",
+        "agentMeta",
+        "aborted",
+        "finalAssistantVisibleText",
+        "finalAssistantRawText",
+        "replayInvalid",
+        "livenessState",
+        "stopReason",
+        "executionTrace",
+        "completion",
+    }
+    allowed_meta = required_meta | {"systemPromptReport", "requestShaping"}
+    if not required_meta.issubset(meta) or not set(meta).issubset(allowed_meta):
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    for report_key in ("systemPromptReport", "requestShaping"):
+        if report_key in meta and type(meta[report_key]) is not dict:
+            raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    duration = meta.get("durationMs")
+    if (
+        type(duration) not in (int, float)
+        or cast("int | float", duration) < 0
+        or (type(duration) is float and not math.isfinite(duration))
+    ):
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    if meta.get("aborted") is True:
+        raise RuntimeIncompleteError("OPENCLAW_ABORTED")
+    if meta.get("aborted") is not False:
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    if meta.get("replayInvalid") is True:
+        raise RuntimeIncompleteError("OPENCLAW_REPLAY_INVALID")
+    if meta.get("replayInvalid") is not False:
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    if (
+        meta.get("finalAssistantVisibleText") != text
+        or meta.get("finalAssistantRawText") != text
+        or meta.get("livenessState") != "working"
+        or meta.get("stopReason") != "stop"
+    ):
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    trace = _dictionary(
+        meta.get("executionTrace"),
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    required_trace = {"winnerProvider", "winnerModel", "attempts", "fallbackUsed", "runner"}
+    if set(trace) != required_trace:
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    if trace.get("fallbackUsed") is True:
+        raise RuntimeIncompleteError("OPENCLAW_FALLBACK_REPORTED")
+    if trace.get("fallbackUsed") is not False or trace.get("runner") != "embedded":
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    completion = _dictionary(
+        meta.get("completion"),
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    if completion != {"stopReason": "stop", "finishReason": "stop"}:
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    agent_meta = _dictionary(
+        meta.get("agentMeta"),
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    required_agent_meta = {"sessionId", "provider", "model", "agentHarnessId"}
+    allowed_agent_meta = required_agent_meta | {
+        "contextTokens",
+        "usage",
+        "lastCallUsage",
+        "promptTokens",
+        "sessionKey",
+    }
+    if not required_agent_meta.issubset(agent_meta) or not set(agent_meta).issubset(
+        allowed_agent_meta
+    ):
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    for counter_key in ("contextTokens", "promptTokens"):
+        if counter_key in agent_meta and (
+            type(agent_meta[counter_key]) is not int or cast("int", agent_meta[counter_key]) < 0
+        ):
+            raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    for usage_key in ("usage", "lastCallUsage"):
+        if usage_key in agent_meta and type(agent_meta[usage_key]) is not dict:
+            raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    if "sessionKey" in agent_meta and agent_meta.get("sessionKey") != session_key:
+        raise RuntimeExecutionError("OPENCLAW_SESSION_MISMATCH")
+    session_id = _safe_id(
+        agent_meta.get("sessionId"),
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    session_id_digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    if expected_session_id_digest is not None and session_id_digest != expected_session_id_digest:
+        raise RuntimeExecutionError("OPENCLAW_SESSION_MISMATCH")
+    provider = _safe_id(
+        agent_meta.get("provider"),
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    model = _safe_id(
+        agent_meta.get("model"),
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    reported_model = (provider, model)
+    if expected_model is not None and reported_model != expected_model:
+        raise RuntimeExecutionError("OPENCLAW_MODEL_MISMATCH")
+    _safe_id(
+        agent_meta.get("agentHarnessId"),
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    if trace.get("winnerProvider") != provider or trace.get("winnerModel") != model:
+        raise RuntimeExecutionError("OPENCLAW_MODEL_MISMATCH")
+    attempts = _list(
+        trace.get("attempts"),
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    if len(attempts) != 1:
+        raise RuntimeExecutionError("OPENCLAW_ENVELOPE_INVALID")
+    attempt = _dictionary(
+        attempts[0],
+        code="OPENCLAW_ENVELOPE_INVALID",
+        error_type=RuntimeExecutionError,
+    )
+    if attempt != {
+        "provider": provider,
+        "model": model,
+        "result": "success",
+        "stage": "assistant",
+    }:
+        raise RuntimeExecutionError("OPENCLAW_MODEL_MISMATCH")
+    intent = _canonical_intent(text)
+    digest = "sha256:" + session_id_digest
+    return (
+        RuntimeTurn(intent, provider, model, digest, "unknown"),
+        reported_model,
+        session_id_digest,
+    )
+
+
+class OpenClawConnector:
+    runtime_id = "openclaw"
+    issue_policy = _OPENCLAW_ISSUE_POLICY
+
+    def __init__(self, *, executable: str | os.PathLike[str] = "openclaw") -> None:
+        self._requested_executable = os.fspath(executable)
+        self._executable: Path | None = None
+        self._listed_targets: tuple[RuntimeTarget, ...] | None = None
+
+    def probe(self) -> RuntimeProbe | None:
+        if os.name != "posix":
+            raise RuntimeConfigurationError("OPENCLAW_PLATFORM_UNSUPPORTED")
+        requested = self._requested_executable
+        resolved = shutil.which(requested) if os.sep not in requested else requested
+        if resolved is None:
+            return None
+        executable = Path(resolved)
+        if not executable.is_file() or not os.access(executable, os.X_OK):
+            return None
+        version = _version_string(
+            _process(
+                [os.fspath(executable), "--version"],
+                deadline_seconds=PROBE_DEADLINE_SECONDS,
+                unavailable_code="OPENCLAW_PROBE_FAILED",
+                error_type=RuntimeExecutionError,
+            )
+        )
+        _require_local_gateway_mode(
+            _process(
+                [
+                    os.fspath(executable),
+                    "config",
+                    "get",
+                    "gateway.mode",
+                    "--json",
+                ],
+                deadline_seconds=PROBE_DEADLINE_SECONDS,
+                unavailable_code="OPENCLAW_CONFIG_MODE_UNAVAILABLE",
+                error_type=RuntimeExecutionError,
+            )
+        )
+        _require_no_gateway_url_config(executable)
+        self._executable = executable
+        self._listed_targets = None
+        return RuntimeProbe(self.runtime_id, executable, version, _OPENCLAW_DISPLAY)
+
+    def list_targets(self, probe: RuntimeProbe) -> tuple[RuntimeTarget, ...]:
+        if self._executable is None:
+            raise RuntimeConfigurationError("OPENCLAW_PROBE_MISMATCH")
+        _require_probe(probe, self._executable)
+        self._listed_targets = _targets_from_output(
+            _process(
+                [os.fspath(self._executable), "agents", "list", "--json"],
+                deadline_seconds=_AGENT_INVENTORY_DEADLINE_SECONDS,
+                unavailable_code="OPENCLAW_AGENTS_UNAVAILABLE",
+                error_type=RuntimeExecutionError,
+            )
+        )
+        return self._listed_targets
+
+    def prepare(
+        self,
+        probe: RuntimeProbe,
+        target: RuntimeTarget,
+        model_override: str | None,
+    ) -> _PreparedOpenClaw:
+        if self._executable is None or self._listed_targets is None:
+            raise RuntimeConfigurationError("OPENCLAW_PROBE_MISMATCH")
+        _require_probe(probe, self._executable)
+        matches = tuple(listed for listed in self._listed_targets if listed.id == target.id)
+        if not matches or target not in matches:
+            raise RuntimeConfigurationError("TARGET_NOT_FOUND")
+        if len(matches) != 1:
+            raise RuntimeConfigurationError("TARGET_AMBIGUOUS")
+        expected_model = _model_pair(
+            model_override if model_override is not None else target.configured_model
+        )
+        self._validate_gateway_output(
+            _process(
+                [
+                    os.fspath(self._executable),
+                    "gateway",
+                    "status",
+                    "--json",
+                    "--require-rpc",
+                ],
+                deadline_seconds=PROBE_DEADLINE_SECONDS,
+                unavailable_code="OPENCLAW_GATEWAY_UNAVAILABLE",
+                error_type=RuntimeIncompleteError,
+            )
+        )
+        return _PreparedOpenClaw(
+            executable=self._executable,
+            target=target,
+            model_override=model_override,
+            expected_model=expected_model,
+        )
+
+    @staticmethod
+    def _validate_gateway_output(raw: bytes) -> None:
+        gateway: dict[str, object] = {}
+        configuration_code: str | None = None
+        execution_code: str | None = None
+        try:
+            gateway = _dictionary(
+                _parse_json(
+                    raw,
+                    code="OPENCLAW_GATEWAY_INVALID",
+                    error_type=RuntimeExecutionError,
+                ),
+                code="OPENCLAW_GATEWAY_INVALID",
+                error_type=RuntimeExecutionError,
+            )
+            OpenClawConnector._validate_gateway(gateway)
+        except RuntimeConfigurationError as error:
+            configuration_code = error.code
+        except RuntimeExecutionError as error:
+            execution_code = error.code
+        raw = b""
+        gateway = {}
+        if configuration_code is not None:
+            raise RuntimeConfigurationError(configuration_code)
+        if execution_code is not None:
+            raise RuntimeExecutionError(execution_code)
+
+    @staticmethod
+    def _validate_gateway(status: dict[str, object]) -> None:
+        if not {"cli", "config", "gateway", "rpc"}.issubset(status):
+            raise RuntimeExecutionError("OPENCLAW_GATEWAY_INVALID")
+        cli = _dictionary(
+            status.get("cli"),
+            code="OPENCLAW_GATEWAY_INVALID",
+            error_type=RuntimeExecutionError,
+        )
+        if "version" not in cli:
+            raise RuntimeExecutionError("OPENCLAW_GATEWAY_INVALID")
+        if "entrypoint" in cli:
+            _string(
+                cli.get("entrypoint"),
+                code="OPENCLAW_GATEWAY_INVALID",
+                error_type=RuntimeExecutionError,
+                maximum=2048,
+            )
+        gateway = _dictionary(
+            status.get("gateway"),
+            code="OPENCLAW_GATEWAY_INVALID",
+            error_type=RuntimeExecutionError,
+        )
+        if (
+            cli.get("version") != SUPPORTED_OPENCLAW.cli_version
+            or gateway.get("version") != SUPPORTED_OPENCLAW.gateway_version
+        ):
+            raise RuntimeConfigurationError("OPENCLAW_VERSION_MISMATCH")
+        if "pluginVersionDrift" in status:
+            plugin_drift = _dictionary(
+                status.get("pluginVersionDrift"),
+                code="OPENCLAW_GATEWAY_INVALID",
+                error_type=RuntimeExecutionError,
+            )
+            if not {"drifts", "gatewayVersion"}.issubset(plugin_drift):
+                raise RuntimeExecutionError("OPENCLAW_GATEWAY_INVALID")
+            if plugin_drift.get("gatewayVersion") != SUPPORTED_OPENCLAW.gateway_version:
+                raise RuntimeConfigurationError("OPENCLAW_VERSION_MISMATCH")
+            drifts = _list(
+                plugin_drift.get("drifts"),
+                code="OPENCLAW_GATEWAY_INVALID",
+                error_type=RuntimeExecutionError,
+            )
+            if drifts:
+                raise RuntimeConfigurationError("OPENCLAW_CONFIG_DRIFT")
+        if "logFile" in status:
+            _string(
+                status.get("logFile"),
+                code="OPENCLAW_GATEWAY_INVALID",
+                error_type=RuntimeExecutionError,
+                maximum=2048,
+            )
+        config = _dictionary(
+            status.get("config"),
+            code="OPENCLAW_GATEWAY_INVALID",
+            error_type=RuntimeExecutionError,
+        )
+        cli_config = _dictionary(
+            config.get("cli"),
+            code="OPENCLAW_GATEWAY_INVALID",
+            error_type=RuntimeExecutionError,
+        )
+        daemon_config = _dictionary(
+            config.get("daemon"),
+            code="OPENCLAW_GATEWAY_INVALID",
+            error_type=RuntimeExecutionError,
+        )
+        required_config_keys = {"exists", "path", "valid"}
+        if (
+            not {"cli", "daemon"}.issubset(config)
+            or not required_config_keys.issubset(cli_config)
+            or not required_config_keys.issubset(daemon_config)
+        ):
+            raise RuntimeExecutionError("OPENCLAW_GATEWAY_INVALID")
+        if config.get("mismatch") is True:
+            raise RuntimeConfigurationError("OPENCLAW_CONFIG_DRIFT")
+        for value in (cli_config, daemon_config):
+            if value.get("exists") is not True or value.get("valid") is not True:
+                raise RuntimeConfigurationError("OPENCLAW_CONFIG_DRIFT")
+            if "controlUi" in value:
+                _dictionary(
+                    value.get("controlUi"),
+                    code="OPENCLAW_GATEWAY_INVALID",
+                    error_type=RuntimeExecutionError,
+                )
+        cli_path = _string(
+            cli_config.get("path"),
+            code="OPENCLAW_GATEWAY_INVALID",
+            error_type=RuntimeExecutionError,
+            maximum=2048,
+        )
+        daemon_path = _string(
+            daemon_config.get("path"),
+            code="OPENCLAW_GATEWAY_INVALID",
+            error_type=RuntimeExecutionError,
+            maximum=2048,
+        )
+        if cli_path != daemon_path:
+            raise RuntimeConfigurationError("OPENCLAW_CONFIG_DRIFT")
+        rpc = _dictionary(
+            status.get("rpc"),
+            code="OPENCLAW_GATEWAY_INVALID",
+            error_type=RuntimeExecutionError,
+        )
+        if rpc.get("version") != SUPPORTED_OPENCLAW.rpc_version:
+            raise RuntimeConfigurationError("OPENCLAW_VERSION_MISMATCH")
+        if rpc.get("ok") is not True:
+            raise RuntimeConfigurationError("OPENCLAW_RPC_UNHEALTHY")
+        if not {"capability", "kind", "ok", "url", "version"}.issubset(rpc):
+            raise RuntimeExecutionError("OPENCLAW_GATEWAY_INVALID")
+        if "auth" in rpc:
+            _dictionary(
+                rpc.get("auth"),
+                code="OPENCLAW_GATEWAY_INVALID",
+                error_type=RuntimeExecutionError,
+            )
+        _string(
+            rpc.get("capability"),
+            code="OPENCLAW_GATEWAY_INVALID",
+            error_type=RuntimeExecutionError,
+        )
+        if rpc.get("kind") != "read":
+            raise RuntimeExecutionError("OPENCLAW_GATEWAY_INVALID")
+        if "server" in rpc:
+            server = _dictionary(
+                rpc.get("server"),
+                code="OPENCLAW_GATEWAY_INVALID",
+                error_type=RuntimeExecutionError,
+            )
+            if server.get("version") != SUPPORTED_OPENCLAW.gateway_version:
+                raise RuntimeConfigurationError("OPENCLAW_VERSION_MISMATCH")
+        if not _is_loopback_url(gateway.get("probeUrl")) or not _is_loopback_url(rpc.get("url")):
+            raise RuntimeConfigurationError("OPENCLAW_REMOTE_DISPATCH")
+
+
+class _PreparedOpenClaw:
+    runtime_id = "openclaw"
+    runtime_version = SUPPORTED_OPENCLAW.envelope_version
+    display = _OPENCLAW_DISPLAY
+    issue_policy = _OPENCLAW_ISSUE_POLICY
+
+    def __init__(
+        self,
+        *,
+        executable: Path,
+        target: RuntimeTarget,
+        model_override: str | None,
+        expected_model: tuple[str, str] | None,
+    ) -> None:
+        self.target = target
+        self.target_label = self._target_label(target.id)
+        self.adapter_instance_id = "openclaw-" + uuid.uuid4().hex
+        self._executable = executable
+        self._model_override = model_override
+        self._expected_model = expected_model
+        self._opened_run_digests: set[str] = set()
+
+    @staticmethod
+    def _target_label(target_id: str) -> str:
+        label = f"openclaw:{target_id}"
+        if len(label) <= 128:
+            return label
+        suffix = hashlib.sha256(target_id.encode("ascii")).hexdigest()[:16]
+        return f"openclaw:{target_id[:102]}:{suffix}"
+
+    def open_run(self, town_run_id: str) -> _OpenClawRun:
+        run_id = _safe_id(
+            town_run_id,
+            code="OPENCLAW_RUN_ID_INVALID",
+            error_type=RuntimeConfigurationError,
+        )
+        session_key = f"town-{run_id}"
+        if len(session_key) > 128:
+            raise RuntimeConfigurationError("OPENCLAW_RUN_ID_INVALID")
+        digest = hashlib.sha256(session_key.encode("utf-8")).hexdigest()
+        if digest in self._opened_run_digests:
+            raise RuntimeConfigurationError("OPENCLAW_RUN_DUPLICATE")
+        self._opened_run_digests.add(digest)
+        return _OpenClawRun(
+            executable=self._executable,
+            target=self.target,
+            session_key=session_key,
+            model_override=self._model_override,
+            expected_model=self._expected_model,
+        )
+
+
+class _OpenClawRun:
+    def __init__(
+        self,
+        *,
+        executable: Path,
+        target: RuntimeTarget,
+        session_key: str,
+        model_override: str | None,
+        expected_model: tuple[str, str] | None,
+    ) -> None:
+        self._executable = executable
+        self._target = target
+        self._session_key = session_key
+        self._model_override = model_override
+        self._expected_model = expected_model
+        self._session_id_digest: str | None = None
+        self._closed = False
+        self._turns = 0
+
+    @staticmethod
+    def _process_code(error: ProcessError) -> str:
+        codes = {
+            "PROCESS_TIMEOUT": "OPENCLAW_TIMEOUT",
+            "PROCESS_OUTPUT_LIMIT": "OPENCLAW_OUTPUT_LIMIT",
+            "PROCESS_EXIT_NONZERO": "OPENCLAW_TRANSPORT_LOSS",
+        }
+        return codes.get(error.code, "OPENCLAW_EXECUTION_FAILED")
+
+    @staticmethod
+    def _erase_and_close_descriptor(descriptor: int) -> bool:
+        if descriptor < 0:
+            return True
+        erased = True
+        try:
+            os.ftruncate(descriptor, 0)
+            os.fsync(descriptor)
+        except OSError:
+            erased = False
+        finally:
+            with suppress(OSError):
+                os.close(descriptor)
+        return erased
+
+    @staticmethod
+    def _write_descriptor(descriptor: int, content: bytes) -> None:
+        offset = 0
+        while offset < len(content):
+            written = os.write(descriptor, content[offset:])
+            if written <= 0:
+                raise OSError
+            offset += written
+        os.fsync(descriptor)
+
+    @staticmethod
+    def _remove_message_file(path: Path | None) -> bool:
+        if path is None:
+            return True
+        try:
+            path.unlink(missing_ok=True)
+            return True
+        except OSError:
+            return False
+
+    def turn(self, observation: Mapping[str, object]) -> RuntimeTurn:
+        if self._closed or self._turns >= 2:
+            raise RuntimeExecutionError("OPENCLAW_RUN_CLOSED")
+        try:
+            observation_invalid = False
+            prompt = b""
+            try:
+                prompt = _prompt_bytes(observation)
+            except Exception:
+                observation_invalid = True
+            if observation_invalid:
+                del observation, prompt
+                raise RuntimeExecutionError("OPENCLAW_OBSERVATION_INVALID")
+            del observation
+
+            descriptor = -1
+            name: str | None = None
+            path: Path | None = None
+            argv: list[str] | None = None
+            raw: bytes | None = None
+            setup_failed = False
+            process_code: str | None = None
+            unexpected: BaseException | None = None
+            removed = True
+            try:
+                descriptor, name = tempfile.mkstemp(prefix="town-openclaw-", suffix=".json")
+                path = Path(name)
+                os.fchmod(descriptor, 0o600)
+                self._write_descriptor(descriptor, prompt)
+                argv = [
+                    os.fspath(self._executable),
+                    "agent",
+                    "--agent",
+                    self._target.id,
+                    "--session-key",
+                    self._session_key,
+                    "--timeout",
+                    "0",
+                    "--message-file",
+                    os.fspath(path),
+                    "--json",
+                ]
+                if self._model_override is not None:
+                    argv.extend(("--model", self._model_override))
+                raw = run_bounded(
+                    argv,
+                    deadline_seconds=TURN_DEADLINE_SECONDS,
+                    environment=_OPENCLAW_ENVIRONMENT,
+                    allowed_environment_keys=_OPENCLAW_ENVIRONMENT_KEYS,
+                    terminate_grace_seconds=TERMINATE_GRACE_SECONDS,
+                    kill_reap_seconds=KILL_REAP_SECONDS,
+                ).stdout
+            except ProcessError as error:
+                process_code = self._process_code(error)
+            except (OSError, ValueError):
+                setup_failed = True
+            except BaseException as error:
+                unexpected = error
+            finally:
+                erased = self._erase_and_close_descriptor(descriptor)
+                removed = self._remove_message_file(path)
+            del argv, descriptor, name, path, prompt
+            if not erased or not removed:
+                del raw, process_code, setup_failed, unexpected
+                raise RuntimeExecutionError("OPENCLAW_MESSAGE_FILE_CLEANUP_FAILED") from None
+            if setup_failed:
+                del raw, process_code, unexpected
+                raise RuntimeExecutionError("OPENCLAW_MESSAGE_FILE_FAILED")
+            if unexpected is not None:
+                error = unexpected
+                del raw, process_code, setup_failed, unexpected
+                raise error
+            if process_code is not None:
+                del raw
+                raise RuntimeExecutionError(process_code) from None
+            assert raw is not None
+
+            parsed: tuple[RuntimeTurn, tuple[str, str], str] | None = None
+            incomplete_code: str | None = None
+            execution_code: str | None = None
+            parser_unexpected: BaseException | None = None
+            try:
+                parsed = _envelope_turn(
+                    raw,
+                    session_key=self._session_key,
+                    expected_model=self._expected_model,
+                    expected_session_id_digest=self._session_id_digest,
+                )
+            except RuntimeIncompleteError as error:
+                incomplete_code = error.code
+            except RuntimeExecutionError as error:
+                execution_code = error.code
+            except BaseException as error:
+                parser_unexpected = error.with_traceback(None)
+                parser_unexpected.__cause__ = None
+                parser_unexpected.__context__ = None
+            del raw
+            if parser_unexpected is not None:
+                error = parser_unexpected
+                del parser_unexpected
+                raise error
+            if incomplete_code is not None:
+                raise RuntimeIncompleteError(incomplete_code)
+            if execution_code is not None:
+                raise RuntimeExecutionError(execution_code)
+            assert parsed is not None
+            turn, reported_model, session_id_digest = parsed
+            del parsed
+            if self._expected_model is None:
+                self._expected_model = reported_model
+            if self._session_id_digest is None:
+                self._session_id_digest = session_id_digest
+            self._turns += 1
+            return turn
+        except BaseException:
+            self._closed = True
+            raise
+
+    def close(self) -> None:
+        self._closed = True

--- a/packages/nest-core/nest_core/agent_test/openclaw_runtime.py
+++ b/packages/nest-core/nest_core/agent_test/openclaw_runtime.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Exact-version, same-host OpenClaw connector for Town's managed runtime seam."""
+"""Version-coherent, same-host OpenClaw connector for Town's managed runtime seam."""
 
 from __future__ import annotations
 
@@ -13,7 +13,6 @@ import tempfile
 import uuid
 from collections.abc import Mapping
 from contextlib import suppress
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, NoReturn, cast
 from urllib.parse import urlsplit
@@ -79,7 +78,9 @@ _ACTIVITY_KEYS = frozenset(
     }
 )
 _ERROR_KEYS = frozenset({"error", "failuresignal"})
-_CLI_VERSION_BANNER = re.compile(r"OpenClaw (2026\.7\.1-2)(?: \([0-9a-f]{7}\))?\Z")
+_CLI_VERSION_BANNER = re.compile(
+    r"(?:OpenClaw )?([A-Za-z0-9][A-Za-z0-9._+-]{0,127})(?: \([0-9a-f]{7}\))?\Z"
+)
 _OPENCLAW_ENVIRONMENT_KEYS = frozenset(
     {"OPENCLAW_CONFIG_PATH", "OPENCLAW_GATEWAY_URL", "OPENCLAW_STATE_DIR"}
 )
@@ -139,22 +140,6 @@ _OPENCLAW_ISSUE_POLICY = RuntimeIssuePolicy(
             "OPENCLAW_TRANSPORT_LOSS",
         }
     ),
-)
-
-
-@dataclass(frozen=True, slots=True)
-class OpenClawCompatibility:
-    cli_version: str
-    gateway_version: str
-    rpc_version: str
-    envelope_version: str
-
-
-SUPPORTED_OPENCLAW = OpenClawCompatibility(
-    cli_version="2026.7.1-2",
-    gateway_version="2026.7.1-2",
-    rpc_version="2026.7.1-2",
-    envelope_version="2026.7.1-2",
 )
 
 
@@ -314,11 +299,11 @@ def _version_string(raw: bytes) -> str:
     except UnicodeDecodeError:
         invalid = True
     match = None if invalid else _CLI_VERSION_BANNER.fullmatch(version)
-    if match is None or match.group(1) != SUPPORTED_OPENCLAW.cli_version:
+    if match is None or match.group(1) == "OpenClaw":
         raw = b""
         version = ""
         raise RuntimeConfigurationError("OPENCLAW_VERSION_UNSUPPORTED")
-    return SUPPORTED_OPENCLAW.cli_version
+    return match.group(1)
 
 
 def _require_local_gateway_mode(raw: bytes) -> None:
@@ -470,11 +455,11 @@ def _targets_from_output(raw: bytes) -> tuple[RuntimeTarget, ...]:
     return targets
 
 
-def _require_probe(probe: RuntimeProbe, executable: Path) -> None:
+def _require_probe(probe: RuntimeProbe, executable: Path, detected_version: str) -> None:
     if (
         probe.runtime_id != "openclaw"
         or probe.executable != executable
-        or probe.version != SUPPORTED_OPENCLAW.cli_version
+        or probe.version != detected_version
         or probe.display != _OPENCLAW_DISPLAY
     ):
         raise RuntimeConfigurationError("OPENCLAW_PROBE_MISMATCH")
@@ -894,9 +879,13 @@ class OpenClawConnector:
     def __init__(self, *, executable: str | os.PathLike[str] = "openclaw") -> None:
         self._requested_executable = os.fspath(executable)
         self._executable: Path | None = None
+        self._detected_version: str | None = None
         self._listed_targets: tuple[RuntimeTarget, ...] | None = None
 
     def probe(self) -> RuntimeProbe | None:
+        self._executable = None
+        self._detected_version = None
+        self._listed_targets = None
         if os.name != "posix":
             raise RuntimeConfigurationError("OPENCLAW_PLATFORM_UNSUPPORTED")
         requested = self._requested_executable
@@ -930,13 +919,13 @@ class OpenClawConnector:
         )
         _require_no_gateway_url_config(executable)
         self._executable = executable
-        self._listed_targets = None
+        self._detected_version = version
         return RuntimeProbe(self.runtime_id, executable, version, _OPENCLAW_DISPLAY)
 
     def list_targets(self, probe: RuntimeProbe) -> tuple[RuntimeTarget, ...]:
-        if self._executable is None:
+        if self._executable is None or self._detected_version is None:
             raise RuntimeConfigurationError("OPENCLAW_PROBE_MISMATCH")
-        _require_probe(probe, self._executable)
+        _require_probe(probe, self._executable, self._detected_version)
         self._listed_targets = _targets_from_output(
             _process(
                 [os.fspath(self._executable), "agents", "list", "--json"],
@@ -953,9 +942,13 @@ class OpenClawConnector:
         target: RuntimeTarget,
         model_override: str | None,
     ) -> _PreparedOpenClaw:
-        if self._executable is None or self._listed_targets is None:
+        if (
+            self._executable is None
+            or self._detected_version is None
+            or self._listed_targets is None
+        ):
             raise RuntimeConfigurationError("OPENCLAW_PROBE_MISMATCH")
-        _require_probe(probe, self._executable)
+        _require_probe(probe, self._executable, self._detected_version)
         matches = tuple(listed for listed in self._listed_targets if listed.id == target.id)
         if not matches or target not in matches:
             raise RuntimeConfigurationError("TARGET_NOT_FOUND")
@@ -976,17 +969,19 @@ class OpenClawConnector:
                 deadline_seconds=PROBE_DEADLINE_SECONDS,
                 unavailable_code="OPENCLAW_GATEWAY_UNAVAILABLE",
                 error_type=RuntimeIncompleteError,
-            )
+            ),
+            detected_version=self._detected_version,
         )
         return _PreparedOpenClaw(
             executable=self._executable,
+            runtime_version=self._detected_version,
             target=target,
             model_override=model_override,
             expected_model=expected_model,
         )
 
     @staticmethod
-    def _validate_gateway_output(raw: bytes) -> None:
+    def _validate_gateway_output(raw: bytes, *, detected_version: str) -> None:
         gateway: dict[str, object] = {}
         configuration_code: str | None = None
         execution_code: str | None = None
@@ -1000,7 +995,7 @@ class OpenClawConnector:
                 code="OPENCLAW_GATEWAY_INVALID",
                 error_type=RuntimeExecutionError,
             )
-            OpenClawConnector._validate_gateway(gateway)
+            OpenClawConnector._validate_gateway(gateway, detected_version=detected_version)
         except RuntimeConfigurationError as error:
             configuration_code = error.code
         except RuntimeExecutionError as error:
@@ -1013,7 +1008,7 @@ class OpenClawConnector:
             raise RuntimeExecutionError(execution_code)
 
     @staticmethod
-    def _validate_gateway(status: dict[str, object]) -> None:
+    def _validate_gateway(status: dict[str, object], *, detected_version: str) -> None:
         if not {"cli", "config", "gateway", "rpc"}.issubset(status):
             raise RuntimeExecutionError("OPENCLAW_GATEWAY_INVALID")
         cli = _dictionary(
@@ -1035,10 +1030,7 @@ class OpenClawConnector:
             code="OPENCLAW_GATEWAY_INVALID",
             error_type=RuntimeExecutionError,
         )
-        if (
-            cli.get("version") != SUPPORTED_OPENCLAW.cli_version
-            or gateway.get("version") != SUPPORTED_OPENCLAW.gateway_version
-        ):
+        if cli.get("version") != detected_version or gateway.get("version") != detected_version:
             raise RuntimeConfigurationError("OPENCLAW_VERSION_MISMATCH")
         if "pluginVersionDrift" in status:
             plugin_drift = _dictionary(
@@ -1048,7 +1040,7 @@ class OpenClawConnector:
             )
             if not {"drifts", "gatewayVersion"}.issubset(plugin_drift):
                 raise RuntimeExecutionError("OPENCLAW_GATEWAY_INVALID")
-            if plugin_drift.get("gatewayVersion") != SUPPORTED_OPENCLAW.gateway_version:
+            if plugin_drift.get("gatewayVersion") != detected_version:
                 raise RuntimeConfigurationError("OPENCLAW_VERSION_MISMATCH")
             drifts = _list(
                 plugin_drift.get("drifts"),
@@ -1116,7 +1108,7 @@ class OpenClawConnector:
             code="OPENCLAW_GATEWAY_INVALID",
             error_type=RuntimeExecutionError,
         )
-        if rpc.get("version") != SUPPORTED_OPENCLAW.rpc_version:
+        if rpc.get("version") != detected_version:
             raise RuntimeConfigurationError("OPENCLAW_VERSION_MISMATCH")
         if rpc.get("ok") is not True:
             raise RuntimeConfigurationError("OPENCLAW_RPC_UNHEALTHY")
@@ -1141,7 +1133,7 @@ class OpenClawConnector:
                 code="OPENCLAW_GATEWAY_INVALID",
                 error_type=RuntimeExecutionError,
             )
-            if server.get("version") != SUPPORTED_OPENCLAW.gateway_version:
+            if server.get("version") != detected_version:
                 raise RuntimeConfigurationError("OPENCLAW_VERSION_MISMATCH")
         if not _is_loopback_url(gateway.get("probeUrl")) or not _is_loopback_url(rpc.get("url")):
             raise RuntimeConfigurationError("OPENCLAW_REMOTE_DISPATCH")
@@ -1149,7 +1141,6 @@ class OpenClawConnector:
 
 class _PreparedOpenClaw:
     runtime_id = "openclaw"
-    runtime_version = SUPPORTED_OPENCLAW.envelope_version
     display = _OPENCLAW_DISPLAY
     issue_policy = _OPENCLAW_ISSUE_POLICY
 
@@ -1157,10 +1148,12 @@ class _PreparedOpenClaw:
         self,
         *,
         executable: Path,
+        runtime_version: str,
         target: RuntimeTarget,
         model_override: str | None,
         expected_model: tuple[str, str] | None,
     ) -> None:
+        self.runtime_version = runtime_version
         self.target = target
         self.target_label = self._target_label(target.id)
         self.adapter_instance_id = "openclaw-" + uuid.uuid4().hex

--- a/packages/nest-core/nest_core/agent_test/runtime_connectors.py
+++ b/packages/nest-core/nest_core/agent_test/runtime_connectors.py
@@ -1,0 +1,374 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Static contracts for managed, session-oriented runtime connectors."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Protocol
+
+_MAX_METADATA_LENGTH = 128
+_ACTIVITIES = frozenset({"none_reported", "reported", "unknown"})
+_ISSUE_CODE_RE = re.compile(r"[A-Z][A-Z0-9_]{0,63}\Z")
+
+
+def _metadata(value: str, *, maximum: int = _MAX_METADATA_LENGTH) -> str:
+    """Validate bounded metadata without retaining or exposing unsafe text."""
+    if type(value) is not str or not value or value != value.strip():
+        raise ValueError("INVALID_RUNTIME_METADATA")
+    if len(value) > maximum or any(
+        ord(character) < 32 or ord(character) == 127 for character in value
+    ):
+        raise ValueError("INVALID_RUNTIME_METADATA")
+    return value
+
+
+def _optional_metadata(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return _metadata(value)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeDisplay:
+    """Bounded connector-owned text that Town may safely render."""
+
+    name: str
+    check_command: str | None
+
+    def __post_init__(self) -> None:
+        _metadata(self.name)
+        if self.check_command is not None:
+            _metadata(self.check_command, maximum=256)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProbe:
+    runtime_id: str
+    executable: Path
+    version: str
+    display: RuntimeDisplay
+
+    def __post_init__(self) -> None:
+        _metadata(self.runtime_id)
+        _metadata(self.version)
+        if type(self.display) is not RuntimeDisplay:
+            raise ValueError("INVALID_RUNTIME_METADATA")
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeTarget:
+    id: str
+    configured_model: str | None
+
+    def __post_init__(self) -> None:
+        _metadata(self.id)
+        _optional_metadata(self.configured_model)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeTurn:
+    intent: Mapping[str, object]
+    provider: str | None
+    model: str | None
+    session_ref_digest: str
+    activity: Literal["none_reported", "reported", "unknown"]
+
+    def __post_init__(self) -> None:
+        _optional_metadata(self.provider)
+        _optional_metadata(self.model)
+        _metadata(self.session_ref_digest)
+        if self.activity not in _ACTIVITIES:
+            raise ValueError("INVALID_RUNTIME_ACTIVITY")
+
+
+class RuntimeRun(Protocol):
+    def turn(self, observation: Mapping[str, object]) -> RuntimeTurn: ...
+
+    def close(self) -> None: ...
+
+
+class PreparedRuntime(Protocol):
+    runtime_id: str
+    runtime_version: str
+    display: RuntimeDisplay
+    target: RuntimeTarget
+    target_label: str
+    issue_policy: RuntimeIssuePolicy
+    adapter_instance_id: str
+
+    def open_run(self, town_run_id: str) -> RuntimeRun: ...
+
+
+class RuntimeConnector(Protocol):
+    runtime_id: str
+    issue_policy: RuntimeIssuePolicy
+
+    def probe(self) -> RuntimeProbe | None: ...
+
+    def list_targets(self, probe: RuntimeProbe) -> tuple[RuntimeTarget, ...]: ...
+
+    def prepare(
+        self,
+        probe: RuntimeProbe,
+        target: RuntimeTarget,
+        model_override: str | None,
+    ) -> PreparedRuntime: ...
+
+
+class _RuntimeError(RuntimeError):
+    """Base for errors whose public text is a stable code only."""
+
+    code: str
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+class RuntimeConfigurationError(_RuntimeError):
+    """The configured runtime or target set cannot be selected safely."""
+
+
+class RuntimeIncompleteError(_RuntimeError):
+    """The selected runtime cannot provide the required managed seam."""
+
+
+class RuntimeExecutionError(_RuntimeError):
+    """A managed runtime operation failed without exposing runtime details."""
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeIssuePolicy:
+    """Connector-owned, class-aware allowlist for post-admission issue codes."""
+
+    configuration: frozenset[str] = frozenset()
+    incomplete: frozenset[str] = frozenset()
+    execution: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        groups = (self.configuration, self.incomplete, self.execution)
+        if any(type(group) is not frozenset for group in groups):
+            raise ValueError("INVALID_RUNTIME_ISSUE_POLICY")
+        codes = tuple(code for group in groups for code in group)
+        if any(type(code) is not str or _ISSUE_CODE_RE.fullmatch(code) is None for code in codes):
+            raise ValueError("INVALID_RUNTIME_ISSUE_POLICY")
+        if len(codes) != len(set(codes)):
+            raise ValueError("INVALID_RUNTIME_ISSUE_POLICY")
+
+    def code_for(
+        self,
+        error: RuntimeConfigurationError | RuntimeIncompleteError | RuntimeExecutionError,
+    ) -> str:
+        if isinstance(error, RuntimeConfigurationError):
+            allowed = self.configuration
+            fallback = "RUNTIME_CONFIGURATION_FAILED"
+        elif isinstance(error, RuntimeIncompleteError):
+            allowed = self.incomplete
+            fallback = "RUNTIME_INCOMPLETE"
+        else:
+            allowed = self.execution
+            fallback = "RUNTIME_EXECUTION_FAILED"
+        return error.code if error.code in allowed else fallback
+
+
+def _safe_error_details(
+    policy: RuntimeIssuePolicy,
+    error: RuntimeConfigurationError | RuntimeIncompleteError | RuntimeExecutionError,
+) -> tuple[
+    type[RuntimeConfigurationError] | type[RuntimeIncompleteError] | type[RuntimeExecutionError],
+    str,
+]:
+    if isinstance(error, RuntimeConfigurationError):
+        error_type = RuntimeConfigurationError
+    elif isinstance(error, RuntimeIncompleteError):
+        error_type = RuntimeIncompleteError
+    else:
+        error_type = RuntimeExecutionError
+    return error_type, policy.code_for(error)
+
+
+def _connector_issue_policy(connector: RuntimeConnector) -> RuntimeIssuePolicy:
+    invalid = False
+    policy: object = None
+    try:
+        policy = connector.issue_policy
+    except Exception:
+        invalid = True
+    if invalid:
+        raise RuntimeExecutionError("RUNTIME_POLICY_INVALID")
+    if type(policy) is not RuntimeIssuePolicy:
+        raise RuntimeExecutionError("RUNTIME_POLICY_INVALID")
+    return policy
+
+
+def _probe_connector(connector: RuntimeConnector) -> RuntimeProbe | None:
+    policy = _connector_issue_policy(connector)
+    probe: RuntimeProbe | None = None
+    failure_type: (
+        type[RuntimeConfigurationError]
+        | type[RuntimeIncompleteError]
+        | type[RuntimeExecutionError]
+        | None
+    ) = None
+    failure_code: str | None = None
+    try:
+        probe = connector.probe()
+    except (RuntimeConfigurationError, RuntimeIncompleteError, RuntimeExecutionError) as error:
+        failure_type, failure_code = _safe_error_details(policy, error)
+    if failure_type is not None:
+        assert failure_code is not None
+        raise failure_type(failure_code)
+    return probe
+
+
+def _list_connector_targets(
+    connector: RuntimeConnector,
+    probe: RuntimeProbe,
+) -> tuple[RuntimeTarget, ...]:
+    policy = _connector_issue_policy(connector)
+    targets: tuple[RuntimeTarget, ...] | None = None
+    failure_type: (
+        type[RuntimeConfigurationError]
+        | type[RuntimeIncompleteError]
+        | type[RuntimeExecutionError]
+        | None
+    ) = None
+    failure_code: str | None = None
+    try:
+        targets = connector.list_targets(probe)
+    except (RuntimeConfigurationError, RuntimeIncompleteError, RuntimeExecutionError) as error:
+        failure_type, failure_code = _safe_error_details(policy, error)
+    if failure_type is not None:
+        assert failure_code is not None
+        raise failure_type(failure_code)
+    assert targets is not None
+    return targets
+
+
+def prepare_runtime(
+    *,
+    connector: RuntimeConnector,
+    probe: RuntimeProbe,
+    target: RuntimeTarget,
+    model_override: str | None,
+) -> PreparedRuntime:
+    """Prepare through the connector's validated policy and bind policy continuity."""
+    policy = _connector_issue_policy(connector)
+    prepared: PreparedRuntime | None = None
+    failure_type: (
+        type[RuntimeConfigurationError]
+        | type[RuntimeIncompleteError]
+        | type[RuntimeExecutionError]
+        | None
+    ) = None
+    failure_code: str | None = None
+    try:
+        prepared = connector.prepare(probe, target, model_override)
+    except (RuntimeConfigurationError, RuntimeIncompleteError, RuntimeExecutionError) as error:
+        failure_type, failure_code = _safe_error_details(policy, error)
+    if failure_type is not None:
+        assert failure_code is not None
+        raise failure_type(failure_code)
+    assert prepared is not None
+    policy_unavailable = False
+    prepared_policy: object = None
+    try:
+        prepared_policy = prepared.issue_policy
+    except Exception:
+        policy_unavailable = True
+    if (
+        policy_unavailable
+        or type(prepared_policy) is not RuntimeIssuePolicy
+        or prepared_policy != policy
+    ):
+        raise RuntimeExecutionError("RUNTIME_POLICY_MISMATCH")
+    return prepared
+
+
+def _connector_for_runtime(
+    requested_runtime: str,
+    connectors: tuple[RuntimeConnector, ...],
+) -> RuntimeConnector:
+    matches = tuple(
+        connector for connector in connectors if connector.runtime_id == requested_runtime
+    )
+    if not matches:
+        raise RuntimeConfigurationError("RUNTIME_NOT_FOUND")
+    if len(matches) != 1:
+        raise RuntimeConfigurationError("RUNTIME_AMBIGUOUS")
+    return matches[0]
+
+
+def _matching_target(
+    connector: RuntimeConnector,
+    probe: RuntimeProbe,
+    target_id: str,
+) -> tuple[RuntimeConnector, RuntimeProbe, RuntimeTarget]:
+    matches = tuple(
+        target for target in _list_connector_targets(connector, probe) if target.id == target_id
+    )
+    if not matches:
+        raise RuntimeConfigurationError("TARGET_NOT_FOUND")
+    if len(matches) != 1:
+        raise RuntimeConfigurationError("TARGET_AMBIGUOUS")
+    return connector, probe, matches[0]
+
+
+def _require_probe_identity(connector: RuntimeConnector, probe: RuntimeProbe) -> None:
+    if probe.runtime_id != connector.runtime_id:
+        raise RuntimeConfigurationError("RUNTIME_ID_MISMATCH")
+
+
+def select_runtime(
+    *,
+    target_id: str,
+    requested_runtime: str | None,
+    connectors: tuple[RuntimeConnector, ...],
+) -> tuple[RuntimeConnector, RuntimeProbe, RuntimeTarget]:
+    """Select exactly one probed connector and exact target.
+
+    An omitted runtime is not a default: absent connectors are skipped, while an
+    inspection failure remains fatal. Selection is made only from exact target
+    matches. An explicit runtime limits probing to that connector first.
+    """
+    _metadata(target_id)
+    if requested_runtime is not None:
+        _metadata(requested_runtime)
+
+    if requested_runtime is not None:
+        connector = _connector_for_runtime(requested_runtime, connectors)
+        probe = _probe_connector(connector)
+        if probe is None:
+            raise RuntimeConfigurationError("RUNTIME_NOT_FOUND")
+        _require_probe_identity(connector, probe)
+        return _matching_target(connector, probe, target_id)
+
+    probed: list[tuple[RuntimeConnector, RuntimeProbe]] = []
+    for connector in connectors:
+        probe = _probe_connector(connector)
+        if probe is None:
+            continue
+        _require_probe_identity(connector, probe)
+        probed.append((connector, probe))
+
+    if not probed:
+        raise RuntimeConfigurationError("RUNTIME_NOT_FOUND")
+
+    candidates: list[tuple[RuntimeConnector, RuntimeProbe, RuntimeTarget]] = []
+    for connector, probe in probed:
+        matches = tuple(
+            target for target in _list_connector_targets(connector, probe) if target.id == target_id
+        )
+        if len(matches) > 1:
+            raise RuntimeConfigurationError("TARGET_AMBIGUOUS")
+        if matches:
+            candidates.append((connector, probe, matches[0]))
+
+    if not candidates:
+        raise RuntimeConfigurationError("TARGET_NOT_FOUND")
+    if len(candidates) != 1:
+        raise RuntimeConfigurationError("RUNTIME_AMBIGUOUS")
+    return candidates[0]

--- a/packages/nest-core/nest_core/agent_test/runtime_subprocess.py
+++ b/packages/nest-core/nest_core/agent_test/runtime_subprocess.py
@@ -1,0 +1,393 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded, code-only subprocess execution for managed runtime connectors."""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+import signal
+import subprocess
+import threading
+import time
+from collections.abc import Mapping
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import IO
+
+PROBE_DEADLINE_SECONDS = 5
+TURN_DEADLINE_SECONDS = 45
+TERMINATE_GRACE_SECONDS = 5
+KILL_REAP_SECONDS = 5
+DEFAULT_OUTPUT_LIMIT_BYTES = 256 * 1024
+
+_ENVIRONMENT_ALLOWLIST = frozenset(
+    {
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "LOGNAME",
+        "PATH",
+        "SHELL",
+        "SYSTEMROOT",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "USER",
+        "WINDIR",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "XDG_STATE_HOME",
+    }
+)
+_ENVIRONMENT_KEY_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,127}\Z")
+
+
+class ProcessError(RuntimeError):
+    """A subprocess failure whose public representation is a stable code only."""
+
+    code: str
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessResult:
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+
+class _SharedOutputBudget:
+    def __init__(self, maximum: int) -> None:
+        self.maximum = maximum
+        self.used = 0
+        self.overflow = threading.Event()
+        self.lock = threading.Lock()
+
+    def retain(self, chunk: bytes) -> bytes:
+        with self.lock:
+            remaining = self.maximum - self.used
+            if remaining <= 0:
+                self.overflow.set()
+                return b""
+            retained = chunk[:remaining]
+            self.used += len(retained)
+            if len(retained) != len(chunk):
+                self.overflow.set()
+            return retained
+
+
+def _filtered_environment(
+    extra: Mapping[str, str] | None,
+    allowed_environment_keys: frozenset[str],
+) -> dict[str, str]:
+    if type(allowed_environment_keys) is not frozenset or any(
+        type(key) is not str or _ENVIRONMENT_KEY_RE.fullmatch(key) is None
+        for key in allowed_environment_keys
+    ):
+        raise ProcessError("PROCESS_INVALID_ENVIRONMENT_POLICY")
+    allowed = _ENVIRONMENT_ALLOWLIST | allowed_environment_keys
+    source = dict(os.environ)
+    if extra is not None:
+        source.update(extra)
+    return {
+        key: value
+        for key, value in source.items()
+        if key in allowed and not key.startswith("TOWN_")
+    }
+
+
+def _validated_argv(argv: list[str]) -> list[str]:
+    if type(argv) is not list or not argv:
+        raise ProcessError("PROCESS_INVALID_ARGV")
+    if any(type(argument) is not str or not argument or "\x00" in argument for argument in argv):
+        raise ProcessError("PROCESS_INVALID_ARGV")
+    return list(argv)
+
+
+def _drain(pipe: IO[bytes], budget: _SharedOutputBudget, retained: bytearray) -> None:
+    try:
+        while chunk := pipe.read(8192):
+            retained.extend(budget.retain(chunk))
+    finally:
+        pipe.close()
+
+
+def _process_group_exists(process_id: int) -> bool:
+    if os.name != "posix":
+        return False
+    try:
+        os.killpg(process_id, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def _signal_group(process: subprocess.Popen[bytes], *, force: bool) -> None:
+    if os.name != "posix" and process.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGKILL if force else signal.SIGTERM)
+        elif force:
+            process.kill()
+        else:
+            process.terminate()
+    except ProcessLookupError:
+        return
+    except OSError as error:
+        with suppress(subprocess.TimeoutExpired):
+            process.wait(timeout=0.02)
+        if os.name == "posix":
+            if not _process_group_exists(process.pid):
+                return
+        elif process.poll() is not None:
+            return
+        raise ProcessError("PROCESS_CLEANUP_FAILED") from error
+
+
+def _reap(
+    process: subprocess.Popen[bytes],
+    *,
+    terminate_grace_seconds: float,
+    kill_reap_seconds: float,
+) -> float:
+    _signal_group(process, force=False)
+    grace_deadline = time.monotonic() + terminate_grace_seconds
+    while True:
+        leader_exited = process.poll() is not None
+        if leader_exited and (os.name != "posix" or not _process_group_exists(process.pid)):
+            return time.monotonic() + kill_reap_seconds
+        remaining = grace_deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        if leader_exited:
+            time.sleep(min(remaining, 0.02))
+            continue
+        with suppress(subprocess.TimeoutExpired):
+            process.wait(timeout=min(remaining, 0.02))
+    cleanup_deadline = time.monotonic() + kill_reap_seconds
+    _signal_group(process, force=True)
+    if process.poll() is None:
+        try:
+            process.wait(timeout=max(0.0, cleanup_deadline - time.monotonic()))
+        except subprocess.TimeoutExpired as error:
+            raise ProcessError("PROCESS_REAP_FAILED") from error
+    return cleanup_deadline
+
+
+def _run_bounded(
+    argv: list[str],
+    *,
+    deadline_seconds: float,
+    max_output_bytes: int = DEFAULT_OUTPUT_LIMIT_BYTES,
+    environment: Mapping[str, str] | None = None,
+    allowed_environment_keys: frozenset[str] = frozenset(),
+    accept_empty_exit_one: bool = False,
+    terminate_grace_seconds: float = TERMINATE_GRACE_SECONDS,
+    kill_reap_seconds: float = KILL_REAP_SECONDS,
+) -> ProcessResult:
+    """Run literal argv with fixed output, environment, time, and cleanup bounds."""
+    arguments = _validated_argv(argv)
+    time_limits = (deadline_seconds, terminate_grace_seconds, kill_reap_seconds)
+    if (
+        type(deadline_seconds) not in (int, float)
+        or deadline_seconds <= 0
+        or type(max_output_bytes) is not int
+        or max_output_bytes <= 0
+        or type(terminate_grace_seconds) not in (int, float)
+        or terminate_grace_seconds < 0
+        or type(kill_reap_seconds) not in (int, float)
+        or kill_reap_seconds <= 0
+        or any(type(limit) is float and not math.isfinite(limit) for limit in time_limits)
+        or sum(time_limits) >= 60
+    ):
+        raise ProcessError("PROCESS_INVALID_LIMIT")
+    if type(accept_empty_exit_one) is not bool:
+        raise ProcessError("PROCESS_INVALID_RETURNCODE_POLICY")
+
+    stdout_pipe: IO[bytes] | None = None
+    stderr_pipe: IO[bytes] | None = None
+    pipes: list[IO[bytes]] = []
+    budget: _SharedOutputBudget | None = None
+    stdout: bytearray | None = None
+    stderr: bytearray | None = None
+    readers: list[threading.Thread] = []
+    started_readers: list[threading.Thread] = []
+    failure_code: str | None = None
+    cleanup_started = False
+    drain_deadline: float | None = None
+    try:
+        process = subprocess.Popen(
+            arguments,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=_filtered_environment(environment, allowed_environment_keys),
+            shell=False,
+            start_new_session=True,
+            creationflags=0,
+        )
+    except (OSError, ValueError) as error:
+        raise ProcessError("PROCESS_START_FAILED") from error
+
+    try:
+        stdout_pipe = process.stdout
+        stderr_pipe = process.stderr
+        pipes.extend(pipe for pipe in (stdout_pipe, stderr_pipe) if pipe is not None)
+        if stdout_pipe is None or stderr_pipe is None:
+            failure_code = "PROCESS_PIPE_FAILED"
+        else:
+            try:
+                budget = _SharedOutputBudget(max_output_bytes)
+                stdout = bytearray()
+                stderr = bytearray()
+                readers.append(
+                    threading.Thread(
+                        target=_drain,
+                        args=(stdout_pipe, budget, stdout),
+                        daemon=True,
+                    )
+                )
+                readers.append(
+                    threading.Thread(
+                        target=_drain,
+                        args=(stderr_pipe, budget, stderr),
+                        daemon=True,
+                    )
+                )
+                for reader in readers:
+                    reader.start()
+                    started_readers.append(reader)
+            except Exception:
+                failure_code = "PROCESS_READER_SETUP_FAILED"
+
+        if failure_code is None:
+            assert budget is not None
+            deadline = time.monotonic() + deadline_seconds
+            while process.poll() is None:
+                if budget.overflow.is_set():
+                    failure_code = "PROCESS_OUTPUT_LIMIT"
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    failure_code = "PROCESS_TIMEOUT"
+                    break
+                try:
+                    process.wait(timeout=min(remaining, 0.02))
+                except subprocess.TimeoutExpired:
+                    continue
+        if failure_code is not None:
+            cleanup_started = True
+            drain_deadline = _reap(
+                process,
+                terminate_grace_seconds=terminate_grace_seconds,
+                kill_reap_seconds=kill_reap_seconds,
+            )
+        elif os.name == "posix" and _process_group_exists(process.pid):
+            failure_code = "PROCESS_DRAIN_FAILED"
+            cleanup_started = True
+            drain_deadline = _reap(
+                process,
+                terminate_grace_seconds=terminate_grace_seconds,
+                kill_reap_seconds=kill_reap_seconds,
+            )
+    except BaseException:
+        if cleanup_started:
+            if drain_deadline is None:
+                drain_deadline = time.monotonic()
+        else:
+            cleanup_started = True
+            try:
+                drain_deadline = _reap(
+                    process,
+                    terminate_grace_seconds=terminate_grace_seconds,
+                    kill_reap_seconds=kill_reap_seconds,
+                )
+            except BaseException:
+                drain_deadline = time.monotonic()
+                raise
+        raise
+    finally:
+        if drain_deadline is None:
+            drain_deadline = time.monotonic() + kill_reap_seconds
+        for index, pipe in enumerate(pipes):
+            if index >= len(started_readers):
+                with suppress(OSError, ValueError):
+                    pipe.close()
+        for reader in started_readers:
+            reader.join(timeout=max(0.0, drain_deadline - time.monotonic()))
+        for index, reader in enumerate(readers):
+            if index < len(pipes) and not reader.is_alive():
+                with suppress(OSError, ValueError):
+                    pipes[index].close()
+
+    if any(reader.is_alive() for reader in started_readers):
+        raise ProcessError("PROCESS_DRAIN_FAILED")
+    if failure_code is not None:
+        raise ProcessError(failure_code)
+    if budget is not None and budget.overflow.is_set():
+        raise ProcessError("PROCESS_OUTPUT_LIMIT")
+    if process.returncode != 0 and not (accept_empty_exit_one and process.returncode == 1):
+        raise ProcessError("PROCESS_EXIT_NONZERO")
+    assert stdout is not None and stderr is not None
+    if process.returncode == 1:
+        stdout.clear()
+        stderr.clear()
+        return ProcessResult(1, b"", b"")
+    return ProcessResult(process.returncode, bytes(stdout), bytes(stderr))
+
+
+def run_bounded(
+    argv: list[str],
+    *,
+    deadline_seconds: float,
+    max_output_bytes: int = DEFAULT_OUTPUT_LIMIT_BYTES,
+    environment: Mapping[str, str] | None = None,
+    allowed_environment_keys: frozenset[str] = frozenset(),
+    terminate_grace_seconds: float = TERMINATE_GRACE_SECONDS,
+    kill_reap_seconds: float = KILL_REAP_SECONDS,
+    accept_empty_exit_one: bool = False,
+) -> ProcessResult:
+    """Run a contained POSIX child without retaining output from failed children.
+
+    A caller may treat exit 1 as an absent optional value; both output streams
+    are erased before that result is returned.
+    """
+    if os.name != "posix":
+        raise ProcessError("PROCESS_UNSUPPORTED_PLATFORM")
+    result: ProcessResult | None = None
+    failure_code: str | None = None
+    unexpected: BaseException | None = None
+    try:
+        result = _run_bounded(
+            argv,
+            deadline_seconds=deadline_seconds,
+            max_output_bytes=max_output_bytes,
+            environment=environment,
+            allowed_environment_keys=allowed_environment_keys,
+            accept_empty_exit_one=accept_empty_exit_one,
+            terminate_grace_seconds=terminate_grace_seconds,
+            kill_reap_seconds=kill_reap_seconds,
+        )
+    except ProcessError as error:
+        failure_code = error.code
+    except BaseException as error:
+        unexpected = error.with_traceback(None)
+        unexpected.__cause__ = None
+        unexpected.__context__ = None
+    del argv, environment, allowed_environment_keys
+    if failure_code is not None:
+        raise ProcessError(failure_code)
+    if unexpected is not None:
+        error = unexpected
+        del unexpected
+        raise error
+    assert result is not None
+    return result

--- a/packages/nest-core/tests/agent_test/fixtures/openclaw-2026.7.1-2-success.json
+++ b/packages/nest-core/tests/agent_test/fixtures/openclaw-2026.7.1-2-success.json
@@ -1,0 +1,46 @@
+{
+  "runId": "run-synthetic-001",
+  "status": "ok",
+  "summary": "completed",
+  "result": {
+    "payloads": [
+      {
+        "text": "{\"capabilities\":[\"sell\"],\"kind\":\"declare_capability\"}",
+        "mediaUrl": null
+      }
+    ],
+    "meta": {
+      "durationMs": 42,
+      "agentMeta": {
+        "sessionId": "session-synthetic-001",
+        "provider": "provider",
+        "model": "model",
+        "agentHarnessId": "synthetic-harness"
+      },
+      "aborted": false,
+      "finalAssistantVisibleText": "{\"capabilities\":[\"sell\"],\"kind\":\"declare_capability\"}",
+      "finalAssistantRawText": "{\"capabilities\":[\"sell\"],\"kind\":\"declare_capability\"}",
+      "replayInvalid": false,
+      "livenessState": "working",
+      "stopReason": "stop",
+      "executionTrace": {
+        "winnerProvider": "provider",
+        "winnerModel": "model",
+        "attempts": [
+          {
+            "provider": "provider",
+            "model": "model",
+            "result": "success",
+            "stage": "assistant"
+          }
+        ],
+        "fallbackUsed": false,
+        "runner": "embedded"
+      },
+      "completion": {
+        "stopReason": "stop",
+        "finishReason": "stop"
+      }
+    }
+  }
+}

--- a/packages/nest-core/tests/agent_test/test_openclaw_runtime.py
+++ b/packages/nest-core/tests/agent_test/test_openclaw_runtime.py
@@ -1,0 +1,1778 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract and adversarial tests for the exact OpenClaw runtime connector."""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+import os
+import sys
+import textwrap
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, cast
+
+import nest_core.agent_test.openclaw_runtime as openclaw_runtime
+import pytest
+from nest_core.agent_test.openclaw_runtime import SUPPORTED_OPENCLAW, OpenClawConnector
+from nest_core.agent_test.runtime_connectors import (
+    RuntimeConfigurationError,
+    RuntimeDisplay,
+    RuntimeExecutionError,
+    RuntimeIncompleteError,
+    RuntimeProbe,
+    RuntimeTarget,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "openclaw-2026.7.1-2-success.json"
+VERSION = "2026.7.1-2"
+VERSION_BANNER = "OpenClaw 2026.7.1-2 (0790d9f)"
+Mutation = Callable[[dict[str, Any]], object]
+
+START_OBSERVATION = {
+    "kind": "start",
+    "logical_time": 0,
+    "allowed_intents": ["declare_capability", "none"],
+}
+MESSAGE_OBSERVATION = {
+    "kind": "message",
+    "logical_time": 1,
+    "allowed_intents": ["send_to_sender", "none"],
+    "message": {
+        "id": "message-001",
+        "sender_id": "requester-0",
+        "media_type": "text/plain; charset=utf-8",
+        "text": "buy:widget:2",
+    },
+}
+START_PROMPT = (
+    "You are completing one basic local NANDA Town agent test.\n"
+    "Return exactly one minified JSON object and no other characters.\n"
+    "Do not return prose, Markdown, or code fences.\n"
+    "Do not invoke tools, access files, memory, messages, channels, or perform any other "
+    "action.\n"
+    "This is the start event. Declare the sell capability by returning exactly "
+    '{"capabilities":["sell"],"kind":"declare_capability"}.\n'
+    'If you cannot do that, return exactly {"kind":"none"}.\n'
+)
+MESSAGE_PROMPT = (
+    "You are completing one basic local NANDA Town agent test.\n"
+    "Return exactly one minified JSON object and no other characters.\n"
+    "Do not return prose, Markdown, or code fences.\n"
+    "Do not invoke tools, access files, memory, messages, channels, or perform any other action.\n"
+    "This is the message event.\n"
+    'Input text: "buy:widget:2"\n'
+    "If the text matches buy:<item>:<quantity>, return one canonical object shaped as "
+    '{"kind":"send_to_sender","media_type":"text/plain; charset=utf-8",'
+    '"text":"sold:<item>:<quantity>"}, replacing <item> and <quantity> with the input '
+    "values.\n"
+    'If you cannot do that, return exactly {"kind":"none"}.\n'
+)
+
+
+def _success_envelope(intent: dict[str, object] | None = None) -> dict[str, Any]:
+    envelope = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    if intent is not None:
+        text = json.dumps(intent, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        payload = envelope["result"]["payloads"][0]
+        meta = envelope["result"]["meta"]
+        payload["text"] = text
+        meta["finalAssistantVisibleText"] = text
+        meta["finalAssistantRawText"] = text
+    return envelope
+
+
+def _gateway() -> dict[str, Any]:
+    """Sanitized v2026.7.1-2 status shape observed from the real Gateway CLI."""
+    return {
+        "cli": {"entrypoint": "/synthetic/openclaw.mjs", "version": VERSION},
+        "config": {
+            "cli": {
+                "controlUi": {},
+                "exists": True,
+                "path": "/synthetic/openclaw.json",
+                "valid": True,
+            },
+            "daemon": {
+                "controlUi": {},
+                "exists": True,
+                "path": "/synthetic/openclaw.json",
+                "valid": True,
+            },
+        },
+        "extraServices": [],
+        "gateway": {
+            "bindHost": "127.0.0.1",
+            "bindMode": "loopback",
+            "controlUiLinks": [],
+            "port": 18789,
+            "portSource": "config",
+            "probeNote": "synthetic",
+            "probeUrl": "ws://127.0.0.1:18789",
+            "version": VERSION,
+        },
+        "logFile": "/synthetic/openclaw.log",
+        "pluginVersionDrift": {"drifts": [], "gatewayVersion": VERSION},
+        "port": {
+            "hints": [],
+            "listeners": [
+                {
+                    "address": "127.0.0.1:18789",
+                    "command": "openclaw",
+                    "commandLine": "openclaw gateway run --bind loopback",
+                    "pid": 1234,
+                }
+            ],
+            "port": 18789,
+            "status": "busy",
+        },
+        "rpc": {
+            "auth": {"capability": "operator", "role": "operator", "scopes": []},
+            "capability": "operator",
+            "kind": "read",
+            "ok": True,
+            "server": {"connId": "synthetic", "version": VERSION},
+            "url": "ws://127.0.0.1:18789",
+            "version": VERSION,
+        },
+        "service": {
+            "command": [],
+            "configAudit": {"issues": [], "ok": True},
+            "label": "synthetic",
+            "loaded": True,
+            "loadedText": "loaded",
+            "notLoadedText": "not loaded",
+            "runtime": {},
+        },
+    }
+
+
+def _agents() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "buyer",
+            "name": "Synthetic Buyer",
+            "workspace": "/synthetic/workspace",
+            "agentDir": "/synthetic/agent",
+            "model": "provider/model",
+            "isDefault": True,
+            "bindings": 0,
+        }
+    ]
+
+
+def _fake_openclaw(
+    tmp_path: Path,
+    *,
+    version: str = VERSION_BANNER,
+    gateway_mode: object = "local",
+    config_env: object | None = None,
+    record_gateway_url: bool = False,
+    agents: object | None = None,
+    gateway: object | None = None,
+    responses: list[object] | None = None,
+) -> tuple[Path, Path, Path]:
+    state_path = tmp_path / "fake-state.json"
+    log_path = tmp_path / "fake-log.jsonl"
+    executable = tmp_path / "openclaw"
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": version,
+                "gateway_mode": gateway_mode,
+                "config_env": config_env,
+                "record_gateway_url": record_gateway_url,
+                "agents": _agents() if agents is None else agents,
+                "gateway": _gateway() if gateway is None else gateway,
+                "responses": responses,
+                "prompt_responses": {
+                    START_PROMPT: _success_envelope(),
+                    MESSAGE_PROMPT: _success_envelope(
+                        {
+                            "kind": "send_to_sender",
+                            "media_type": "text/plain; charset=utf-8",
+                            "text": "sold:widget:2",
+                        }
+                    ),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    executable.write_text(
+        textwrap.dedent(
+            f"""\
+            #!{os.fspath(Path(sys.executable))}
+            import json
+            import os
+            import pathlib
+            import stat
+            import sys
+            import time
+
+            state_path = pathlib.Path({str(state_path)!r})
+            log_path = pathlib.Path({str(log_path)!r})
+            state = json.loads(state_path.read_text())
+            args = sys.argv[1:]
+            record = {{
+                "argv": args,
+                "town_env": sorted(k for k in os.environ if k.startswith("TOWN_")),
+            }}
+            if state["record_gateway_url"]:
+                record["gateway_url"] = os.environ.get("OPENCLAW_GATEWAY_URL")
+
+            if args and args[0] == "agent":
+                count = int(state.get("agent_count", 0))
+                state["agent_count"] = count + 1
+                message_path = pathlib.Path(args[args.index("--message-file") + 1])
+                record.update({{
+                    "message_path": str(message_path),
+                    "message_mode": stat.S_IMODE(message_path.stat().st_mode),
+                    "message": message_path.read_text(),
+                    "stdin_closed": sys.stdin.buffer.read() == b"",
+                }})
+                responses = state["responses"]
+                response = (
+                    state["prompt_responses"].get(message_path.read_text(), {{"invalid": True}})
+                    if responses is None
+                    else responses[min(count, len(responses) - 1)]
+                )
+                if isinstance(response, dict) and response.get("fake") == "timeout":
+                    state_path.write_text(json.dumps(state))
+                    with log_path.open("a") as stream:
+                        stream.write(json.dumps(record) + "\\n")
+                    time.sleep(60)
+                if isinstance(response, dict) and response.get("fake") == "transport_loss":
+                    output = ""
+                    exit_code = 9
+                elif isinstance(response, dict) and response.get("fake") == "overflow":
+                    output = "x" * 400000
+                    exit_code = 0
+                elif isinstance(response, str):
+                    output = response
+                    exit_code = 0
+                else:
+                    output = json.dumps(response)
+                    exit_code = 0
+                state_path.write_text(json.dumps(state))
+            elif args == ["--version"]:
+                output = state["version"]
+                exit_code = 0
+            elif args == ["config", "get", "gateway.mode", "--json"]:
+                output = json.dumps(state["gateway_mode"])
+                exit_code = 0
+            elif args == ["config", "get", "env", "--json"]:
+                output = "" if state["config_env"] is None else json.dumps(state["config_env"])
+                exit_code = 1 if state["config_env"] is None else 0
+            elif args == ["agents", "list", "--json"]:
+                output = (
+                    state["agents"]
+                    if isinstance(state["agents"], str)
+                    else json.dumps(state["agents"])
+                )
+                exit_code = 0
+            elif args == ["gateway", "status", "--json", "--require-rpc"]:
+                output = (
+                    state["gateway"]
+                    if isinstance(state["gateway"], str)
+                    else json.dumps(state["gateway"])
+                )
+                exit_code = 0
+            else:
+                output = "unexpected argv"
+                exit_code = 17
+
+            with log_path.open("a") as stream:
+                stream.write(json.dumps(record) + "\\n")
+            if output:
+                print(output)
+            raise SystemExit(exit_code)
+            """
+        ),
+        encoding="utf-8",
+    )
+    executable.chmod(0o700)
+    return executable, state_path, log_path
+
+
+def _logs(log_path: Path) -> list[dict[str, Any]]:
+    if not log_path.exists():
+        return []
+    return [json.loads(line) for line in log_path.read_text().splitlines()]
+
+
+def _prepared(
+    tmp_path: Path,
+    *,
+    agents: object | None = None,
+    gateway: object | None = None,
+    responses: list[object] | None = None,
+    model_override: str | None = None,
+) -> tuple[Any, Path]:
+    executable, _, log_path = _fake_openclaw(
+        tmp_path,
+        agents=agents,
+        gateway=gateway,
+        responses=responses,
+    )
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    targets = connector.list_targets(probe)
+    prepared = connector.prepare(probe, targets[0], model_override)
+    return prepared, log_path
+
+
+def _turn(prepared: Any, *, town_run_id: str = "run-001") -> Any:
+    run = prepared.open_run(town_run_id)
+    return run.turn(START_OBSERVATION)
+
+
+def _assert_code(error_type: type[Exception], code: str, callback: Any) -> None:
+    with pytest.raises(error_type) as caught:
+        callback()
+    assert str(caught.value) == code, (
+        repr(caught.value.__cause__),
+        repr(caught.value.__cause__.__cause__) if caught.value.__cause__ else None,
+    )
+    assert caught.value.args == (code,)
+
+
+def _traceback_locals(error: BaseException) -> str:
+    values: list[str] = []
+    pending: list[BaseException] = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        values.append(repr(current))
+        traceback = current.__traceback__
+        while traceback is not None:
+            filename = traceback.tb_frame.f_code.co_filename
+            if "/tests/" not in filename:
+                values.extend(repr(value) for value in traceback.tb_frame.f_locals.values())
+            traceback = traceback.tb_next
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+    return " ".join(values)
+
+
+def test_fixture_matches_the_sanitized_characterized_success_envelope() -> None:
+    raw = FIXTURE.read_text(encoding="utf-8")
+    envelope = json.loads(raw)
+    meta = envelope["result"]["meta"]
+
+    assert set(envelope) == {"runId", "status", "summary", "result"}
+    assert len(envelope["result"]["payloads"]) == 1
+    assert set(envelope["result"]["payloads"][0]) == {"text", "mediaUrl"}
+    assert envelope["result"]["payloads"][0]["mediaUrl"] is None
+    assert set(meta) == {
+        "durationMs",
+        "agentMeta",
+        "aborted",
+        "finalAssistantVisibleText",
+        "finalAssistantRawText",
+        "replayInvalid",
+        "livenessState",
+        "stopReason",
+        "executionTrace",
+        "completion",
+    }
+    assert meta["livenessState"] == "working"
+    assert meta["stopReason"] == "stop"
+    assert meta["executionTrace"]["fallbackUsed"] is False
+    assert meta["executionTrace"]["runner"] == "embedded"
+    assert "sessionKey" not in meta["agentMeta"]
+    assert not any(
+        marker in raw
+        for marker in (
+            "/Users/",
+            "/home/",
+            "Bearer ",
+            "systemPrompt",
+            "usage",
+            "toolSummary",
+            "pendingToolCalls",
+            "transport",
+            "fallbackFrom",
+            "fallbackReason",
+        )
+    )
+
+
+def test_turn_projects_exact_bounded_prompts_and_fake_output_depends_on_them(
+    tmp_path: Path,
+) -> None:
+    prepared, log_path = _prepared(tmp_path)
+    run = prepared.open_run("prompt-contract")
+
+    start = run.turn(START_OBSERVATION)
+    message = run.turn(MESSAGE_OBSERVATION)
+
+    prompts = [entry["message"] for entry in _logs(log_path) if entry["argv"][0] == "agent"]
+    assert prompts == [START_PROMPT, MESSAGE_PROMPT]
+    assert start.intent == {"capabilities": ["sell"], "kind": "declare_capability"}
+    assert message.intent == {
+        "kind": "send_to_sender",
+        "media_type": "text/plain; charset=utf-8",
+        "text": "sold:widget:2",
+    }
+    assert "sold:widget:2" not in MESSAGE_PROMPT
+    assert "run_id" not in START_PROMPT + MESSAGE_PROMPT
+    assert "session" not in START_PROMPT.lower() + MESSAGE_PROMPT.lower()
+
+
+def test_parser_accepts_safe_additive_characterized_metadata_without_returning_it(
+    tmp_path: Path,
+) -> None:
+    response = _success_envelope()
+    response["result"]["meta"].update(
+        {
+            "systemPromptReport": {
+                "mode": "synthetic",
+                "tools": ["configured-but-not-called"],
+                "messages": {"context": 1},
+            },
+            "requestShaping": {"strategy": "none"},
+        }
+    )
+    response["result"]["meta"]["agentMeta"].update(
+        {
+            "contextTokens": 114688,
+            "usage": {"input": 22, "output": 8},
+            "lastCallUsage": {"input": 22, "output": 8},
+            "promptTokens": 22,
+        }
+    )
+    prepared, _ = _prepared(tmp_path, responses=[response])
+
+    turn = _turn(prepared)
+
+    assert turn.intent == {"capabilities": ["sell"], "kind": "declare_capability"}
+    assert not hasattr(turn, "usage")
+    assert not hasattr(turn, "system_prompt_report")
+
+
+def test_non_posix_platform_fails_as_configuration_before_any_child(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import nest_core.agent_test.openclaw_runtime as runtime_module
+
+    executable, _, log_path = _fake_openclaw(tmp_path)
+    connector = OpenClawConnector(executable=executable)
+    monkeypatch.setattr(runtime_module.os, "name", "nt")
+
+    _assert_code(
+        RuntimeConfigurationError,
+        "OPENCLAW_PLATFORM_UNSUPPORTED",
+        connector.probe,
+    )
+    assert _logs(log_path) == []
+
+
+_OBSERVATION_MUTATIONS: list[Mutation] = [
+    lambda value: value.update(extra="not-profile-owned"),
+    lambda value: value["message"].update(sender_id="other"),
+    lambda value: value["message"].update(media_type="text/plain"),
+    lambda value: value["message"].update(text="buy:other:1"),
+]
+
+
+@pytest.mark.parametrize("mutation", _OBSERVATION_MUTATIONS)
+def test_altered_profile_observation_fails_before_an_agent_turn(
+    tmp_path: Path, mutation: Mutation
+) -> None:
+    prepared, log_path = _prepared(tmp_path)
+    run = prepared.open_run("observation-contract")
+    observation = copy.deepcopy(MESSAGE_OBSERVATION)
+    mutation(observation)
+
+    _assert_code(
+        RuntimeExecutionError,
+        "OPENCLAW_OBSERVATION_INVALID",
+        lambda: run.turn(observation),
+    )
+    assert not [entry for entry in _logs(log_path) if entry["argv"][0] == "agent"]
+
+
+def test_fractional_duration_is_accepted_without_becoming_public_metadata(
+    tmp_path: Path,
+) -> None:
+    response = _success_envelope()
+    response["result"]["meta"]["durationMs"] = 42.5
+    prepared, _ = _prepared(tmp_path, responses=[response])
+
+    turn = _turn(prepared)
+
+    assert turn.intent == {"capabilities": ["sell"], "kind": "declare_capability"}
+    assert not hasattr(turn, "duration_ms")
+
+
+def test_single_compatibility_record_is_exact_not_capability_widened() -> None:
+    assert SUPPORTED_OPENCLAW.cli_version == VERSION
+    assert SUPPORTED_OPENCLAW.gateway_version == VERSION
+    assert SUPPORTED_OPENCLAW.rpc_version == VERSION
+    assert SUPPORTED_OPENCLAW.envelope_version == VERSION
+
+
+def test_missing_executable_is_an_uninspectable_probe(tmp_path: Path) -> None:
+    connector = OpenClawConnector(executable=tmp_path / "missing-openclaw")
+    assert connector.probe() is None
+
+
+@pytest.mark.parametrize("version", [VERSION_BANNER, f"OpenClaw {VERSION}"])
+def test_probe_accepts_the_characterized_version_banner(
+    tmp_path: Path,
+    version: str,
+) -> None:
+    executable, _, _ = _fake_openclaw(tmp_path, version=version)
+    connector = OpenClawConnector(executable=executable)
+
+    assert connector.probe() == RuntimeProbe(
+        "openclaw",
+        executable,
+        VERSION,
+        RuntimeDisplay("OpenClaw", "openclaw gateway status"),
+    )
+
+
+@pytest.mark.parametrize("gateway_mode", ["remote", None, "", "LOCAL", {"mode": "local"}])
+def test_probe_rejects_any_gateway_mode_other_than_exact_local_before_inventory(
+    tmp_path: Path,
+    gateway_mode: object,
+) -> None:
+    executable, _, log_path = _fake_openclaw(tmp_path, gateway_mode=gateway_mode)
+    connector = OpenClawConnector(executable=executable)
+
+    _assert_code(
+        RuntimeConfigurationError,
+        "OPENCLAW_REMOTE_DISPATCH",
+        connector.probe,
+    )
+
+    assert [entry["argv"] for entry in _logs(log_path)] == [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+    ]
+
+
+@pytest.mark.parametrize(
+    "config_env",
+    [
+        {"OPENCLAW_GATEWAY_URL": "wss://remote.example"},
+        {"vars": {"OPENCLAW_GATEWAY_URL": "wss://remote.example"}},
+        {"vars": {" OPENCLAW_GATEWAY_URL ": "wss://remote.example"}},
+        {"\ufeff OPENCLAW_GATEWAY_URL ": "wss://remote.example"},
+        {"vars": {"\ufeffOPENCLAW_GATEWAY_URL": "wss://remote.example"}},
+    ],
+)
+def test_probe_rejects_config_environment_gateway_url_before_inventory(
+    tmp_path: Path,
+    config_env: object,
+) -> None:
+    executable, _, log_path = _fake_openclaw(tmp_path, config_env=config_env)
+    connector = OpenClawConnector(executable=executable)
+
+    _assert_code(
+        RuntimeConfigurationError,
+        "OPENCLAW_REMOTE_DISPATCH",
+        connector.probe,
+    )
+
+    assert [entry["argv"] for entry in _logs(log_path)] == [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+        ["config", "get", "env", "--json"],
+    ]
+
+
+def test_probe_accepts_absent_or_unrelated_config_environment(tmp_path: Path) -> None:
+    config_environments = (
+        None,
+        {"vars": {"SAFE_KEY": "value"}},
+        {"OPENCLAW_GATEWAY_URL_BACKUP": "wss://unused.example"},
+        {"vars": {"MY_OPENCLAW_GATEWAY_URL": "wss://unused.example"}},
+    )
+    for index, config_env in enumerate(config_environments):
+        case = tmp_path / str(index)
+        case.mkdir()
+        executable, _, _ = _fake_openclaw(case, config_env=config_env)
+
+        assert OpenClawConnector(executable=executable).probe() is not None
+
+
+@pytest.mark.parametrize("config_env", [[], "invalid", 1])
+def test_probe_rejects_invalid_config_environment_before_inventory(
+    tmp_path: Path,
+    config_env: object,
+) -> None:
+    executable, _, log_path = _fake_openclaw(tmp_path, config_env=config_env)
+    connector = OpenClawConnector(executable=executable)
+
+    _assert_code(
+        RuntimeExecutionError,
+        "OPENCLAW_CONFIG_ENV_INVALID",
+        connector.probe,
+    )
+
+    assert [entry["argv"] for entry in _logs(log_path)] == [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+        ["config", "get", "env", "--json"],
+    ]
+
+
+def test_config_environment_values_are_not_retained_on_route_rejection(tmp_path: Path) -> None:
+    executable, _, _ = _fake_openclaw(
+        tmp_path,
+        config_env={"vars": {"OPENCLAW_GATEWAY_URL": "private-config-value-canary"}},
+    )
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        OpenClawConnector(executable=executable).probe()
+
+    assert caught.value.code == "OPENCLAW_REMOTE_DISPATCH"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert "private-config-value-canary" not in _traceback_locals(caught.value)
+
+
+def test_every_openclaw_child_neutralizes_gateway_url_overrides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENCLAW_GATEWAY_URL", "wss://remote-gateway-canary.example")
+    executable, _, log_path = _fake_openclaw(tmp_path, record_gateway_url=True)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+    prepared = connector.prepare(probe, target, None)
+
+    _turn(prepared)
+
+    records = _logs(log_path)
+    assert [record["argv"] for record in records] == [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+        ["config", "get", "env", "--json"],
+        ["agents", "list", "--json"],
+        ["gateway", "status", "--json", "--require-rpc"],
+        [
+            "agent",
+            "--agent",
+            "buyer",
+            "--session-key",
+            "town-run-001",
+            "--timeout",
+            "0",
+            "--message-file",
+            records[-1]["argv"][-2],
+            "--json",
+        ],
+    ]
+    assert {record["gateway_url"] for record in records} == {""}
+    assert "remote-gateway-canary" not in json.dumps(records)
+
+
+def test_prepare_accepts_the_characterized_gateway_status_shape(tmp_path: Path) -> None:
+    executable, _, _ = _fake_openclaw(tmp_path, gateway=_gateway())
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    prepared = connector.prepare(probe, target, None)
+
+    assert prepared.runtime_version == VERSION
+
+
+_OPTIONAL_GATEWAY_REMOVALS: list[Mutation] = [
+    lambda value: value.pop("pluginVersionDrift"),
+    lambda value: value.pop("port"),
+    lambda value: value.pop("extraServices"),
+    lambda value: value["cli"].pop("entrypoint"),
+    lambda value: value["config"]["cli"].pop("controlUi"),
+    lambda value: value["config"]["daemon"].pop("controlUi"),
+    lambda value: (value["rpc"].pop("auth"), value["rpc"].pop("server")),
+]
+
+
+@pytest.mark.parametrize("remove", _OPTIONAL_GATEWAY_REMOVALS)
+def test_prepare_allows_officially_optional_gateway_diagnostics(
+    tmp_path: Path,
+    remove: Mutation,
+) -> None:
+    gateway = _gateway()
+    remove(gateway)
+    executable, _, _ = _fake_openclaw(tmp_path, gateway=gateway)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    assert connector.prepare(probe, target, None).runtime_version == VERSION
+
+
+def test_prepare_requests_only_the_read_rpc_gateway_status(tmp_path: Path) -> None:
+    executable, _, log_path = _fake_openclaw(tmp_path)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    connector.prepare(probe, target, None)
+
+    assert _logs(log_path)[-1]["argv"] == [
+        "gateway",
+        "status",
+        "--json",
+        "--require-rpc",
+    ]
+
+
+def test_prepare_does_not_police_gateway_listener_exposure(tmp_path: Path) -> None:
+    gateway = _gateway()
+    gateway["gateway"].update(bindHost="0.0.0.0", bindMode="lan")
+    gateway["port"]["listeners"][0]["address"] = "TCP *:18789 (LISTEN)"
+    gateway["extraServices"].append({"label": "user-managed-service"})
+    executable, _, _ = _fake_openclaw(tmp_path, gateway=gateway)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    assert connector.prepare(probe, target, None).runtime_version == VERSION
+
+
+@pytest.mark.parametrize("route", ["probe", "rpc"])
+def test_prepare_still_requires_a_local_route_with_lan_listener_advisories(
+    tmp_path: Path,
+    route: str,
+) -> None:
+    gateway = _gateway()
+    gateway["gateway"].update(bindHost="0.0.0.0", bindMode="lan")
+    gateway["port"]["listeners"][0]["address"] = "TCP *:18789 (LISTEN)"
+    gateway["extraServices"].append({"label": "user-managed-service"})
+    if route == "probe":
+        gateway["gateway"]["probeUrl"] = "ws://192.0.2.10:18789"
+    else:
+        gateway["rpc"]["url"] = "ws://192.0.2.10:18789"
+    executable, _, _ = _fake_openclaw(tmp_path, gateway=gateway)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    _assert_code(
+        RuntimeConfigurationError,
+        "OPENCLAW_REMOTE_DISPATCH",
+        lambda: connector.prepare(probe, target, None),
+    )
+
+
+def test_prepare_allows_official_additive_gateway_diagnostics(tmp_path: Path) -> None:
+    gateway = _gateway()
+    gateway["config"].update(mismatch=False, issues=[], warnings=[])
+    gateway.update(issues=[], warnings=[])
+    executable, _, _ = _fake_openclaw(tmp_path, gateway=gateway)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    assert connector.prepare(probe, target, None).runtime_version == VERSION
+
+
+@pytest.mark.parametrize(
+    "version",
+    [VERSION, "2026.7.1", "2026.7.1-3", "openclaw 2026.7.1-2", "latest"],
+)
+def test_probe_accepts_only_the_exact_cli_version(tmp_path: Path, version: str) -> None:
+    executable, _, _ = _fake_openclaw(tmp_path, version=version)
+    connector = OpenClawConnector(executable=executable)
+
+    _assert_code(
+        RuntimeConfigurationError,
+        "OPENCLAW_VERSION_UNSUPPORTED",
+        connector.probe,
+    )
+
+
+def test_unsupported_valid_version_output_is_not_retained(tmp_path: Path) -> None:
+    executable, _, _ = _fake_openclaw(tmp_path, version="private-version-canary")
+    connector = OpenClawConnector(executable=executable)
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        connector.probe()
+
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert "private-version-canary" not in _traceback_locals(caught.value)
+
+
+def test_invalid_utf8_version_output_is_code_only(tmp_path: Path) -> None:
+    executable = tmp_path / "openclaw"
+    executable.write_text(
+        f"#!{os.fspath(Path(sys.executable))}\n"
+        "import sys\n"
+        "sys.stdout.buffer.write(b'private-version\\xff')\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o700)
+    connector = OpenClawConnector(executable=executable)
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        connector.probe()
+
+    assert caught.value.code == "OPENCLAW_VERSION_UNSUPPORTED"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert "private-version" not in repr(caught.value)
+    assert "private-version" not in _traceback_locals(caught.value)
+
+
+def test_probe_and_agents_use_only_the_frozen_read_only_argv(tmp_path: Path) -> None:
+    executable, _, log_path = _fake_openclaw(tmp_path)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe == RuntimeProbe(
+        "openclaw",
+        executable,
+        VERSION,
+        RuntimeDisplay("OpenClaw", "openclaw gateway status"),
+    )
+    assert probe is not None
+
+    targets = connector.list_targets(probe)
+
+    assert targets == (RuntimeTarget("buyer", "provider/model"),)
+    assert _logs(log_path) == [
+        {"argv": ["--version"], "town_env": []},
+        {"argv": ["config", "get", "gateway.mode", "--json"], "town_env": []},
+        {"argv": ["config", "get", "env", "--json"], "town_env": []},
+        {"argv": ["agents", "list", "--json"], "town_env": []},
+    ]
+    assert not hasattr(targets[0], "workspace")
+    assert not hasattr(targets[0], "agentDir")
+
+
+def test_read_only_preflight_has_bounded_general_deadlines(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable, _, _ = _fake_openclaw(tmp_path)
+    original = openclaw_runtime.run_bounded
+    calls: list[tuple[tuple[str, ...], float]] = []
+
+    def observe_deadline(argv: list[str], **kwargs: Any) -> Any:
+        calls.append((tuple(argv[1:]), kwargs["deadline_seconds"]))
+        return original(argv, **kwargs)
+
+    monkeypatch.setattr(openclaw_runtime, "run_bounded", observe_deadline)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+
+    target = connector.list_targets(probe)[0]
+    connector.prepare(probe, target, None)
+
+    assert calls == [
+        (("--version",), 5),
+        (("config", "get", "gateway.mode", "--json"), 5),
+        (("config", "get", "env", "--json"), 5),
+        (("agents", "list", "--json"), 30),
+        (("gateway", "status", "--json", "--require-rpc"), 5),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("agents", "error_type", "code"),
+    [
+        (
+            '[{"id":"buyer","id":"seller","model":"provider/model"}]',
+            RuntimeExecutionError,
+            "OPENCLAW_AGENTS_INVALID",
+        ),
+        ("not-json", RuntimeExecutionError, "OPENCLAW_AGENTS_INVALID"),
+        ([{"id": "buyer", "model": 7}], RuntimeExecutionError, "OPENCLAW_AGENTS_INVALID"),
+        (
+            [{"id": "buyer", "model": None}, {"id": "buyer", "model": None}],
+            RuntimeConfigurationError,
+            "TARGET_AMBIGUOUS",
+        ),
+        (
+            [{"id": "x" * 129, "model": None}],
+            RuntimeExecutionError,
+            "OPENCLAW_AGENTS_INVALID",
+        ),
+    ],
+)
+def test_agent_listing_rejects_duplicates_malformed_types_and_sizes(
+    tmp_path: Path,
+    agents: object,
+    error_type: type[Exception],
+    code: str,
+) -> None:
+    executable, _, _ = _fake_openclaw(tmp_path, agents=agents)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+
+    _assert_code(error_type, code, lambda: connector.list_targets(probe))
+
+
+def test_invalid_agent_listing_paths_are_not_retained(tmp_path: Path) -> None:
+    agents = [
+        {
+            "id": 7,
+            "model": "provider/model",
+            "workspace": "/private-agent-workspace-canary",
+        }
+    ]
+    executable, _, _ = _fake_openclaw(tmp_path, agents=agents)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+
+    with pytest.raises(RuntimeExecutionError) as caught:
+        connector.list_targets(probe)
+
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert "/private-agent-workspace-canary" not in _traceback_locals(caught.value)
+
+
+_GATEWAY_MUTATIONS: list[tuple[Mutation, str]] = [
+    (lambda value: value["cli"].update(version="2026.7.1-3"), "OPENCLAW_VERSION_MISMATCH"),
+    (lambda value: value["gateway"].update(version="2026.7.1"), "OPENCLAW_VERSION_MISMATCH"),
+    (lambda value: value["rpc"].update(version="unknown"), "OPENCLAW_VERSION_MISMATCH"),
+    (
+        lambda value: value["rpc"]["server"].update(version="unknown"),
+        "OPENCLAW_VERSION_MISMATCH",
+    ),
+    (
+        lambda value: value["config"]["daemon"].update(path="/synthetic/other.json"),
+        "OPENCLAW_CONFIG_DRIFT",
+    ),
+    (lambda value: value["config"].update(mismatch=True), "OPENCLAW_CONFIG_DRIFT"),
+    (lambda value: value["rpc"].update(ok=False), "OPENCLAW_RPC_UNHEALTHY"),
+    (
+        lambda value: value["gateway"].update(probeUrl="ws://192.0.2.10:18789"),
+        "OPENCLAW_REMOTE_DISPATCH",
+    ),
+    (
+        lambda value: value["rpc"].update(url="ws://example.test:18789"),
+        "OPENCLAW_REMOTE_DISPATCH",
+    ),
+]
+
+
+@pytest.mark.parametrize(("mutate", "code"), _GATEWAY_MUTATIONS)
+def test_prepare_requires_exact_versions_config_coherence_rpc_and_loopback(
+    tmp_path: Path, mutate: Mutation, code: str
+) -> None:
+    gateway = _gateway()
+    mutate(gateway)
+    executable, _, log_path = _fake_openclaw(tmp_path, gateway=gateway)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    _assert_code(
+        RuntimeConfigurationError,
+        code,
+        lambda: connector.prepare(probe, target, None),
+    )
+    assert [entry["argv"] for entry in _logs(log_path)] == [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+        ["config", "get", "env", "--json"],
+        ["agents", "list", "--json"],
+        ["gateway", "status", "--json", "--require-rpc"],
+    ]
+
+
+@pytest.mark.parametrize("gateway", ["not-json", '{"cliVersion":"x","cliVersion":"y"}', []])
+def test_prepare_rejects_malformed_or_duplicate_gateway_output(
+    tmp_path: Path, gateway: object
+) -> None:
+    executable, _, _ = _fake_openclaw(tmp_path, gateway=gateway)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    _assert_code(
+        RuntimeExecutionError,
+        "OPENCLAW_GATEWAY_INVALID",
+        lambda: connector.prepare(probe, target, None),
+    )
+
+
+def test_prepared_openclaw_owns_safe_display_label_and_issue_policy(tmp_path: Path) -> None:
+    prepared, _ = _prepared(tmp_path)
+
+    assert prepared.runtime_id == "openclaw"
+    assert prepared.display == RuntimeDisplay("OpenClaw", "openclaw gateway status")
+    assert prepared.target_label == "openclaw:buyer"
+    assert OpenClawConnector.issue_policy is prepared.issue_policy
+    assert prepared.issue_policy.code_for(
+        RuntimeIncompleteError("OPENCLAW_GATEWAY_UNAVAILABLE")
+    ) == ("OPENCLAW_GATEWAY_UNAVAILABLE")
+    assert prepared.issue_policy.code_for(RuntimeExecutionError("OPENCLAW_GATEWAY_INVALID")) == (
+        "OPENCLAW_GATEWAY_INVALID"
+    )
+    assert prepared.issue_policy.code_for(RuntimeExecutionError("OPENCLAW_TIMEOUT")) == (
+        "OPENCLAW_TIMEOUT"
+    )
+    assert prepared.issue_policy.code_for(RuntimeExecutionError("UNKNOWN_OPENCLAW_CODE")) == (
+        "RUNTIME_EXECUTION_FAILED"
+    )
+
+
+def test_gateway_structural_output_failure_is_execution_not_user_configuration(
+    tmp_path: Path,
+) -> None:
+    gateway = _gateway()
+    del gateway["gateway"]
+    executable, _, _ = _fake_openclaw(tmp_path, gateway=gateway)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    _assert_code(
+        RuntimeExecutionError,
+        "OPENCLAW_GATEWAY_INVALID",
+        lambda: connector.prepare(probe, target, None),
+    )
+
+
+def test_invalid_gateway_paths_are_not_retained(tmp_path: Path) -> None:
+    gateway = _gateway()
+    gateway["gateway"]["version"] = "invalid"
+    gateway["config"]["cli"]["path"] = "/private-config-canary"
+    gateway["config"]["daemon"]["path"] = "/private-config-canary"
+    executable, _, _ = _fake_openclaw(tmp_path, gateway=gateway)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        connector.prepare(probe, target, None)
+
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert "/private-config-canary" not in _traceback_locals(caught.value)
+
+
+def test_nonfinite_json_is_malformed_not_a_version_mismatch(tmp_path: Path) -> None:
+    executable, _, _ = _fake_openclaw(tmp_path, gateway='{"cliVersion":NaN}')
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    _assert_code(
+        RuntimeExecutionError,
+        "OPENCLAW_GATEWAY_INVALID",
+        lambda: connector.prepare(probe, target, None),
+    )
+
+
+def test_oversized_json_integer_is_rejected_before_gateway_validation(tmp_path: Path) -> None:
+    gateway = _gateway()
+    gateway["unknownCounter"] = 2**80
+    executable, _, _ = _fake_openclaw(tmp_path, gateway=gateway)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    _assert_code(
+        RuntimeExecutionError,
+        "OPENCLAW_GATEWAY_INVALID",
+        lambda: connector.prepare(probe, target, None),
+    )
+
+
+def test_empty_model_override_does_not_fall_back_to_configured_model(tmp_path: Path) -> None:
+    executable, _, log_path = _fake_openclaw(tmp_path)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+
+    _assert_code(
+        RuntimeConfigurationError,
+        "OPENCLAW_MODEL_INVALID",
+        lambda: connector.prepare(probe, target, ""),
+    )
+    assert [entry["argv"] for entry in _logs(log_path)] == [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+        ["config", "get", "env", "--json"],
+        ["agents", "list", "--json"],
+    ]
+
+
+def test_prepare_rejects_unknown_target_without_running_gateway(tmp_path: Path) -> None:
+    executable, _, log_path = _fake_openclaw(tmp_path)
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+    assert probe is not None
+    connector.list_targets(probe)
+
+    _assert_code(
+        RuntimeConfigurationError,
+        "TARGET_NOT_FOUND",
+        lambda: connector.prepare(probe, RuntimeTarget("unknown", None), None),
+    )
+    assert [entry["argv"] for entry in _logs(log_path)] == [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+        ["config", "get", "env", "--json"],
+        ["agents", "list", "--json"],
+    ]
+
+
+def test_turn_uses_exact_argv_private_prompt_and_no_town_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TOWN_BEARER", "private-bearer-canary")
+    prepared, log_path = _prepared(tmp_path)
+    turn = _turn(prepared)
+    agent_log = _logs(log_path)[-1]
+    message_path = Path(agent_log["message_path"])
+
+    assert agent_log["argv"][:6] == [
+        "agent",
+        "--agent",
+        "buyer",
+        "--session-key",
+        "town-run-001",
+        "--timeout",
+    ]
+    assert agent_log["argv"][6] == "0"
+    assert agent_log["argv"][7] == "--message-file"
+    assert agent_log["argv"][8] == agent_log["message_path"]
+    assert agent_log["argv"][9:] == ["--json"]
+    assert not ({"--deliver", "--local", "--channel"} & set(agent_log["argv"]))
+    assert agent_log["message_mode"] == 0o600
+    assert agent_log["stdin_closed"] is True
+    assert agent_log["town_env"] == []
+    assert "private-bearer-canary" not in json.dumps(agent_log)
+    assert not message_path.exists()
+    assert turn.intent == {"capabilities": ["sell"], "kind": "declare_capability"}
+    assert turn.provider == "provider"
+    assert turn.model == "model"
+    assert turn.activity == "unknown"
+    assert "town-run-001" not in turn.session_ref_digest
+
+
+def test_every_openclaw_child_explicitly_requests_only_its_connector_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import nest_core.agent_test.openclaw_runtime as runtime_module
+
+    real_run_bounded = runtime_module.run_bounded
+    policies: list[frozenset[str]] = []
+    environments: list[dict[str, str]] = []
+
+    def capture_policy(argv: list[str], **kwargs: Any) -> Any:
+        policies.append(kwargs["allowed_environment_keys"])
+        environments.append(kwargs["environment"])
+        return real_run_bounded(argv, **kwargs)
+
+    monkeypatch.setattr(runtime_module, "run_bounded", capture_policy)
+    prepared, _ = _prepared(tmp_path)
+    _turn(prepared)
+
+    expected_policy = frozenset(
+        {"OPENCLAW_CONFIG_PATH", "OPENCLAW_GATEWAY_URL", "OPENCLAW_STATE_DIR"}
+    )
+    assert policies == [expected_policy] * 6
+    assert environments == [{"OPENCLAW_GATEWAY_URL": ""}] * 6
+
+
+def test_message_file_setup_failure_closes_fd_removes_path_and_is_code_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import nest_core.agent_test.openclaw_runtime as runtime_module
+
+    prepared, log_path = _prepared(tmp_path)
+    run = prepared.open_run("file-failure")
+    created: dict[str, object] = {}
+    real_mkstemp = runtime_module.tempfile.mkstemp
+
+    def tracked_mkstemp(*args: Any, **kwargs: Any) -> tuple[int, str]:
+        descriptor, path = cast("tuple[int, str]", real_mkstemp(*args, **kwargs))
+        created.update(descriptor=descriptor, path=path)
+        return descriptor, path
+
+    def fail_fchmod(_descriptor: int, _mode: int) -> None:
+        raise OSError
+
+    monkeypatch.setattr(runtime_module.tempfile, "mkstemp", tracked_mkstemp)
+    monkeypatch.setattr(runtime_module.os, "fchmod", fail_fchmod)
+
+    with pytest.raises(RuntimeExecutionError) as caught:
+        run.turn(START_OBSERVATION)
+
+    assert caught.value.code == "OPENCLAW_MESSAGE_FILE_FAILED"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert not Path(cast("str", created["path"])).exists()
+    assert cast("str", created["path"]) not in _traceback_locals(caught.value)
+    with pytest.raises(OSError):
+        os.fstat(cast("int", created["descriptor"]))
+    assert not [entry for entry in _logs(log_path) if entry["argv"][0] == "agent"]
+
+
+def test_invalid_observation_retains_no_prompt_or_parser_context(tmp_path: Path) -> None:
+    prepared, _ = _prepared(tmp_path)
+    run = prepared.open_run("invalid-observation")
+
+    class Unserializable:
+        def __repr__(self) -> str:
+            return "raw-observation-canary"
+
+    observation = {
+        "privatePrompt": "raw-observation-canary",
+        "value": Unserializable(),
+    }
+    with pytest.raises(RuntimeExecutionError) as caught:
+        run.turn(observation)
+
+    assert caught.value.code == "OPENCLAW_OBSERVATION_INVALID"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert "raw-observation-canary" not in _traceback_locals(caught.value)
+
+
+def test_hostile_mapping_failure_retains_no_observation_or_exception_data(tmp_path: Path) -> None:
+    prepared, _ = _prepared(tmp_path)
+    run = prepared.open_run("hostile-observation")
+
+    class HostileMapping(Mapping[str, object]):
+        def __getitem__(self, _key: str) -> object:
+            raise KeyError
+
+        def __iter__(self) -> Any:
+            raise RuntimeError("hostile-observation-canary")
+
+        def __len__(self) -> int:
+            return 1
+
+    with pytest.raises(RuntimeExecutionError) as caught:
+        run.turn(HostileMapping())
+
+    assert caught.value.code == "OPENCLAW_OBSERVATION_INVALID"
+    assert str(caught.value) == "OPENCLAW_OBSERVATION_INVALID"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert "hostile-observation-canary" not in _traceback_locals(caught.value)
+
+
+def test_failed_turn_traceback_retains_no_prompt_envelope_or_message_path(tmp_path: Path) -> None:
+    response = _success_envelope()
+    response["privateEnvelope"] = "raw-envelope-canary"
+    prepared, log_path = _prepared(tmp_path, responses=[response])
+    run = prepared.open_run("traceback")
+
+    with pytest.raises(RuntimeExecutionError) as caught:
+        run.turn(START_OBSERVATION)
+
+    retained = _traceback_locals(caught.value)
+    message_path = _logs(log_path)[-1]["message_path"]
+    assert START_PROMPT not in retained
+    assert "raw-envelope-canary" not in retained
+    assert message_path not in retained
+
+
+def test_message_file_is_removed_when_turn_is_cancelled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import nest_core.agent_test.openclaw_runtime as runtime_module
+
+    prepared, _ = _prepared(tmp_path)
+    run = prepared.open_run("cancelled")
+    created: dict[str, str] = {}
+    real_mkstemp = runtime_module.tempfile.mkstemp
+
+    def tracked_mkstemp(*args: Any, **kwargs: Any) -> tuple[int, str]:
+        descriptor, path = cast("tuple[int, str]", real_mkstemp(*args, **kwargs))
+        created["path"] = path
+        return descriptor, path
+
+    def cancel(*_args: Any, **_kwargs: Any) -> Any:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(runtime_module.tempfile, "mkstemp", tracked_mkstemp)
+    monkeypatch.setattr(runtime_module, "run_bounded", cancel)
+
+    with pytest.raises(KeyboardInterrupt):
+        run.turn(START_OBSERVATION)
+
+    assert not Path(created["path"]).exists()
+
+
+def test_unlink_failure_leaves_only_an_erased_message_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import nest_core.agent_test.openclaw_runtime as runtime_module
+
+    prepared, _ = _prepared(tmp_path)
+    run = prepared.open_run("unlink-failure")
+    created: dict[str, str] = {}
+    real_mkstemp = runtime_module.tempfile.mkstemp
+    real_unlink = runtime_module.Path.unlink
+
+    def tracked_mkstemp(*args: Any, **kwargs: Any) -> tuple[int, str]:
+        descriptor, path = cast("tuple[int, str]", real_mkstemp(*args, **kwargs))
+        created["path"] = path
+        return descriptor, path
+
+    def fail_private_unlink(path: Path, *, missing_ok: bool = False) -> None:
+        if os.fspath(path) == created.get("path"):
+            raise OSError
+        real_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(runtime_module.tempfile, "mkstemp", tracked_mkstemp)
+    monkeypatch.setattr(runtime_module.Path, "unlink", fail_private_unlink)
+
+    try:
+        with pytest.raises(RuntimeExecutionError) as caught:
+            run.turn(START_OBSERVATION)
+
+        message_path = Path(created["path"])
+        assert caught.value.code == "OPENCLAW_MESSAGE_FILE_CLEANUP_FAILED"
+        assert caught.value.__cause__ is None
+        assert caught.value.__context__ is None
+        assert message_path.exists()
+        assert message_path.read_bytes() == b""
+        assert START_PROMPT not in _traceback_locals(caught.value)
+    finally:
+        if "path" in created:
+            real_unlink(Path(created["path"]), missing_ok=True)
+
+
+def test_setup_cancellation_closes_fd_and_removes_message_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import nest_core.agent_test.openclaw_runtime as runtime_module
+
+    prepared, _ = _prepared(tmp_path)
+    run = prepared.open_run("setup-cancelled")
+    created: dict[str, object] = {}
+    real_mkstemp = runtime_module.tempfile.mkstemp
+
+    def tracked_mkstemp(*args: Any, **kwargs: Any) -> tuple[int, str]:
+        descriptor, path = cast("tuple[int, str]", real_mkstemp(*args, **kwargs))
+        created.update(descriptor=descriptor, path=path)
+        return descriptor, path
+
+    def cancel_fchmod(_descriptor: int, _mode: int) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(runtime_module.tempfile, "mkstemp", tracked_mkstemp)
+    monkeypatch.setattr(runtime_module.os, "fchmod", cancel_fchmod)
+
+    with pytest.raises(KeyboardInterrupt):
+        run.turn(START_OBSERVATION)
+
+    assert not Path(cast("str", created["path"])).exists()
+    with pytest.raises(OSError):
+        os.fstat(cast("int", created["descriptor"]))
+
+
+def test_parser_cancellation_retains_no_raw_envelope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import nest_core.agent_test.openclaw_runtime as runtime_module
+
+    response = _success_envelope()
+    response["privateEnvelope"] = "parser-cancellation-envelope-canary"
+    prepared, _ = _prepared(tmp_path, responses=[response])
+    run = prepared.open_run("parser-cancelled")
+
+    def cancel_parser(*_args: Any, **_kwargs: Any) -> Any:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(runtime_module, "_envelope_turn", cancel_parser)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        run.turn(START_OBSERVATION)
+
+    assert "parser-cancellation-envelope-canary" not in _traceback_locals(caught.value)
+
+
+def test_optional_model_override_is_the_only_extra_agent_flag(tmp_path: Path) -> None:
+    prepared, log_path = _prepared(tmp_path, model_override="provider/model")
+
+    _turn(prepared)
+
+    argv = _logs(log_path)[-1]["argv"]
+    assert argv[-3:] == ["--json", "--model", "provider/model"]
+
+
+def test_two_turns_share_one_fresh_session_and_close_does_not_delete_transcript(
+    tmp_path: Path,
+) -> None:
+    first = _success_envelope()
+    second = _success_envelope({"kind": "none"})
+    prepared, log_path = _prepared(tmp_path, responses=[first, second])
+    run = prepared.open_run("fresh-run")
+
+    run.turn(START_OBSERVATION)
+    turn = run.turn(MESSAGE_OBSERVATION)
+    run.close()
+
+    agent_argv = [entry["argv"] for entry in _logs(log_path) if entry["argv"][0] == "agent"]
+    assert [argv[4] for argv in agent_argv] == ["town-fresh-run", "town-fresh-run"]
+    assert turn.intent == {"kind": "none"}
+    assert not any("delete" in argument for argv in agent_argv for argument in argv)
+
+
+def test_second_turn_requires_the_exact_same_reported_session_id(tmp_path: Path) -> None:
+    first = _success_envelope()
+    second = _success_envelope()
+    second["result"]["meta"]["agentMeta"]["sessionId"] = "session-synthetic-002"
+    prepared, log_path = _prepared(tmp_path, responses=[first, second])
+    run = prepared.open_run("session-lineage")
+
+    run.turn(START_OBSERVATION)
+    _assert_code(
+        RuntimeExecutionError,
+        "OPENCLAW_SESSION_MISMATCH",
+        lambda: run.turn(MESSAGE_OBSERVATION),
+    )
+    _assert_code(
+        RuntimeExecutionError,
+        "OPENCLAW_RUN_CLOSED",
+        lambda: run.turn(MESSAGE_OBSERVATION),
+    )
+    assert len([entry for entry in _logs(log_path) if entry["argv"][0] == "agent"]) == 2
+
+
+_ENVELOPE_MUTATIONS: list[tuple[Mutation, type[Exception], str]] = [
+    (
+        lambda value: value["result"]["meta"].update(toolSummary=[]),
+        RuntimeIncompleteError,
+        "OPENCLAW_ACTIVITY_REPORTED",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(pendingToolCalls=[]),
+        RuntimeIncompleteError,
+        "OPENCLAW_ACTIVITY_REPORTED",
+    ),
+    (
+        lambda value: value["result"].update(delivery={"ok": True}),
+        RuntimeIncompleteError,
+        "OPENCLAW_ACTIVITY_REPORTED",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(automation={"kind": "cron"}),
+        RuntimeIncompleteError,
+        "OPENCLAW_ACTIVITY_REPORTED",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(spawnedSession={"id": "synthetic"}),
+        RuntimeIncompleteError,
+        "OPENCLAW_ACTIVITY_REPORTED",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(didSendViaMessagingTool=True),
+        RuntimeIncompleteError,
+        "OPENCLAW_ACTIVITY_REPORTED",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(acceptedSessionSpawns=1),
+        RuntimeIncompleteError,
+        "OPENCLAW_ACTIVITY_REPORTED",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(successfulCronAdds=1),
+        RuntimeIncompleteError,
+        "OPENCLAW_ACTIVITY_REPORTED",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(error="synthetic"),
+        RuntimeIncompleteError,
+        "OPENCLAW_RUN_ERROR",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(failureSignal="synthetic"),
+        RuntimeIncompleteError,
+        "OPENCLAW_RUN_ERROR",
+    ),
+    (
+        lambda value: value["result"]["meta"]["executionTrace"].update(toolCalls=[]),
+        RuntimeIncompleteError,
+        "OPENCLAW_ACTIVITY_REPORTED",
+    ),
+    (
+        lambda value: value["result"]["meta"]["executionTrace"].update(fallbackUsed=True),
+        RuntimeIncompleteError,
+        "OPENCLAW_FALLBACK_REPORTED",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(fallback=True),
+        RuntimeIncompleteError,
+        "OPENCLAW_FALLBACK_REPORTED",
+    ),
+    (
+        lambda value: value["result"]["meta"]["agentMeta"].update(modelFallback="x"),
+        RuntimeIncompleteError,
+        "OPENCLAW_FALLBACK_REPORTED",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(aborted=True),
+        RuntimeIncompleteError,
+        "OPENCLAW_ABORTED",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(replayInvalid=True),
+        RuntimeIncompleteError,
+        "OPENCLAW_REPLAY_INVALID",
+    ),
+    (lambda value: value.update(status="error"), RuntimeIncompleteError, "OPENCLAW_RUN_ERROR"),
+    (
+        lambda value: value["result"]["meta"].update(transport={}),
+        RuntimeIncompleteError,
+        "OPENCLAW_TRANSPORT_AMBIGUOUS",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(finalAssistantVisibleText="wrong"),
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(finalAssistantRawText="wrong"),
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+    ),
+    (
+        lambda value: value["result"]["payloads"][0].update(mediaUrl="https://example.invalid"),
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+    ),
+    (
+        lambda value: value["result"]["meta"]["agentMeta"].update(sessionKey="town-other"),
+        RuntimeExecutionError,
+        "OPENCLAW_SESSION_MISMATCH",
+    ),
+    (
+        lambda value: value["result"]["meta"]["agentMeta"].update(provider="other"),
+        RuntimeExecutionError,
+        "OPENCLAW_MODEL_MISMATCH",
+    ),
+    (
+        lambda value: value["result"]["meta"]["agentMeta"].update(model="other"),
+        RuntimeExecutionError,
+        "OPENCLAW_MODEL_MISMATCH",
+    ),
+    (
+        lambda value: value["result"]["meta"]["executionTrace"].update(winnerModel="other"),
+        RuntimeExecutionError,
+        "OPENCLAW_MODEL_MISMATCH",
+    ),
+    (
+        lambda value: value["result"]["meta"]["executionTrace"].update(attempts=[]),
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+    ),
+    (
+        lambda value: value["result"]["meta"]["executionTrace"].update(runner="other"),
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+    ),
+    (
+        lambda value: value["result"]["meta"]["agentMeta"].update(agentHarnessId="not safe"),
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(durationMs=False),
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(durationMs=-1),
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(durationMs=math.inf),
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+    ),
+    (
+        lambda value: value["result"]["meta"].update(unknownMeta="synthetic"),
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+    ),
+    (
+        lambda value: value["result"]["meta"]["agentMeta"].update(unknownAgentMeta="synthetic"),
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+    ),
+    (
+        lambda value: value["result"]["meta"]["executionTrace"].update(unknownTrace="synthetic"),
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+    ),
+]
+
+
+@pytest.mark.parametrize(("mutation", "error_type", "code"), _ENVELOPE_MUTATIONS)
+def test_envelope_rejects_activity_fallback_abort_replay_transport_and_lineage(
+    tmp_path: Path, mutation: Mutation, error_type: type[Exception], code: str
+) -> None:
+    response = _success_envelope()
+    mutation(response)
+    prepared, _ = _prepared(tmp_path, responses=[response])
+
+    _assert_code(error_type, code, lambda: _turn(prepared))
+
+
+@pytest.mark.parametrize(
+    ("text", "code"),
+    [
+        ('{ "kind": "none" }', "OPENCLAW_INTENT_NONCANONICAL"),
+        ('```json\n{"kind":"none"}\n```', "OPENCLAW_INTENT_INVALID"),
+        ('{"command":"id","kind":"shell"}', "OPENCLAW_INTENT_FORBIDDEN"),
+        ('{"extra":true,"kind":"none"}', "OPENCLAW_INTENT_FORBIDDEN"),
+        (
+            '{"kind":"send_to_sender","media_type":"text/html","text":"x"}',
+            "OPENCLAW_INTENT_FORBIDDEN",
+        ),
+        (
+            '{"kind":"send_to_sender","media_type":"text/plain; charset=utf-8","text":"x"}',
+            "OPENCLAW_MODEL_MISMATCH",
+        ),
+        ("not-json", "OPENCLAW_INTENT_INVALID"),
+    ],
+)
+def test_intent_must_be_canonical_bounded_and_forbidden_actions_stay_closed(
+    tmp_path: Path, text: str, code: str
+) -> None:
+    response = _success_envelope()
+    response["result"]["payloads"][0]["text"] = text
+    response["result"]["meta"]["finalAssistantVisibleText"] = text
+    response["result"]["meta"]["finalAssistantRawText"] = text
+    if code == "OPENCLAW_MODEL_MISMATCH":
+        response["result"]["meta"]["agentMeta"]["model"] = "different"
+    prepared, _ = _prepared(tmp_path, responses=[response])
+
+    _assert_code(RuntimeExecutionError, code, lambda: _turn(prepared))
+
+
+def test_semantic_none_remains_evaluator_input_not_transport_failure(tmp_path: Path) -> None:
+    response = _success_envelope()
+    text = '{"kind":"none"}'
+    response["result"]["payloads"][0]["text"] = text
+    response["result"]["meta"]["finalAssistantVisibleText"] = text
+    response["result"]["meta"]["finalAssistantRawText"] = text
+    prepared, _ = _prepared(tmp_path, responses=[response])
+
+    turn = _turn(prepared)
+
+    assert turn.intent == {"kind": "none"}
+
+
+@pytest.mark.parametrize(
+    ("response", "code"),
+    [
+        ("not-json", "OPENCLAW_ENVELOPE_INVALID"),
+        ('{"runId":"one","runId":"two"}', "OPENCLAW_ENVELOPE_INVALID"),
+        ("", "OPENCLAW_ENVELOPE_INVALID"),
+        ({"fake": "overflow"}, "OPENCLAW_OUTPUT_LIMIT"),
+        ({"fake": "timeout"}, "OPENCLAW_TIMEOUT"),
+        ({"fake": "transport_loss"}, "OPENCLAW_TRANSPORT_LOSS"),
+    ],
+)
+def test_failed_turn_starts_exactly_one_child_and_never_retries_or_continues(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    response: object,
+    code: str,
+) -> None:
+    import nest_core.agent_test.openclaw_runtime as runtime_module
+
+    if response == {"fake": "timeout"}:
+        monkeypatch.setattr(runtime_module, "TURN_DEADLINE_SECONDS", 0.05)
+        monkeypatch.setattr(runtime_module, "TERMINATE_GRACE_SECONDS", 0.05)
+        monkeypatch.setattr(runtime_module, "KILL_REAP_SECONDS", 0.2)
+    prepared, _ = _prepared(tmp_path, responses=[response])
+    real_run_bounded = runtime_module.run_bounded
+    message_paths: list[Path] = []
+
+    def counted_run_bounded(argv: list[str], **kwargs: Any) -> Any:
+        if len(argv) > 1 and argv[1] == "agent":
+            message_paths.append(Path(argv[argv.index("--message-file") + 1]))
+        return real_run_bounded(argv, **kwargs)
+
+    monkeypatch.setattr(runtime_module, "run_bounded", counted_run_bounded)
+    run = prepared.open_run("one-shot")
+    _assert_code(RuntimeExecutionError, code, lambda: run.turn(START_OBSERVATION))
+    _assert_code(
+        RuntimeExecutionError,
+        "OPENCLAW_RUN_CLOSED",
+        lambda: run.turn(START_OBSERVATION),
+    )
+
+    assert len(message_paths) == 1
+    assert not message_paths[0].exists()
+
+
+def test_invalid_child_json_is_code_only_without_a_raw_parser_cause(tmp_path: Path) -> None:
+    prepared, _ = _prepared(tmp_path, responses=["private-child-output-not-json"])
+    run = prepared.open_run("sanitized")
+
+    with pytest.raises(RuntimeExecutionError) as caught:
+        run.turn(START_OBSERVATION)
+
+    assert caught.value.code == "OPENCLAW_ENVELOPE_INVALID"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert "private-child-output" not in repr(caught.value)
+    assert "private-child-output" not in _traceback_locals(caught.value)
+
+
+def test_invalid_intent_json_is_code_only_without_a_raw_parser_cause(tmp_path: Path) -> None:
+    response = _success_envelope()
+    text = "private-intent-output-not-json"
+    response["result"]["payloads"][0]["text"] = text
+    response["result"]["meta"]["finalAssistantVisibleText"] = text
+    response["result"]["meta"]["finalAssistantRawText"] = text
+    prepared, _ = _prepared(tmp_path, responses=[response])
+
+    with pytest.raises(RuntimeExecutionError) as caught:
+        _turn(prepared)
+
+    assert caught.value.code == "OPENCLAW_INTENT_INVALID"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert "private-intent-output" not in repr(caught.value)
+    assert "private-intent-output" not in _traceback_locals(caught.value)
+
+
+def test_duplicate_keys_and_oversized_nested_values_are_rejected(tmp_path: Path) -> None:
+    oversized = copy.deepcopy(_success_envelope())
+    oversized["summary"] = "x" * 1025
+    prepared, _ = _prepared(tmp_path, responses=[oversized])
+
+    _assert_code(
+        RuntimeExecutionError,
+        "OPENCLAW_ENVELOPE_INVALID",
+        lambda: _turn(prepared),
+    )

--- a/packages/nest-core/tests/agent_test/test_openclaw_runtime.py
+++ b/packages/nest-core/tests/agent_test/test_openclaw_runtime.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Contract and adversarial tests for the exact OpenClaw runtime connector."""
+"""Contract and adversarial tests for the version-coherent OpenClaw runtime connector."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ from typing import Any, cast
 
 import nest_core.agent_test.openclaw_runtime as openclaw_runtime
 import pytest
-from nest_core.agent_test.openclaw_runtime import SUPPORTED_OPENCLAW, OpenClawConnector
+from nest_core.agent_test.openclaw_runtime import OpenClawConnector
 from nest_core.agent_test.runtime_connectors import (
     RuntimeConfigurationError,
     RuntimeDisplay,
@@ -83,10 +83,10 @@ def _success_envelope(intent: dict[str, object] | None = None) -> dict[str, Any]
     return envelope
 
 
-def _gateway() -> dict[str, Any]:
+def _gateway(*, version: str = VERSION) -> dict[str, Any]:
     """Sanitized v2026.7.1-2 status shape observed from the real Gateway CLI."""
     return {
-        "cli": {"entrypoint": "/synthetic/openclaw.mjs", "version": VERSION},
+        "cli": {"entrypoint": "/synthetic/openclaw.mjs", "version": version},
         "config": {
             "cli": {
                 "controlUi": {},
@@ -110,10 +110,10 @@ def _gateway() -> dict[str, Any]:
             "portSource": "config",
             "probeNote": "synthetic",
             "probeUrl": "ws://127.0.0.1:18789",
-            "version": VERSION,
+            "version": version,
         },
         "logFile": "/synthetic/openclaw.log",
-        "pluginVersionDrift": {"drifts": [], "gatewayVersion": VERSION},
+        "pluginVersionDrift": {"drifts": [], "gatewayVersion": version},
         "port": {
             "hints": [],
             "listeners": [
@@ -132,9 +132,9 @@ def _gateway() -> dict[str, Any]:
             "capability": "operator",
             "kind": "read",
             "ok": True,
-            "server": {"connId": "synthetic", "version": VERSION},
+            "server": {"connId": "synthetic", "version": version},
             "url": "ws://127.0.0.1:18789",
-            "version": VERSION,
+            "version": version,
         },
         "service": {
             "command": [],
@@ -513,13 +513,6 @@ def test_fractional_duration_is_accepted_without_becoming_public_metadata(
     assert not hasattr(turn, "duration_ms")
 
 
-def test_single_compatibility_record_is_exact_not_capability_widened() -> None:
-    assert SUPPORTED_OPENCLAW.cli_version == VERSION
-    assert SUPPORTED_OPENCLAW.gateway_version == VERSION
-    assert SUPPORTED_OPENCLAW.rpc_version == VERSION
-    assert SUPPORTED_OPENCLAW.envelope_version == VERSION
-
-
 def test_missing_executable_is_an_uninspectable_probe(tmp_path: Path) -> None:
     connector = OpenClawConnector(executable=tmp_path / "missing-openclaw")
     assert connector.probe() is None
@@ -539,6 +532,101 @@ def test_probe_accepts_the_characterized_version_banner(
         VERSION,
         RuntimeDisplay("OpenClaw", "openclaw gateway status"),
     )
+
+
+@pytest.mark.parametrize(
+    ("banner", "detected_version"),
+    [
+        ("2032.11.4-rc.2+build_7", "2032.11.4-rc.2+build_7"),
+        ("OpenClaw 2032.11.4-rc.2+build_7 (abcdef0)", "2032.11.4-rc.2+build_7"),
+    ],
+)
+def test_coherent_bare_and_branded_versions_prepare_run_and_record_detected_version(
+    tmp_path: Path,
+    banner: str,
+    detected_version: str,
+) -> None:
+    executable, _, _ = _fake_openclaw(
+        tmp_path,
+        version=banner,
+        gateway=_gateway(version=detected_version),
+    )
+    connector = OpenClawConnector(executable=executable)
+
+    probe = connector.probe()
+
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+    prepared = connector.prepare(probe, target, None)
+    turn = _turn(prepared)
+
+    assert probe.version == detected_version
+    assert prepared.runtime_version == detected_version
+    assert turn.intent == {"capabilities": ["sell"], "kind": "declare_capability"}
+
+
+@pytest.mark.parametrize(
+    "banner",
+    [
+        "",
+        "OpenClaw",
+        "OpenClaw 2032.11.4 unexpected",
+        "OpenClaw " + "x" * 129,
+    ],
+)
+def test_malformed_version_banners_fail_before_agent_inventory(
+    tmp_path: Path,
+    banner: str,
+) -> None:
+    executable, _, log_path = _fake_openclaw(tmp_path, version=banner)
+    connector = OpenClawConnector(executable=executable)
+
+    _assert_code(
+        RuntimeConfigurationError,
+        "OPENCLAW_VERSION_UNSUPPORTED",
+        connector.probe,
+    )
+
+    assert [entry["argv"] for entry in _logs(log_path)] == [["--version"]]
+
+
+_MIXED_VERSION_MUTATIONS: list[Mutation] = [
+    lambda gateway: gateway["cli"].update(version="2032.11.4-rc.3"),
+    lambda gateway: gateway["gateway"].update(version="2032.11.4-rc.3"),
+    lambda gateway: gateway["rpc"].update(version="2032.11.4-rc.3"),
+    lambda gateway: gateway["rpc"]["server"].update(version="2032.11.4-rc.3"),
+]
+
+
+@pytest.mark.parametrize("mutate", _MIXED_VERSION_MUTATIONS)
+def test_mixed_component_versions_are_rejected_against_detected_cli_version(
+    tmp_path: Path,
+    mutate: Mutation,
+) -> None:
+    detected_version = "2032.11.4-rc.2"
+    gateway = _gateway(version=detected_version)
+    mutate(gateway)
+    executable, _, log_path = _fake_openclaw(
+        tmp_path,
+        version=f"OpenClaw {detected_version}",
+        gateway=gateway,
+    )
+    connector = OpenClawConnector(executable=executable)
+    probe = connector.probe()
+
+    assert probe is not None
+    target = connector.list_targets(probe)[0]
+    _assert_code(
+        RuntimeConfigurationError,
+        "OPENCLAW_VERSION_MISMATCH",
+        lambda: connector.prepare(probe, target, None),
+    )
+    assert [entry["argv"] for entry in _logs(log_path)][-1] == [
+        "gateway",
+        "status",
+        "--json",
+        "--require-rpc",
+    ]
 
 
 @pytest.mark.parametrize("gateway_mode", ["remote", None, "", "LOCAL", {"mode": "local"}])
@@ -789,33 +877,6 @@ def test_prepare_allows_official_additive_gateway_diagnostics(tmp_path: Path) ->
     assert connector.prepare(probe, target, None).runtime_version == VERSION
 
 
-@pytest.mark.parametrize(
-    "version",
-    [VERSION, "2026.7.1", "2026.7.1-3", "openclaw 2026.7.1-2", "latest"],
-)
-def test_probe_accepts_only_the_exact_cli_version(tmp_path: Path, version: str) -> None:
-    executable, _, _ = _fake_openclaw(tmp_path, version=version)
-    connector = OpenClawConnector(executable=executable)
-
-    _assert_code(
-        RuntimeConfigurationError,
-        "OPENCLAW_VERSION_UNSUPPORTED",
-        connector.probe,
-    )
-
-
-def test_unsupported_valid_version_output_is_not_retained(tmp_path: Path) -> None:
-    executable, _, _ = _fake_openclaw(tmp_path, version="private-version-canary")
-    connector = OpenClawConnector(executable=executable)
-
-    with pytest.raises(RuntimeConfigurationError) as caught:
-        connector.probe()
-
-    assert caught.value.__cause__ is None
-    assert caught.value.__context__ is None
-    assert "private-version-canary" not in _traceback_locals(caught.value)
-
-
 def test_invalid_utf8_version_output_is_code_only(tmp_path: Path) -> None:
     executable = tmp_path / "openclaw"
     executable.write_text(
@@ -974,7 +1035,7 @@ _GATEWAY_MUTATIONS: list[tuple[Mutation, str]] = [
 
 
 @pytest.mark.parametrize(("mutate", "code"), _GATEWAY_MUTATIONS)
-def test_prepare_requires_exact_versions_config_coherence_rpc_and_loopback(
+def test_prepare_requires_version_config_coherence_rpc_and_loopback(
     tmp_path: Path, mutate: Mutation, code: str
 ) -> None:
     gateway = _gateway()

--- a/packages/nest-core/tests/agent_test/test_runtime_connectors.py
+++ b/packages/nest-core/tests/agent_test/test_runtime_connectors.py
@@ -1,0 +1,453 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the generic managed-runtime connector seam."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import Any, cast, get_type_hints
+
+import pytest
+from nest_core.agent_test.runtime_connectors import (
+    PreparedRuntime,
+    RuntimeConfigurationError,
+    RuntimeConnector,
+    RuntimeDisplay,
+    RuntimeExecutionError,
+    RuntimeIncompleteError,
+    RuntimeIssuePolicy,
+    RuntimeProbe,
+    RuntimeRun,
+    RuntimeTarget,
+    RuntimeTurn,
+    prepare_runtime,
+    select_runtime,
+)
+
+
+class FakeConnector:
+    def __init__(
+        self,
+        runtime_id: str,
+        probe: RuntimeProbe | None,
+        targets: tuple[RuntimeTarget, ...] = (),
+        *,
+        probe_error: RuntimeError | None = None,
+        list_error: RuntimeError | None = None,
+        prepare_error: RuntimeError | None = None,
+        issue_policy: RuntimeIssuePolicy | None = None,
+    ) -> None:
+        self.runtime_id = runtime_id
+        self.issue_policy = issue_policy or RuntimeIssuePolicy()
+        self.probe_value = probe
+        self.target_values = targets
+        self.probe_error = probe_error
+        self.list_error = list_error
+        self.prepare_error = prepare_error
+        self.probe_calls = 0
+        self.list_targets_calls = 0
+
+    def probe(self) -> RuntimeProbe | None:
+        self.probe_calls += 1
+        if self.probe_error is not None:
+            raise self.probe_error
+        return self.probe_value
+
+    def list_targets(self, probe: RuntimeProbe) -> tuple[RuntimeTarget, ...]:
+        self.list_targets_calls += 1
+        if self.list_error is not None:
+            raise self.list_error
+        assert probe is self.probe_value
+        return self.target_values
+
+    def prepare(
+        self,
+        probe: RuntimeProbe,
+        target: RuntimeTarget,
+        model_override: str | None,
+    ) -> PreparedRuntime:
+        if self.prepare_error is not None:
+            raise self.prepare_error
+        raise NotImplementedError
+
+
+def _probe(runtime_id: str) -> RuntimeProbe:
+    return RuntimeProbe(
+        runtime_id,
+        Path(f"/opt/{runtime_id}"),
+        "1.2.3",
+        RuntimeDisplay(runtime_id.title(), f"{runtime_id} doctor"),
+    )
+
+
+def _target(target_id: str) -> RuntimeTarget:
+    return RuntimeTarget(target_id, None)
+
+
+def test_explicit_runtime_probes_only_the_requested_connector() -> None:
+    requested = FakeConnector("requested", _probe("requested"), (_target("agent"),))
+    unrelated = FakeConnector("unrelated", _probe("unrelated"), (_target("agent"),))
+
+    result = select_runtime(
+        target_id="agent",
+        requested_runtime="requested",
+        connectors=(requested, unrelated),
+    )
+
+    assert result == (requested, requested.probe_value, requested.target_values[0])
+    assert requested.probe_calls == 1
+    assert requested.list_targets_calls == 1
+    assert unrelated.probe_calls == 0
+    assert unrelated.list_targets_calls == 0
+
+
+def test_selection_requires_an_exact_target_match() -> None:
+    connector = FakeConnector("runtime", _probe("runtime"), (_target("agent-prod"),))
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        select_runtime(target_id="agent", requested_runtime=None, connectors=(connector,))
+
+    assert caught.value.code == "TARGET_NOT_FOUND"
+    assert str(caught.value) == "TARGET_NOT_FOUND"
+
+
+def test_one_unambiguous_target_selects() -> None:
+    connector = FakeConnector(
+        "runtime", _probe("runtime"), (_target("other"), _target("agent"), _target("third"))
+    )
+
+    selected_connector, probe, target = select_runtime(
+        target_id="agent", requested_runtime=None, connectors=(connector,)
+    )
+
+    assert selected_connector is connector
+    assert probe is connector.probe_value
+    assert target is connector.target_values[1]
+
+
+def test_multiple_matching_targets_are_a_configuration_error() -> None:
+    connector = FakeConnector("runtime", _probe("runtime"), (_target("agent"), _target("agent")))
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        select_runtime(target_id="agent", requested_runtime=None, connectors=(connector,))
+
+    assert caught.value.code == "TARGET_AMBIGUOUS"
+    assert str(caught.value) == "TARGET_AMBIGUOUS"
+
+
+def test_multiple_connectors_matching_target_are_ambiguous() -> None:
+    first = FakeConnector("first", _probe("first"), (_target("agent"),))
+    second = FakeConnector("second", _probe("second"), (_target("agent"),))
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        select_runtime(target_id="agent", requested_runtime=None, connectors=(first, second))
+
+    assert caught.value.code == "RUNTIME_AMBIGUOUS"
+
+
+def test_auto_selection_skips_a_connector_that_is_definitely_absent() -> None:
+    inspectable = FakeConnector("inspectable", _probe("inspectable"), (_target("agent"),))
+    absent = FakeConnector("hermes", None)
+
+    selected = select_runtime(
+        target_id="agent",
+        requested_runtime=None,
+        connectors=(absent, inspectable),
+    )
+
+    assert selected == (inspectable, inspectable.probe_value, inspectable.target_values[0])
+    assert absent.probe_calls == 1
+    assert absent.list_targets_calls == 0
+    assert inspectable.list_targets_calls == 1
+
+
+def test_all_absent_connectors_fail_without_target_inspection() -> None:
+    openclaw = FakeConnector("openclaw", None)
+    hermes = FakeConnector("hermes", None)
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        select_runtime(target_id="agent", requested_runtime=None, connectors=(openclaw, hermes))
+
+    assert caught.value.code == "RUNTIME_NOT_FOUND"
+    assert openclaw.list_targets_calls == hermes.list_targets_calls == 0
+
+
+def test_explicit_absent_connector_fails_before_target_inspection() -> None:
+    connector = FakeConnector("hermes", None)
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        select_runtime(target_id="agent", requested_runtime="hermes", connectors=(connector,))
+
+    assert caught.value.code == "RUNTIME_NOT_FOUND"
+    assert connector.probe_calls == 1
+    assert connector.list_targets_calls == 0
+
+
+def test_typed_probe_inspection_failure_fails_closed_in_auto_mode() -> None:
+    openclaw = FakeConnector("openclaw", _probe("openclaw"), (_target("agent"),))
+    hermes = FakeConnector(
+        "hermes",
+        None,
+        probe_error=RuntimeExecutionError("HERMES_PROBE_FAILED"),
+        issue_policy=RuntimeIssuePolicy(execution=frozenset({"HERMES_PROBE_FAILED"})),
+    )
+
+    with pytest.raises(RuntimeExecutionError) as caught:
+        select_runtime(target_id="agent", requested_runtime=None, connectors=(openclaw, hermes))
+
+    assert caught.value.code == "HERMES_PROBE_FAILED"
+    assert openclaw.list_targets_calls == 0
+    assert hermes.list_targets_calls == 0
+
+
+def test_invalid_connector_policy_fails_before_probe() -> None:
+    connector = FakeConnector("hermes", _probe("hermes"), (_target("agent"),))
+    connector.issue_policy = cast("Any", object())
+
+    with pytest.raises(RuntimeExecutionError) as caught:
+        select_runtime(target_id="agent", requested_runtime=None, connectors=(connector,))
+
+    assert caught.value.code == "RUNTIME_POLICY_INVALID"
+    assert connector.probe_calls == 0
+    assert connector.list_targets_calls == 0
+
+
+def test_sanitized_connector_error_drops_private_exception_context() -> None:
+    connector = FakeConnector(
+        "hermes",
+        None,
+        probe_error=RuntimeExecutionError("PRIVATE_TOKEN_ABC123"),
+    )
+
+    with pytest.raises(RuntimeExecutionError) as caught:
+        select_runtime(target_id="agent", requested_runtime=None, connectors=(connector,))
+
+    assert caught.value.code == "RUNTIME_EXECUTION_FAILED"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert "PRIVATE_TOKEN_ABC123" not in repr(caught.value)
+
+
+@pytest.mark.parametrize(
+    ("stage", "failure", "error_type", "fallback"),
+    [
+        (
+            "probe",
+            RuntimeConfigurationError("PRIVATE_TOKEN_ABC123"),
+            RuntimeConfigurationError,
+            "RUNTIME_CONFIGURATION_FAILED",
+        ),
+        (
+            "list",
+            RuntimeIncompleteError("PRIVATE_TOKEN_ABC123"),
+            RuntimeIncompleteError,
+            "RUNTIME_INCOMPLETE",
+        ),
+        (
+            "prepare",
+            RuntimeExecutionError("PRIVATE_TOKEN_ABC123"),
+            RuntimeExecutionError,
+            "RUNTIME_EXECUTION_FAILED",
+        ),
+    ],
+)
+def test_probe_list_and_prepare_drop_private_error_context_and_traceback_locals(
+    stage: str,
+    failure: RuntimeError,
+    error_type: type[RuntimeError],
+    fallback: str,
+) -> None:
+    probe = _probe("hermes")
+    target = _target("agent")
+    connector = FakeConnector(
+        "hermes",
+        probe,
+        (target,),
+        probe_error=failure if stage == "probe" else None,
+        list_error=failure if stage == "list" else None,
+        prepare_error=failure if stage == "prepare" else None,
+    )
+
+    with pytest.raises(error_type) as caught:
+        if stage == "prepare":
+            prepare_runtime(
+                connector=connector,
+                probe=probe,
+                target=target,
+                model_override=None,
+            )
+        else:
+            select_runtime(
+                target_id="agent",
+                requested_runtime=None,
+                connectors=(connector,),
+            )
+
+    assert str(caught.value) == fallback
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    traceback = caught.value.__traceback__
+    retained: list[str] = []
+    while traceback is not None:
+        if "/tests/" not in traceback.tb_frame.f_code.co_filename:
+            retained.append(repr(traceback.tb_frame.f_locals))
+        traceback = traceback.tb_next
+    assert "PRIVATE_TOKEN_ABC123" not in " ".join(retained)
+
+
+def test_policy_access_failure_drops_private_error_before_probe() -> None:
+    class BrokenPolicyConnector:
+        runtime_id = "hermes"
+
+        @property
+        def issue_policy(self) -> RuntimeIssuePolicy:
+            raise RuntimeExecutionError("PRIVATE_TOKEN_ABC123")
+
+        def probe(self) -> RuntimeProbe | None:
+            raise AssertionError("probe must not run")
+
+        def list_targets(self, probe: RuntimeProbe) -> tuple[RuntimeTarget, ...]:
+            raise AssertionError(probe)
+
+        def prepare(
+            self,
+            probe: RuntimeProbe,
+            target: RuntimeTarget,
+            model_override: str | None,
+        ) -> PreparedRuntime:
+            raise AssertionError((probe, target, model_override))
+
+    with pytest.raises(RuntimeExecutionError) as caught:
+        select_runtime(
+            target_id="agent",
+            requested_runtime=None,
+            connectors=(cast("RuntimeConnector", BrokenPolicyConnector()),),
+        )
+
+    assert caught.value.code == "RUNTIME_POLICY_INVALID"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+def test_unknown_explicit_runtime_does_not_probe_path_order_candidates() -> None:
+    first = FakeConnector("first", _probe("first"), (_target("agent"),))
+    second = FakeConnector("second", _probe("second"), (_target("agent"),))
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        select_runtime(target_id="agent", requested_runtime="missing", connectors=(first, second))
+
+    assert caught.value.code == "RUNTIME_NOT_FOUND"
+    assert first.probe_calls == 0
+    assert second.probe_calls == 0
+
+
+def test_explicit_runtime_rejects_a_probe_with_a_different_runtime_id() -> None:
+    connector = FakeConnector("openclaw", _probe("hermes"), (_target("agent"),))
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        select_runtime(target_id="agent", requested_runtime="openclaw", connectors=(connector,))
+
+    assert caught.value.code == "RUNTIME_ID_MISMATCH"
+    assert connector.list_targets_calls == 0
+
+
+def test_implicit_runtime_rejects_a_probe_with_a_different_runtime_id() -> None:
+    connector = FakeConnector("openclaw", _probe("hermes"), (_target("agent"),))
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        select_runtime(target_id="agent", requested_runtime=None, connectors=(connector,))
+
+    assert caught.value.code == "RUNTIME_ID_MISMATCH"
+    assert connector.list_targets_calls == 0
+
+
+def test_missing_runtime_without_default_is_not_selected_by_order() -> None:
+    first = FakeConnector("first", _probe("first"), ())
+    second = FakeConnector("second", _probe("second"), ())
+
+    with pytest.raises(RuntimeConfigurationError) as caught:
+        select_runtime(target_id="agent", requested_runtime=None, connectors=(first, second))
+
+    assert caught.value.code == "TARGET_NOT_FOUND"
+
+
+def test_contract_dataclasses_are_frozen_and_preserve_unknown_activity() -> None:
+    display = RuntimeDisplay("Runtime", "runtime doctor")
+    probe = RuntimeProbe("runtime", Path("/opt/runtime"), "1.2.3", display)
+    target = RuntimeTarget("agent", None)
+    turn = RuntimeTurn(
+        intent={"kind": "none"},
+        provider=None,
+        model=None,
+        session_ref_digest="sha256:unknown",
+        activity="unknown",
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        probe.runtime_id = "other"  # type: ignore[misc]
+    assert target.configured_model is None
+    assert turn.activity == "unknown"
+
+
+def test_runtime_issue_policy_is_frozen_class_aware_and_fail_closed() -> None:
+    policy = RuntimeIssuePolicy(
+        configuration=frozenset({"HERMES_CONFIG_INVALID"}),
+        incomplete=frozenset({"HERMES_UNAVAILABLE"}),
+        execution=frozenset({"HERMES_TIMEOUT"}),
+    )
+
+    assert policy.code_for(RuntimeConfigurationError("HERMES_CONFIG_INVALID")) == (
+        "HERMES_CONFIG_INVALID"
+    )
+    assert policy.code_for(RuntimeIncompleteError("HERMES_UNAVAILABLE")) == ("HERMES_UNAVAILABLE")
+    assert policy.code_for(RuntimeExecutionError("HERMES_TIMEOUT")) == "HERMES_TIMEOUT"
+    assert policy.code_for(RuntimeIncompleteError("HERMES_TIMEOUT")) == "RUNTIME_INCOMPLETE"
+    assert policy.code_for(RuntimeExecutionError("SYNTACTICALLY_VALID")) == (
+        "RUNTIME_EXECUTION_FAILED"
+    )
+    with pytest.raises(FrozenInstanceError):
+        policy.execution = frozenset()  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        RuntimeDisplay("Hermes", "hermes doctor"),
+        RuntimeDisplay("Hermes Runtime", None),
+    ],
+)
+def test_runtime_display_is_bounded_safe_metadata(metadata: RuntimeDisplay) -> None:
+    assert metadata.name.startswith("Hermes")
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: RuntimeDisplay("Hermes\nspoof", None),
+        lambda: RuntimeDisplay("Hermes", "hermes doctor\x1b[31m"),
+        lambda: RuntimeIssuePolicy(execution=frozenset({"private-code"})),
+        lambda: RuntimeIssuePolicy(
+            configuration=frozenset({"HERMES_DUPLICATE"}),
+            execution=frozenset({"HERMES_DUPLICATE"}),
+        ),
+    ],
+)
+def test_runtime_display_and_issue_policy_reject_unsafe_or_ambiguous_metadata(
+    factory: object,
+) -> None:
+    with pytest.raises(ValueError):
+        cast("Any", factory)()
+
+
+def test_protocols_are_static_only_and_exceptions_are_code_only() -> None:
+    assert "turn" in RuntimeRun.__dict__
+    assert get_type_hints(PreparedRuntime)["runtime_id"] is str
+    assert get_type_hints(PreparedRuntime)["display"] is RuntimeDisplay
+    assert get_type_hints(PreparedRuntime)["issue_policy"] is RuntimeIssuePolicy
+    assert get_type_hints(RuntimeConnector)["runtime_id"] is str
+    assert get_type_hints(RuntimeConnector)["issue_policy"] is RuntimeIssuePolicy
+    assert str(RuntimeIncompleteError("INCOMPLETE")) == "INCOMPLETE"
+    assert str(RuntimeExecutionError("EXECUTION_FAILED")) == "EXECUTION_FAILED"
+    assert isinstance(RuntimeRun, type)
+    assert isinstance(PreparedRuntime, type)
+    assert isinstance(RuntimeConnector, type)

--- a/packages/nest-core/tests/agent_test/test_runtime_subprocess.py
+++ b/packages/nest-core/tests/agent_test/test_runtime_subprocess.py
@@ -1,0 +1,444 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial tests for the bounded runtime subprocess boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sys
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nest_core.agent_test.runtime_subprocess import (
+    KILL_REAP_SECONDS,
+    PROBE_DEADLINE_SECONDS,
+    TERMINATE_GRACE_SECONDS,
+    TURN_DEADLINE_SECONDS,
+    ProcessError,
+    run_bounded,
+)
+
+
+def _python(source: str, *arguments: str) -> list[str]:
+    return [sys.executable, "-c", source, *arguments]
+
+
+def _wait_for_file(path: Path) -> None:
+    deadline = time.monotonic() + 2
+    while not path.exists():
+        if time.monotonic() >= deadline:
+            raise AssertionError("child did not create synchronization file")
+        time.sleep(0.01)
+
+
+def _wait_for_pid_exit(pid: int) -> None:
+    deadline = time.monotonic() + 2
+    while True:
+        try:
+            os.kill(pid, signal.SIGCONT)
+        except ProcessLookupError:
+            return
+        if time.monotonic() >= deadline:
+            raise AssertionError("descendant process was not killed")
+        time.sleep(0.01)
+
+
+def _traceback_locals(error: BaseException) -> str:
+    values: list[str] = []
+    traceback = error.__traceback__
+    while traceback is not None:
+        filename = traceback.tb_frame.f_code.co_filename
+        if "/tests/" not in filename:
+            values.extend(repr(value) for value in traceback.tb_frame.f_locals.values())
+        traceback = traceback.tb_next
+    return " ".join(values)
+
+
+def test_frozen_deadlines_fit_inside_town_callback() -> None:
+    assert PROBE_DEADLINE_SECONDS < TURN_DEADLINE_SECONDS
+    assert TURN_DEADLINE_SECONDS == 45
+    assert TERMINATE_GRACE_SECONDS == 5
+    assert KILL_REAP_SECONDS == 5
+    assert TURN_DEADLINE_SECONDS + TERMINATE_GRACE_SECONDS + KILL_REAP_SECONDS < 60
+
+
+def test_stdout_and_stderr_are_continuously_drained_but_strictly_bounded() -> None:
+    source = (
+        "import sys; sys.stdout.write('private-out' * 10000); "
+        "sys.stderr.write('private-err' * 10000)"
+    )
+
+    with pytest.raises(ProcessError) as caught:
+        run_bounded(_python(source), deadline_seconds=2, max_output_bytes=128)
+
+    assert caught.value.code == "PROCESS_OUTPUT_LIMIT"
+    assert str(caught.value) == "PROCESS_OUTPUT_LIMIT"
+    assert "private" not in repr(caught.value)
+
+
+@pytest.mark.parametrize("deadline", [0.03, 0.08])
+def test_probe_and_turn_deadlines_raise_only_a_stable_code(deadline: float) -> None:
+    with pytest.raises(ProcessError) as caught:
+        run_bounded(
+            _python("import time; time.sleep(30)"),
+            deadline_seconds=deadline,
+            terminate_grace_seconds=0.05,
+            kill_reap_seconds=0.2,
+        )
+
+    assert caught.value.code == "PROCESS_TIMEOUT"
+    assert str(caught.value) == "PROCESS_TIMEOUT"
+
+
+@pytest.mark.parametrize(
+    "limits",
+    [
+        {"deadline_seconds": float("nan")},
+        {"deadline_seconds": float("inf")},
+        {"deadline_seconds": float("-inf")},
+        {"deadline_seconds": 1, "terminate_grace_seconds": float("nan")},
+        {"deadline_seconds": 1, "terminate_grace_seconds": float("inf")},
+        {"deadline_seconds": 1, "kill_reap_seconds": float("inf")},
+    ],
+)
+def test_non_finite_time_limits_are_rejected_before_spawn(limits: dict[str, Any]) -> None:
+    with pytest.raises(ProcessError, match="^PROCESS_INVALID_LIMIT$"):
+        run_bounded(_python("raise SystemExit(93)"), **limits)
+
+
+def test_child_stdin_is_closed() -> None:
+    result = run_bounded(
+        _python("import sys; print('closed' if sys.stdin.buffer.read() == b'' else 'open')"),
+        deadline_seconds=2,
+    )
+
+    assert result.stdout == b"closed\n"
+    assert result.stderr == b""
+
+
+def test_optional_exit_one_discards_both_output_streams() -> None:
+    result = run_bounded(
+        _python(
+            "import sys; print('absent'); sys.stderr.write('not-found\\n'); raise SystemExit(1)"
+        ),
+        deadline_seconds=2,
+        accept_empty_exit_one=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == result.stderr == b""
+
+
+def test_optional_exit_other_than_one_remains_a_code_only_failure() -> None:
+    with pytest.raises(ProcessError) as caught:
+        run_bounded(
+            _python(
+                "import sys; value = 'pri' + 'vate'; print(value + '-stdout'); "
+                "sys.stderr.write(value + '-stderr'); "
+                "raise SystemExit(2)"
+            ),
+            deadline_seconds=2,
+            accept_empty_exit_one=True,
+        )
+
+    assert caught.value.code == "PROCESS_EXIT_NONZERO"
+    assert "private" not in repr(caught.value)
+    assert "private" not in _traceback_locals(caught.value)
+
+
+def test_second_reader_start_failure_cleans_child_pipes_and_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import nest_core.agent_test.runtime_subprocess as subprocess_module
+
+    processes: list[Any] = []
+    real_popen = subprocess_module.subprocess.Popen
+    real_start = subprocess_module.threading.Thread.start
+    starts = 0
+
+    def tracked_popen(*args: Any, **kwargs: Any) -> Any:
+        process = real_popen(*args, **kwargs)
+        processes.append(process)
+        return process
+
+    def fail_second_start(thread: Any) -> None:
+        nonlocal starts
+        starts += 1
+        if starts == 2:
+            raise RuntimeError("reader-start-canary")
+        real_start(thread)
+
+    monkeypatch.setattr(subprocess_module.subprocess, "Popen", tracked_popen)
+    monkeypatch.setattr(subprocess_module.threading.Thread, "start", fail_second_start)
+
+    with pytest.raises(ProcessError) as caught:
+        run_bounded(
+            _python("import time; time.sleep(30)"),
+            deadline_seconds=1,
+            terminate_grace_seconds=0.05,
+            kill_reap_seconds=0.3,
+        )
+
+    assert caught.value.code == "PROCESS_READER_SETUP_FAILED"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert "reader-start-canary" not in _traceback_locals(caught.value)
+    assert len(processes) == 1
+    assert processes[0].poll() is not None
+    assert processes[0].stdout is not None and processes[0].stdout.closed
+    assert processes[0].stderr is not None and processes[0].stderr.closed
+
+
+def test_argv_is_a_literal_list_and_shell_metacharacters_are_not_executed(tmp_path: Path) -> None:
+    canary = tmp_path / "shell-expanded"
+    literal = f"; touch {canary}"
+    result = run_bounded(
+        _python("import sys; print(sys.argv[1])", literal),
+        deadline_seconds=2,
+    )
+
+    assert result.stdout.decode().strip() == literal
+    assert not canary.exists()
+    with pytest.raises(ProcessError, match="^PROCESS_INVALID_ARGV$"):
+        run_bounded("echo unsafe", deadline_seconds=2)  # type: ignore[arg-type]
+
+
+def test_platform_without_process_tree_containment_fails_closed_before_spawn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import nest_core.agent_test.runtime_subprocess as subprocess_module
+
+    started = False
+
+    def forbidden_spawn(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal started
+        started = True
+        raise AssertionError
+
+    monkeypatch.setattr(subprocess_module.os, "name", "nt")
+    monkeypatch.setattr(subprocess_module.subprocess, "Popen", forbidden_spawn)
+
+    with pytest.raises(ProcessError, match="^PROCESS_UNSUPPORTED_PLATFORM$"):
+        run_bounded(_python("pass"), deadline_seconds=1)
+
+    assert started is False
+
+
+def test_child_environment_filters_all_town_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TOWN_BEARER", "bearer-canary-private")
+    monkeypatch.setenv("TOWN_PROMPT", "prompt-canary-private")
+    result = run_bounded(
+        _python(
+            "import json, os; print(json.dumps("
+            "{k: v for k, v in os.environ.items() if k.startswith('TOWN_')}))"
+        ),
+        deadline_seconds=2,
+    )
+
+    assert json.loads(result.stdout) == {}
+    assert b"canary" not in result.stdout + result.stderr
+
+
+def test_connector_environment_keys_require_an_explicit_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENCLAW_CONFIG_PATH", "/private/openclaw-config")
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", "/private/openclaw-state")
+    source = (
+        "import json, os; print(json.dumps({k: os.environ.get(k) for k in "
+        "['OPENCLAW_CONFIG_PATH', 'OPENCLAW_STATE_DIR']}))"
+    )
+
+    without_policy = run_bounded(_python(source), deadline_seconds=2)
+    with_policy = run_bounded(
+        _python(source),
+        deadline_seconds=2,
+        allowed_environment_keys=frozenset({"OPENCLAW_CONFIG_PATH", "OPENCLAW_STATE_DIR"}),
+    )
+
+    assert json.loads(without_policy.stdout) == {
+        "OPENCLAW_CONFIG_PATH": None,
+        "OPENCLAW_STATE_DIR": None,
+    }
+    assert json.loads(with_policy.stdout) == {
+        "OPENCLAW_CONFIG_PATH": "/private/openclaw-config",
+        "OPENCLAW_STATE_DIR": "/private/openclaw-state",
+    }
+
+
+def test_connector_policy_cannot_allow_town_or_invalid_environment_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TOWN_BEARER", "private-bearer")
+    result = run_bounded(
+        _python("import os; print(os.environ.get('TOWN_BEARER', 'absent'))"),
+        deadline_seconds=2,
+        allowed_environment_keys=frozenset({"TOWN_BEARER"}),
+    )
+
+    assert result.stdout == b"absent\n"
+    with pytest.raises(ProcessError, match="^PROCESS_INVALID_ENVIRONMENT_POLICY$"):
+        run_bounded(
+            _python("raise SystemExit(93)"),
+            deadline_seconds=2,
+            allowed_environment_keys=frozenset({"INVALID-KEY"}),
+        )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group signal semantics")
+def test_timeout_gracefully_terminates_the_managed_process_group(tmp_path: Path) -> None:
+    marker = tmp_path / "terminated"
+    source = (
+        "import pathlib, signal, sys, time; "
+        "marker=pathlib.Path(sys.argv[1]); "
+        "signal.signal(signal.SIGTERM, lambda *_: (marker.write_text('term'), sys.exit(0))); "
+        "print('ready', flush=True); time.sleep(30)"
+    )
+
+    with pytest.raises(ProcessError, match="^PROCESS_TIMEOUT$"):
+        run_bounded(
+            _python(source, str(marker)),
+            deadline_seconds=0.1,
+            terminate_grace_seconds=0.5,
+            kill_reap_seconds=0.2,
+        )
+
+    _wait_for_file(marker)
+    assert marker.read_text() == "term"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group signal semantics")
+def test_child_ignoring_termination_is_force_killed_and_reaped(tmp_path: Path) -> None:
+    pid_file = tmp_path / "pid"
+    source = (
+        "import os, pathlib, signal, sys, time; "
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)"
+    )
+
+    with pytest.raises(ProcessError, match="^PROCESS_TIMEOUT$"):
+        run_bounded(
+            _python(source, str(pid_file)),
+            deadline_seconds=0.1,
+            terminate_grace_seconds=0.05,
+            kill_reap_seconds=0.5,
+        )
+
+    _wait_for_file(pid_file)
+    pid = int(pid_file.read_text())
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, signal.SIGCONT)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group signal semantics")
+def test_leader_exit_does_not_leave_term_ignoring_group_descendant(tmp_path: Path) -> None:
+    pid_file = tmp_path / "descendant-pid"
+    descendant = (
+        "import os, pathlib, signal, sys, time; "
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)"
+    )
+    source = (
+        "import pathlib, subprocess, sys, time\n"
+        f"subprocess.Popen([sys.executable, '-c', {descendant!r}, sys.argv[1]])\n"
+        "path = pathlib.Path(sys.argv[1])\n"
+        "deadline = time.monotonic() + 2\n"
+        "while not path.exists() and time.monotonic() < deadline:\n"
+        "    time.sleep(0.01)\n"
+        "time.sleep(30)\n"
+    )
+    pid: int | None = None
+    try:
+        with pytest.raises(ProcessError, match="^PROCESS_TIMEOUT$"):
+            run_bounded(
+                _python(source, str(pid_file)),
+                deadline_seconds=0.1,
+                terminate_grace_seconds=0.1,
+                kill_reap_seconds=0.4,
+            )
+        _wait_for_file(pid_file)
+        pid = int(pid_file.read_text())
+        _wait_for_pid_exit(pid)
+    finally:
+        if pid is None and pid_file.exists():
+            pid = int(pid_file.read_text())
+        if pid is not None:
+            with suppress(ProcessLookupError):
+                os.kill(pid, signal.SIGKILL)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX inherited-pipe semantics")
+def test_normally_exiting_leader_does_not_leave_same_group_descendant(tmp_path: Path) -> None:
+    pid_file = tmp_path / "normal-descendant-pid"
+    descendant = (
+        "import os, pathlib, signal, sys, time; "
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)"
+    )
+    source = (
+        "import pathlib, subprocess, sys, time\n"
+        f"subprocess.Popen([sys.executable, '-c', {descendant!r}, sys.argv[1]])\n"
+        "path = pathlib.Path(sys.argv[1])\n"
+        "deadline = time.monotonic() + 2\n"
+        "while not path.exists() and time.monotonic() < deadline:\n"
+        "    time.sleep(0.01)\n"
+    )
+    pid: int | None = None
+    try:
+        with pytest.raises(ProcessError, match="^PROCESS_DRAIN_FAILED$"):
+            run_bounded(
+                _python(source, str(pid_file)),
+                deadline_seconds=1,
+                terminate_grace_seconds=0.05,
+                kill_reap_seconds=0.3,
+            )
+        _wait_for_file(pid_file)
+        pid = int(pid_file.read_text())
+        _wait_for_pid_exit(pid)
+    finally:
+        if pid is None and pid_file.exists():
+            pid = int(pid_file.read_text())
+        if pid is not None:
+            with suppress(ProcessLookupError):
+                os.kill(pid, signal.SIGKILL)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX inherited-pipe semantics")
+def test_forced_reap_and_both_output_drains_share_one_cleanup_budget() -> None:
+    source = (
+        "import subprocess, sys, time; "
+        "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(1)'], "
+        "start_new_session=True); time.sleep(30)"
+    )
+    started = time.monotonic()
+
+    with pytest.raises(ProcessError, match="^PROCESS_DRAIN_FAILED$"):
+        run_bounded(
+            _python(source),
+            deadline_seconds=0.05,
+            terminate_grace_seconds=0.05,
+            kill_reap_seconds=0.15,
+        )
+
+    assert time.monotonic() - started < 0.33
+
+
+def test_nonzero_exit_never_exposes_child_output() -> None:
+    with pytest.raises(ProcessError) as caught:
+        run_bounded(
+            _python(
+                "import sys; print('stdout-secret'); "
+                "print('stderr-secret', file=sys.stderr); raise SystemExit(7)"
+            ),
+            deadline_seconds=2,
+        )
+
+    assert caught.value.code == "PROCESS_EXIT_NONZERO"
+    assert str(caught.value) == "PROCESS_EXIT_NONZERO"
+    assert "secret" not in repr(caught.value)
+    assert "stdout-secret" not in _traceback_locals(caught.value)
+    assert "stderr-secret" not in _traceback_locals(caught.value)

--- a/packages/nest-core/tests/agent_test/test_runtime_subprocess.py
+++ b/packages/nest-core/tests/agent_test/test_runtime_subprocess.py
@@ -412,19 +412,21 @@ def test_forced_reap_and_both_output_drains_share_one_cleanup_budget() -> None:
     source = (
         "import subprocess, sys, time; "
         "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(1)'], "
-        "start_new_session=True); time.sleep(30)"
+        "start_new_session=True); "
+        "sys.stdout.buffer.write(b'x' * 16384); sys.stdout.buffer.flush(); time.sleep(30)"
     )
     started = time.monotonic()
 
     with pytest.raises(ProcessError, match="^PROCESS_DRAIN_FAILED$"):
         run_bounded(
             _python(source),
-            deadline_seconds=0.05,
+            deadline_seconds=2,
+            max_output_bytes=64,
             terminate_grace_seconds=0.05,
             kill_reap_seconds=0.15,
         )
 
-    assert time.monotonic() - started < 0.33
+    assert time.monotonic() - started < 1
 
 
 def test_nonzero_exit_never_exposes_child_output() -> None:


### PR DESCRIPTION
## Problem

Testing an existing OpenClaw agent needs a bounded connector that checks the behavior Town relies on without locking users to one release or guessing across incompatible routes, retries, or output envelopes.

## Change

- accept any bounded, parseable OpenClaw version and report the detected version
- require the CLI, Gateway, and RPC versions to agree; validate optional server and plugin versions when reported
- require local Gateway mode, reject configured Gateway URL overrides, and clear inherited overrides before turns
- use bounded no-shell subprocesses, private prompt files, strict canonical intents, and strict characterized envelopes
- reject fallback, remote dispatch, reported activity, malformed sessions, and version/model drift without retrying a turn with alternate syntax

## Verification

- final stack: `make ci-local` — all 5 checks passed; 2,081 passed, 2 skipped, 1 deselected
- focused connector suite: 143 passed; subprocess suite: 25 passed, including concurrent cleanup stress
- coherent alternate-version installed-process E2E and clean archive/installed-wheel quickstart: PASS
- independent final connector/version review: READY, no Critical or Important findings

## Stack

**7 of 9. Depends on PR 6.** PR 8 bridges the prepared runtime into Town; PR 9 exposes the command and guide.

**Merge note:** After #225 merges into `main`, retarget this PR to `main`, wait for its CI, and only then merge it.