### PR TITLE
feat(agent-test): sign test results and verify them offline

### DIFF
--- a/packages/nest-core/nest_core/agent_test/__init__.py
+++ b/packages/nest-core/nest_core/agent_test/__init__.py
@@ -2,6 +2,15 @@
 """Frozen 1 contracts for NANDA Town agent-test workflows."""
 
 from .aggregation import Aggregation, aggregate
+from .attestation import (
+    ATTESTATION_SCHEMA_VERSION,
+    AttestationError,
+    AttestationVerdict,
+    MutableDependency,
+    build_attestation,
+    result_digest,
+    verify_attestation,
+)
 from .ids import new_ulid
 from .models import TestObservation, TestProfile, TestResult
 from .profiles import (
@@ -13,15 +22,22 @@ from .profiles import (
 )
 
 __all__ = [
+    "ATTESTATION_SCHEMA_VERSION",
     "Aggregation",
+    "AttestationError",
+    "AttestationVerdict",
+    "MutableDependency",
     "ResolvedTestProfile",
     "TestObservation",
     "TestProfile",
     "TestResult",
     "aggregate",
+    "build_attestation",
     "load_profile",
     "new_ulid",
     "profile_digest",
+    "result_digest",
     "resolve_profile",
     "resolve_test_profile",
+    "verify_attestation",
 ]

--- a/packages/nest-core/nest_core/agent_test/attestation.py
+++ b/packages/nest-core/nest_core/agent_test/attestation.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Detached signing and offline verification for ``town.test-result/1``.
+
+A result already binds what it ran against: the profile by ``profile.digest``,
+the run by ``execution.seed`` and ``execution.scenario``, the trace by an
+artifact digest. The document carrying those bindings is itself unsigned, so a
+reader who did not run it cannot tell an untouched result from an edited one —
+changing ``evaluation.verdict`` is a text edit that leaves every one of those
+internal digests valid.
+
+This module closes that one gap. It never modifies the result. It digests the
+document *as received* with :func:`~nest_core.canonical.jcs_digest`, restates the
+facts a reader needs in order to interpret the verdict, and signs the whole
+statement. Verification recomputes the digest and checks the signature, reaching
+nothing but the two objects it is handed — no network, no service, no registry.
+
+Reusing ``nest_core.canonical`` is deliberate rather than incidental. The
+attestation is a receipt in exactly the shape the rest of the repository already
+signs and verifies, over exactly the same canonicalization, so an attested
+digest and a sealed one can never disagree about what a document *is*.
+
+Signing validates the document through :class:`TestResult` rather than around it,
+so a signature can only ever cover something the contract already accepts. Every
+invariant the model enforces is inherited for free — that a completed ``pass``
+has no non-passing required check, that an ``incomplete`` run is
+``inconclusive``, that conclusive checks carry evidence. None of that is
+re-implemented here; a self-contradicting result is refused because the contract
+refuses it.
+
+One thing the contract cannot know is added. A hosted model can be revised
+without notice, mutating what was tested while every local digest stays valid, so
+``mutable_dependencies`` is required and an empty sequence is a positive claim
+rather than a default — the difference between "nothing was unfrozen" and "nobody
+said". It is why an attested verdict is a statement about a run at a time rather
+than a standing certificate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Final, cast
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from pydantic import ValidationError
+
+from nest_core.canonical import issuer_signed_payload, jcs_digest, verify_receipt_signature
+
+from .models import TestResult
+
+ATTESTATION_SCHEMA_VERSION: Final = "town.test-attestation/1"
+RESULT_SCHEMA_VERSION: Final = "town.test-result/1"
+
+
+class AttestationError(Exception):
+    """The result cannot be honestly attested in the form it was given."""
+
+
+@dataclass(frozen=True)
+class MutableDependency:
+    """Something that could change underneath the run's pinned artifacts.
+
+    The case this exists for is a hosted model: every local artifact stays frozen
+    and every digest stays valid while the thing under test is quietly revised.
+    Naming it is what keeps the attestation honest about what it could not freeze,
+    and is why a rung or verdict is a statement about a run at a time rather than
+    a standing certificate.
+    """
+
+    name: str
+    kind: str
+    observed_at: str
+    observed_version: str | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        """Return the JSON form embedded in the signed statement."""
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "observed_at": self.observed_at,
+            "observed_version": self.observed_version,
+        }
+
+
+@dataclass(frozen=True)
+class AttestationVerdict:
+    """Outcome of checking an attestation against the result it claims to cover."""
+
+    ok: bool
+    issuer_did: str | None = None
+    mutable_dependencies: tuple[dict[str, Any], ...] = ()
+    reasons: tuple[str, ...] = ()
+
+
+def result_digest(result: Mapping[str, Any]) -> str:
+    """Return the lowercase-hex JCS digest of *result* exactly as received.
+
+    This is the binding between statement and document. It covers the whole
+    result, so every field is load-bearing: a changed verdict, a widened coverage
+    claim, or a swapped seed all break it.
+    """
+    return jcs_digest(dict(result))
+
+
+def _validate_shape(result: Mapping[str, Any]) -> TestResult:
+    """Parse *result* through the contract's own model, failing closed."""
+    try:
+        return TestResult.model_validate(dict(result))
+    except ValidationError as exc:
+        raise AttestationError(f"result does not satisfy {RESULT_SCHEMA_VERSION}: {exc}") from exc
+
+
+def _histogram(parsed: TestResult) -> dict[str, int]:
+    """Return the verbatim count of each check status.
+
+    Nothing is folded together. A reader gets the same breakdown the result
+    carried, so ``inconclusive`` can never be mistaken for a pass on the way into
+    the signed statement.
+    """
+    counts: dict[str, int] = {}
+    for check in parsed.evaluation.checks:
+        counts[check.status] = counts.get(check.status, 0) + 1
+    return counts
+
+
+def build_attestation(
+    result: Mapping[str, Any],
+    *,
+    signing_key: Ed25519PrivateKey,
+    mutable_dependencies: Sequence[MutableDependency],
+    attested_at: str | None = None,
+) -> dict[str, Any]:
+    """Return a signed statement covering *result*, which is never modified.
+
+    *mutable_dependencies* is required. Pass an empty sequence to make the
+    positive claim that nothing in this run could change underneath its pinned
+    artifacts.
+    """
+    parsed = _validate_shape(result)
+    histogram = _histogram(parsed)
+
+    statement: dict[str, Any] = {
+        "schema_version": ATTESTATION_SCHEMA_VERSION,
+        "result_schema_version": parsed.schema_version,
+        "result_digest": result_digest(result),
+        "run_id": parsed.run_id,
+        "profile": {
+            "id": parsed.profile.id,
+            "version": parsed.profile.version,
+            "digest": parsed.profile.digest,
+        },
+        "execution": {
+            "scenario": parsed.execution.scenario,
+            "seed": parsed.execution.seed,
+            "status": parsed.execution.status,
+            "finished_at": parsed.execution.finished_at,
+        },
+        "evaluation": {
+            "verdict": parsed.evaluation.verdict,
+            "check_histogram": histogram,
+        },
+        "target": {
+            "kind": parsed.target.kind,
+            "label": parsed.target.label,
+            "attribution": parsed.target.attribution,
+        },
+        "tool": {
+            "name": parsed.tool.name,
+            "version": parsed.tool.version,
+            "commit": parsed.tool.commit,
+        },
+        "mutable_dependencies": [dep.to_json() for dep in mutable_dependencies],
+        "attested_at": attested_at or parsed.execution.finished_at,
+        "issuer_did": signing_key.public_key().public_bytes_raw().hex(),
+    }
+    statement["signature"] = signing_key.sign(issuer_signed_payload(statement)).hex()
+    return statement
+
+
+def verify_attestation(
+    result: Mapping[str, Any], attestation: Mapping[str, Any]
+) -> AttestationVerdict:
+    """Check that *attestation* covers *result*. Offline: reads nothing else.
+
+    The signature is checked first, so every field consulted afterwards is one the
+    issuer actually committed to; only then is the result's digest recomputed and
+    compared.
+    """
+    statement = dict(attestation)
+    if not verify_receipt_signature(statement):
+        return AttestationVerdict(ok=False, reasons=("signature does not verify",))
+
+    reasons: list[str] = []
+    issuer = statement.get("issuer_did")
+    issuer_did = issuer if isinstance(issuer, str) else None
+
+    if statement.get("schema_version") != ATTESTATION_SCHEMA_VERSION:
+        reasons.append(
+            f"attestation schema_version is {statement.get('schema_version')!r}, "
+            f"expected {ATTESTATION_SCHEMA_VERSION!r}"
+        )
+
+    claimed = statement.get("result_digest")
+    actual = result_digest(result)
+    if claimed != actual:
+        reasons.append(
+            f"result does not match the attestation "
+            f"(attested {claimed}, this result digests to {actual})"
+        )
+
+    if statement.get("result_schema_version") != result.get("schema_version"):
+        reasons.append("result schema_version differs from the attested one")
+
+    if "mutable_dependencies" not in statement:
+        reasons.append("attestation does not state whether any dependency was unfrozen")
+
+    raw_deps = statement.get("mutable_dependencies")
+    deps: tuple[dict[str, Any], ...] = ()
+    if isinstance(raw_deps, list):
+        entries = cast("list[Any]", raw_deps)
+        deps = tuple(
+            dict(cast("dict[str, Any]", entry)) for entry in entries if isinstance(entry, dict)
+        )
+
+    return AttestationVerdict(
+        ok=not reasons,
+        issuer_did=issuer_did,
+        mutable_dependencies=deps,
+        reasons=tuple(reasons),
+    )

--- a/packages/nest-core/tests/agent_test/test_attestation.py
+++ b/packages/nest-core/tests/agent_test/test_attestation.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for detached attestation over ``town.test-result/1``.
+
+The round trip is one test. The rest pin the properties the signature is
+supposed to carry: that every field of the result is covered, that a document
+whose verdict its own checks do not support is refused, and that whether
+anything was left unfrozen is always stated rather than inferred.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from nest_core.agent_test import (
+    ATTESTATION_SCHEMA_VERSION,
+    AttestationError,
+    MutableDependency,
+    build_attestation,
+    result_digest,
+    verify_attestation,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / f"{name}.json").read_text())
+
+
+@pytest.fixture
+def key() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(bytes(range(32)))
+
+
+@pytest.fixture
+def result() -> dict[str, Any]:
+    return _load("result-pass")
+
+
+def _sign(
+    result: dict[str, Any],
+    key: Ed25519PrivateKey,
+    deps: list[MutableDependency] | None = None,
+) -> dict[str, Any]:
+    return build_attestation(result, signing_key=key, mutable_dependencies=deps or [])
+
+
+def test_round_trip_verifies(result: dict[str, Any], key: Ed25519PrivateKey) -> None:
+    verdict = verify_attestation(result, _sign(result, key))
+    assert verdict.ok, verdict.reasons
+    assert verdict.issuer_did == key.public_key().public_bytes_raw().hex()
+
+
+def test_signing_does_not_modify_the_result(result: dict[str, Any], key: Ed25519PrivateKey) -> None:
+    before = copy.deepcopy(result)
+    _sign(result, key)
+    assert result == before
+
+
+def test_statement_restates_the_bindings(result: dict[str, Any], key: Ed25519PrivateKey) -> None:
+    statement = _sign(result, key)
+    assert statement["schema_version"] == ATTESTATION_SCHEMA_VERSION
+    assert statement["profile"]["digest"] == result["profile"]["digest"]
+    assert statement["execution"]["seed"] == result["execution"]["seed"]
+    assert statement["evaluation"]["verdict"] == result["evaluation"]["verdict"]
+
+
+def _flip_verdict(result: dict[str, Any]) -> None:
+    result["evaluation"]["verdict"] = "fail"
+
+
+def _change_seed(result: dict[str, Any]) -> None:
+    result["execution"]["seed"] = 8
+
+
+def _rename_target(result: dict[str, Any]) -> None:
+    result["target"]["label"] = "someone-else"
+
+
+def _widen_coverage(result: dict[str, Any]) -> None:
+    result["coverage"][1]["status"] = "exercised"
+
+
+def _swap_trace_digest(result: dict[str, Any]) -> None:
+    result["artifacts"][0]["digest"] = "sha256:" + "11" * 32
+
+
+def _swap_profile_digest(result: dict[str, Any]) -> None:
+    result["profile"]["digest"] = "sha256:" + "ab" * 32
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(_flip_verdict, id="verdict"),
+        pytest.param(_change_seed, id="seed"),
+        pytest.param(_rename_target, id="target"),
+        pytest.param(_widen_coverage, id="coverage"),
+        pytest.param(_swap_trace_digest, id="trace-digest"),
+        pytest.param(_swap_profile_digest, id="profile-digest"),
+    ],
+)
+def test_any_edit_breaks_the_binding(
+    result: dict[str, Any],
+    key: Ed25519PrivateKey,
+    mutate: Callable[[dict[str, Any]], None],
+) -> None:
+    """The digest covers the whole document, so every field is load-bearing."""
+    statement = _sign(result, key)
+    tampered = copy.deepcopy(result)
+    mutate(tampered)
+    verdict = verify_attestation(tampered, statement)
+    assert not verdict.ok
+    assert any("does not match" in reason for reason in verdict.reasons)
+
+
+def test_attestation_for_another_run_is_rejected(
+    result: dict[str, Any], key: Ed25519PrivateKey
+) -> None:
+    other = copy.deepcopy(result)
+    other["run_id"] = "01K00000000000000000000009"
+    assert not verify_attestation(result, _sign(other, key)).ok
+
+
+def test_edited_statement_fails_the_signature(
+    result: dict[str, Any], key: Ed25519PrivateKey
+) -> None:
+    statement = _sign(result, key)
+    statement["evaluation"]["verdict"] = "fail"
+    verdict = verify_attestation(result, statement)
+    assert not verdict.ok
+    assert verdict.reasons == ("signature does not verify",)
+
+
+def test_histogram_restates_statuses_verbatim(
+    result: dict[str, Any], key: Ed25519PrivateKey
+) -> None:
+    """Statuses are counted as they stand, never folded into coarser buckets."""
+    assert _sign(result, key)["evaluation"]["check_histogram"] == {"pass": 1}
+
+
+def _fail_a_required_check(result: dict[str, Any]) -> None:
+    result["evaluation"]["checks"].append(
+        {
+            "id": "broken",
+            "required": True,
+            "status": "fail",
+            "summary": "did not complete",
+            "evidence_refs": ["trace.jsonl#seq=2"],
+        }
+    )
+
+
+def _claim_failure_without_one(result: dict[str, Any]) -> None:
+    result["evaluation"]["verdict"] = "fail"
+
+
+def _use_an_unknown_status(result: dict[str, Any]) -> None:
+    result["evaluation"]["checks"][0]["status"] = "probably-fine"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected"),
+    [
+        pytest.param(
+            _fail_a_required_check,
+            "every required check to pass",
+            id="pass-over-a-failed-check",
+        ),
+        pytest.param(
+            _claim_failure_without_one,
+            "one failure and no inconclusive",
+            id="fail-with-no-failure",
+        ),
+        pytest.param(_use_an_unknown_status, "status", id="unknown-check-status"),
+    ],
+)
+def test_the_contract_gates_what_can_be_signed(
+    result: dict[str, Any],
+    key: Ed25519PrivateKey,
+    mutate: Callable[[dict[str, Any]], None],
+    expected: str,
+) -> None:
+    """Consistency is inherited from TestResult rather than re-implemented.
+
+    Signing parses through the contract's own model, so a document the contract
+    rejects can never be signed, and this module carries no second copy of those
+    rules to drift out of step with it.
+    """
+    mutate(result)
+    with pytest.raises(AttestationError, match="does not satisfy") as excinfo:
+        _sign(result, key)
+    assert expected in str(excinfo.value)
+
+
+def test_unfrozen_dependencies_are_carried_and_surfaced(
+    result: dict[str, Any], key: Ed25519PrivateKey
+) -> None:
+    dep = MutableDependency(
+        name="a-hosted-model",
+        kind="hosted-model",
+        observed_at="2026-08-23T00:00:00Z",
+    )
+    verdict = verify_attestation(result, _sign(result, key, [dep]))
+    assert verdict.ok, verdict.reasons
+    assert verdict.mutable_dependencies == (
+        {
+            "name": "a-hosted-model",
+            "kind": "hosted-model",
+            "observed_at": "2026-08-23T00:00:00Z",
+            "observed_version": None,
+        },
+    )
+
+
+def test_no_unfrozen_dependencies_is_a_signed_claim(
+    result: dict[str, Any], key: Ed25519PrivateKey
+) -> None:
+    """An empty list is present in the statement: 'none' and 'unsaid' differ."""
+    assert _sign(result, key)["mutable_dependencies"] == []
+
+
+def test_digest_ignores_key_order(result: dict[str, Any]) -> None:
+    """JCS means presentation cannot change identity."""
+    reordered = json.loads(json.dumps(result, sort_keys=True))
+    assert result_digest(reordered) == result_digest(result)
+
+
+def test_incomplete_result_attests(key: Ed25519PrivateKey) -> None:
+    incomplete = _load("result-incomplete")
+    verdict = verify_attestation(incomplete, _sign(incomplete, key))
+    assert verdict.ok, verdict.reasons


### PR DESCRIPTION
## Problem

A `town.test-result/1` document binds what it ran against: the profile by `profile.digest`, the run by `execution.seed` and `execution.scenario`, the trace by an artifact digest. The document carrying those bindings is itself unsigned.

So a reader who did not run it cannot distinguish an untouched result from an edited one. Changing `evaluation.verdict` is a text edit, and it leaves every one of those internal digests valid. That is fine while results stay on the machine that produced them, and it stops being fine as soon as results are compared between participants or aggregated over time, because any such view inherits the trust assumptions of whoever supplied each file.

## Change

Adds `nest_core.agent_test.attestation`: a detached statement over a result.

- digests the result **as received** with `jcs_digest`, restates the facts a reader needs in order to interpret the verdict, and signs the statement with Ed25519
- `verify_attestation(result, attestation)` recomputes the digest and checks the signature, reading nothing but the two objects it is handed — no network, no service, no registry
- the result document is never modified

Detached rather than embedded because `TestResult` is `extra="forbid"`, so no existing schema changes.

Two things are deliberately **not** re-implemented:

- **Consistency is inherited.** Signing parses through `TestResult`, so `_result_state_is_consistent` and the `Literal` status constraints already gate what can be signed. A self-contradicting document is refused because the contract refuses it, not because this module carries a second copy of those rules to drift out of step with it.
- **Canonicalization and signature verification are `nest_core.canonical`'s.** `jcs_digest`, `issuer_signed_payload`, and `verify_receipt_signature` are used as they stand, so an attested digest and a sealed one can never disagree about what a document is. The statement is a receipt in the shape this repository already signs.

One thing is added that the contract cannot know about. A hosted model can be revised without notice, mutating what was tested while every local digest stays valid — so `mutable_dependencies` is a required argument, and an empty sequence is a positive claim rather than a default. It is the difference between "nothing was unfrozen" and "nobody said", and it is why an attested verdict is a statement about a run at a time rather than a standing certificate.

```python
attestation = build_attestation(
    result, signing_key=key, mutable_dependencies=[
        MutableDependency("a-hosted-model", "hosted-model", "2026-08-23T00:00:00Z"),
    ]
)
verify_attestation(result, attestation).ok  # False if either object was touched
```

**No new dependencies.** `cryptography` is already a hard dependency of `nest-core`.

## Verification

- `make ci-local` — all 5 checks passed; 1463 passed, 1 skipped, 1 deselected
- pyright strict clean
- 19 tests, using this branch's existing `result-pass` / `result-incomplete` fixtures rather than new synthetic documents, so the tests exercise the contract as shipped
- six parametrised tamper cases (verdict, seed, target label, coverage status, trace digest, profile digest) confirm the digest covers the whole document
- three parametrised cases confirm the contract, not this module, is what rejects an unsupported verdict or an unknown status
- offline verification confirmed by running it inside a network namespace with no network configured
- 3 files, 484 insertions, 0 deletions

## Scope

Library only. No CLI command, no transport, no runtime, no changes to the driver path — matching this PR's base, which defines contracts only. Wiring a `nest` subcommand is small and belongs after the CLI PRs in this stack land.

## Stack

**Depends on #221.** Targets `feat/town-agent-test-contract-1` because that is the narrowest true dependency: this consumes the contract that PR defines and nothing later in the stack.

**Merge note:** after #221 merges into `main`, retarget this to `main`, wait for its CI, and only then merge it.

Opened as a draft and as a proposal rather than a request. Nothing in the stack depends on this and it unblocks nothing, so it should not take review time from the PRs that do. Happy to mark it ready, move it, reshape it, or close it.
