### PR TITLE
feat(agent-test): test an existing OpenClaw agent from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ That's the whole "hello world". No clone, no path, no setup.
 - [Hackathon](#hackathon)
 - [Install](#install)
 - [The 60-second tour](#the-60-second-tour)
-- [Test a local agent adapter](#test-a-local-agent-adapter)
+- [Test an existing OpenClaw agent](#test-an-existing-openclaw-agent)
 - [Test your own protocol](#test-your-own-protocol)
 - [Built-in scenarios](#built-in-scenarios)
 - [The 12 layers](#the-12-layers)
@@ -135,25 +135,23 @@ Same seed → byte-identical trace, every time.
 
 ---
 
-## Test a local agent adapter
+## Test an existing OpenClaw agent
 
-Bring an agent through a strict loopback adapter, run one frozen
-capability-fulfillment workflow through Town's pinned, run-local Registry
-implementation and simulator, and receive a per-stage evidence report. Town
-translates the adapter's declared capability into a provider card; Town's
-reference requester discovers it. This does not test the external agent's own
-Registry protocol.
-
-Generation 1 is the first frozen agent-test contract/profile generation, not a
-Town or nest-core 1.0 release. The Generation 1 Bring Your Agent preview is
-checkout-only and requires Python 3.12+ plus `uv`. Follow
-[the Generation 1 local-agent adapter guide](docs/bring-your-agent.md) to start
-the reference adapter and set the shared caller credential. After the adapter
-is running:
+From a checkout, Town can run one bounded agent workflow
+against an existing trusted OpenClaw `2026.7.1-2` target on the computer where
+Town is running and return a
+five-stage evidence report:
 
 ```bash
-uv run nest test agent --endpoint http://127.0.0.1:8787
+uv run nest test agent <agent-id>
 ```
+
+Follow the [short OpenClaw agent guide](docs/bring-your-agent.md) for exact
+requirements, setup, result limits, and troubleshooting. A pass covers only the
+frozen synthetic workflow through Town's pinned local components; it is not a
+claim of general agent compatibility, safety, trust, or reliability.
+Custom endpoint adapters and automation are documented separately in the
+[technical agent-test adapter reference](docs/agent-test-adapter-reference.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,12 @@ Same seed → byte-identical trace, every time.
 From a checkout, Town can run one bounded agent workflow against an existing
 trusted OpenClaw target on the computer where Town is running and return a
 five-stage evidence report. Town tries the installed version and validates the
-commands and JSON response shapes it needs; `2026.7.1-2` is the release tested
-against a real OpenClaw installation. An incompatible command or response fails
-clearly before Town starts an agent/model turn.
+pre-dispatch probe, configuration, inventory, and Gateway commands and JSON
+response shapes it needs; `2026.7.1-2` is the release tested against a real
+OpenClaw installation. An incompatibility in those checks fails clearly before
+Town starts an agent/model turn. If the dispatched agent command, its flags, or
+its response envelope is incompatible, Town reports that result without trying
+an alternate command syntax; a model turn may already have occurred.
 
 ```bash
 uv run nest test agent <agent-id>

--- a/README.md
+++ b/README.md
@@ -137,19 +137,21 @@ Same seed → byte-identical trace, every time.
 
 ## Test an existing OpenClaw agent
 
-From a checkout, Town can run one bounded agent workflow
-against an existing trusted OpenClaw `2026.7.1-2` target on the computer where
-Town is running and return a
-five-stage evidence report:
+From a checkout, Town can run one bounded agent workflow against an existing
+trusted OpenClaw target on the computer where Town is running and return a
+five-stage evidence report. Town tries the installed version and validates the
+commands and JSON response shapes it needs; `2026.7.1-2` is the release tested
+against a real OpenClaw installation. An incompatible command or response fails
+clearly before Town starts an agent/model turn.
 
 ```bash
 uv run nest test agent <agent-id>
 ```
 
-Follow the [short OpenClaw agent guide](docs/bring-your-agent.md) for exact
-requirements, setup, result limits, and troubleshooting. A pass covers only the
-frozen synthetic workflow through Town's pinned local components; it is not a
-claim of general agent compatibility, safety, trust, or reliability.
+Follow the [short OpenClaw agent guide](docs/bring-your-agent.md) for setup,
+result limits, and troubleshooting. A pass covers only the frozen synthetic
+workflow through Town's pinned local components; it is not a claim of general
+agent compatibility, safety, trust, or reliability.
 Custom endpoint adapters and automation are documented separately in the
 [technical agent-test adapter reference](docs/agent-test-adapter-reference.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,10 @@ go deeper.
 
 - **[quickstart.md](quickstart.md)** — Install, run a scenario,
   validate the trace. Five minutes, no clone required.
+- **[bring-your-agent.md](bring-your-agent.md)** — Run the bounded local test
+  against an existing OpenClaw agent on the computer where Town is running.
+- **[agent-test-adapter-reference.md](agent-test-adapter-reference.md)** —
+  Advanced endpoint, wire-contract, automation, and evidence details.
 - **[concepts.md](concepts.md)** — The 12 layers, fidelity tiers,
   scenarios, plugins, traces, determinism.
 

--- a/docs/agent-test-adapter-reference.md
+++ b/docs/agent-test-adapter-reference.md
@@ -116,16 +116,22 @@ The reference adapter's focused implementation notes are in
 
 ## Managed OpenClaw boundary
 
-The supported connector probes only exact OpenClaw `2026.7.1-2`, lists agents
-through the read-only JSON inventory, and checks a healthy read RPC through the
-local OpenClaw CLI. Before agent turns, Town requires exact local Gateway mode,
-rejects configured `OPENCLAW_GATEWAY_URL` overrides, and clears inherited URL
-overrides. The probe and RPC URLs used by the connector must be
-literal-loopback URLs; Town does not require the Gateway to be exposed only on
-loopback. Each Town run creates a fresh OpenClaw session key and uses it for
-exactly two model turns. Prompts are passed through private temporary files and
-removed after each invocation. Town does not use `--deliver` or `--local` and
-does not pass its internal bearer or `TOWN_*` environment into OpenClaw.
+The connector reads and records the installed OpenClaw version; it has no
+exact-release allowlist. It lists agents through the read-only JSON inventory,
+checks a healthy read RPC through the local OpenClaw CLI, and requires the CLI,
+Gateway, RPC, and reported server versions to agree. `2026.7.1-2` is the only
+release tested against a real OpenClaw installation. A missing required command,
+incompatible JSON response, or version disagreement fails clearly before an
+agent/model turn.
+
+Before agent turns, Town requires exact local Gateway mode, rejects configured
+`OPENCLAW_GATEWAY_URL` overrides, and clears inherited URL overrides. The probe
+and RPC URLs used by the connector must be literal-loopback URLs; Town does not
+require the Gateway to be exposed only on loopback. Each Town run creates a
+fresh OpenClaw session key and uses it for exactly two model turns. Prompts are
+passed through private temporary files and removed after each invocation. Town
+does not use `--deliver` or `--local` and does not pass its internal bearer or
+`TOWN_*` environment into OpenClaw.
 
 The accepted sanitized envelope must report one stable session, configured
 provider/model, completed turn, and no fallback or explicit delivery/tool

--- a/docs/agent-test-adapter-reference.md
+++ b/docs/agent-test-adapter-reference.md
@@ -116,13 +116,18 @@ The reference adapter's focused implementation notes are in
 
 ## Managed OpenClaw boundary
 
-The connector reads and records the installed OpenClaw version; it has no
-exact-release allowlist. It lists agents through the read-only JSON inventory,
-checks a healthy read RPC through the local OpenClaw CLI, and requires the CLI,
-Gateway, RPC, and reported server versions to agree. `2026.7.1-2` is the only
-release tested against a real OpenClaw installation. A missing required command,
-incompatible JSON response, or version disagreement fails clearly before an
+The connector reads the installed OpenClaw version and reports it in command
+progress; it has no exact-release allowlist. Before dispatching an agent
+command, it validates the version probe, local configuration, read-only JSON
+inventory, and Gateway status JSON, and requires the CLI, Gateway, RPC, and
+reported server versions to agree. `2026.7.1-2` is the only release tested
+against a real OpenClaw installation. A missing or incompatible pre-dispatch
+command/JSON response, or a version disagreement, fails clearly before an
 agent/model turn.
+
+After dispatch begins, an agent command/flag failure or incompatible response
+envelope can be detected after a model turn. Town reports that outcome and does
+not retry the turn with alternate command syntax.
 
 Before agent turns, Town requires exact local Gateway mode, rejects configured
 `OPENCLAW_GATEWAY_URL` overrides, and clears inherited URL overrides. The probe

--- a/docs/agent-test-adapter-reference.md
+++ b/docs/agent-test-adapter-reference.md
@@ -119,11 +119,11 @@ The reference adapter's focused implementation notes are in
 The connector reads the installed OpenClaw version and reports it in command
 progress; it has no exact-release allowlist. Before dispatching an agent
 command, it validates the version probe, local configuration, read-only JSON
-inventory, and Gateway status JSON, and requires the CLI, Gateway, RPC, and
-reported server versions to agree. `2026.7.1-2` is the only release tested
-against a real OpenClaw installation. A missing or incompatible pre-dispatch
-command/JSON response, or a version disagreement, fails clearly before an
-agent/model turn.
+inventory, and Gateway status JSON. The required CLI, Gateway, and RPC versions
+must agree; optional server and plugin versions must also agree when OpenClaw
+reports them. `2026.7.1-2` is the only release tested against a real OpenClaw
+installation. A missing or incompatible pre-dispatch command/JSON response, or
+a version disagreement, fails clearly before an agent/model turn.
 
 After dispatch begins, an agent command/flag failure or incompatible response
 envelope can be detected after a model turn. Town reports that outcome and does

--- a/docs/agent-test-adapter-reference.md
+++ b/docs/agent-test-adapter-reference.md
@@ -1,0 +1,181 @@
+# Agent-test adapter technical reference
+
+This reference documents Town's advanced endpoint mode and the exact
+Generation 1 adapter contract. Most users testing through the local OpenClaw
+CLI should start with the
+[short OpenClaw guide](bring-your-agent.md).
+
+Generation 1 is the first frozen agent-test contract and profile generation,
+not a Town or `nest-core` 1.0 release. Endpoint mode is a deterministic teaching
+and integration seam, not a hosted service, production server, or sandbox.
+
+## Run the reference adapter
+
+The checked-in standard-library adapter declares `sell` and answers
+`buy:widget:2` with `sold:widget:2`. The run state is released after stop; the
+adapter process continues serving until you press Ctrl-C. From a clean checkout
+with Python 3.12 or newer and `uv`, install the locked workspace:
+
+```bash
+uv sync --frozen
+uv run python -c 'import secrets; print(secrets.token_hex(32))'
+```
+
+Copy the fresh 64-character lowercase hexadecimal value into
+`TOWN_AGENT_TOKEN` in both terminals. Never pass it as a command-line argument
+or save it in source, shell history, logs, or a committed file.
+
+Terminal 1, from the repository root:
+
+```bash
+read -r -s TOWN_AGENT_TOKEN && export TOWN_AGENT_TOKEN
+uv run python examples/agent-test/reference_adapter.py
+```
+
+Terminal 2, after the adapter is ready:
+
+```bash
+read -r -s TOWN_AGENT_TOKEN && export TOWN_AGENT_TOKEN
+uv run nest test agent --endpoint http://127.0.0.1:8787 \
+  --target-label my-local-agent
+```
+
+The snippets above are for Bash and zsh. In PowerShell, use
+`$env:TOWN_AGENT_TOKEN = Read-Host -MaskInput` in both terminals. After the run
+and adapter have stopped, remove the parent-shell value with
+`unset TOWN_AGENT_TOKEN` or `Remove-Item Env:TOWN_AGENT_TOKEN`.
+
+The bearer authenticates Town as the adapter's caller. It does not authenticate
+the adapter as a server identity. The adapter hashes the value and removes the
+raw value from its own environment before accepting decisions. A parent shell
+that exported it still retains it. If an adapter launches another runtime,
+construct the child's environment from an explicit allowlist and exclude
+`TOWN_AGENT_TOKEN`.
+
+## Replace the deterministic decision
+
+Start from
+[`examples/agent-test/reference_adapter.py`](../examples/agent-test/reference_adapter.py).
+Preserve the HTTP framing, validation, digest binding, replay handling, and
+one-run state machine. Change `ADAPTER_INSTANCE_ID` to stable self-asserted
+metadata for your adapter, then replace only `decide_intent` with the call to
+your trusted runtime:
+
+```python
+def decide_intent(observation: dict[str, Any]) -> dict[str, Any]:
+    kind = observation["kind"]
+    if kind == "start":
+        return {"kind": "declare_capability", "capabilities": ["sell"]}
+    if kind == "message":
+        return {
+            "kind": "send_to_sender",
+            "media_type": "text/plain; charset=utf-8",
+            "text": "sold:widget:2",
+        }
+    return {"kind": "none"}
+```
+
+The adapter accepts a bounded `start`, `message`, and terminal `stop` sequence.
+Town observes only the returned intents. It cannot infer whether a state
+machine, local model, hosted model, or hardcoded function produced them.
+
+## HTTP contract
+
+The public wire contract is `town-agent-driver/1`:
+
+- `GET /town-driver/1/ready` advertises the exact supported profile and current
+  one-run capacity.
+- `POST /town-driver/1/decide` carries one observation and accepts one intent.
+- Requests use `Authorization: Bearer <token>`,
+  `Town-Driver-Contract: town-agent-driver/1`, and exact SHA-256 body binding.
+- The endpoint must be a canonical literal-loopback origin with an explicit
+  port. Redirects, proxy environment variables, cookies, compression, remote
+  hosts, and ambiguous URL forms are rejected.
+- A successful event is byte-idempotent. Repeating its event ID with the same
+  bytes returns the same response bytes; changed bytes conflict.
+- A custom start or message exception returns the fixed retryable
+  `ADAPTER_INTERNAL` error without advancing the run. The first schema-valid
+  request still binds that event ID, so only the exact request bytes may retry.
+  Raw exception text is not returned or logged.
+- A legal terminal stop returns `none`, releases capacity, and remains
+  byte-idempotent. `run_complete` cannot skip the required exchange.
+
+The frozen resources are:
+
+- [Capability-fulfillment profile](../packages/nest-core/nest_core/agent_test/resources/profiles/capability-fulfillment-1.json)
+- [Driver request schema](../packages/nest-core/nest_core/agent_test/resources/schemas/driver-request-1.schema.json)
+- [Driver response schema](../packages/nest-core/nest_core/agent_test/resources/schemas/driver-response-1.schema.json)
+- [Driver readiness schema](../packages/nest-core/nest_core/agent_test/resources/schemas/driver-ready-1.schema.json)
+- [Driver error schema](../packages/nest-core/nest_core/agent_test/resources/schemas/driver-error-1.schema.json)
+- [Test Profile schema](../packages/nest-core/nest_core/agent_test/resources/schemas/test-profile-1.schema.json)
+- [Test observation schema](../packages/nest-core/nest_core/agent_test/resources/schemas/test-observation-1.schema.json)
+- [Test result schema](../packages/nest-core/nest_core/agent_test/resources/schemas/test-result-1.schema.json)
+
+The reference adapter's focused implementation notes are in
+[`examples/agent-test/README.md`](../examples/agent-test/README.md).
+
+## Managed OpenClaw boundary
+
+The supported connector probes only exact OpenClaw `2026.7.1-2`, lists agents
+through the read-only JSON inventory, and checks a healthy read RPC through the
+local OpenClaw CLI. Before agent turns, Town requires exact local Gateway mode,
+rejects configured `OPENCLAW_GATEWAY_URL` overrides, and clears inherited URL
+overrides. The probe and RPC URLs used by the connector must be
+literal-loopback URLs; Town does not require the Gateway to be exposed only on
+loopback. Each Town run creates a fresh OpenClaw session key and uses it for
+exactly two model turns. Prompts are passed through private temporary files and
+removed after each invocation. Town does not use `--deliver` or `--local` and
+does not pass its internal bearer or `TOWN_*` environment into OpenClaw.
+
+The accepted sanitized envelope must report one stable session, configured
+provider/model, completed turn, and no fallback or explicit delivery/tool
+activity. Absence of such activity fields leaves activity unknown; it is not
+proof that configured tools, hooks, or plugins did not run. Town does not replay
+an uncertain model turn after a timeout or malformed response.
+
+## Automation, exit codes, and evidence
+
+Add `--format json` for automation. Advanced endpoint callers can select the
+exact frozen profile with
+`--profile nanda/agent/capability-fulfillment@1`. Safe progress and diagnostics
+remain on stderr.
+
+| Code | Meaning |
+|---:|---|
+| `0` | Completed with all required checks passing. |
+| `1` | Completed with a conclusive failed check, or invalid contract response. |
+| `2` | Configuration or compatibility was rejected before admission. |
+| `3` | Town encountered an internal execution error. |
+| `4` | The run was incomplete or evidence was inconclusive. |
+| `130` | The user interrupted the invocation. |
+
+Before admission, machine JSON stdout is empty and no run directory is
+created. After admission, stdout is byte-for-byte identical to `result.json`.
+The default directory is `.town/runs/<run-id>/`; `--output-dir` accepts an exact
+new or empty non-symlink directory.
+
+- `result.json` is the terminal verdict, five check outcomes, coverage
+  boundaries, diagnostics, and trace digest.
+- `trace.jsonl` is the simulator trace and typed `test.*` evidence referenced by
+  the result.
+
+These are mutable local diagnostics, not attestations. On POSIX, Town creates
+the default hierarchy with mode `0700` and artifact files with mode `0600`.
+For an existing explicit output directory, its mode is the caller's
+responsibility. Other operating systems do not share a portable POSIX-mode
+guarantee, and ignore rules are not a security boundary.
+
+## Maintainer verification
+
+The normal process-level E2E uses a fake OpenClaw executable and never contacts
+a live OpenClaw host. Before a release handoff, also run the clean
+committed-archive and installed-wheel proof:
+
+```bash
+python scripts/check_agent_test_quickstart.py
+```
+
+The checker rejects dirty or untracked inputs, archives committed `HEAD`,
+replaces source installs with built wheels, disables source package paths, and
+then exercises both the endpoint reference adapter and the auto-detected plus
+explicit OpenClaw commands.

--- a/docs/bring-your-agent.md
+++ b/docs/bring-your-agent.md
@@ -1,287 +1,139 @@
-# Test a local agent adapter
+# Test an existing OpenClaw agent
 
-Nanda Town can exercise one strict boundary between Town and code you control.
-Town sends a separate local adapter three bounded observations—start, one
-synthetic request, and stop—and the adapter returns one permitted intent for
-each observation.
+Nanda Town runs one small, repeatable capability test against an existing
+OpenClaw agent on the computer where Town is running. It asks the agent to declare `sell`, routes `buy:widget:2`
+through Town's pinned run-local Registry and simulator, and checks for the exact
+`sold:widget:2` response. This tests one bounded Town integration path; it is
+not a general evaluation of the agent.
 
-This Bring Your Agent preview slice is intentionally narrower than “test any agent.” It gives
-agent authors a repeatable integration check without a public network, model
-credential, or hosted dependency. The checked-in reference is Python, but the
-HTTP contract is language-neutral.
+## Requirements
 
-Generation 1 is the first frozen agent-test contract/profile generation, not a
-Town or nest-core 1.0 release.
+- The Town and OpenClaw commands must run on the same computer.
+- Run Town and OpenClaw on macOS or Linux. Native Windows is not supported in
+  this preview.
+- OpenClaw must be exactly version `2026.7.1-2`.
+- `openclaw config get gateway.mode --json` must return exactly `"local"`, and
+  OpenClaw must not configure an `OPENCLAW_GATEWAY_URL` override.
+- The OpenClaw Gateway must be healthy.
+- The agent ID must already exist in OpenClaw, and you must trust its
+  configuration and code.
+- Python 3.12 or newer and
+  [uv](https://docs.astral.sh/uv/getting-started/installation/) must be installed.
 
-> **What a pass means:** Town observed valid, request-bound responses to its
-> bearer-authenticated requests for the frozen capability-fulfillment profile.
-> The responses carried one stable, self-asserted adapter instance ID. Town
-> translated the adapter's declared capability into a card in its pinned,
-> run-local Registry implementation, and Town's reference requester discovered
-> and exercised that card through the simulator.
->
-> **What it does not mean:** The bearer is a caller credential; it does not
-> authenticate the adapter as a server identity. The adapter instance ID is
-> metadata supplied by the adapter, not a verified identity. This profile does
-> not test an external agent's own Registry protocol or discovery
-> implementation. It also does not establish that a model was used, that the
-> response was not hardcoded, or that the agent is generally compatible, safe,
-> trusted, or reliable.
-
-## Security boundary: trusted local code, not a sandbox
-
-The adapter and any runtime it calls execute with your operating-system user
-privileges. A separate process and a loopback-only endpoint are useful
-boundaries, but **Town does not sandbox the adapter or runtime**. Only run code
-you trust. It can read or modify anything your user account can access.
-
-The reference adapter reads and validates `TOWN_AGENT_TOKEN`, hashes it, and
-removes the raw value from its own process environment before accepting a
-decision. Exporting a variable in a shell still leaves it in that parent shell,
-and other processes under the same OS account may be able to inspect it.
-
-If your adapter starts a child runtime, construct the child's environment from
-an explicit allowlist of only the variables it needs. Do not pass a copy of
-`os.environ`, and never include `TOWN_AGENT_TOKEN` in the child environment.
-Keep model or service credentials in the runtime's own narrowly scoped secret
-configuration, not in Town's bearer variable.
-
-## Run the reference journey
-
-The reference adapter declares `sell`, answers `buy:widget:2` with
-`sold:widget:2`, and stops. Its job is to prove the integration path before you
-connect your own runtime.
-
-This Alpha feature is **checkout-only**. It requires Python 3.12 or newer and
-[uv](https://docs.astral.sh/uv/getting-started/installation/). From the repository
-checkout, install the exact locked workspace:
+If OpenClaw runs on another computer, SSH into that computer and run Town there:
 
 ```bash
+ssh <user>@<openclaw-host>
+```
+
+Town does not connect directly to a remote OpenClaw Gateway in this preview.
+After signing in, follow the same setup and test commands below on that computer.
+
+## Set up Town
+
+This preview runs from a Town checkout. Clone it, install the locked workspace,
+and stay in the `nandatown` repository directory for every Town command below:
+
+```bash
+git clone https://github.com/projnanda/nandatown.git
+cd nandatown
 uv sync --frozen
 ```
 
 Do not use an older or unpinned package install to evaluate this checkout.
 
-Generate one fresh 64-character local test token:
+## Choose the OpenClaw agent
+
+List the configured agents without changing them:
 
 ```bash
-uv run python -c 'import secrets; print(secrets.token_hex(32))'
+openclaw agents list
 ```
 
-Copy that value into `TOWN_AGENT_TOKEN` in both terminals. Do not pass it as a
-command-line argument or save it in source, shell history, logs, or a committed
-file.
+Choose the exact agent ID shown by OpenClaw. Town does not create, install, or
+reconfigure an agent.
 
-**Terminal 1 — run the reference adapter**
+From the `nandatown` directory, run:
 
 ```bash
-read -r -s TOWN_AGENT_TOKEN && export TOWN_AGENT_TOKEN
-uv run python examples/agent-test/reference_adapter.py
+uv run nest test agent <agent-id>
 ```
 
-Paste the generated value at the hidden prompt, then press Enter. The adapter
-listens only on `127.0.0.1:8787`.
-
-**Terminal 2 — after the adapter is running, run Town**
+For example only, if the listed agent ID is `everett`:
 
 ```bash
-read -r -s TOWN_AGENT_TOKEN && export TOWN_AGENT_TOKEN
-uv run nest test agent --endpoint http://127.0.0.1:8787 \
-  --target-label my-local-agent
+uv run nest test agent everett
 ```
 
-The `read -r -s` snippets are for Bash and zsh. In PowerShell, set the same
-value in each terminal with
-`$env:TOWN_AGENT_TOKEN = Read-Host -MaskInput`, then use the same `uv run`
-commands.
+Town auto-detects the supported local runtime when exactly one runtime contains
+that exact target. If the message offers an explicit command, copy it exactly;
+for this release that form is `uv run nest test agent <agent-id> --runtime openclaw`.
 
-After Town finishes and after you stop the adapter, remove the token from both
-parent shells:
+## Read the five stages
 
-```bash
-unset TOWN_AGENT_TOKEN
-```
+The result keeps earlier failures visible instead of collapsing everything into
+one score:
 
-```powershell
-Remove-Item Env:TOWN_AGENT_TOKEN
-```
+1. **Agent responded** — the local driver exchange returned allowed answers.
+2. **Capability registered** — Town registered the declared `sell` capability
+   in its pinned run-local Registry.
+3. **Agent discovered** — Town's reference requester found that run-local card.
+4. **Request delivered** — Town routed the exact synthetic request through its
+   simulator.
+5. **Response verified** — the requester received exactly `sold:widget:2`.
 
-A successful run ends with `RESULT: PASS` and writes a new evidence directory
-under `.town/runs/<run-id>/`. Use `--output-dir <new-or-empty-directory>` to
-choose an exact location. For automation, add `--format json`; advanced callers
-that need the exact frozen reference can add
-`--profile nanda/agent/capability-fulfillment@1`. After an admitted run, stdout
-is byte-for-byte identical to `result.json`, while safe progress and diagnostics
-remain on stderr.
+`Not evaluated` means the run did not produce enough evidence for that stage.
+It does not mean pass.
 
-## What Town evaluates
+## Cost and safety boundary
 
-The report separates five questions so that a downstream success cannot hide
-an earlier failure:
+A completed run asks the selected OpenClaw agent for two model turns: one
+capability declaration and one response to the synthetic request. Each Town run
+uses a fresh OpenClaw session, but OpenClaw may retain that session and its
+normal transcript; Town does not delete them. The cost is whatever those two
+turns cost under that agent's configured provider and model.
 
-1. **Bearer-authenticated driver contract** — did one stable, self-asserted
-   adapter instance return valid, request-bound intents for the required
-   exchanges?
-2. **Provider registered** — did Town translate the adapter's declared `sell`
-   capability into a provider card in the pinned, run-local Registry
-   implementation?
-3. **Provider discovered** — did Town's reference requester find and select that
-   card through the Registry lookup result?
-4. **Request routed** — did Town route the exact synthetic request through its
-   simulator to the selected provider?
-5. **Exact fulfillment returned** — did the expected response travel back
-   through Town and reach the requester?
+Town does not pass OpenClaw's delivery or local-execution flags, but **this is
+not a sandbox**. OpenClaw and the selected agent still run with your user
+privileges and their configured tools, hooks, and plugins. Disable anything you
+do not want available before testing. With the supported envelope, an absence
+of reported tool or delivery activity leaves that activity **unknown**; Town
+does not claim that nothing ran. If OpenClaw explicitly reports fallback,
+delivery, or tool activity, Town stops with an incomplete result instead of
+scoring it as agent behavior.
 
-This is a test of Town's pinned Registry implementation and the adapter's
-declared capability, not the external agent's own Registry protocol.
+## Fix common problems
 
-`Not evaluated` means Town could not produce a sound verdict for a check in this
-run, including when an earlier required stage prevented a dependent check from
-running. `Not tested` is reserved for a property the profile deliberately places
-outside its coverage. Neither means pass.
+- **Native Windows:** run Town and OpenClaw together on macOS or Linux. Town
+  rejects this preview connector before starting an agent/model turn on native
+  Windows.
+- **Unsupported or mismatched version:** confirm `openclaw --version` is exactly
+  `2026.7.1-2`. Other versions are rejected rather than guessed compatible.
+- **Gateway unavailable or unhealthy:** run `openclaw gateway status`, restore
+  the Gateway on the computer where you are running Town, then retry.
+- **Remote dispatch rejected:** run
+  `openclaw config get gateway.mode --json` on the OpenClaw computer. It must
+  return exactly `"local"`; remove any configured `OPENCLAW_GATEWAY_URL`
+  override, then retry. Town stops before an agent/model turn in this case.
+- **Target not found:** rerun `openclaw agents list` and copy the exact ID,
+  including case and punctuation.
+- **Several runtimes match:** use the explicit command Town prints. Do not pick
+  a runtime by trial and error.
+- **Model mismatch:** use the agent's configured model, or supply a deliberate
+  `--model provider/model` override.
+- **Fallback, activity, or timeout:** inspect the OpenClaw configuration and
+  agent behavior. Town reports the run as incomplete; it does not silently
+  retry the model turn.
+- **Output directory rejected:** remove the explicit `--output-dir`, or choose a
+  new or empty non-symlink directory.
 
-The evidence directory contains:
+## What PASS means
 
-- `result.json`: the terminal verdict, per-check outcomes, coverage boundaries,
-  diagnostics, and trace digest.
-- `trace.jsonl`: the simulator trace plus typed `test.*` observations referenced
-  by the report.
+PASS means Town observed valid answers for this frozen synthetic workflow and
+all five stages completed through Town's pinned local components. It does not
+prove that arbitrary agents work, that the agent's own discovery or Registry
+protocol works, that a model produced the response, or that the agent is safe,
+trusted, reliable, production-ready, or compatible across NANDA.
 
-These files are mutable local diagnostics, not attestations. On POSIX systems,
-Town creates the default `.town/runs/<run-id>/` hierarchy with mode `0700` and
-artifact files with mode `0600`. If you provide an existing empty
-`--output-dir`, Town preserves that directory's mode; you are responsible for
-securing it. Other operating systems do not share a portable POSIX-mode
-guarantee. `.town/` is ignored by this repository, but ignore rules are not a
-security boundary.
-
-## Connect your own runtime
-
-Start from
-[`examples/agent-test/reference_adapter.py`](../examples/agent-test/reference_adapter.py).
-Preserve its HTTP framing, strict validation, digest binding, replay handling,
-and one-run state machine. Before testing your code:
-
-1. Change `ADAPTER_INSTANCE_ID` from `town-reference-adapter` to a stable
-   value that describes your adapter, such as `my-agent-adapter`. It remains
-   self-asserted metadata, not a verified identity.
-2. Replace only this deterministic decision function with a call to your trusted
-   runtime:
-
-```python
-def decide_intent(observation: dict[str, Any]) -> dict[str, Any]:
-    """Deterministic replace point: map one validated observation to one intent."""
-    kind = observation["kind"]
-    if kind == "start":
-        return {"kind": "declare_capability", "capabilities": ["sell"]}
-    if kind == "message":
-        return {
-            "kind": "send_to_sender",
-            "media_type": "text/plain; charset=utf-8",
-            "text": "sold:widget:2",
-        }
-    return {"kind": "none"}
-```
-
-The mapping is bounded:
-
-| Observation | Allowed result used by the reference adapter |
-|---|---|
-| `start` | declare the `sell` capability |
-| `message` containing `buy:widget:2` | return a plain-text response to the sender |
-| `stop` | return `none` and release the run |
-
-Your bridge may call a state machine, local model, hosted model, or another
-runtime. Town observes only the adapter's response to Town's
-bearer-authenticated request; it cannot infer which implementation produced it.
-
-## HTTP contract and exact resources
-
-The public wire contract is `town-agent-driver/1`:
-
-- `GET /town-driver/1/ready` advertises the exact supported profile and current
-  one-run capacity.
-- `POST /town-driver/1/decide` carries one observation and accepts one intent.
-- Requests use `Authorization: Bearer <token>`,
-  `Town-Driver-Contract: town-agent-driver/1`, and exact SHA-256 body binding.
-  The bearer lets the adapter authenticate its caller; it is not server identity.
-- The endpoint must be a canonical literal-loopback origin with an explicit
-  port. Redirects, proxy environment variables, cookies, compression, remote
-  hosts, and ambiguous URL forms are rejected.
-- Successful events are idempotent. Repeating one event with the same bytes
-  returns the same response bytes; reusing its event ID with changed bytes is a
-  conflict.
-- If a custom start or message decision raises an exception, the adapter returns
-  a fixed retryable `ADAPTER_INTERNAL` error without advancing the run. The same
-  event and exact request bytes may be retried after the runtime recovers. The
-  first schema-valid request still binds its event ID, so changed bytes conflict.
-  Raw exception text is never returned or logged.
-- Legal terminal stops return `none`, release the one-run capacity, and remain
-  byte-idempotent after release. A `run_failed`, `run_incomplete`, or
-  `user_interrupted` stop may account for a missing or failed message decision;
-  `run_complete` cannot skip the required exchange.
-
-The exact frozen Generation 1 profile and schemas are checked-in resources:
-
-- [Generation 1 capability-fulfillment profile](../packages/nest-core/nest_core/agent_test/resources/profiles/capability-fulfillment-1.json)
-- [Generation 1 driver request schema](../packages/nest-core/nest_core/agent_test/resources/schemas/driver-request-1.schema.json)
-- [Generation 1 driver response schema](../packages/nest-core/nest_core/agent_test/resources/schemas/driver-response-1.schema.json)
-- [Generation 1 driver readiness schema](../packages/nest-core/nest_core/agent_test/resources/schemas/driver-ready-1.schema.json)
-- [Generation 1 driver error schema](../packages/nest-core/nest_core/agent_test/resources/schemas/driver-error-1.schema.json)
-- [Generation 1 Test Profile schema](../packages/nest-core/nest_core/agent_test/resources/schemas/test-profile-1.schema.json)
-- [Generation 1 test observation schema](../packages/nest-core/nest_core/agent_test/resources/schemas/test-observation-1.schema.json)
-- [Generation 1 test result schema](../packages/nest-core/nest_core/agent_test/resources/schemas/test-result-1.schema.json)
-
-The standard-library reference is a teaching example, not a production server.
-Its focused notes are in
-[`examples/agent-test/README.md`](../examples/agent-test/README.md).
-
-## Exit codes and artifact admission
-
-| Code | Meaning |
-|---:|---|
-| `0` | Completed with all required checks passing. |
-| `1` | Completed with a conclusive failed check, or the adapter returned an invalid contract response. |
-| `2` | Configuration or compatibility was rejected before admission. |
-| `3` | Town encountered an internal execution error. |
-| `4` | The run was incomplete or evidence was inconclusive. |
-| `130` | The user interrupted the invocation. |
-
-If the invocation stops before Town admits a run, machine JSON stdout is empty
-and Town creates no `result.json`, `trace.jsonl`, or run directory. After
-admission, `result.json` is the authoritative terminal record even when output
-rendering is interrupted.
-
-## Troubleshooting
-
-- **`TOWN_AGENT_TOKEN is not set` or token format error:** enter the same fresh
-  64-character lowercase hexadecimal value in both terminals.
-- **Connection refused or incomplete result:** start the adapter first and
-  verify that no other process owns port 8787.
-- **Unsupported profile or contract:** use the exact command above; the Bring
-  Your Agent preview supports only the Generation 1 `capability-fulfillment`
-  profile.
-- **Pinned reference Registry is unavailable:** from the same checkout, rerun
-  `uv sync --frozen`, then invoke Town through `uv run nest`.
-- **Output directory rejected:** choose a path that does not exist or is an
-  empty, non-symlink directory. Town does not overwrite an earlier run.
-- **Contract failure:** inspect the safe diagnostic in `result.json` when a run
-  was admitted, compare requests and responses with the linked schemas, and
-  retry with a new output path.
-
-For maintainers, the source-tree process journey runs in normal pytest. Before a
-release handoff, also run the explicit clean-package proof:
-
-```bash
-TOWN_RUN_PACKAGE_QUICKSTART=1 \
-  uv run pytest \
-  packages/nest-core/tests/agent_test/test_end_to_end.py::test_clean_archive_wheel_quickstart_checker
-```
-
-## Deliberately deferred
-
-This slice does not include OpenClaw, Docker, A2A, MCP, remote endpoints,
-authentication beyond the local bearer, multi-turn workflows, model scoring,
-signed evidence, public identity or reputation, services, arbitrary SDK
-execution, or hosted testing. Those can be added behind new profiles and
-adapters without changing what this Generation 1 result claims.
+For custom adapters, automation, wire details, evidence files, and maintainer
+checks, see the [technical agent-test adapter reference](agent-test-adapter-reference.md).

--- a/docs/bring-your-agent.md
+++ b/docs/bring-your-agent.md
@@ -11,7 +11,9 @@ not a general evaluation of the agent.
 - The Town and OpenClaw commands must run on the same computer.
 - Run Town and OpenClaw on macOS or Linux. Native Windows is not supported in
   this preview.
-- OpenClaw must be exactly version `2026.7.1-2`.
+- Town tries the installed OpenClaw version and checks the commands and JSON
+  responses needed for this test. `2026.7.1-2` is the release tested against a
+  real OpenClaw installation.
 - `openclaw config get gateway.mode --json` must return exactly `"local"`, and
   OpenClaw must not configure an `OPENCLAW_GATEWAY_URL` override.
 - The OpenClaw Gateway must be healthy.
@@ -65,9 +67,9 @@ For example only, if the listed agent ID is `everett`:
 uv run nest test agent everett
 ```
 
-Town auto-detects the supported local runtime when exactly one runtime contains
-that exact target. If the message offers an explicit command, copy it exactly;
-for this release that form is `uv run nest test agent <agent-id> --runtime openclaw`.
+Town auto-detects the local runtime when exactly one runtime contains that
+exact target. If the message offers an explicit command, copy it exactly; for
+this release that form is `uv run nest test agent <agent-id> --runtime openclaw`.
 
 ## Read the five stages
 
@@ -107,8 +109,10 @@ scoring it as agent behavior.
 - **Native Windows:** run Town and OpenClaw together on macOS or Linux. Town
   rejects this preview connector before starting an agent/model turn on native
   Windows.
-- **Unsupported or mismatched version:** confirm `openclaw --version` is exactly
-  `2026.7.1-2`. Other versions are rejected rather than guessed compatible.
+- **Version or command incompatibility:** check `openclaw --version` and update
+  OpenClaw if needed. Town tries the installed version, but stops clearly
+  before an agent/model turn when a required command or JSON response is
+  incompatible.
 - **Gateway unavailable or unhealthy:** run `openclaw gateway status`, restore
   the Gateway on the computer where you are running Town, then retry.
 - **Remote dispatch rejected:** run

--- a/docs/bring-your-agent.md
+++ b/docs/bring-your-agent.md
@@ -11,9 +11,10 @@ not a general evaluation of the agent.
 - The Town and OpenClaw commands must run on the same computer.
 - Run Town and OpenClaw on macOS or Linux. Native Windows is not supported in
   this preview.
-- Town tries the installed OpenClaw version and checks the commands and JSON
-  responses needed for this test. `2026.7.1-2` is the release tested against a
-  real OpenClaw installation.
+- Town tries the installed OpenClaw version and, before a model turn, checks
+  the probe, configuration, agent inventory, and Gateway JSON it needs for
+  this test. `2026.7.1-2` is the release tested against a real OpenClaw
+  installation.
 - `openclaw config get gateway.mode --json` must return exactly `"local"`, and
   OpenClaw must not configure an `OPENCLAW_GATEWAY_URL` override.
 - The OpenClaw Gateway must be healthy.
@@ -109,10 +110,14 @@ scoring it as agent behavior.
 - **Native Windows:** run Town and OpenClaw together on macOS or Linux. Town
   rejects this preview connector before starting an agent/model turn on native
   Windows.
-- **Version or command incompatibility:** check `openclaw --version` and update
-  OpenClaw if needed. Town tries the installed version, but stops clearly
-  before an agent/model turn when a required command or JSON response is
-  incompatible.
+- **Version or preflight incompatibility:** check `openclaw --version` and
+  update OpenClaw if needed. Town tries the installed version, but stops
+  clearly before an agent/model turn when a required probe, configuration,
+  inventory, or Gateway command/JSON response is incompatible.
+- **Agent command or response incompatibility:** after Town dispatches an
+  agent command, an unsupported flag or incompatible response envelope can be
+  detected after a model turn. Town reports the failure and does not retry with
+  alternate command syntax.
 - **Gateway unavailable or unhealthy:** run `openclaw gateway status`, restore
   the Gateway on the computer where you are running Town, then retry.
 - **Remote dispatch rejected:** run

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -92,6 +92,9 @@ report.
 
 ## What's next
 
+- **Test an existing OpenClaw agent:** [bring-your-agent.md](bring-your-agent.md)
+- **Build or automate an advanced agent adapter:**
+  [agent-test-adapter-reference.md](agent-test-adapter-reference.md)
 - **Plug in your own layer:** [writing-a-plugin.md](writing-a-plugin.md)
 - **Build a new scenario:** [writing-a-scenario.md](writing-a-scenario.md)
 - **How the layers fit together:** [concepts.md](concepts.md)

--- a/examples/agent-test/README.md
+++ b/examples/agent-test/README.md
@@ -1,58 +1,22 @@
 # Reference local agent adapter
 
-`reference_adapter.py` is the one Python reference for Nanda Town's strict local
-agent-driver boundary. The HTTP contract is language-neutral. This is a
-deterministic teaching bridge, not a hosted service, general agent runtime,
-benchmark agent, or production server.
+`reference_adapter.py` is the checked-in Python teaching implementation for
+Town's strict Generation 1 local agent-driver boundary. It is deterministic,
+uses only the standard library, and supports one active
+`capability-fulfillment` run. It is not a hosted service, general agent runtime,
+benchmark agent, production server, or sandbox.
 
-It uses only Python's standard library, binds literal `127.0.0.1`, reads the
-bearer only from `TOWN_AGENT_TOKEN`, and supports exactly one active
-Generation 1 `capability-fulfillment` run. Generation 1 is the first frozen
-agent-test contract/profile generation, not a Town or nest-core 1.0 release. It
-never accepts the token as a command-line argument or writes it into responses,
-run/decision state, or logs. After
-validating and hashing the token, it removes the raw value from its own process
-environment before serving decisions. The parent shell still retains an
-exported value until you remove it.
+The canonical instructions for running, modifying, and automating this example
+are in the
+[`agent-test adapter technical reference`](../../docs/agent-test-adapter-reference.md).
+That reference owns the security boundary, caller credential, wire contract,
+schemas, state machine, evidence, exit codes, and maintainer verification so
+this implementation note does not drift into a second guide.
 
-**This is not a sandbox.** The adapter and anything it calls run with your user
-privileges. Only connect trusted code. If the adapter starts a child runtime,
-build the child's environment from an explicit allowlist and exclude
-`TOWN_AGENT_TOKEN`; never copy the adapter's full environment.
+The intended customization point is `decide_intent`: preserve the surrounding
+validation and lifecycle and replace the deterministic decision with a call to
+trusted code. Change `ADAPTER_INSTANCE_ID` to stable self-asserted metadata for
+your adapter; it is not a verified identity.
 
-The Generation 1 Bring Your Agent preview is checkout-only and requires Python
-3.12 or newer. From a clean checkout, install
-[uv](https://docs.astral.sh/uv/getting-started/installation/) using its official
-guide, then install the exact locked workspace and run the adapter:
-
-```bash
-uv sync --frozen
-read -r -s TOWN_AGENT_TOKEN && export TOWN_AGENT_TOKEN
-uv run python examples/agent-test/reference_adapter.py
-```
-
-Paste the same fresh 64-character lowercase hexadecimal token at the hidden
-`read` prompt in both terminals. Then run Town in the second terminal:
-
-```bash
-read -r -s TOWN_AGENT_TOKEN && export TOWN_AGENT_TOKEN
-uv run nest test agent --endpoint http://127.0.0.1:8787
-```
-
-Do not pass the token as an argument or save it in source, shell history, logs,
-or a committed file. The `read -r -s` snippets are for Bash and zsh; the full
-guide gives the PowerShell equivalent and cleanup commands.
-
-To connect a real runtime, preserve the HTTP framing, strict request validation,
-digest binding, replay handling, and one-run state machine. Change
-`ADAPTER_INSTANCE_ID` to a stable value for your adapter; it is self-asserted
-metadata, not a verified identity. Replace only the `decide_intent` function
-with a call to your trusted runtime. The adapter keeps a failed start/message
-decision retryable without advancing state, but still binds that event ID to the
-first schema-valid request bytes. An exact request can retry after recovery;
-changed bytes conflict. The adapter handles terminal stop/release itself. The
-full workflow, claims, limitations, and troubleshooting guide are in
-[`docs/bring-your-agent.md`](../../docs/bring-your-agent.md).
-
-The optional `--port` flag changes only the literal-loopback port; `--port 0` is
+The optional `--port` flag changes only the loopback port; `--port 0` is
 reserved for ephemeral test processes.

--- a/packages/nest-cli/tests/test_cli.py
+++ b/packages/nest-cli/tests/test_cli.py
@@ -30,6 +30,11 @@ class TestAgentTestShim:
         assert app is core_app
         assert shim.exit_code == 0
         assert shim.stdout == core.stdout
+        assert "basic local agent test" in shim.stdout
+        assert "[TARGET]" in " ".join(shim.stdout.replace("│", "").split())
+        assert "OpenClaw" in shim.stdout
+        assert "capability-fulfillment" not in shim.stdout
+        assert "bearer" not in shim.stdout.lower()
 
 
 class TestDoctor:

--- a/packages/nest-core/nest_core/agent_test/cli.py
+++ b/packages/nest-core/nest_core/agent_test/cli.py
@@ -15,13 +15,16 @@ from typing import TYPE_CHECKING, Any, NoReturn
 import typer
 
 if TYPE_CHECKING:
+    from .managed_runtime import ManagedAgentTestOutcome
     from .runner import AgentTestOutcome
+    from .runtime_connectors import RuntimeConnector, RuntimeDisplay
 
 _PROFILE_ALIAS = "capability-fulfillment"
 _PROFILE_EXACT = "nanda/agent/capability-fulfillment@1"
 _PROFILE_REFERENCES = frozenset({_PROFILE_ALIAS, _PROFILE_EXACT})
 _TOKEN_RE = re.compile(r"[0-9a-f]{64}\Z")
 _ENVIRONMENT_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,127}\Z")
+_MANAGED_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}\Z")
 _INCOMPLETE_REASON_CODES = frozenset(
     {
         "ADAPTER_INSTANCE_CHANGED",
@@ -44,8 +47,12 @@ def _typer_option(*args: Any, **kwargs: Any) -> Any:
     return typer.Option(*args, **kwargs)  # pyright: ignore[reportUnknownMemberType]
 
 
+def _typer_argument(*args: Any, **kwargs: Any) -> Any:
+    return typer.Argument(*args, **kwargs)  # pyright: ignore[reportUnknownMemberType]
+
+
 test_app = typer.Typer(
-    help="Run local NANDA Town adapter tests.",
+    help="Test an existing agent with Town.",
     no_args_is_help=True,
 )
 
@@ -102,6 +109,30 @@ def _pre_admission_incomplete_error(*, code: str, endpoint: str) -> NoReturn:
     raise typer.Exit(4)
 
 
+def _agent_pre_admission_error(code: str) -> NoReturn:
+    if code == "REFERENCE_REGISTRY_MISSING":
+        typer.echo(
+            "Configuration error: pinned reference Registry is unavailable.",
+            err=True,
+        )
+        typer.echo("Next: pip install 'nest-core[plugins]'", err=True)
+    elif code == "OUTPUT_DIR_INVALID":
+        typer.echo(
+            "Configuration error: output directory must be new or empty and must not "
+            "be a file or symlink.",
+            err=True,
+        )
+    elif code == "TARGET_LABEL_INVALID":
+        typer.echo(
+            "Configuration error: --target-label must be nonempty, trimmed, "
+            "control-free, and at most 128 UTF-8 bytes.",
+            err=True,
+        )
+    else:
+        typer.echo("Configuration error: Town could not admit this invocation.", err=True)
+    raise typer.Exit(2)
+
+
 def _write_stdout_bytes(content: bytes) -> None:
     """Write the machine result without text transcoding or an implicit newline."""
     sys.stdout.buffer.write(content)
@@ -122,6 +153,33 @@ def _validate_output_directory(output_dir: Path | None) -> None:
         _configuration_error(
             "output directory must be new or empty and must not be a file or symlink."
         )
+
+
+def _valid_runtime_metadata(value: str) -> bool:
+    return (
+        bool(value)
+        and value == value.strip()
+        and len(value) <= 128
+        and not any(ord(character) < 32 or ord(character) == 127 for character in value)
+    )
+
+
+def _validate_managed_user_values(*, target: str, runtime: str | None, model: str | None) -> None:
+    if not _valid_runtime_metadata(target):
+        _configuration_error(
+            "TARGET must be nonempty, trimmed, control-free, and at most 128 characters."
+        )
+    if runtime is not None and not _valid_runtime_metadata(runtime):
+        _configuration_error(
+            "--runtime must be nonempty, trimmed, control-free, and at most 128 characters."
+        )
+    if model is not None:
+        parts = model.split("/")
+        if len(parts) != 2 or any(_MANAGED_ID_RE.fullmatch(part) is None for part in parts):
+            _configuration_error(
+                "--model must be provider/model using letters, digits, dots, underscores, "
+                "colons, or hyphens."
+            )
 
 
 async def _execute_agent_test(
@@ -156,8 +214,29 @@ async def _execute_agent_test(
     )
 
 
-def _render_human(outcome: AgentTestOutcome) -> str:
-    result = outcome.result
+_STAGES = (
+    ("driver.contract", "Connected to the agent"),
+    ("registry.provider-registered", "Offered the test capability"),
+    ("registry.provider-discovered", "Found through local discovery"),
+    ("delivery.request-routed", "Received the test request"),
+    ("capability.synthetic-request-fulfilled", "Returned the expected response"),
+)
+_STAGE_STATUS = {
+    "pass": "PASS",
+    "fail": "FAIL",
+    "not_tested": "NOT RUN",
+    "inconclusive": "INCOMPLETE",
+    "error": "ERROR",
+}
+_NOT_TESTED_BOUNDARY = (
+    "  Persistent discovery, real network delivery, identity, authorization, trust,\n"
+    "  payments, negotiation, safety, and long-term reliability."
+)
+_SAFE_RUNTIME_CODE_RE = re.compile(r"[A-Z][A-Z0-9_]{0,63}\Z")
+
+
+def _render_human(outcome: AgentTestOutcome, *, target: str) -> str:
+    checks = {check.id: check.status for check in outcome.result.evaluation.checks}
     headline = {
         0: "RESULT: PASS",
         1: "RESULT: FAIL",
@@ -165,77 +244,86 @@ def _render_human(outcome: AgentTestOutcome) -> str:
         4: "RESULT: INCOMPLETE",
         130: "RESULT: INTERRUPTED",
     }.get(outcome.exit_code, "RESULT: ERROR")
-    lines = [
-        headline,
-        f"Run: {result.run_id}",
-        f"Profile: {result.profile.id}@{result.profile.version}",
-        f"Profile digest: {result.profile.digest}",
-        f"Target label: {result.target.label} (local evidence label; not verified identity)",
-        (
-            "Request authentication: Town sent bearer-authenticated requests using the "
-            "caller credential"
-        ),
-        (
-            "Adapter instance (self-asserted): "
-            f"{result.driver.adapter_instance_id or 'not observed'}"
-        ),
+    stage_lines = [
+        f"  {_STAGE_STATUS.get(checks.get(check_id, 'not_tested'), 'ERROR'):<12}{label}"
+        for check_id, label in _STAGES
     ]
-
-    checks_by_status = {
-        status: [check for check in result.evaluation.checks if check.status == status]
-        for status in ("pass", "fail", "not_tested", "inconclusive", "error")
-    }
-
-    def add_section(title: str, entries: list[str]) -> None:
-        if entries:
-            lines.extend([title, *(f"  - {entry}" for entry in entries)])
-
-    add_section(
-        "Passed",
-        [f"{check.id}: {check.summary}" for check in checks_by_status["pass"]],
-    )
-    add_section(
-        "Failed",
-        [f"{check.id}: {check.summary}" for check in checks_by_status["fail"]],
-    )
-    incomplete_checks = [
-        check for status in ("inconclusive", "error") for check in checks_by_status[status]
-    ]
-    incomplete_coverage = [item for item in result.coverage if item.status == "unknown"]
-    add_section(
-        "Incomplete",
-        [f"{check.id}: {check.summary}" for check in incomplete_checks]
-        + [
-            f"Coverage {item.claim}: {item.reason_code or 'NOT_OBSERVED'}"
-            for item in incomplete_coverage
-        ],
-    )
-    not_evaluated_entries = [
-        f"{check.id}: {check.summary}" for check in checks_by_status["not_tested"]
-    ]
-    if result.evaluation.verdict == "not_evaluated":
-        not_evaluated_entries.insert(0, "Town did not evaluate this profile.")
-    add_section("Not evaluated", not_evaluated_entries)
-    add_section(
-        "Not tested",
-        [
-            f"{item.claim}: {item.reason_code or 'OUT_OF_PROFILE'}"
-            for item in result.coverage
-            if item.status == "not_tested"
-        ],
-    )
-
     next_step = {
-        0: "Review the scoped result and trace evidence.",
-        1: "Update the failed adapter behavior, then rerun this profile.",
-        3: "Review Town diagnostics, then rerun this profile.",
-        4: (
-            f"Start or check the local adapter at {result.driver.endpoint_origin}, "
-            "then rerun this profile."
-        ),
-        130: "Rerun this profile when ready.",
-    }.get(outcome.exit_code, "Review Town diagnostics, then rerun this profile.")
-    next_steps = [next_step]
+        0: "Review the result and trace evidence.",
+        1: "Update the agent's failed behavior, then rerun the test.",
+        3: "Review Town's diagnostics, then rerun the test.",
+        4: "Check the local agent and runtime, then rerun the test.",
+        130: "Rerun the test when ready.",
+    }.get(outcome.exit_code, "Review Town's diagnostics, then rerun the test.")
+    return "\n".join(
+        [
+            headline,
+            f"Target: {target}",
+            "This was a basic local agent test.",
+            "",
+            "Stages",
+            *stage_lines,
+            "",
+            "Not tested",
+            _NOT_TESTED_BOUNDARY,
+            "",
+            "Next",
+            f"  {next_step}",
+            "",
+            "Artifacts",
+            f"  Directory: {outcome.output_directory}",
+            "",
+        ]
+    )
+
+
+def _write_endpoint_progress(
+    *, profile_reference: str, endpoint: str, output_dir: Path | None, verbose: bool
+) -> None:
+    typer.echo("Running a basic local agent test...", err=True)
+    if verbose:
+        typer.echo(f"Profile: {profile_reference}", err=True)
+        typer.echo(f"Endpoint: {endpoint}", err=True)
+        typer.echo(
+            f"Output: {output_dir if output_dir is not None else '.town/runs/<run-id>'}",
+            err=True,
+        )
+
+
+def _write_managed_progress(
+    *,
+    runtime_display: RuntimeDisplay,
+    runtime_version: str,
+    target: str,
+    profile_reference: str,
+    model: str | None,
+    output_dir: Path | None,
+    verbose: bool,
+) -> None:
+    typer.echo(
+        f"Running a basic local agent test for {target} with "
+        f"{runtime_display.name} {runtime_version}...",
+        err=True,
+    )
+    if verbose:
+        typer.echo(f"Profile: {profile_reference}", err=True)
+        typer.echo(f"Model: {model or 'configured target model'}", err=True)
+        typer.echo(
+            f"Output: {output_dir if output_dir is not None else '.town/runs/<run-id>'}",
+            err=True,
+        )
+
+
+def _write_verbose_result(outcome: AgentTestOutcome) -> None:
+    result = outcome.result
+    typer.echo(f"Run: {result.run_id}", err=True)
+    typer.echo(f"Profile: {result.profile.id}@{result.profile.version}", err=True)
+    typer.echo(f"Profile digest: {result.profile.digest}", err=True)
+    typer.echo(f"Endpoint: {result.driver.endpoint_origin}", err=True)
+    typer.echo(
+        f"Adapter instance: {result.driver.adapter_instance_id or 'not observed'}",
+        err=True,
+    )
     trace_artifact = next(
         (artifact for artifact in result.artifacts if artifact.kind == "trace"),
         None,
@@ -243,27 +331,126 @@ def _render_human(outcome: AgentTestOutcome) -> str:
     if trace_artifact is not None:
         trace_path = outcome.output_directory / trace_artifact.path
         relative_trace = os.path.relpath(trace_path, start=Path.cwd())
-        next_steps.append(f"Inspect the trace: nest inspect {shlex.quote(relative_trace)}")
-    add_section("Next", next_steps)
-    artifacts = [f"result: {outcome.output_directory / 'result.json'}"]
-    artifacts.extend(
-        f"{artifact.kind}: {outcome.output_directory / artifact.path}"
-        for artifact in result.artifacts
-    )
-    add_section("Artifacts", artifacts)
-    return "\n".join(lines) + "\n"
+        typer.echo(
+            f"Inspect the trace: nest inspect {shlex.quote(relative_trace)}",
+            err=True,
+        )
 
 
-def _write_progress(
-    *, profile_reference: str, endpoint: str, output_dir: Path | None, verbose: bool
-) -> None:
-    typer.echo("Running local adapter test...", err=True)
-    if not verbose:
+def _available_runtime_connectors() -> tuple[RuntimeConnector, ...]:
+    from .openclaw_runtime import OpenClawConnector
+
+    return (OpenClawConnector(),)
+
+
+def _runtime_commands(target: str, connectors: tuple[RuntimeConnector, ...]) -> list[str]:
+    quoted_target = shlex.quote(target)
+    return [
+        f"nest test agent {quoted_target} --runtime {shlex.quote(connector.runtime_id)}"
+        for connector in connectors
+    ]
+
+
+def _target_inventory_commands(connectors: tuple[RuntimeConnector, ...]) -> list[str]:
+    commands = {
+        connector.runtime_id: "openclaw agents list"
+        for connector in connectors
+        if connector.runtime_id == "openclaw"
+    }
+    return list(commands.values())
+
+
+def _managed_pre_admission_error(
+    *,
+    kind: str,
+    code: str,
+    target: str,
+    connectors: tuple[RuntimeConnector, ...],
+    runtime_display: RuntimeDisplay | None,
+) -> NoReturn:
+    fallback = {
+        "configuration": "RUNTIME_CONFIGURATION_FAILED",
+        "incomplete": "RUNTIME_INCOMPLETE",
+        "execution": "RUNTIME_EXECUTION_FAILED",
+    }.get(kind, "RUNTIME_EXECUTION_FAILED")
+    safe_code = code if _SAFE_RUNTIME_CODE_RE.fullmatch(code) is not None else fallback
+    commands = _runtime_commands(target, connectors)
+    runtime_name = runtime_display.name if runtime_display is not None else "managed"
+    check_command = runtime_display.check_command if runtime_display is not None else None
+    if kind == "configuration":
+        typer.echo(f"Configuration error: {safe_code}", err=True)
+        if safe_code == "RUNTIME_NOT_FOUND":
+            typer.echo(
+                "Next: Install a supported managed runtime version and ensure its "
+                "executable is on PATH, then rerun.",
+                err=True,
+            )
+        elif safe_code == "TARGET_NOT_FOUND":
+            typer.echo("Next: List configured agents and copy the exact target ID:", err=True)
+            for command in _target_inventory_commands(connectors):
+                typer.echo(f"  {command}", err=True)
+        elif safe_code == "RUNTIME_AMBIGUOUS":
+            typer.echo("Next: Choose one runtime explicitly:", err=True)
+            for command in commands:
+                typer.echo(f"  {command}", err=True)
+        elif safe_code == "TARGET_AMBIGUOUS":
+            typer.echo(
+                "Next: Resolve duplicate exact target IDs, then verify the inventory:", err=True
+            )
+            for command in _target_inventory_commands(connectors):
+                typer.echo(f"  {command}", err=True)
+        elif safe_code == "OPENCLAW_PLATFORM_UNSUPPORTED":
+            typer.echo(
+                "Next: Run Town and OpenClaw together on macOS or Linux. Native Windows "
+                "is not supported in this preview. No agent/model turn was started.",
+                err=True,
+            )
+        elif safe_code == "OPENCLAW_REMOTE_DISPATCH":
+            typer.echo(
+                "Next: Run Town on the OpenClaw computer and check "
+                "`openclaw config get gateway.mode --json`; it must be exactly "
+                '`"local"`. Remove any configured `OPENCLAW_GATEWAY_URL` override, '
+                "then retry. No agent/model turn was started.",
+                err=True,
+            )
+        else:
+            check = f" with `{check_command}`" if check_command is not None else ""
+            typer.echo(
+                f"Next: Check the {runtime_name} runtime{check} and target configuration, "
+                "then retry.",
+                err=True,
+            )
+        raise typer.Exit(2)
+    if kind == "incomplete":
+        typer.echo("RESULT: INCOMPLETE", err=True)
+        typer.echo(f"Reason: {safe_code}", err=True)
+        check = f" with `{check_command}`" if check_command is not None else ""
+        rerun = f", then rerun `{commands[0]}`" if commands else ""
+        typer.echo(f"Next: Start or check the {runtime_name} runtime{check}{rerun}.", err=True)
+        raise typer.Exit(4)
+    typer.echo("RESULT: ERROR", err=True)
+    typer.echo(f"Runtime issue: {safe_code}", err=True)
+    check = f" with `{check_command}`" if check_command is not None else ""
+    typer.echo(f"Next: Check the {runtime_name} runtime{check}, then retry.", err=True)
+    raise typer.Exit(3)
+
+
+def _write_managed_issue(outcome: ManagedAgentTestOutcome) -> None:
+    if outcome.issue_code is None:
         return
-    typer.echo(f"Profile: {profile_reference}", err=True)
-    typer.echo(f"Endpoint: {endpoint}", err=True)
+    code = (
+        outcome.issue_code
+        if _SAFE_RUNTIME_CODE_RE.fullmatch(outcome.issue_code) is not None
+        else "RUNTIME_EXECUTION_FAILED"
+    )
+    typer.echo(f"Runtime issue: {code}", err=True)
+    check_command = outcome.runtime_display.check_command
+    check = f" with `{check_command}`" if check_command is not None else ""
     typer.echo(
-        f"Output: {output_dir if output_dir is not None else '.town/runs/<run-id>'}",
+        f"Next: Check the {outcome.runtime_display.name} runtime{check} and target "
+        "configuration, then rerun "
+        f"`nest test agent {shlex.quote(outcome.target_id)} --runtime "
+        f"{shlex.quote(outcome.runtime_id)}`.",
         err=True,
     )
 
@@ -285,35 +472,49 @@ _OUTPUT_FORMAT_OPTION = _typer_option(
 @test_app.command(
     "agent",
     help=(
-        "Test one local agent adapter with bearer-authenticated requests using the "
-        "Generation 1 capability-fulfillment profile. Generation 1 is the first frozen "
-        "agent-test contract/profile generation, not a Town or nest-core 1.0 release."
+        "Run a basic local agent test with a supported managed runtime or adapter. "
+        "Town currently supports existing agents in OpenClaw."
     ),
 )
 def agent(
+    target: str | None = _typer_argument(
+        None,
+        help="Agent name in the selected runtime.",
+    ),
+    runtime: str | None = _typer_option(
+        None,
+        "--runtime",
+        help="Auto-detected when omitted; currently OpenClaw on macOS or Linux.",
+    ),
+    model: str | None = _typer_option(
+        None,
+        "--model",
+        help="Optional model override for this run.",
+    ),
     profile: str = _typer_option(
         _PROFILE_ALIAS,
         "--profile",
-        help="Advanced: built-in profile alias or exact versioned reference.",
+        help="Built-in test profile.",
+        rich_help_panel="Advanced adapter options",
+        show_default=False,
+    ),
+    endpoint: str | None = _typer_option(
+        None,
+        "--endpoint",
+        help="Advanced local adapter origin.",
         rich_help_panel="Advanced adapter options",
     ),
-    endpoint: str = _typer_option(
-        ...,
-        "--endpoint",
-        help="Adapter origin: http://127.0.0.1:<port> or http://[::1]:<port>.",
-    ),
-    target_label: str = _typer_option(
-        "local-agent",
+    target_label: str | None = _typer_option(
+        None,
         "--target-label",
-        help="Local evidence label for this target; not a verified identity.",
+        help="Adapter-mode evidence label.",
+        rich_help_panel="Advanced adapter options",
     ),
-    token_env: str = _typer_option(
-        "TOWN_AGENT_TOKEN",
+    token_env: str | None = _typer_option(
+        None,
         "--token-env",
-        help=(
-            "Environment variable containing the bearer caller credential: a 64-character "
-            "lowercase hexadecimal token."
-        ),
+        help="Adapter-mode token variable.",
+        rich_help_panel="Advanced adapter options",
     ),
     output_format: _OutputFormat = _OUTPUT_FORMAT_OPTION,
     output_dir: str | None = _typer_option(
@@ -332,20 +533,50 @@ def agent(
         help="Write additional safe progress details to stderr.",
     ),
 ) -> None:
-    """Run the frozen local adapter profile."""
+    """Test one existing managed agent or one advanced local adapter."""
+    endpoint_mode = endpoint is not None
     try:
         output_path = None if output_dir is None else Path(output_dir)
+        if endpoint_mode:
+            conflicts = [
+                flag
+                for flag, value in (
+                    ("TARGET", target),
+                    ("--runtime", runtime),
+                    ("--model", model),
+                )
+                if value is not None
+            ]
+            if conflicts:
+                _configuration_error(
+                    "--endpoint cannot be combined with " + ", ".join(conflicts) + "."
+                )
+        else:
+            if target is None:
+                _configuration_error(
+                    "choose a target with `nest test agent TARGET`, or use --endpoint ORIGIN."
+                )
+            if target_label is not None or token_env is not None:
+                _configuration_error(
+                    "--target-label and --token-env are only valid with --endpoint."
+                )
+            _validate_managed_user_values(target=target, runtime=runtime, model=model)
         if profile not in _PROFILE_REFERENCES:
             _configuration_error(f"unknown Test Profile; use {_PROFILE_ALIAS} or {_PROFILE_EXACT}.")
-        if _ENVIRONMENT_NAME_RE.fullmatch(token_env) is None:
-            _configuration_error("--token-env must name a valid environment variable.")
-        token = os.environ.pop(token_env, None)
-        if token is None or not token:
-            _configuration_error(f"{token_env} is not set.")
-        if _TOKEN_RE.fullmatch(token) is None:
-            _configuration_error(
-                f"{token_env} must contain exactly 64 lowercase hexadecimal characters."
-            )
+        token = ""
+        resolved_token_env = token_env or "TOWN_AGENT_TOKEN"
+        resolved_target_label = target_label or "local-agent"
+        if endpoint_mode:
+            if _ENVIRONMENT_NAME_RE.fullmatch(resolved_token_env) is None:
+                _configuration_error("--token-env must name a valid environment variable.")
+            token = os.environ.pop(resolved_token_env, None) or ""
+            if not token:
+                _configuration_error(f"{resolved_token_env} is not set.")
+            if _TOKEN_RE.fullmatch(token) is None:
+                _configuration_error(
+                    f"{resolved_token_env} must contain exactly 64 lowercase hexadecimal "
+                    "characters."
+                )
         _validate_output_directory(output_path)
     except (KeyboardInterrupt, asyncio.CancelledError):
         _interrupted_error()
@@ -359,7 +590,6 @@ def agent(
             DriverIncompleteError,
             TownDriverError,
         )
-        from .http_driver import parse_loopback_origin
         from .profiles import resolve_test_profile
         from .runner import AgentTestPreAdmissionError, AgentTestTownError
     except (KeyboardInterrupt, asyncio.CancelledError):
@@ -372,20 +602,8 @@ def agent(
         )
 
     try:
-        endpoint = parse_loopback_origin(endpoint)
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        _interrupted_error()
-    except ValueError:
-        _configuration_error("endpoint must be http://127.0.0.1:<port> or http://[::1]:<port>.")
-    try:
         resolved_profile = resolve_test_profile(profile)
         profile_reference = f"{resolved_profile.reference.id}@{resolved_profile.reference.version}"
-        _write_progress(
-            profile_reference=profile_reference,
-            endpoint=endpoint,
-            output_dir=output_path,
-            verbose=verbose,
-        )
     except (KeyboardInterrupt, asyncio.CancelledError):
         _interrupted_error()
     except KeyError:
@@ -397,97 +615,241 @@ def agent(
             3,
         )
 
-    try:
-        outcome = asyncio.run(
-            _execute_agent_test(
-                profile=profile,
-                endpoint=endpoint,
-                token=token,
+    managed_diagnostics: ManagedAgentTestOutcome | None = None
+    if endpoint_mode:
+        assert endpoint is not None
+        try:
+            from .http_driver import parse_loopback_origin
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            _interrupted_error()
+        except Exception:
+            _terminal_error(
+                "RESULT: ERROR",
+                "Town could not prepare the basic local agent test.",
+                3,
+            )
+        try:
+            parsed_endpoint = parse_loopback_origin(endpoint)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            _interrupted_error()
+        except ValueError:
+            _configuration_error("endpoint must be http://127.0.0.1:<port> or http://[::1]:<port>.")
+        try:
+            _write_endpoint_progress(
+                profile_reference=profile_reference,
+                endpoint=parsed_endpoint,
                 output_dir=output_path,
-                target_label=target_label,
+                verbose=verbose,
             )
-        )
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        _interrupted_error()
-    except AgentTestPreAdmissionError as error:
-        if error.code == "REFERENCE_REGISTRY_MISSING":
-            typer.echo(
-                "Configuration error: pinned reference Registry is unavailable.",
-                err=True,
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            _interrupted_error()
+        try:
+            outcome = asyncio.run(
+                _execute_agent_test(
+                    profile=profile,
+                    endpoint=parsed_endpoint,
+                    token=token,
+                    output_dir=output_path,
+                    target_label=resolved_target_label,
+                )
             )
-            typer.echo("Next: pip install 'nest-core[plugins]'", err=True)
-        elif error.code == "OUTPUT_DIR_INVALID":
-            typer.echo(
-                "Configuration error: output directory must be new or empty and must not be a "
-                "file or symlink.",
-                err=True,
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            _interrupted_error()
+        except AgentTestPreAdmissionError as error:
+            _agent_pre_admission_error(error.code)
+        except (DriverConfigurationError, DriverCompatibilityError) as error:
+            if isinstance(error, DriverCompatibilityError):
+                detail = (
+                    "Configuration error: local adapter does not support the frozen profile or "
+                    "driver contract."
+                )
+            else:
+                detail = (
+                    "Configuration error: local adapter configuration was rejected before "
+                    "admission."
+                )
+            typer.echo(detail, err=True)
+            raise typer.Exit(2) from None
+        except DriverContractError:
+            _terminal_error(
+                "RESULT: FAIL",
+                "The local agent returned an invalid response to Town's test request.",
+                1,
             )
-        elif error.code == "TARGET_LABEL_INVALID":
-            typer.echo(
-                "Configuration error: --target-label must be nonempty, trimmed, control-free, "
-                "and at most 128 UTF-8 bytes.",
-                err=True,
+        except DriverIncompleteError as error:
+            _pre_admission_incomplete_error(
+                code=error.code,
+                endpoint=parsed_endpoint,
             )
-        else:
-            typer.echo("Configuration error: Town could not admit this invocation.", err=True)
-        raise typer.Exit(2) from None
-    except (DriverConfigurationError, DriverCompatibilityError) as error:
-        if isinstance(error, DriverCompatibilityError):
-            detail = (
-                "Configuration error: local adapter does not support the frozen profile or "
-                "driver contract."
+        except (TownDriverError, AgentTestTownError):
+            _terminal_error(
+                "RESULT: ERROR",
+                "Town could not complete the basic local agent test.",
+                3,
             )
-        else:
-            detail = (
-                "Configuration error: local adapter configuration was rejected before admission."
+        except TimeoutError:
+            _pre_admission_incomplete_error(
+                code="TIMEOUT",
+                endpoint=parsed_endpoint,
             )
-        typer.echo(detail, err=True)
-        raise typer.Exit(2) from None
-    except DriverContractError:
-        _terminal_error(
-            "RESULT: FAIL",
-            (
-                "Driver contract: the local adapter returned an invalid response to Town's "
-                "bearer-authenticated request."
-            ),
-            1,
-        )
-    except DriverIncompleteError as error:
-        _pre_admission_incomplete_error(
-            code=error.code,
-            endpoint=endpoint,
-        )
-    except (TownDriverError, AgentTestTownError):
-        _terminal_error(
-            "RESULT: ERROR",
-            "Town could not complete the local adapter test.",
-            3,
-        )
-    except TimeoutError:
-        _pre_admission_incomplete_error(
-            code="TIMEOUT",
-            endpoint=endpoint,
-        )
-    except AgentDriverError:
-        _terminal_error(
-            "RESULT: ERROR",
-            "Town could not classify a local adapter failure.",
-            3,
-        )
-    except Exception:
-        _terminal_error(
-            "RESULT: ERROR",
-            "Town could not complete the local adapter test.",
-            3,
-        )
+        except AgentDriverError:
+            _terminal_error(
+                "RESULT: ERROR",
+                "Town could not classify a local agent failure.",
+                3,
+            )
+        except Exception:
+            _terminal_error(
+                "RESULT: ERROR",
+                "Town could not complete the basic local agent test.",
+                3,
+            )
+        display_target = resolved_target_label
+    else:
+        assert target is not None
+        try:
+            from .managed_runtime import run_managed_agent_test
+            from .runtime_connectors import (
+                RuntimeConfigurationError,
+                RuntimeExecutionError,
+                RuntimeIncompleteError,
+                prepare_runtime,
+                select_runtime,
+            )
+
+            connectors = _available_runtime_connectors()
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            _interrupted_error()
+        except Exception:
+            _terminal_error(
+                "RESULT: ERROR",
+                "Town could not load the managed runtime connector.",
+                3,
+            )
+
+        selected_runtime_display: RuntimeDisplay | None = None
+        try:
+            connector, probe, selected_target = select_runtime(
+                target_id=target,
+                requested_runtime=runtime,
+                connectors=connectors,
+            )
+            selected_runtime_display = probe.display
+            prepared_runtime = prepare_runtime(
+                connector=connector,
+                probe=probe,
+                target=selected_target,
+                model_override=model,
+            )
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            _interrupted_error()
+        except RuntimeConfigurationError as error:
+            _managed_pre_admission_error(
+                kind="configuration",
+                code=error.code,
+                target=target,
+                connectors=connectors,
+                runtime_display=selected_runtime_display,
+            )
+        except RuntimeIncompleteError as error:
+            _managed_pre_admission_error(
+                kind="incomplete",
+                code=error.code,
+                target=target,
+                connectors=connectors,
+                runtime_display=selected_runtime_display,
+            )
+        except RuntimeExecutionError as error:
+            _managed_pre_admission_error(
+                kind="execution",
+                code=error.code,
+                target=target,
+                connectors=connectors,
+                runtime_display=selected_runtime_display,
+            )
+        except Exception:
+            _terminal_error(
+                "RESULT: ERROR",
+                "Town's managed runtime connector failed unexpectedly.",
+                3,
+            )
+
+        try:
+            _write_managed_progress(
+                runtime_display=probe.display,
+                runtime_version=probe.version,
+                target=target,
+                profile_reference=profile_reference,
+                model=model or selected_target.configured_model,
+                output_dir=output_path,
+                verbose=verbose,
+            )
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            _interrupted_error()
+        try:
+            managed_outcome = asyncio.run(
+                run_managed_agent_test(
+                    prepared_runtime=prepared_runtime,
+                    profile=profile,
+                    output_dir=output_path,
+                    base_dir=Path.cwd(),
+                )
+            )
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            _interrupted_error()
+        except AgentTestPreAdmissionError as error:
+            _agent_pre_admission_error(error.code)
+        except RuntimeConfigurationError as error:
+            _managed_pre_admission_error(
+                kind="configuration",
+                code=error.code,
+                target=target,
+                connectors=connectors,
+                runtime_display=prepared_runtime.display,
+            )
+        except RuntimeIncompleteError as error:
+            _managed_pre_admission_error(
+                kind="incomplete",
+                code=error.code,
+                target=target,
+                connectors=connectors,
+                runtime_display=prepared_runtime.display,
+            )
+        except RuntimeExecutionError as error:
+            _managed_pre_admission_error(
+                kind="execution",
+                code=error.code,
+                target=target,
+                connectors=connectors,
+                runtime_display=prepared_runtime.display,
+            )
+        except (TownDriverError, AgentTestTownError):
+            _terminal_error(
+                "RESULT: ERROR",
+                "Town could not complete the managed agent test.",
+                3,
+            )
+        except Exception:
+            _terminal_error(
+                "RESULT: ERROR",
+                "Town could not complete the managed agent test.",
+                3,
+            )
+        managed_diagnostics = managed_outcome
+        outcome = managed_outcome.outcome
+        display_target = target
 
     try:
+        if managed_diagnostics is not None:
+            _write_managed_issue(managed_diagnostics)
         _write_diagnostics(outcome)
+        if verbose:
+            _write_verbose_result(outcome)
         if output_format == _OutputFormat.JSON:
             _write_stdout_bytes(outcome.result_bytes)
         else:
             typer.echo(
-                _render_human(outcome),
+                _render_human(outcome, target=display_target),
                 nl=False,
                 color=False if no_color else None,
             )

--- a/packages/nest-core/tests/agent_test/test_cli.py
+++ b/packages/nest-core/tests/agent_test/test_cli.py
@@ -33,6 +33,15 @@ from nest_core.agent_test.runner import (
     AgentTestPreAdmissionError,
     AgentTestTownError,
 )
+from nest_core.agent_test.runtime_connectors import (
+    RuntimeConfigurationError,
+    RuntimeDisplay,
+    RuntimeExecutionError,
+    RuntimeIncompleteError,
+    RuntimeIssuePolicy,
+    RuntimeProbe,
+    RuntimeTarget,
+)
 from nest_core.cli import app
 from typer.testing import CliRunner
 
@@ -47,6 +56,112 @@ PLAIN_HELP_ENV: dict[str, str | None] = {
     "GITHUB_ACTIONS": None,
     "TERM": "dumb",
 }
+OPENCLAW_VERSION = "2026.7.1-2"
+OPENCLAW_TEST_POLICY = RuntimeIssuePolicy(
+    configuration=frozenset(
+        {
+            "OPENCLAW_MODEL_INVALID",
+            "OPENCLAW_PLATFORM_UNSUPPORTED",
+            "OPENCLAW_REMOTE_DISPATCH",
+        }
+    ),
+    incomplete=frozenset({"OPENCLAW_GATEWAY_UNAVAILABLE"}),
+    execution=frozenset({"OPENCLAW_GATEWAY_INVALID"}),
+)
+
+
+class _FakePreparedRuntime:
+    def __init__(
+        self,
+        runtime_id: str,
+        runtime_version: str,
+        display: RuntimeDisplay,
+        target: RuntimeTarget,
+        issue_policy: RuntimeIssuePolicy,
+    ) -> None:
+        self.runtime_id = runtime_id
+        self.runtime_version = runtime_version
+        self.display = display
+        self.target = target
+        self.issue_policy = issue_policy
+        self.target_label = f"{runtime_id}:{target.id}"
+        self.adapter_instance_id = f"{runtime_id}:cli-test"
+
+
+class _FakeConnector:
+    def __init__(
+        self,
+        runtime_id: str,
+        targets: tuple[RuntimeTarget, ...],
+        *,
+        probe: RuntimeProbe | None | bool = True,
+        probe_error: BaseException | None = None,
+        list_error: BaseException | None = None,
+        prepare_error: BaseException | None = None,
+        issue_policy: RuntimeIssuePolicy | None = None,
+        prepared_issue_policy: RuntimeIssuePolicy | None = None,
+    ) -> None:
+        self.runtime_id = runtime_id
+        self.issue_policy = (
+            issue_policy
+            if issue_policy is not None
+            else OPENCLAW_TEST_POLICY
+            if runtime_id == "openclaw"
+            else RuntimeIssuePolicy()
+        )
+        self.prepared_issue_policy = prepared_issue_policy
+        self.display = RuntimeDisplay(
+            "OpenClaw" if runtime_id == "openclaw" else runtime_id.title(),
+            ("openclaw gateway status" if runtime_id == "openclaw" else f"{runtime_id} doctor"),
+        )
+        self.targets = targets
+        self.probe_value = (
+            RuntimeProbe(
+                runtime_id,
+                Path(f"/opt/{runtime_id}"),
+                OPENCLAW_VERSION,
+                self.display,
+            )
+            if probe is True
+            else probe
+        )
+        self.probe_error = probe_error
+        self.list_error = list_error
+        self.prepare_error = prepare_error
+        self.probe_calls = 0
+        self.list_targets_calls = 0
+        self.prepare_calls: list[tuple[RuntimeProbe, RuntimeTarget, str | None]] = []
+
+    def probe(self) -> RuntimeProbe | None:
+        self.probe_calls += 1
+        if self.probe_error is not None:
+            raise self.probe_error
+        assert self.probe_value is None or isinstance(self.probe_value, RuntimeProbe)
+        return self.probe_value
+
+    def list_targets(self, probe: RuntimeProbe) -> tuple[RuntimeTarget, ...]:
+        self.list_targets_calls += 1
+        if self.list_error is not None:
+            raise self.list_error
+        assert probe is self.probe_value
+        return self.targets
+
+    def prepare(
+        self,
+        probe: RuntimeProbe,
+        target: RuntimeTarget,
+        model_override: str | None,
+    ) -> _FakePreparedRuntime:
+        self.prepare_calls.append((probe, target, model_override))
+        if self.prepare_error is not None:
+            raise self.prepare_error
+        return _FakePreparedRuntime(
+            self.runtime_id,
+            probe.version,
+            probe.display,
+            target,
+            self.prepared_issue_policy or self.issue_policy,
+        )
 
 
 class _InterruptServer(ThreadingHTTPServer):
@@ -151,9 +266,61 @@ def _serve_interrupt_adapter() -> Generator[_InterruptServer]:
 def _result_data(exit_code: int) -> dict[str, Any]:
     fixture = "result-incomplete.json" if exit_code in {4, 130} else "result-pass.json"
     data: dict[str, Any] = json.loads((FIXTURES / fixture).read_text(encoding="utf-8"))
+    check_ids = (
+        "driver.contract",
+        "registry.provider-registered",
+        "registry.provider-discovered",
+        "delivery.request-routed",
+        "capability.synthetic-request-fulfilled",
+    )
+    not_tested_claims = (
+        "nanda.index.persistent-discovery",
+        "nanda.comms.real-network-delivery",
+        "nanda.identity",
+        "nanda.authorization",
+        "nanda.trust",
+        "nanda.payments",
+        "nanda.negotiation",
+        "agent.safety",
+        "agent.long-term-reliability",
+    )
+    data["coverage"] = [item for item in data["coverage"] if item["status"] != "not_tested"] + [
+        {
+            "claim": claim,
+            "status": "not_tested",
+            "reason_code": "OUT_OF_PROFILE",
+            "evidence_refs": [],
+        }
+        for claim in not_tested_claims
+    ]
+    if exit_code in {4, 130}:
+        data["evaluation"]["checks"] = [
+            data["evaluation"]["checks"][0],
+            *(
+                {
+                    "id": check_id,
+                    "required": True,
+                    "status": "not_tested",
+                    "summary": "This stage was not reached",
+                    "evidence_refs": [],
+                }
+                for check_id in check_ids[1:]
+            ),
+        ]
+    else:
+        data["evaluation"]["checks"] = [
+            {
+                "id": check_id,
+                "required": True,
+                "status": "pass",
+                "summary": "The expected local evidence was observed",
+                "evidence_refs": ["trace.jsonl#seq=1"],
+            }
+            for check_id in check_ids
+        ]
     if exit_code == 1:
         data["evaluation"]["verdict"] = "fail"
-        data["evaluation"]["checks"][0].update(
+        data["evaluation"]["checks"][-1].update(
             status="fail", summary="The adapter returned the wrong synthetic response"
         )
     elif exit_code == 3:
@@ -238,34 +405,75 @@ def _invoke(
     return runner.invoke(app, args, color=False), calls, outcome
 
 
+def _invoke_managed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    target: str = "everett",
+    outcome_exit: int = 0,
+    issue_code: str | None = None,
+    connectors: tuple[_FakeConnector, ...] | None = None,
+    extra: list[str] | None = None,
+) -> tuple[Any, list[dict[str, object]], AgentTestOutcome, tuple[_FakeConnector, ...]]:
+    import nest_core.agent_test.cli as agent_cli
+    import nest_core.agent_test.managed_runtime as managed_runtime
+    from nest_core.agent_test.managed_runtime import ManagedAgentTestOutcome
+
+    outcome = _outcome(tmp_path, outcome_exit)
+    selected_connectors = connectors or (
+        _FakeConnector("openclaw", (RuntimeTarget(target, "provider/configured"),)),
+    )
+    calls: list[dict[str, object]] = []
+
+    async def fake_managed(**kwargs: object) -> ManagedAgentTestOutcome:
+        calls.append(kwargs)
+        prepared = cast("_FakePreparedRuntime", kwargs["prepared_runtime"])
+        return ManagedAgentTestOutcome(
+            outcome=outcome,
+            runtime_id=prepared.runtime_id,
+            runtime_version=prepared.runtime_version,
+            runtime_display=prepared.display,
+            target_id=target,
+            issue_code=issue_code,
+        )
+
+    monkeypatch.setattr(
+        agent_cli,
+        "_available_runtime_connectors",
+        lambda: selected_connectors,
+        raising=False,
+    )
+    monkeypatch.setattr(managed_runtime, "run_managed_agent_test", fake_managed)
+    args = ["test", "agent", target]
+    if extra:
+        args.extend(extra)
+    return runner.invoke(app, args, color=False), calls, outcome, selected_connectors
+
+
 def test_test_and_agent_help_freeze_the_additive_command_tree() -> None:
     test_help = runner.invoke(app, ["test", "--help"], color=False, env=PLAIN_HELP_ENV)
     agent_help = runner.invoke(app, ["test", "agent", "--help"], color=False, env=PLAIN_HELP_ENV)
 
     assert test_help.exit_code == 0
-    assert "Run local NANDA Town adapter tests." in test_help.stdout
+    assert "Test an existing agent with Town." in test_help.stdout
     assert "agent" in test_help.stdout
     assert agent_help.exit_code == 0
     normalized = " ".join(agent_help.stdout.replace("│", "").split())
-    assert (
-        "Test one local agent adapter with bearer-authenticated requests using the "
-        "Generation 1 capability-fulfillment profile." in normalized
-    )
-    assert (
-        "Generation 1 is the first frozen agent-test contract/profile generation, not a Town "
-        "or nest-core 1.0 release." in normalized
+    assert "Usage: nest test agent [OPTIONS] [TARGET]" in normalized
+    assert "Run a basic local agent test with a supported managed runtime or adapter." in (
+        normalized
     )
     for expected in (
+        "TARGET",
+        "Agent name in the selected runtime.",
+        "--runtime",
+        "Auto-detected when omitted; currently OpenClaw on macOS or Linux.",
+        "--model",
+        "Optional model override for this run.",
         "--profile",
-        "Advanced: built-in profile alias or exact versioned reference.",
         "--endpoint",
-        "Adapter origin: http://127.0.0.1:<port> or http://[::1]:<port>.",
         "--target-label",
-        "Local evidence label for this target; not a verified identity.",
-        "local-agent",
         "--token-env",
-        "TOWN_AGENT_TOKEN",
-        "Environment variable containing the bearer caller credential",
         "--format",
         "[human|json]",
         "--output-dir",
@@ -274,7 +482,19 @@ def test_test_and_agent_help_freeze_the_additive_command_tree() -> None:
         "--verbose",
     ):
         assert expected in normalized
-    assert "agent [OPTIONS] PROFILE" not in normalized
+    advanced_panel = normalized.index("Advanced adapter options")
+    for advanced in ("--profile", "--endpoint", "--target-label", "--token-env"):
+        assert normalized.index(advanced) > advanced_panel
+    for forbidden in (
+        "capability-fulfillment",
+        PROFILE_EXACT,
+        "sha256:",
+        "bearer",
+        "127.0.0.1",
+        "[::1]",
+        "adapter instance",
+    ):
+        assert forbidden.lower() not in normalized.lower()
 
 
 def test_agent_help_is_plain_when_color_is_disabled() -> None:
@@ -284,7 +504,7 @@ def test_agent_help_is_plain_when_color_is_disabled() -> None:
     assert "\x1b[" not in result.stdout
 
 
-def test_cli_import_keeps_http_driver_and_runner_lazy() -> None:
+def test_cli_import_keeps_endpoint_and_managed_runtime_implementation_lazy() -> None:
     completed = subprocess.run(
         [
             sys.executable,
@@ -292,7 +512,9 @@ def test_cli_import_keeps_http_driver_and_runner_lazy() -> None:
             (
                 "import sys; import nest_core.cli; "
                 "assert 'nest_core.agent_test.http_driver' not in sys.modules; "
-                "assert 'nest_core.agent_test.runner' not in sys.modules"
+                "assert 'nest_core.agent_test.runner' not in sys.modules; "
+                "assert 'nest_core.agent_test.openclaw_runtime' not in sys.modules; "
+                "assert 'nest_core.agent_test.managed_runtime' not in sys.modules"
             ),
         ],
         check=False,
@@ -402,6 +624,48 @@ def test_interrupt_during_output_directory_validation_is_safe_exit_130_without_b
     assert not (tmp_path / ".town").exists()
 
 
+@pytest.mark.parametrize(
+    ("mode_args", "progress_name"),
+    [
+        (["--endpoint", ENDPOINT], "_write_endpoint_progress"),
+        (["everett"], "_write_managed_progress"),
+    ],
+)
+def test_interrupt_during_progress_is_safe_exit_130_without_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mode_args: list[str],
+    progress_name: str,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    def interrupt_progress(**_kwargs: object) -> NoReturn:
+        raise KeyboardInterrupt("interrupt-progress-canary")
+
+    connector = _FakeConnector("openclaw", (RuntimeTarget("everett", None),))
+    monkeypatch.setattr(
+        agent_cli,
+        "_available_runtime_connectors",
+        lambda: (connector,),
+        raising=False,
+    )
+    monkeypatch.setattr(agent_cli, progress_name, interrupt_progress)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["test", "agent", *mode_args, "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == 130
+    assert result.stdout_bytes == b""
+    assert "RESULT: INTERRUPTED" in result.stderr
+    assert "interrupt-progress-canary" not in result.stderr
+    assert not (tmp_path / ".town").exists()
+
+
 def test_alias_and_exact_profile_reference_reach_the_same_frozen_runner(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -416,6 +680,752 @@ def test_alias_and_exact_profile_reference_reach_the_same_frozen_runner(
     assert default.stdout == exact.stdout
     assert default_calls[0]["profile"] == PROFILE_ALIAS
     assert exact_calls[0]["profile"] == PROFILE_EXACT
+
+
+def test_managed_default_and_exact_profile_reach_the_same_frozen_runner(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    default, default_calls, _, _ = _invoke_managed(monkeypatch, tmp_path)
+    exact, exact_calls, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        extra=["--profile", PROFILE_EXACT],
+    )
+
+    assert default.exit_code == exact.exit_code == 0
+    assert default.stdout == exact.stdout
+    assert default_calls[0]["profile"] == PROFILE_ALIAS
+    assert exact_calls[0]["profile"] == PROFILE_EXACT
+
+
+def test_managed_target_detects_exactly_one_connector_and_forwards_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    target = RuntimeTarget("everett", "provider/configured")
+    connector = _FakeConnector("openclaw", (RuntimeTarget("other", None), target))
+
+    result, calls, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        connectors=(connector,),
+        extra=["--model", "provider/override"],
+    )
+
+    assert result.exit_code == 0
+    assert connector.probe_calls == 1
+    assert connector.list_targets_calls == 1
+    assert connector.prepare_calls == [(connector.probe_value, target, "provider/override")]
+    assert calls[0]["prepared_runtime"] is not None
+    assert calls[0]["base_dir"] == Path.cwd()
+
+
+def test_explicit_runtime_probes_no_other_connector(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    requested = _FakeConnector("openclaw", (RuntimeTarget("everett", None),))
+    unrelated = _FakeConnector("other", (RuntimeTarget("everett", None),))
+
+    result, _, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        connectors=(requested, unrelated),
+        extra=["--runtime", "openclaw"],
+    )
+
+    assert result.exit_code == 0
+    assert requested.probe_calls == requested.list_targets_calls == 1
+    assert unrelated.probe_calls == unrelated.list_targets_calls == 0
+
+
+def test_missing_runtime_explains_install_version_and_path_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    connector = _FakeConnector("openclaw", (), probe=None)
+
+    result, calls, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        connectors=(connector,),
+        extra=["--format", "json"],
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert calls == []
+    assert "Configuration error: RUNTIME_NOT_FOUND" in result.stderr
+    assert "Install a supported managed runtime version" in result.stderr
+    assert "PATH" in result.stderr
+    assert "--runtime openclaw" not in result.stderr
+    assert not (tmp_path / ".town").exists()
+
+
+def test_unsupported_openclaw_platform_exits_2_before_inference_with_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    connector = _FakeConnector(
+        "openclaw",
+        (),
+        probe_error=RuntimeConfigurationError("OPENCLAW_PLATFORM_UNSUPPORTED"),
+    )
+
+    result, calls, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        connectors=(connector,),
+        extra=["--format", "json"],
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert calls == []
+    assert "Configuration error: OPENCLAW_PLATFORM_UNSUPPORTED" in result.stderr
+    assert "macOS or Linux" in result.stderr
+    assert "Native Windows is not supported" in result.stderr
+    assert "No agent/model turn was started" in result.stderr
+    assert not (tmp_path / ".town").exists()
+
+
+def test_remote_openclaw_route_exits_2_with_local_mode_recovery_before_inference(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    connector = _FakeConnector(
+        "openclaw",
+        (),
+        probe_error=RuntimeConfigurationError("OPENCLAW_REMOTE_DISPATCH"),
+    )
+
+    result, calls, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        connectors=(connector,),
+        extra=["--format", "json"],
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert calls == []
+    assert "Configuration error: OPENCLAW_REMOTE_DISPATCH" in result.stderr
+    assert "openclaw config get gateway.mode --json" in result.stderr
+    assert 'must be exactly `"local"`' in result.stderr
+    assert "OPENCLAW_GATEWAY_URL" in result.stderr
+    assert "No agent/model turn was started" in result.stderr
+    assert not (tmp_path / ".town").exists()
+
+
+def test_missing_target_points_to_openclaw_agent_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    connector = _FakeConnector("openclaw", (RuntimeTarget("other", None),))
+
+    result, calls, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        connectors=(connector,),
+        extra=["--format", "json"],
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert calls == []
+    assert "Configuration error: TARGET_NOT_FOUND" in result.stderr
+    assert "openclaw agents list" in result.stderr
+    assert "--runtime openclaw" not in result.stderr
+    assert not (tmp_path / ".town").exists()
+
+
+def test_ambiguous_runtime_offers_copy_ready_explicit_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    connectors = (
+        _FakeConnector("openclaw", (RuntimeTarget("everett", None),)),
+        _FakeConnector("other", (RuntimeTarget("everett", None),)),
+    )
+
+    result, calls, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        connectors=connectors,
+        extra=["--format", "json"],
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert calls == []
+    assert "Configuration error: RUNTIME_AMBIGUOUS" in result.stderr
+    assert "Next: Choose one runtime explicitly:" in result.stderr
+    assert "nest test agent everett --runtime openclaw" in result.stderr
+    assert "nest test agent everett --runtime other" in result.stderr
+    assert not (tmp_path / ".town").exists()
+
+
+def test_ambiguous_target_does_not_claim_an_explicit_runtime_will_fix_duplicates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    connector = _FakeConnector(
+        "openclaw",
+        (RuntimeTarget("everett", None), RuntimeTarget("everett", None)),
+    )
+
+    result, calls, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        connectors=(connector,),
+        extra=["--format", "json"],
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert calls == []
+    assert "Configuration error: TARGET_AMBIGUOUS" in result.stderr
+    assert "duplicate" in result.stderr.lower()
+    assert "openclaw agents list" in result.stderr
+    assert "--runtime openclaw" not in result.stderr
+    assert not (tmp_path / ".town").exists()
+
+
+def test_endpoint_mode_bypasses_all_runtime_probes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    connector = _FakeConnector("openclaw", (RuntimeTarget("everett", None),))
+    monkeypatch.setattr(
+        agent_cli,
+        "_available_runtime_connectors",
+        lambda: (connector,),
+        raising=False,
+    )
+
+    result, calls, _ = _invoke(monkeypatch, tmp_path)
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    assert connector.probe_calls == connector.list_targets_calls == 0
+
+
+@pytest.mark.parametrize("output_format", ["human", "json"])
+def test_managed_mode_never_prompts_for_runtime_or_target(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    output_format: str,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    def reject_prompt(*_args: object, **_kwargs: object) -> NoReturn:
+        raise AssertionError("the CLI must not prompt")
+
+    monkeypatch.setattr(agent_cli.typer, "prompt", reject_prompt)
+    result, _, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        extra=["--format", output_format],
+    )
+
+    assert result.exit_code == 0
+
+
+def test_no_target_without_endpoint_exits_2_before_probe_or_token_read(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    connector = _FakeConnector("openclaw", (RuntimeTarget("everett", None),))
+    monkeypatch.setattr(
+        agent_cli,
+        "_available_runtime_connectors",
+        lambda: (connector,),
+        raising=False,
+    )
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["test", "agent", "--format", "json"], color=False)
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert "nest test agent TARGET" in result.stderr
+    assert os.environ["TOWN_AGENT_TOKEN"] == TOKEN
+    assert connector.probe_calls == connector.list_targets_calls == 0
+    assert not (tmp_path / ".town").exists()
+
+
+@pytest.mark.parametrize(
+    "conflict",
+    [
+        ["everett"],
+        ["--runtime", "openclaw"],
+        ["--model", "provider/model"],
+    ],
+)
+def test_endpoint_conflicts_exit_2_before_probe_or_token_read(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    conflict: list[str],
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    connector = _FakeConnector("openclaw", (RuntimeTarget("everett", None),))
+    monkeypatch.setattr(
+        agent_cli,
+        "_available_runtime_connectors",
+        lambda: (connector,),
+        raising=False,
+    )
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["test", "agent", *conflict, "--endpoint", ENDPOINT, "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert "--endpoint cannot be combined" in result.stderr
+    assert os.environ["TOWN_AGENT_TOKEN"] == TOKEN
+    assert connector.probe_calls == connector.list_targets_calls == 0
+    assert not (tmp_path / ".town").exists()
+
+
+@pytest.mark.parametrize(
+    "adapter_option",
+    [["--token-env", "PRIVATE_TOKEN"], ["--target-label", "private-label"]],
+)
+def test_managed_adapter_options_exit_2_without_consuming_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    adapter_option: list[str],
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    connector = _FakeConnector("openclaw", (RuntimeTarget("everett", None),))
+    monkeypatch.setattr(
+        agent_cli,
+        "_available_runtime_connectors",
+        lambda: (connector,),
+        raising=False,
+    )
+    monkeypatch.setenv("PRIVATE_TOKEN", TOKEN)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["test", "agent", "everett", *adapter_option, "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert "only valid with --endpoint" in result.stderr
+    assert os.environ["PRIVATE_TOKEN"] == TOKEN
+    assert connector.probe_calls == connector.list_targets_calls == 0
+    assert not (tmp_path / ".town").exists()
+
+
+@pytest.mark.parametrize(
+    ("error", "exit_code", "expected"),
+    [
+        (RuntimeConfigurationError("OPENCLAW_MODEL_INVALID"), 2, "Configuration error"),
+        (RuntimeIncompleteError("OPENCLAW_GATEWAY_UNAVAILABLE"), 4, "RESULT: INCOMPLETE"),
+        (RuntimeExecutionError("OPENCLAW_GATEWAY_INVALID"), 3, "RESULT: ERROR"),
+    ],
+)
+def test_managed_pre_admission_error_mapping_has_empty_stdout_and_no_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    error: RuntimeError,
+    exit_code: int,
+    expected: str,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    connector = _FakeConnector(
+        "openclaw",
+        (RuntimeTarget("everett", None),),
+        prepare_error=error,
+    )
+    monkeypatch.setattr(
+        agent_cli,
+        "_available_runtime_connectors",
+        lambda: (connector,),
+        raising=False,
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["test", "agent", "everett", "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == exit_code
+    assert result.stdout_bytes == b""
+    assert expected in result.stderr
+    assert str(error) in result.stderr
+    assert "Next:" in result.stderr
+    if str(error) == "OPENCLAW_GATEWAY_UNAVAILABLE":
+        assert "openclaw gateway" in result.stderr
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_synthetic_managed_connector_controls_display_and_recovery_text(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    connector = _FakeConnector("hermes", (RuntimeTarget("everett", None),))
+
+    result, _, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        connectors=(connector,),
+        issue_code="HERMES_TIMEOUT",
+    )
+
+    assert result.exit_code == 0
+    assert f"Hermes {OPENCLAW_VERSION}" in result.stderr
+    assert "hermes doctor" in result.stderr
+    assert "--runtime hermes" in result.stderr
+    assert "OpenClaw" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("error", "exit_code", "headline", "safe_code"),
+    [
+        (
+            RuntimeConfigurationError("PRIVATE\nCONFIG"),
+            2,
+            "Configuration error",
+            "RUNTIME_CONFIGURATION_FAILED",
+        ),
+        (
+            RuntimeIncompleteError("PRIVATE\nINCOMPLETE"),
+            4,
+            "RESULT: INCOMPLETE",
+            "RUNTIME_INCOMPLETE",
+        ),
+        (
+            RuntimeExecutionError("PRIVATE\nEXECUTION"),
+            3,
+            "RESULT: ERROR",
+            "RUNTIME_EXECUTION_FAILED",
+        ),
+    ],
+)
+def test_managed_exception_class_controls_exit_and_unsafe_codes_are_sanitized(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    error: RuntimeError,
+    exit_code: int,
+    headline: str,
+    safe_code: str,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    connector = _FakeConnector(
+        "hermes",
+        (RuntimeTarget("everett", None),),
+        probe_error=error,
+    )
+    monkeypatch.setattr(agent_cli, "_available_runtime_connectors", lambda: (connector,))
+
+    result = runner.invoke(app, ["test", "agent", "everett"], color=False)
+
+    assert result.exit_code == exit_code
+    assert headline in result.stderr
+    assert safe_code in result.stderr
+    assert "PRIVATE" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("stage", "error", "exit_code", "fallback"),
+    [
+        (
+            "probe",
+            RuntimeConfigurationError("PRIVATE_TOKEN_ABC123"),
+            2,
+            "RUNTIME_CONFIGURATION_FAILED",
+        ),
+        (
+            "list",
+            RuntimeIncompleteError("PRIVATE_TOKEN_ABC123"),
+            4,
+            "RUNTIME_INCOMPLETE",
+        ),
+        (
+            "prepare",
+            RuntimeExecutionError("PRIVATE_TOKEN_ABC123"),
+            3,
+            "RUNTIME_EXECUTION_FAILED",
+        ),
+    ],
+)
+def test_unowned_syntactically_valid_connector_codes_never_reach_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stage: str,
+    error: RuntimeError,
+    exit_code: int,
+    fallback: str,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    connector = _FakeConnector(
+        "hermes",
+        (RuntimeTarget("everett", None),),
+        probe_error=error if stage == "probe" else None,
+        list_error=error if stage == "list" else None,
+        prepare_error=error if stage == "prepare" else None,
+    )
+    monkeypatch.setattr(agent_cli, "_available_runtime_connectors", lambda: (connector,))
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["test", "agent", "everett", "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == exit_code
+    assert result.stdout_bytes == b""
+    assert fallback in result.stderr
+    assert "PRIVATE_TOKEN_ABC123" not in result.stderr
+    assert "runtime runtime" not in result.stderr
+    assert not (tmp_path / ".town").exists()
+
+
+def test_prepared_runtime_policy_mismatch_fails_before_progress_or_inference(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    connector = _FakeConnector(
+        "hermes",
+        (RuntimeTarget("everett", None),),
+        issue_policy=RuntimeIssuePolicy(execution=frozenset({"HERMES_TIMEOUT"})),
+        prepared_issue_policy=RuntimeIssuePolicy(execution=frozenset({"HERMES_OTHER_FAILURE"})),
+    )
+    monkeypatch.setattr(agent_cli, "_available_runtime_connectors", lambda: (connector,))
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["test", "agent", "everett", "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == 3
+    assert result.stdout_bytes == b""
+    assert "RUNTIME_POLICY_MISMATCH" in result.stderr
+    assert "Running a basic local agent test" not in result.stderr
+    assert not (tmp_path / ".town").exists()
+
+
+def test_equal_frozen_prepared_policy_preserves_continuity_without_identity_coupling(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    connector_policy = RuntimeIssuePolicy(execution=frozenset({"HERMES_TIMEOUT"}))
+    prepared_policy = RuntimeIssuePolicy(execution=frozenset({"HERMES_TIMEOUT"}))
+    connector = _FakeConnector(
+        "hermes",
+        (RuntimeTarget("everett", None),),
+        issue_policy=connector_policy,
+        prepared_issue_policy=prepared_policy,
+    )
+
+    result, calls, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        connectors=(connector,),
+    )
+
+    prepared = cast("_FakePreparedRuntime", calls[0]["prepared_runtime"])
+    assert result.exit_code == 0
+    assert prepared.issue_policy == connector.issue_policy
+    assert prepared.issue_policy is not connector.issue_policy
+
+
+@pytest.mark.parametrize("stage", ["probe", "list", "prepare"])
+def test_unexpected_connector_value_error_is_safe_exit_3_before_admission(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stage: str,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    private_detail = f"private-connector-{stage}-{TOKEN}"
+    failure = ValueError(private_detail)
+    connector = _FakeConnector(
+        "openclaw",
+        (RuntimeTarget("everett", None),),
+        probe_error=failure if stage == "probe" else None,
+        list_error=failure if stage == "list" else None,
+        prepare_error=failure if stage == "prepare" else None,
+    )
+    monkeypatch.setattr(agent_cli, "_available_runtime_connectors", lambda: (connector,))
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["test", "agent", "everett", "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == 3
+    assert result.stdout_bytes == b""
+    assert "RESULT: ERROR" in result.stderr
+    assert "managed runtime connector failed unexpectedly" in result.stderr
+    assert private_detail not in result.stderr
+    assert TOKEN not in result.stderr
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    ("managed_args", "expected"),
+    [
+        ([" bad-target "], "TARGET must be"),
+        (["everett", "--runtime", " bad-runtime "], "--runtime must be"),
+        (["everett", "--model", "provider"], "--model must be provider/model"),
+    ],
+)
+def test_invalid_managed_user_values_exit_2_before_connector_loading(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    managed_args: list[str],
+    expected: str,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    loaded = False
+
+    def must_not_load_connectors() -> NoReturn:
+        nonlocal loaded
+        loaded = True
+        raise AssertionError("connector loading crossed the user-validation boundary")
+
+    monkeypatch.setattr(agent_cli, "_available_runtime_connectors", must_not_load_connectors)
+    monkeypatch.setenv("TOWN_AGENT_TOKEN", TOKEN)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["test", "agent", *managed_args, "--format", "json"],
+        color=False,
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert expected in result.stderr
+    assert loaded is False
+    assert os.environ["TOWN_AGENT_TOKEN"] == TOKEN
+    assert TOKEN not in result.stderr
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_managed_output_directory_admission_race_keeps_actionable_exit_2(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+    import nest_core.agent_test.managed_runtime as managed_runtime
+
+    async def fail_admission(**_kwargs: object) -> NoReturn:
+        raise AgentTestPreAdmissionError("OUTPUT_DIR_INVALID")
+
+    connector = _FakeConnector("openclaw", (RuntimeTarget("everett", None),))
+    monkeypatch.setattr(agent_cli, "_available_runtime_connectors", lambda: (connector,))
+    monkeypatch.setattr(managed_runtime, "run_managed_agent_test", fail_admission)
+    output_directory = tmp_path / "result"
+
+    result = runner.invoke(
+        app,
+        [
+            "test",
+            "agent",
+            "everett",
+            "--output-dir",
+            str(output_directory),
+            "--format",
+            "json",
+        ],
+        color=False,
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout_bytes == b""
+    assert "output directory must be new or empty and must not be a file or symlink" in (
+        result.stderr
+    )
+    assert not output_directory.exists()
+
+
+@pytest.mark.parametrize("exit_code", [0, 1, 3, 4, 130])
+def test_managed_admitted_exit_codes_preserve_result_json_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    exit_code: int,
+) -> None:
+    issue_code = "OPENCLAW_TIMEOUT" if exit_code == 4 else None
+
+    result, _, outcome, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        outcome_exit=exit_code,
+        issue_code=issue_code,
+        extra=["--format", "json"],
+    )
+
+    assert result.exit_code == exit_code
+    assert result.stdout_bytes == outcome.result_bytes
+    assert result.stdout_bytes == (outcome.output_directory / "result.json").read_bytes()
+    machine_result = json.loads(result.stdout_bytes)
+    assert machine_result["profile"] == {
+        "id": "nanda/agent/capability-fulfillment",
+        "version": "1",
+        "digest": "sha256:436622e70cd84690e39c24f93236c7639adefea2fe9ea72a1dddb25e65609c58",
+    }
+    assert machine_result["driver"]["endpoint_origin"] == ENDPOINT
+    assert "adapter_instance_id" in machine_result["driver"]
+    assert f"OpenClaw {OPENCLAW_VERSION}" in result.stderr
+    assert "everett" in result.stderr
+    if issue_code is not None:
+        assert f"Runtime issue: {issue_code}" in result.stderr
+        assert "Next:" in result.stderr
+
+
+def test_managed_verbose_diagnostics_retain_runtime_model_and_result_identifiers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    result, _, _, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        extra=["--model", "provider/override", "--verbose"],
+    )
+
+    assert result.exit_code == 0
+    for technical_identifier in (
+        f"OpenClaw {OPENCLAW_VERSION}",
+        "everett",
+        "Model: provider/override",
+        PROFILE_EXACT,
+        "sha256:436622e70cd84690e39c24f93236c7639adefea2fe9ea72a1dddb25e65609c58",
+        ENDPOINT,
+        "01K00000000000000000000000",
+    ):
+        assert technical_identifier in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -654,6 +1664,48 @@ def test_unsafe_target_label_is_rejected_before_admission_without_bundle(
     assert TOKEN not in result.stderr
 
 
+def test_default_human_output_is_a_plain_fixed_basic_local_agent_test(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    result, _, outcome = _invoke(monkeypatch, tmp_path)
+
+    expected = f"""RESULT: PASS
+Target: local-agent
+This was a basic local agent test.
+
+Stages
+  PASS        Connected to the agent
+  PASS        Offered the test capability
+  PASS        Found through local discovery
+  PASS        Received the test request
+  PASS        Returned the expected response
+
+Not tested
+  Persistent discovery, real network delivery, identity, authorization, trust,
+  payments, negotiation, safety, and long-term reliability.
+
+Next
+  Review the result and trace evidence.
+
+Artifacts
+  Directory: {outcome.output_directory}
+"""
+    assert result.exit_code == 0
+    assert result.stdout == expected
+    for forbidden in (
+        "capability-fulfillment",
+        PROFILE_EXACT,
+        "sha256:",
+        "bearer",
+        ENDPOINT,
+        "loopback",
+        "adapter instance",
+        "01K00000000000000000000000",
+    ):
+        assert forbidden.lower() not in result.stdout.lower()
+
+
 @pytest.mark.parametrize(
     ("exit_code", "headline"),
     [
@@ -664,44 +1716,40 @@ def test_unsafe_target_label_is_rejected_before_admission_without_bundle(
         (130, "RESULT: INTERRUPTED"),
     ],
 )
-def test_human_terminal_outcomes_have_honest_ordered_sections(
+def test_human_terminal_outcomes_keep_five_plain_stages_and_next_action(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     exit_code: int,
     headline: str,
 ) -> None:
-    result, _, outcome = _invoke(monkeypatch, tmp_path, outcome_exit=exit_code)
+    result, _, _ = _invoke(monkeypatch, tmp_path, outcome_exit=exit_code)
 
     assert result.exit_code == exit_code
     assert result.stdout.startswith(headline + "\n")
-    assert "Run: 01K00000000000000000000001" in result.stdout
-    assert f"Profile: {PROFILE_EXACT}" in result.stdout
-    assert (
-        "Target label: local-agent (local evidence label; not verified identity)" in result.stdout
-    )
-    expected_instance = outcome.result.driver.adapter_instance_id or "not observed"
-    assert (
-        "Request authentication: Town sent bearer-authenticated requests using the caller "
-        "credential" in result.stdout
-    )
-    assert f"Adapter instance (self-asserted): {expected_instance}" in result.stdout
-    assert "Next\n" in result.stdout
-    assert "Artifacts\n" in result.stdout
-    expected_sections = {
-        0: ["Passed", "Not tested", "Next", "Artifacts"],
-        1: ["Failed", "Not tested", "Next", "Artifacts"],
-        3: ["Not evaluated", "Next", "Artifacts"],
-        4: ["Incomplete", "Next", "Artifacts"],
-        130: ["Incomplete", "Next", "Artifacts"],
-    }[exit_code]
-    positions = [result.stdout.index(section + "\n") for section in expected_sections]
+    assert result.stdout.count("Connected to the agent") == 1
+    assert result.stdout.count("Offered the test capability") == 1
+    assert result.stdout.count("Found through local discovery") == 1
+    assert result.stdout.count("Received the test request") == 1
+    assert result.stdout.count("Returned the expected response") == 1
+    positions = [
+        result.stdout.index(section) for section in ("Stages", "Not tested", "Next", "Artifacts")
+    ]
     assert positions == sorted(positions)
     lowered = result.stdout.lower()
-    for forbidden in ("compatible", "certified", "safe", "trusted", "reliable", "llm"):
+    for forbidden in (
+        "capability-fulfillment",
+        PROFILE_EXACT,
+        "sha256:",
+        "bearer",
+        ENDPOINT,
+        "loopback",
+        "adapter instance",
+        "compatible",
+        "certified",
+        "trusted",
+        "llm",
+    ):
         assert re.search(rf"\b{forbidden}\b", lowered) is None
-    if exit_code == 4:
-        assert "TRANSPORT_LOSS" in result.stdout
-        assert f"Start or check the local adapter at {ENDPOINT}, then rerun" in result.stdout
 
 
 def test_no_color_explicitly_disables_color_for_human_output(
@@ -745,23 +1793,23 @@ def test_json_stdout_is_exact_result_bytes_and_progress_is_only_stderr(
     assert result.stdout_bytes == outcome.result_bytes
     assert result.stdout_bytes == (outcome.output_directory / "result.json").read_bytes()
     assert str(tmp_path).encode() not in result.stdout_bytes
-    assert b"Running local adapter test" not in result.stdout_bytes
-    assert "Running local adapter test" in result.stderr
+    assert b"Running a basic local agent test" not in result.stdout_bytes
+    assert "Running a basic local agent test" in result.stderr
 
 
 def test_human_next_offers_a_working_portable_trace_inspect_command(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.chdir(tmp_path)
-    result, _, outcome = _invoke(monkeypatch, tmp_path)
+    result, _, outcome = _invoke(monkeypatch, tmp_path, extra=["--verbose"])
 
     trace = outcome.output_directory / "trace.jsonl"
     relative_trace = trace.relative_to(tmp_path)
     command = f"nest inspect {relative_trace}"
     assert result.exit_code == 0
-    assert f"Inspect the trace: {command}" in result.stdout
+    assert f"Inspect the trace: {command}" in result.stderr
     assert str(tmp_path) not in next(
-        line for line in result.stdout.splitlines() if "nest inspect" in line
+        line for line in result.stderr.splitlines() if "nest inspect" in line
     )
     inspected = runner.invoke(app, ["inspect", str(relative_trace)], color=False)
     assert inspected.exit_code == 0
@@ -838,11 +1886,10 @@ def test_causally_unobserved_check_is_not_merged_with_out_of_profile_coverage(
     )
 
     assert rendered.exit_code == 4
-    not_evaluated = rendered.stdout.index("Not evaluated\n")
-    causal_check = rendered.stdout.index("driver.contract:")
+    causal_check = rendered.stdout.index("Connected to the agent")
     not_tested = rendered.stdout.index("Not tested\n")
-    out_of_profile = rendered.stdout.index("agent.safety:")
-    assert not_evaluated < causal_check < not_tested < out_of_profile
+    out_of_profile = rendered.stdout.index("safety")
+    assert causal_check < not_tested < out_of_profile
 
 
 def test_verbose_changes_stderr_only_and_never_prints_the_token(
@@ -855,7 +1902,11 @@ def test_verbose_changes_stderr_only_and_never_prints_the_token(
     assert normal.stdout == verbose.stdout
     assert normal.stderr != verbose.stderr
     assert PROFILE_EXACT in verbose.stderr
+    assert "sha256:436622e70cd84690e39c24f93236c7639adefea2fe9ea72a1dddb25e65609c58" in (
+        verbose.stderr
+    )
     assert ENDPOINT in verbose.stderr
+    assert "01K00000000000000000000000" in verbose.stderr
     assert TOKEN not in normal.stdout + normal.stderr + verbose.stdout + verbose.stderr
 
 
@@ -931,6 +1982,32 @@ def test_interrupt_during_terminal_diagnostics_distinguishes_finalized_result(
     assert TOKEN not in result.stderr
 
 
+def test_interrupt_during_managed_issue_diagnostics_preserves_finalized_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import nest_core.agent_test.cli as agent_cli
+
+    def interrupt_issue(_outcome: object) -> NoReturn:
+        raise KeyboardInterrupt("interrupt-runtime-issue-canary")
+
+    monkeypatch.setattr(agent_cli, "_write_managed_issue", interrupt_issue)
+    result, _, outcome, _ = _invoke_managed(
+        monkeypatch,
+        tmp_path,
+        outcome_exit=4,
+        issue_code="OPENCLAW_TIMEOUT",
+        extra=["--format", "json"],
+    )
+
+    assert result.exit_code == 130
+    assert result.stdout_bytes == b""
+    assert "RESULT: OUTPUT INTERRUPTED" in result.stderr
+    assert "test finalized as INCOMPLETE; result.json remains authoritative" in result.stderr
+    assert "interrupt-runtime-issue-canary" not in result.stderr
+    assert (outcome.output_directory / "result.json").read_bytes() == outcome.result_bytes
+
+
 @pytest.mark.parametrize(
     ("failure", "exit_code", "terminal"),
     [
@@ -955,8 +2032,7 @@ def test_interrupt_during_terminal_diagnostics_distinguishes_finalized_result(
         (
             DriverContractError("MALFORMED_RESPONSE"),
             1,
-            "Driver contract: the local adapter returned an invalid response to Town's "
-            "bearer-authenticated request.",
+            "The local agent returned an invalid response to Town's test request.",
         ),
         (
             DriverIncompleteError("TRANSPORT_LOSS"),
@@ -966,12 +2042,12 @@ def test_interrupt_during_terminal_diagnostics_distinguishes_finalized_result(
         (
             TownDriverError("PROFILE_MISMATCH"),
             3,
-            "Town could not complete the local adapter test.",
+            "Town could not complete the basic local agent test.",
         ),
         (
             AgentTestTownError("TOWN_EXECUTION_ERROR"),
             3,
-            "Town could not complete the local adapter test.",
+            "Town could not complete the basic local agent test.",
         ),
         (TimeoutError("secret-timeout-detail"), 4, "RESULT: INCOMPLETE"),
         (RuntimeError("secret-runtime-detail"), 3, "RESULT: ERROR"),

--- a/packages/nest-core/tests/agent_test/test_end_to_end.py
+++ b/packages/nest-core/tests/agent_test/test_end_to_end.py
@@ -26,6 +26,12 @@ from nest_core.agent_test.models import TestObservation, TestResult
 REPOSITORY_ROOT = Path(__file__).parents[4]
 ADAPTER_PATH = REPOSITORY_ROOT / "examples" / "agent-test" / "reference_adapter.py"
 CHECKER_PATH = REPOSITORY_ROOT / "scripts" / "check_agent_test_quickstart.py"
+ROOT_README = REPOSITORY_ROOT / "README.md"
+DOCS_INDEX = REPOSITORY_ROOT / "docs" / "README.md"
+DOCS_QUICKSTART = REPOSITORY_ROOT / "docs" / "quickstart.md"
+BEGINNER_GUIDE = REPOSITORY_ROOT / "docs" / "bring-your-agent.md"
+ADAPTER_REFERENCE = REPOSITORY_ROOT / "docs" / "agent-test-adapter-reference.md"
+EXAMPLE_README = REPOSITORY_ROOT / "examples" / "agent-test" / "README.md"
 TOKEN = "9" * 64
 CONTRACT = "town-agent-driver/1"
 
@@ -355,6 +361,90 @@ def test_checker_recursively_enumerates_every_artifact_file(tmp_path: Path) -> N
     (output / "result.json").write_bytes(b"{}")
 
     assert checker._artifact_files(output) == [nested, output / "result.json"]
+
+
+def test_checker_exercises_installed_openclaw_auto_explicit_and_preflight_paths(
+    tmp_path: Path,
+) -> None:
+    """Dropping the installed managed-runtime journey from the release check must fail."""
+    checker = _load_checker()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    environment = checker._safe_environment()
+
+    checker._verify_installed_openclaw(
+        nest=_installed_nest(),
+        runtime=runtime,
+        environment=environment,
+    )
+    logs = [
+        json.loads(line) for line in (runtime / "fake-bin" / "log.jsonl").read_text().splitlines()
+    ]
+    assert len(logs) == 30
+    assert [record["argument_names"] for record in logs[14:]] == [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+        ["config", "get", "env", "--json"],
+        ["agents", "list", "--json"],
+    ] * 4
+
+
+def test_checker_raw_prompt_scan_rejects_an_embedded_prompt() -> None:
+    """The release scan must inspect prompt bytes, not only whole-file digests."""
+    checker = _load_checker()
+    prompt = b'{"private":"clean-wheel-raw-prompt"}'
+    retained = b"prefix\n" + prompt + b"\nsuffix"
+
+    with pytest.raises(checker._CheckFailureError, match="raw OpenClaw prompt"):
+        checker._assert_no_raw_prompts([retained], [prompt])
+
+
+def test_public_docs_route_beginner_and_advanced_readers_without_duplication() -> None:
+    """Public indexes must route to both guides while the example stays implementation-only."""
+    assert "docs/bring-your-agent.md" in ROOT_README.read_text()
+    assert "docs/agent-test-adapter-reference.md" in ROOT_README.read_text()
+    assert "bring-your-agent.md" in DOCS_INDEX.read_text()
+    assert "agent-test-adapter-reference.md" in DOCS_INDEX.read_text()
+    assert "bring-your-agent.md" in DOCS_QUICKSTART.read_text()
+    assert "agent-test-adapter-reference.md" in DOCS_QUICKSTART.read_text()
+
+    example = EXAMPLE_README.read_text()
+    assert "../../docs/agent-test-adapter-reference.md" in example
+    for duplicated_detail in (
+        "TOWN_AGENT_TOKEN",
+        "two terminals",
+        "127.0.0.1",
+        "digest binding",
+        "replay",
+        "--endpoint",
+    ):
+        assert duplicated_detail not in example
+
+    beginner = BEGINNER_GUIDE.read_text()
+    assert "agent-test-adapter-reference.md" in beginner
+    reference = ADAPTER_REFERENCE.read_text()
+    assert "run state is released after stop" in reference
+    assert "adapter process continues serving until you press Ctrl-C" in reference
+
+
+def test_public_beginner_readme_hides_the_internal_profile_name() -> None:
+    assert "capability-fulfillment" not in ROOT_README.read_text()
+
+
+def test_beginner_guide_discloses_openclaw_session_retention() -> None:
+    beginner = " ".join(BEGINNER_GUIDE.read_text().split())
+    assert (
+        "Each Town run uses a fresh OpenClaw session, but OpenClaw may retain that session "
+        "and its normal transcript; Town does not delete them."
+    ) in beginner
+
+
+def test_beginner_guide_explains_how_to_test_an_agent_on_another_computer() -> None:
+    beginner = " ".join(BEGINNER_GUIDE.read_text().split())
+    assert "If OpenClaw runs on another computer" in beginner
+    assert "SSH into that computer and run Town there" in beginner
+    assert "does not connect directly to a remote OpenClaw Gateway" in beginner
+    assert "Gateway must be healthy and bound to loopback" not in beginner
 
 
 @pytest.mark.skipif(

--- a/packages/nest-core/tests/agent_test/test_openclaw_end_to_end.py
+++ b/packages/nest-core/tests/agent_test/test_openclaw_end_to_end.py
@@ -500,10 +500,10 @@ def test_headline_command_autodetects_one_exact_target_and_reuses_one_session(
     )
 
 
-def test_public_command_accepts_and_records_a_coherent_alternate_openclaw_version(
+def test_public_command_accepts_and_reports_a_coherent_alternate_openclaw_version(
     tmp_path: Path,
 ) -> None:
-    """A stale release allowlist or unrecorded probe version must fail this boundary."""
+    """A stale release allowlist or unreported public probe version must fail here."""
     fake_bin = tmp_path / "bin"
     prompts = tmp_path / "prompts"
     runtime = tmp_path / "runtime"

--- a/packages/nest-core/tests/agent_test/test_openclaw_end_to_end.py
+++ b/packages/nest-core/tests/agent_test/test_openclaw_end_to_end.py
@@ -70,6 +70,7 @@ def _install_fake_openclaw(
     fake_bin: Path,
     *,
     variant: str = "success",
+    version: str = "2026.7.1-2",
     linger_port: int | None = None,
 ) -> Path:
     """Install a four-command fake with private, test-only prompt capture."""
@@ -98,6 +99,7 @@ def _install_fake_openclaw(
         ready_path = pathlib.Path(__READY__)
         capture_directory = pathlib.Path(__CAPTURES__)
         variant = __VARIANT__
+        version = __VERSION__
         linger_port = __PORT__
         start_prompt = __START_PROMPT__
         message_prompt = __MESSAGE_PROMPT__
@@ -122,7 +124,7 @@ def _install_fake_openclaw(
 
         if args == ["--version"]:
             append_log(["--version"])
-            emit("OpenClaw 2026.7.1-2 (0790d9f)")
+            emit("OpenClaw " + version + " (0790d9f)")
             raise SystemExit(0)
 
         if args == ["config", "get", "gateway.mode", "--json"]:
@@ -152,7 +154,7 @@ def _install_fake_openclaw(
         if args == ["gateway", "status", "--json", "--require-rpc"]:
             append_log(["gateway", "status", "--json", "--require-rpc"])
             emit({
-                "cli": {"entrypoint": "/synthetic/openclaw.mjs", "version": "2026.7.1-2"},
+                "cli": {"entrypoint": "/synthetic/openclaw.mjs", "version": version},
                 "config": {
                     "cli": {
                         "controlUi": {},
@@ -172,7 +174,7 @@ def _install_fake_openclaw(
                     "bindMode": "lan",
                     "bindHost": "0.0.0.0",
                     "probeUrl": "ws://127.0.0.1:18789",
-                    "version": "2026.7.1-2",
+                    "version": version,
                 },
                 "port": {
                     "hints": [],
@@ -184,7 +186,7 @@ def _install_fake_openclaw(
                     "capability": "operator",
                     "kind": "read",
                     "ok": True,
-                    "version": "2026.7.1-2",
+                    "version": version,
                     "url": "ws://127.0.0.1:18789",
                 },
             })
@@ -339,6 +341,7 @@ def _install_fake_openclaw(
         .replace("__READY__", repr(str(ready_path)))
         .replace("__CAPTURES__", repr(str(capture_directory)))
         .replace("__VARIANT__", repr(variant))
+        .replace("__VERSION__", repr(version))
         .replace("__PORT__", repr(linger_port))
         .replace("__START_PROMPT__", repr(START_PROMPT))
         .replace("__MESSAGE_PROMPT__", repr(MESSAGE_PROMPT))
@@ -495,6 +498,32 @@ def test_headline_command_autodetects_one_exact_target_and_reuses_one_session(
         ),
         raw_prompts=first_prompts + second_prompts,
     )
+
+
+def test_public_command_accepts_and_records_a_coherent_alternate_openclaw_version(
+    tmp_path: Path,
+) -> None:
+    """A stale release allowlist or unrecorded probe version must fail this boundary."""
+    fake_bin = tmp_path / "bin"
+    prompts = tmp_path / "prompts"
+    runtime = tmp_path / "runtime"
+    for directory in (fake_bin, prompts, runtime):
+        directory.mkdir()
+    _install_fake_openclaw(fake_bin, version="2027.1.0-preview.3+compat")
+
+    completed = _run(
+        runtime,
+        _environment(fake_bin, prompts),
+        "fixture-agent",
+        "--format",
+        "json",
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    result, _ = _result_bundle(runtime, completed)
+    _assert_five_passes(result)
+    assert b"OpenClaw 2027.1.0-preview.3+compat" in completed.stderr
+    assert len(_read_and_remove_private_prompt_captures(fake_bin)) == 2
 
 
 def test_explicit_runtime_uses_only_the_openclaw_connector(tmp_path: Path) -> None:

--- a/packages/nest-core/tests/agent_test/test_openclaw_end_to_end.py
+++ b/packages/nest-core/tests/agent_test/test_openclaw_end_to_end.py
@@ -1,0 +1,648 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Installed-process proof for Town's exact OpenClaw quickstart boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+BEARER_CANARY = "town-managed-bearer-must-not-cross-the-openclaw-boundary"
+PASS_CHECKS = [
+    "driver.contract",
+    "registry.provider-registered",
+    "registry.provider-discovered",
+    "delivery.request-routed",
+    "capability.synthetic-request-fulfilled",
+]
+START_PROMPT = (
+    b"You are completing one basic local NANDA Town agent test.\n"
+    b"Return exactly one minified JSON object and no other characters.\n"
+    b"Do not return prose, Markdown, or code fences.\n"
+    b"Do not invoke tools, access files, memory, messages, channels, or perform any "
+    b"other action.\n"
+    b"This is the start event. Declare the sell capability by returning exactly "
+    b'{"capabilities":["sell"],"kind":"declare_capability"}.\n'
+    b'If you cannot do that, return exactly {"kind":"none"}.\n'
+)
+MESSAGE_PROMPT = (
+    b"You are completing one basic local NANDA Town agent test.\n"
+    b"Return exactly one minified JSON object and no other characters.\n"
+    b"Do not return prose, Markdown, or code fences.\n"
+    b"Do not invoke tools, access files, memory, messages, channels, or perform any "
+    b"other action.\n"
+    b"This is the message event.\n"
+    b'Input text: "buy:widget:2"\n'
+    b"If the text matches buy:<item>:<quantity>, return one canonical object shaped as "
+    b'{"kind":"send_to_sender","media_type":"text/plain; charset=utf-8",'
+    b'"text":"sold:<item>:<quantity>"}, replacing <item> and <quantity> with the '
+    b"input values.\n"
+    b'If you cannot do that, return exactly {"kind":"none"}.\n'
+)
+
+
+def _installed_nest() -> Path:
+    for name in ("nest", "nest.exe"):
+        command = Path(sys.executable).with_name(name)
+        if command.is_file():
+            return command
+    raise AssertionError("the installed test environment must expose the nest console script")
+
+
+def _environment(fake_bin: Path, prompt_directory: Path) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["PATH"] = os.pathsep.join((str(fake_bin), environment.get("PATH", "")))
+    environment["TMPDIR"] = str(prompt_directory)
+    environment["TOWN_FAKE_BEARER"] = BEARER_CANARY
+    environment["PYTHONNOUSERSITE"] = "1"
+    environment.pop("PYTHONPATH", None)
+    return environment
+
+
+def _install_fake_openclaw(
+    fake_bin: Path,
+    *,
+    variant: str = "success",
+    linger_port: int | None = None,
+) -> Path:
+    """Install a four-command fake with private, test-only prompt capture."""
+    state_path = fake_bin / "fake-openclaw-state.json"
+    log_path = fake_bin / "fake-openclaw-log.jsonl"
+    ready_path = fake_bin / "fake-openclaw-child-ready"
+    capture_directory = fake_bin / "private-prompt-captures"
+    capture_directory.mkdir(mode=0o700)
+    state_path.write_text('{"turns":{}}', encoding="utf-8")
+    executable = fake_bin / ("openclaw.exe" if os.name == "nt" else "openclaw")
+    script = textwrap.dedent(
+        """\
+        #!__PYTHON__
+        import hashlib
+        import json
+        import os
+        import pathlib
+        import socket
+        import stat
+        import subprocess
+        import sys
+        import time
+
+        state_path = pathlib.Path(__STATE__)
+        log_path = pathlib.Path(__LOG__)
+        ready_path = pathlib.Path(__READY__)
+        capture_directory = pathlib.Path(__CAPTURES__)
+        variant = __VARIANT__
+        linger_port = __PORT__
+        start_prompt = __START_PROMPT__
+        message_prompt = __MESSAGE_PROMPT__
+        args = sys.argv[1:]
+
+        def append_log(argument_names, **fields):
+            record = {
+                "argument_names": argument_names,
+                "town_environment_names": sorted(
+                    name for name in os.environ if name.startswith("TOWN_")
+                ),
+                **fields,
+            }
+            with log_path.open("a", encoding="utf-8") as stream:
+                stream.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\\n")
+
+        def emit(value):
+            if isinstance(value, str):
+                print(value)
+            else:
+                print(json.dumps(value, sort_keys=True, separators=(",", ":")))
+
+        if args == ["--version"]:
+            append_log(["--version"])
+            emit("OpenClaw 2026.7.1-2 (0790d9f)")
+            raise SystemExit(0)
+
+        if args == ["config", "get", "gateway.mode", "--json"]:
+            append_log(["config", "get", "gateway.mode", "--json"])
+            emit(json.dumps("local"))
+            raise SystemExit(0)
+
+        if args == ["config", "get", "env", "--json"]:
+            append_log(["config", "get", "env", "--json"])
+            raise SystemExit(1)
+
+        if args == ["agents", "list", "--json"]:
+            append_log(["agents", "list", "--json"])
+            emit([
+                {
+                    "id": "fixture-agent",
+                    "name": "Fixture Agent",
+                    "workspace": "/synthetic/workspace",
+                    "agentDir": "/synthetic/agent",
+                    "model": "fixture/model",
+                    "isDefault": True,
+                    "bindings": 0,
+                }
+            ])
+            raise SystemExit(0)
+
+        if args == ["gateway", "status", "--json", "--require-rpc"]:
+            append_log(["gateway", "status", "--json", "--require-rpc"])
+            emit({
+                "cli": {"entrypoint": "/synthetic/openclaw.mjs", "version": "2026.7.1-2"},
+                "config": {
+                    "cli": {
+                        "controlUi": {},
+                        "exists": True,
+                        "path": "/synthetic/openclaw.json",
+                        "valid": True,
+                    },
+                    "daemon": {
+                        "controlUi": {},
+                        "exists": True,
+                        "path": "/synthetic/openclaw.json",
+                        "valid": True,
+                    },
+                },
+                "extraServices": [{"label": "user-managed-service"}],
+                "gateway": {
+                    "bindMode": "lan",
+                    "bindHost": "0.0.0.0",
+                    "probeUrl": "ws://127.0.0.1:18789",
+                    "version": "2026.7.1-2",
+                },
+                "port": {
+                    "hints": [],
+                    "listeners": [{"address": "TCP *:18789 (LISTEN)"}],
+                    "port": 18789,
+                    "status": "busy",
+                },
+                "rpc": {
+                    "capability": "operator",
+                    "kind": "read",
+                    "ok": True,
+                    "version": "2026.7.1-2",
+                    "url": "ws://127.0.0.1:18789",
+                },
+            })
+            raise SystemExit(0)
+
+        expected_flags = [
+            "agent",
+            "--agent",
+            "--session-key",
+            "--timeout",
+            "--message-file",
+            "--json",
+        ]
+        argument_names = (
+            [args[0], *[argument for argument in args[1:] if argument.startswith("--")]]
+            if args
+            else []
+        )
+        if not args or argument_names != expected_flags:
+            append_log(argument_names)
+            raise SystemExit(17)
+        if args[args.index("--agent") + 1] != "fixture-agent":
+            append_log(argument_names)
+            raise SystemExit(18)
+        if args[args.index("--timeout") + 1] != "0":
+            append_log(argument_names)
+            raise SystemExit(19)
+
+        session_key = args[args.index("--session-key") + 1]
+        message_path = pathlib.Path(args[args.index("--message-file") + 1])
+        message = message_path.read_bytes()
+        message_digest = "sha256:" + hashlib.sha256(message).hexdigest()
+        message_mode = stat.S_IMODE(message_path.stat().st_mode)
+        capture_path = capture_directory / (message_digest.removeprefix("sha256:") + ".json")
+        capture_descriptor = os.open(
+            capture_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            offset = 0
+            while offset < len(message):
+                written = os.write(capture_descriptor, message[offset:])
+                if written <= 0:
+                    raise OSError
+                offset += written
+            os.fsync(capture_descriptor)
+        finally:
+            os.close(capture_descriptor)
+        append_log(
+            argument_names,
+            message_digest=message_digest,
+            message_mode=message_mode,
+            session_key=session_key,
+        )
+        if message == start_prompt:
+            expected_turn = 0
+            intent = {"capabilities": ["sell"], "kind": "declare_capability"}
+        elif message == message_prompt:
+            expected_turn = 1
+            intent = {
+                "kind": "send_to_sender",
+                "media_type": "text/plain; charset=utf-8",
+                "text": "sold:widget:2",
+            }
+        else:
+            raise SystemExit(23)
+        del message
+
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        turn = int(state["turns"].get(session_key, 0))
+        if turn != expected_turn:
+            raise SystemExit(24)
+        state["turns"][session_key] = turn + 1
+        state_path.write_text(
+            json.dumps(state, sort_keys=True, separators=(",", ":")),
+            encoding="utf-8",
+        )
+
+        if variant == "timeout":
+            if not isinstance(linger_port, int):
+                raise SystemExit(20)
+            child_code = (
+                "import pathlib,socket,sys,time;"
+                "s=socket.socket();"
+                "s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1);"
+                "s.bind(('127.0.0.1',int(sys.argv[1])));"
+                "s.listen();"
+                "pathlib.Path(sys.argv[2]).write_text('ready');"
+                "time.sleep(60)"
+            )
+            child = subprocess.Popen(
+                [sys.executable, "-c", child_code, str(linger_port), str(ready_path)]
+            )
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not ready_path.exists():
+                if child.poll() is not None:
+                    raise SystemExit(21)
+                time.sleep(0.01)
+            child.wait()
+            raise SystemExit(22)
+
+        text = json.dumps(intent, sort_keys=True, separators=(",", ":"))
+        session_digest = hashlib.sha256(session_key.encode("utf-8")).hexdigest()
+        envelope = {
+            "runId": "run-" + session_digest[:16],
+            "status": "ok",
+            "summary": "completed",
+            "result": {
+                "payloads": [{"text": text, "mediaUrl": None}],
+                "meta": {
+                    "durationMs": 1,
+                    "agentMeta": {
+                        "sessionId": "session-" + session_digest[:16],
+                        "provider": "fixture",
+                        "model": "model",
+                        "agentHarnessId": "fixture-agent",
+                    },
+                    "aborted": False,
+                    "finalAssistantVisibleText": text,
+                    "finalAssistantRawText": text,
+                    "replayInvalid": False,
+                    "livenessState": "working",
+                    "stopReason": "stop",
+                    "executionTrace": {
+                        "winnerProvider": "fixture",
+                        "winnerModel": "model",
+                        "attempts": [{
+                            "provider": "fixture",
+                            "model": "model",
+                            "result": "success",
+                            "stage": "assistant",
+                        }],
+                        "fallbackUsed": False,
+                        "runner": "embedded",
+                    },
+                    "completion": {"stopReason": "stop", "finishReason": "stop"},
+                },
+            },
+        }
+        if variant == "fallback":
+            envelope["fallback"] = True
+        elif variant == "activity":
+            envelope["toolCalls"] = []
+        emit(envelope)
+        """
+    )
+    script = (
+        script.replace("__PYTHON__", os.fspath(Path(sys.executable)))
+        .replace("__STATE__", repr(str(state_path)))
+        .replace("__LOG__", repr(str(log_path)))
+        .replace("__READY__", repr(str(ready_path)))
+        .replace("__CAPTURES__", repr(str(capture_directory)))
+        .replace("__VARIANT__", repr(variant))
+        .replace("__PORT__", repr(linger_port))
+        .replace("__START_PROMPT__", repr(START_PROMPT))
+        .replace("__MESSAGE_PROMPT__", repr(MESSAGE_PROMPT))
+    )
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    return log_path
+
+
+def _run(
+    cwd: Path,
+    environment: dict[str, str],
+    *arguments: str,
+    timeout: int = 20,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        [str(_installed_nest()), "test", "agent", *arguments],
+        cwd=cwd,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _logs(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _result_bundle(
+    cwd: Path, completed: subprocess.CompletedProcess[bytes]
+) -> tuple[dict[str, Any], Path]:
+    result = json.loads(completed.stdout)
+    bundle = cwd / ".town" / "runs" / result["run_id"]
+    assert completed.stdout == (bundle / "result.json").read_bytes()
+    return result, bundle
+
+
+def _assert_five_passes(result: dict[str, Any]) -> None:
+    assert result["execution"]["status"] == "completed"
+    assert result["evaluation"]["verdict"] == "pass"
+    assert [(check["id"], check["status"]) for check in result["evaluation"]["checks"]] == [
+        (check_id, "pass") for check_id in PASS_CHECKS
+    ]
+
+
+def _assert_no_sensitive_bytes(
+    *roots: Path,
+    streams: tuple[bytes, ...] = (),
+    raw_prompts: tuple[bytes, ...] = (),
+) -> None:
+    values = list(streams)
+    for root in roots:
+        values.extend(path.read_bytes() for path in root.rglob("*") if path.is_file())
+    assert all(BEARER_CANARY.encode("ascii") not in value for value in values)
+    assert all(b'"observation":' not in value for value in values if b'"argument_names"' in value)
+    assert all(prompt and prompt not in value for prompt in raw_prompts for value in values)
+
+
+def _read_and_remove_private_prompt_captures(fake_bin: Path) -> tuple[bytes, ...]:
+    capture_directory = fake_bin / "private-prompt-captures"
+    assert capture_directory.stat().st_mode & 0o777 == 0o700
+    captures = sorted(capture_directory.iterdir())
+    assert all(path.stat().st_mode & 0o777 == 0o600 for path in captures)
+    values = tuple(path.read_bytes() for path in captures)
+    for path in captures:
+        path.unlink()
+    assert list(capture_directory.iterdir()) == []
+    return values
+
+
+def _assert_port_released(port: int) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", port))
+
+
+def test_sensitive_scan_rejects_an_artifact_that_embeds_the_raw_prompt(tmp_path: Path) -> None:
+    """A wrapper around a prompt must not evade a whole-file digest comparison."""
+    prompt = b'{"private":"raw-prompt-canary"}'
+    artifact = tmp_path / "trace.jsonl"
+    artifact.write_bytes(b"prefix\n" + prompt + b"\nsuffix")
+
+    with pytest.raises(AssertionError):
+        _assert_no_sensitive_bytes(
+            tmp_path,
+            raw_prompts=(prompt,),
+        )
+
+
+def test_headline_command_autodetects_one_exact_target_and_reuses_one_session(
+    tmp_path: Path,
+) -> None:
+    """Extra probes, prompt retention, or session reuse across Town runs must fail."""
+    fake_bin = tmp_path / "bin"
+    prompts = tmp_path / "prompts"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    for directory in (fake_bin, prompts, first, second):
+        directory.mkdir()
+    log_path = _install_fake_openclaw(fake_bin)
+    environment = _environment(fake_bin, prompts)
+
+    first_completed = _run(first, environment, "fixture-agent", "--format", "json")
+    assert first_completed.returncode == 0, first_completed.stderr.decode(errors="replace")
+    first_result, first_bundle = _result_bundle(first, first_completed)
+    _assert_five_passes(first_result)
+    first_logs = _logs(log_path)
+    first_prompts = _read_and_remove_private_prompt_captures(fake_bin)
+
+    assert [entry["argument_names"] for entry in first_logs] == [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+        ["config", "get", "env", "--json"],
+        ["agents", "list", "--json"],
+        ["gateway", "status", "--json", "--require-rpc"],
+        ["agent", "--agent", "--session-key", "--timeout", "--message-file", "--json"],
+        ["agent", "--agent", "--session-key", "--timeout", "--message-file", "--json"],
+    ]
+    first_turns = [entry for entry in first_logs if entry["argument_names"][0] == "agent"]
+    assert len({entry["session_key"] for entry in first_turns}) == 1
+    assert len({entry["message_digest"] for entry in first_turns}) == 2
+    assert len(first_prompts) == 2
+    assert all(entry["message_mode"] == 0o600 for entry in first_turns)
+    assert all(entry["town_environment_names"] == [] for entry in first_logs)
+    assert all("--deliver" not in entry["argument_names"] for entry in first_logs)
+    assert all("--local" not in entry["argument_names"] for entry in first_logs)
+    assert list(prompts.iterdir()) == []
+
+    second_completed = _run(second, environment, "fixture-agent", "--format", "json")
+    assert second_completed.returncode == 0, second_completed.stderr.decode(errors="replace")
+    second_result, second_bundle = _result_bundle(second, second_completed)
+    _assert_five_passes(second_result)
+    second_prompts = _read_and_remove_private_prompt_captures(fake_bin)
+    all_turns = [entry for entry in _logs(log_path) if entry["argument_names"][0] == "agent"]
+    sessions = [entry["session_key"] for entry in all_turns]
+    assert len(all_turns) == 4
+    assert sessions[0] == sessions[1]
+    assert sessions[2] == sessions[3]
+    assert sessions[0] != sessions[2]
+    assert len(second_prompts) == 2
+    assert list(prompts.iterdir()) == []
+
+    _assert_no_sensitive_bytes(
+        first_bundle,
+        second_bundle,
+        streams=(
+            first_completed.stdout,
+            first_completed.stderr,
+            second_completed.stdout,
+            second_completed.stderr,
+            log_path.read_bytes(),
+        ),
+        raw_prompts=first_prompts + second_prompts,
+    )
+
+
+def test_explicit_runtime_uses_only_the_openclaw_connector(tmp_path: Path) -> None:
+    """An explicit OpenClaw selection must not widen connector discovery."""
+    fake_bin = tmp_path / "bin"
+    prompts = tmp_path / "prompts"
+    runtime = tmp_path / "runtime"
+    for directory in (fake_bin, prompts, runtime):
+        directory.mkdir()
+    log_path = _install_fake_openclaw(fake_bin)
+
+    completed = _run(
+        runtime,
+        _environment(fake_bin, prompts),
+        "fixture-agent",
+        "--runtime",
+        "openclaw",
+        "--format",
+        "json",
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    result, _ = _result_bundle(runtime, completed)
+    _assert_five_passes(result)
+    assert len(_read_and_remove_private_prompt_captures(fake_bin)) == 2
+    assert [entry["argument_names"] for entry in _logs(log_path)[:5]] == [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+        ["config", "get", "env", "--json"],
+        ["agents", "list", "--json"],
+        ["gateway", "status", "--json", "--require-rpc"],
+    ]
+
+
+@pytest.mark.parametrize(
+    "unknown_target",
+    ["unknown", "fixture", "FIXTURE-AGENT", "Fixture Agent"],
+)
+def test_unknown_target_stops_after_read_only_inventory_without_artifacts(
+    tmp_path: Path,
+    unknown_target: str,
+) -> None:
+    """An absent exact target must never reach gateway preparation or run admission."""
+    fake_bin = tmp_path / "bin"
+    prompts = tmp_path / "prompts"
+    runtime = tmp_path / "runtime"
+    for directory in (fake_bin, prompts, runtime):
+        directory.mkdir()
+    log_path = _install_fake_openclaw(fake_bin)
+
+    completed = _run(
+        runtime,
+        _environment(fake_bin, prompts),
+        unknown_target,
+        "--format",
+        "json",
+    )
+
+    assert completed.returncode == 2
+    assert completed.stdout == b""
+    assert b"TARGET_NOT_FOUND" in completed.stderr
+    assert [entry["argument_names"] for entry in _logs(log_path)] == [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+        ["config", "get", "env", "--json"],
+        ["agents", "list", "--json"],
+    ]
+    assert not (runtime / ".town").exists()
+    assert list(prompts.iterdir()) == []
+    assert _read_and_remove_private_prompt_captures(fake_bin) == ()
+
+
+@pytest.mark.parametrize(
+    ("variant", "issue_code"),
+    [
+        ("fallback", "OPENCLAW_FALLBACK_REPORTED"),
+        ("activity", "OPENCLAW_ACTIVITY_REPORTED"),
+    ],
+)
+def test_reported_fallback_or_activity_is_incomplete(
+    tmp_path: Path,
+    variant: str,
+    issue_code: str,
+) -> None:
+    """OpenClaw fallback or tool activity must not be scored as agent behavior."""
+    fake_bin = tmp_path / "bin"
+    prompts = tmp_path / "prompts"
+    runtime = tmp_path / "runtime"
+    for directory in (fake_bin, prompts, runtime):
+        directory.mkdir()
+    log_path = _install_fake_openclaw(fake_bin, variant=variant)
+
+    completed = _run(
+        runtime,
+        _environment(fake_bin, prompts),
+        "fixture-agent",
+        "--format",
+        "json",
+    )
+
+    assert completed.returncode == 4
+    assert issue_code.encode("ascii") in completed.stderr
+    result, bundle = _result_bundle(runtime, completed)
+    assert result["execution"]["status"] == "incomplete"
+    assert result["evaluation"]["verdict"] == "inconclusive"
+    raw_prompts = _read_and_remove_private_prompt_captures(fake_bin)
+    assert len(raw_prompts) == 1
+    assert list(prompts.iterdir()) == []
+    _assert_no_sensitive_bytes(
+        bundle,
+        streams=(completed.stdout, completed.stderr, log_path.read_bytes()),
+        raw_prompts=raw_prompts,
+    )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process-group cleanup assertion requires POSIX")
+def test_timeout_reaps_fake_openclaw_child_and_releases_its_port(tmp_path: Path) -> None:
+    """A timed-out OpenClaw turn must not leave its process group or listener behind."""
+    fake_bin = tmp_path / "bin"
+    prompts = tmp_path / "prompts"
+    runtime = tmp_path / "runtime"
+    for directory in (fake_bin, prompts, runtime):
+        directory.mkdir()
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as reserved:
+        reserved.bind(("127.0.0.1", 0))
+        port = int(reserved.getsockname()[1])
+    log_path = _install_fake_openclaw(fake_bin, variant="timeout", linger_port=port)
+
+    completed = _run(
+        runtime,
+        _environment(fake_bin, prompts),
+        "fixture-agent",
+        "--format",
+        "json",
+        timeout=58,
+    )
+
+    assert completed.returncode == 4
+    assert b"OPENCLAW_TIMEOUT" in completed.stderr
+    result, bundle = _result_bundle(runtime, completed)
+    assert result["execution"]["status"] == "incomplete"
+    assert result["evaluation"]["verdict"] == "inconclusive"
+    raw_prompts = _read_and_remove_private_prompt_captures(fake_bin)
+    assert len(raw_prompts) == 1
+    _assert_port_released(port)
+    assert list(prompts.iterdir()) == []
+    _assert_no_sensitive_bytes(
+        bundle,
+        streams=(completed.stdout, completed.stderr, log_path.read_bytes()),
+        raw_prompts=raw_prompts,
+    )

--- a/scripts/check_agent_test_quickstart.py
+++ b/scripts/check_agent_test_quickstart.py
@@ -14,12 +14,45 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import textwrap
 import time
 from http.client import HTTPConnection
 from pathlib import Path
 
 _CONTRACT = "town-agent-driver/1"
 _PROFILE_DIGEST = "sha256:436622e70cd84690e39c24f93236c7639adefea2fe9ea72a1dddb25e65609c58"
+_OPENCLAW_SECRET = "clean-wheel-managed-bearer-must-not-cross-runtime-boundary"
+_OPENCLAW_START_PROMPT = (
+    b"You are completing one basic local NANDA Town agent test.\n"
+    b"Return exactly one minified JSON object and no other characters.\n"
+    b"Do not return prose, Markdown, or code fences.\n"
+    b"Do not invoke tools, access files, memory, messages, channels, or perform any "
+    b"other action.\n"
+    b"This is the start event. Declare the sell capability by returning exactly "
+    b'{"capabilities":["sell"],"kind":"declare_capability"}.\n'
+    b'If you cannot do that, return exactly {"kind":"none"}.\n'
+)
+_OPENCLAW_MESSAGE_PROMPT = (
+    b"You are completing one basic local NANDA Town agent test.\n"
+    b"Return exactly one minified JSON object and no other characters.\n"
+    b"Do not return prose, Markdown, or code fences.\n"
+    b"Do not invoke tools, access files, memory, messages, channels, or perform any "
+    b"other action.\n"
+    b"This is the message event.\n"
+    b'Input text: "buy:widget:2"\n'
+    b"If the text matches buy:<item>:<quantity>, return one canonical object shaped as "
+    b'{"kind":"send_to_sender","media_type":"text/plain; charset=utf-8",'
+    b'"text":"sold:<item>:<quantity>"}, replacing <item> and <quantity> with the '
+    b"input values.\n"
+    b'If you cannot do that, return exactly {"kind":"none"}.\n'
+)
+_PASS_CHECKS = [
+    "driver.contract",
+    "registry.provider-registered",
+    "registry.provider-discovered",
+    "delivery.request-routed",
+    "capability.synthetic-request-fulfilled",
+]
 
 
 class _CheckFailureError(RuntimeError):
@@ -101,6 +134,25 @@ def _artifact_files(output: Path) -> list[Path]:
     return sorted(path for path in output.rglob("*") if path.is_file())
 
 
+def _assert_no_raw_prompts(values: list[bytes], raw_prompts: list[bytes]) -> None:
+    if any(not prompt or prompt in value for prompt in raw_prompts for value in values):
+        raise _CheckFailureError("raw OpenClaw prompt appeared in installed artifacts")
+
+
+def _read_private_prompt_captures(directory: Path) -> list[bytes]:
+    if directory.stat().st_mode & 0o777 != 0o700:
+        raise _CheckFailureError("fake OpenClaw prompt capture directory was not private")
+    captures = sorted(directory.iterdir())
+    if any(path.stat().st_mode & 0o777 != 0o600 for path in captures):
+        raise _CheckFailureError("fake OpenClaw prompt capture was not private")
+    values = [path.read_bytes() for path in captures]
+    for path in captures:
+        path.unlink()
+    if list(directory.iterdir()):
+        raise _CheckFailureError("fake OpenClaw prompt capture cleanup failed")
+    return values
+
+
 def _reserve_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
         listener.bind(("127.0.0.1", 0))
@@ -179,6 +231,414 @@ for name in (
     )
 
 
+def _write_fake_openclaw(directory: Path) -> tuple[Path, Path]:
+    directory.mkdir()
+    state_path = directory / "state.json"
+    log_path = directory / "log.jsonl"
+    capture_directory = directory / "private-prompt-captures"
+    capture_directory.mkdir(mode=0o700)
+    state_path.write_text('{"turns":{}}', encoding="utf-8")
+    executable = directory / ("openclaw.exe" if os.name == "nt" else "openclaw")
+    script = textwrap.dedent(
+        """\
+        #!__PYTHON__
+        import hashlib
+        import json
+        import os
+        import pathlib
+        import stat
+        import sys
+
+        state_path = pathlib.Path(__STATE__)
+        log_path = pathlib.Path(__LOG__)
+        capture_directory = pathlib.Path(__CAPTURES__)
+        start_prompt = __START_PROMPT__
+        message_prompt = __MESSAGE_PROMPT__
+        args = sys.argv[1:]
+
+        def append_log(argument_names, **fields):
+            record = {
+                "argument_names": argument_names,
+                "town_environment_names": sorted(
+                    name for name in os.environ if name.startswith("TOWN_")
+                ),
+                **fields,
+            }
+            with log_path.open("a", encoding="utf-8") as stream:
+                stream.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\\n")
+
+        def emit(value):
+            print(
+                value
+                if isinstance(value, str)
+                else json.dumps(value, sort_keys=True, separators=(",", ":"))
+            )
+
+        if args == ["--version"]:
+            append_log(["--version"])
+            emit("OpenClaw 2026.7.1-2 (0790d9f)")
+            raise SystemExit(0)
+        if args == ["config", "get", "gateway.mode", "--json"]:
+            append_log(["config", "get", "gateway.mode", "--json"])
+            emit(json.dumps("local"))
+            raise SystemExit(0)
+        if args == ["config", "get", "env", "--json"]:
+            append_log(["config", "get", "env", "--json"])
+            raise SystemExit(1)
+        if args == ["agents", "list", "--json"]:
+            append_log(["agents", "list", "--json"])
+            emit([
+                {
+                    "id": "fixture-agent",
+                    "name": "Fixture Agent",
+                    "workspace": "/synthetic/workspace",
+                    "agentDir": "/synthetic/agent",
+                    "model": "fixture/model",
+                    "isDefault": True,
+                    "bindings": 0,
+                }
+            ])
+            raise SystemExit(0)
+        if args == ["gateway", "status", "--json", "--require-rpc"]:
+            append_log(["gateway", "status", "--json", "--require-rpc"])
+            emit({
+                "cli": {"entrypoint": "/synthetic/openclaw.mjs", "version": "2026.7.1-2"},
+                "config": {
+                    "cli": {
+                        "controlUi": {},
+                        "exists": True,
+                        "path": "/synthetic/openclaw.json",
+                        "valid": True,
+                    },
+                    "daemon": {
+                        "controlUi": {},
+                        "exists": True,
+                        "path": "/synthetic/openclaw.json",
+                        "valid": True,
+                    },
+                },
+                "extraServices": [{"label": "user-managed-service"}],
+                "gateway": {
+                    "bindMode": "lan",
+                    "bindHost": "0.0.0.0",
+                    "probeUrl": "ws://127.0.0.1:18789",
+                    "version": "2026.7.1-2",
+                },
+                "port": {
+                    "hints": [],
+                    "listeners": [{"address": "TCP *:18789 (LISTEN)"}],
+                    "port": 18789,
+                    "status": "busy",
+                },
+                "rpc": {
+                    "capability": "operator",
+                    "kind": "read",
+                    "ok": True,
+                    "version": "2026.7.1-2",
+                    "url": "ws://127.0.0.1:18789",
+                },
+            })
+            raise SystemExit(0)
+
+        argument_names = (
+            [args[0], *[argument for argument in args[1:] if argument.startswith("--")]]
+            if args
+            else []
+        )
+        expected = [
+            "agent",
+            "--agent",
+            "--session-key",
+            "--timeout",
+            "--message-file",
+            "--json",
+        ]
+        if not args or argument_names != expected:
+            append_log(argument_names)
+            raise SystemExit(17)
+        if args[args.index("--agent") + 1] != "fixture-agent":
+            append_log(argument_names)
+            raise SystemExit(18)
+        session_key = args[args.index("--session-key") + 1]
+        message_path = pathlib.Path(args[args.index("--message-file") + 1])
+        message = message_path.read_bytes()
+        message_digest = "sha256:" + hashlib.sha256(message).hexdigest()
+        capture_path = capture_directory / (message_digest.removeprefix("sha256:") + ".json")
+        capture_descriptor = os.open(
+            capture_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            offset = 0
+            while offset < len(message):
+                written = os.write(capture_descriptor, message[offset:])
+                if written <= 0:
+                    raise OSError
+                offset += written
+            os.fsync(capture_descriptor)
+        finally:
+            os.close(capture_descriptor)
+        append_log(
+            argument_names,
+            message_digest=message_digest,
+            message_mode=stat.S_IMODE(message_path.stat().st_mode),
+            session_key=session_key,
+        )
+        if message == start_prompt:
+            expected_turn = 0
+            intent = {"capabilities": ["sell"], "kind": "declare_capability"}
+        elif message == message_prompt:
+            expected_turn = 1
+            intent = {
+                "kind": "send_to_sender",
+                "media_type": "text/plain; charset=utf-8",
+                "text": "sold:widget:2",
+            }
+        else:
+            raise SystemExit(19)
+        del message
+
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        turn = int(state["turns"].get(session_key, 0))
+        if turn != expected_turn:
+            raise SystemExit(20)
+        state["turns"][session_key] = turn + 1
+        state_path.write_text(
+            json.dumps(state, sort_keys=True, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        text = json.dumps(intent, sort_keys=True, separators=(",", ":"))
+        session_digest = hashlib.sha256(session_key.encode("utf-8")).hexdigest()
+        emit({
+            "runId": "run-" + session_digest[:16],
+            "status": "ok",
+            "summary": "completed",
+            "result": {
+                "payloads": [{"text": text, "mediaUrl": None}],
+                "meta": {
+                    "durationMs": 1,
+                    "agentMeta": {
+                        "sessionId": "session-" + session_digest[:16],
+                        "provider": "fixture",
+                        "model": "model",
+                        "agentHarnessId": "fixture-agent",
+                    },
+                    "aborted": False,
+                    "finalAssistantVisibleText": text,
+                    "finalAssistantRawText": text,
+                    "replayInvalid": False,
+                    "livenessState": "working",
+                    "stopReason": "stop",
+                    "executionTrace": {
+                        "winnerProvider": "fixture",
+                        "winnerModel": "model",
+                        "attempts": [{
+                            "provider": "fixture",
+                            "model": "model",
+                            "result": "success",
+                            "stage": "assistant",
+                        }],
+                        "fallbackUsed": False,
+                        "runner": "embedded",
+                    },
+                    "completion": {"stopReason": "stop", "finishReason": "stop"},
+                },
+            },
+        })
+        """
+    )
+    script = (
+        script.replace("__PYTHON__", os.fspath(Path(sys.executable)))
+        .replace("__STATE__", repr(str(state_path)))
+        .replace("__LOG__", repr(str(log_path)))
+        .replace("__CAPTURES__", repr(str(capture_directory)))
+        .replace("__START_PROMPT__", repr(_OPENCLAW_START_PROMPT))
+        .replace("__MESSAGE_PROMPT__", repr(_OPENCLAW_MESSAGE_PROMPT))
+    )
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    return executable, log_path
+
+
+def _invoke_installed(
+    nest: Path,
+    arguments: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        [str(nest), *arguments],
+        cwd=cwd,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def _managed_result(
+    completed: subprocess.CompletedProcess[bytes], cwd: Path
+) -> tuple[dict[str, object], Path]:
+    if completed.returncode != 0:
+        raise _CheckFailureError("installed OpenClaw command did not pass")
+    try:
+        result = json.loads(completed.stdout)
+        bundle = cwd / ".town" / "runs" / result["run_id"]
+        result_bytes = (bundle / "result.json").read_bytes()
+        checks = result["evaluation"]["checks"]
+    except (KeyError, OSError, TypeError, ValueError) as error:
+        raise _CheckFailureError("installed OpenClaw result was invalid") from error
+    if completed.stdout != result_bytes:
+        raise _CheckFailureError("installed OpenClaw JSON did not match result.json")
+    if (
+        result["execution"]["status"] != "completed"
+        or result["evaluation"]["verdict"] != "pass"
+        or [(check["id"], check["status"]) for check in checks]
+        != [(check_id, "pass") for check_id in _PASS_CHECKS]
+    ):
+        raise _CheckFailureError("installed OpenClaw checks were not all passing")
+    return result, bundle
+
+
+def _verify_installed_openclaw(
+    *,
+    nest: Path,
+    runtime: Path,
+    environment: dict[str, str],
+) -> None:
+    fake_bin = runtime / "fake-bin"
+    prompts = runtime / "prompts"
+    auto = runtime / "auto"
+    explicit = runtime / "explicit"
+    unknown_targets = ("unknown", "fixture", "FIXTURE-AGENT", "Fixture Agent")
+    unknown_directories = [
+        (target, runtime / f"unknown-{index}")
+        for index, target in enumerate(unknown_targets, start=1)
+    ]
+    for directory in (prompts, auto, explicit, *(path for _, path in unknown_directories)):
+        directory.mkdir()
+    _, log_path = _write_fake_openclaw(fake_bin)
+    managed_environment = environment.copy()
+    managed_environment["PATH"] = os.pathsep.join(
+        (str(fake_bin), managed_environment.get("PATH", ""))
+    )
+    managed_environment["TMPDIR"] = str(prompts)
+    managed_environment["TOWN_FAKE_BEARER"] = _OPENCLAW_SECRET
+
+    auto_completed = _invoke_installed(
+        nest,
+        ["test", "agent", "fixture-agent", "--format", "json"],
+        cwd=auto,
+        environment=managed_environment,
+    )
+    _, auto_bundle = _managed_result(auto_completed, auto)
+    capture_directory = fake_bin / "private-prompt-captures"
+    raw_prompts = _read_private_prompt_captures(capture_directory)
+    if len(raw_prompts) != 2:
+        raise _CheckFailureError("auto-detected OpenClaw prompt count changed")
+    first_logs = [json.loads(line) for line in log_path.read_text().splitlines()]
+    expected_inventory = [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+        ["config", "get", "env", "--json"],
+        ["agents", "list", "--json"],
+        ["gateway", "status", "--json", "--require-rpc"],
+    ]
+    if [record["argument_names"] for record in first_logs[:5]] != expected_inventory:
+        raise _CheckFailureError("auto-detected OpenClaw inventory path changed")
+    if len(first_logs) != 7 or any(record["town_environment_names"] for record in first_logs):
+        raise _CheckFailureError("auto-detected OpenClaw process boundary changed")
+    turn_logs = first_logs[5:]
+    if any(
+        record["message_mode"] != 0o600
+        or "--deliver" in record["argument_names"]
+        or "--local" in record["argument_names"]
+        for record in turn_logs
+    ):
+        raise _CheckFailureError("installed OpenClaw prompt containment changed")
+
+    explicit_completed = _invoke_installed(
+        nest,
+        [
+            "test",
+            "agent",
+            "fixture-agent",
+            "--runtime",
+            "openclaw",
+            "--format",
+            "json",
+        ],
+        cwd=explicit,
+        environment=managed_environment,
+    )
+    _, explicit_bundle = _managed_result(explicit_completed, explicit)
+    explicit_prompts = _read_private_prompt_captures(capture_directory)
+    if len(explicit_prompts) != 2:
+        raise _CheckFailureError("explicit OpenClaw prompt count changed")
+    raw_prompts.extend(explicit_prompts)
+    all_logs = [json.loads(line) for line in log_path.read_text().splitlines()]
+    if [record["argument_names"] for record in all_logs[7:12]] != expected_inventory:
+        raise _CheckFailureError("explicit OpenClaw connector path changed")
+    if len(all_logs) != 14:
+        raise _CheckFailureError("explicit OpenClaw invoked an unexpected process")
+    auto_sessions = [record["session_key"] for record in all_logs[5:7]]
+    explicit_sessions = [record["session_key"] for record in all_logs[12:14]]
+    if (
+        len(set(auto_sessions)) != 1
+        or len(set(explicit_sessions)) != 1
+        or auto_sessions[0] == explicit_sessions[0]
+    ):
+        raise _CheckFailureError("installed OpenClaw session isolation changed")
+
+    unknown_results: list[subprocess.CompletedProcess[bytes]] = []
+    for target, directory in unknown_directories:
+        unknown_completed = _invoke_installed(
+            nest,
+            ["test", "agent", target, "--format", "json"],
+            cwd=directory,
+            environment=managed_environment,
+        )
+        unknown_results.append(unknown_completed)
+        if (
+            unknown_completed.returncode != 2
+            or unknown_completed.stdout
+            or (directory / ".town").exists()
+        ):
+            raise _CheckFailureError("unknown OpenClaw target crossed the preflight boundary")
+    all_logs = [json.loads(line) for line in log_path.read_text().splitlines()]
+    expected_near_match_logs = [
+        ["--version"],
+        ["config", "get", "gateway.mode", "--json"],
+        ["config", "get", "env", "--json"],
+        ["agents", "list", "--json"],
+    ] * len(unknown_targets)
+    if [record["argument_names"] for record in all_logs[14:]] != expected_near_match_logs:
+        raise _CheckFailureError("OpenClaw near-match target reached inference")
+    if list(prompts.iterdir()):
+        raise _CheckFailureError("installed OpenClaw prompt file remained after execution")
+
+    log_bytes = log_path.read_bytes()
+    secret = _OPENCLAW_SECRET.encode("ascii")
+    scanned = [
+        auto_completed.stdout,
+        auto_completed.stderr,
+        explicit_completed.stdout,
+        explicit_completed.stderr,
+        *(value for result in unknown_results for value in (result.stdout, result.stderr)),
+        log_bytes,
+        *(path.read_bytes() for path in _artifact_files(auto_bundle)),
+        *(path.read_bytes() for path in _artifact_files(explicit_bundle)),
+    ]
+    if any(secret in value for value in scanned):
+        raise _CheckFailureError("managed runtime secret appeared in installed output")
+    if b'"observation":' in log_bytes or b"allowed_intents" in log_bytes:
+        raise _CheckFailureError("raw OpenClaw prompt appeared in fixture logs")
+    _assert_no_raw_prompts(scanned, raw_prompts)
+
+
 def _check() -> None:
     source = Path(__file__).resolve().parents[1]
     uv = shutil.which("uv")
@@ -245,6 +705,7 @@ def _check() -> None:
         shutil.copy2(archive / "examples" / "agent-test" / "reference_adapter.py", adapter_path)
         (archive / "packages").rename(archive / "source-packages-disabled")
         _verify_installed_resources(python, base_environment, runtime, virtual_environment)
+        nest = _venv_executable(virtual_environment, "nest")
 
         token = secrets.token_hex(32)
         runtime_environment = base_environment.copy()
@@ -265,7 +726,7 @@ def _check() -> None:
             output = runtime / "evidence"
             completed = _run(
                 [
-                    str(_venv_executable(virtual_environment, "nest")),
+                    str(nest),
                     "test",
                     "agent",
                     "--endpoint",
@@ -309,6 +770,11 @@ def _check() -> None:
         ]
         if any(secret in value for value in scanned):
             raise _CheckFailureError("runtime secret appeared in quickstart output")
+        _verify_installed_openclaw(
+            nest=nest,
+            runtime=runtime,
+            environment=base_environment,
+        )
 
 
 def main() -> int:


### PR DESCRIPTION
## Problem

The headline workflow should be one clear command for a terminal-comfortable developer, not a private bridge or hand-edited adapter.

## Change

- add `nest test agent <agent-id>` with safe OpenClaw autodetection and explicit `--runtime openclaw`
- try the installed OpenClaw version and validate the required command/JSON behavior instead of using a release allowlist
- keep the frozen workflow internal to the friendly default while retaining advanced endpoint/profile controls
- add a short beginner guide, separate technical reference, actionable recovery messages, and installed-process checks

## Verification

- final stack: `make ci-local` — all 5 checks passed; 2,081 passed, 2 skipped, 1 deselected
- clean committed-archive/installed-wheel quickstart: PASS
- installed-process E2E passes with a coherent alternate version string and the public autodetected command
- real Linux acceptance with an existing configured OpenClaw `2026.7.1-2` agent: exact public command passed all five stages
- result schema/profile validation, trace digest, 18-event trace, artifact modes, and secret scan passed; Gateway PID/restart count was unchanged
- independent final product/security/version reviews found no Critical or Important issues

## Scope

**9 of 9. Depends on PR 8.** This proves one bounded synthetic sell/buy workflow through Town. It does not promise every historical OpenClaw command shape, and it does not claim general agent compatibility, verified model identity, absence of unreported tool activity, public-network delivery, safety, trust, or long-term reliability.

**Merge note:** After #227 merges into `main`, retarget this PR to `main`, wait for its CI, and only then merge it.