### PR TITLE
fix(receipt): refuse Town Proof when coverage is incomplete

### DIFF
--- a/src/nandatown/receipt.py
+++ b/src/nandatown/receipt.py
@@ -149,8 +149,17 @@ def render_proof(bundle_dir: str,
         reasons.append(f"the evidence is {age_days:.1f} days old,"
                        f" beyond the {freshness_days:.0f} day freshness"
                        " window")
-    if not payload["coverage"]["tested"]:
+    tested = payload["coverage"]["tested"]
+    not_tested = payload["coverage"].get("not_tested")
+    if not tested:
         reasons.append("nothing was tested")
+    if (not isinstance(not_tested, list)
+            or not all(isinstance(stage, str) for stage in not_tested)):
+        reasons.append("coverage is incomplete; stages not tested were"
+                       " not recorded")
+    elif not_tested:
+        reasons.append("coverage is incomplete; stages not tested: "
+                       + ", ".join(not_tested))
 
     if reasons:
         lines = ["No Town Proof. The badge renders only from"
@@ -158,8 +167,6 @@ def render_proof(bundle_dir: str,
         lines += [f"  {r}" for r in reasons]
         return False, "\n".join(lines) + "\n"
 
-    tested = payload["coverage"]["tested"]
-    not_tested = payload["coverage"]["not_tested"]
     coverage = f"{len(tested)} stages tested"
     if not_tested:
         coverage += f" ({', '.join(not_tested)} not tested)"

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,25 +1,31 @@
 import json
 import os
 
+import pytest
 from fastapi.testclient import TestClient
 
-from nandatown.a2a_adapter import build_a2a_app
+from nandatown.a2a_adapter import build_a2a_app, build_agent_card
 from nandatown.cli import main
 from nandatown.path_runner import run_path_test
 from nandatown.receipt import make_receipt, render_proof, verify_receipt
+from nandatown.records import fingerprint
 
 
 def passed_bundle(tmp_path):
+    expected = fingerprint(build_agent_card("http://testserver"))
     bundle_dir, result = run_path_test(
         "http://testserver", str(tmp_path),
+        pin_card_digest=expected,
         http=TestClient(build_a2a_app("http://testserver")))
     assert result.verdict == "passed"
     return bundle_dir
 
 
 def failed_bundle(tmp_path):
+    expected = fingerprint(build_agent_card("http://testserver"))
     bundle_dir, result = run_path_test(
         "http://testserver", str(tmp_path / "bad"),
+        pin_card_digest=expected,
         http=TestClient(build_a2a_app("http://testserver",
                                       defect="wrong_total")))
     assert result.verdict == "failed"
@@ -58,8 +64,34 @@ def test_tampered_receipt_is_caught(tmp_path):
     assert any("signature" in p for p in problems)
 
 
+@pytest.mark.parametrize("bad_not_tested", [None, [1]])
+def test_proof_refuses_receipt_with_tampered_coverage_shape(
+        tmp_path, bad_not_tested):
+    bundle_dir = passed_bundle(tmp_path)
+    path = make_receipt(bundle_dir)
+    with open(path) as f:
+        receipt = json.load(f)
+    if bad_not_tested is None:
+        del receipt["payload"]["coverage"]["not_tested"]
+    else:
+        receipt["payload"]["coverage"]["not_tested"] = bad_not_tested
+    with open(path, "w") as f:
+        json.dump(receipt, f)
+
+    ok, text = render_proof(bundle_dir)
+    assert not ok
+    assert "TOWN-TESTED" not in text
+    assert "signature" in text
+
+
 def test_proof_renders_only_from_passing_fresh_evidence(tmp_path):
     bundle_dir = passed_bundle(tmp_path)
+    path = make_receipt(bundle_dir)
+    assert verify_receipt(path, bundle_dir=bundle_dir) == []
+    with open(path) as f:
+        receipt = json.load(f)
+    assert receipt["payload"]["coverage"]["not_tested"] == []
+
     ok, text = render_proof(bundle_dir)
     assert ok, text
     assert "TOWN-TESTED" in text
@@ -71,6 +103,26 @@ def test_proof_renders_only_from_passing_fresh_evidence(tmp_path):
     assert not ok
     assert "No Town Proof" in text
     assert "verdict is failed" in text
+
+
+def test_partial_coverage_receipt_verifies_but_refuses_proof(tmp_path):
+    bundle_dir, result = run_path_test(
+        "http://testserver", str(tmp_path),
+        http=TestClient(build_a2a_app("http://testserver")))
+    assert result.verdict == "passed"
+
+    path = make_receipt(bundle_dir)
+    with open(path) as f:
+        receipt = json.load(f)
+    assert receipt["payload"]["coverage"]["not_tested"] == [
+        "descriptor_consistency"]
+    assert verify_receipt(path, bundle_dir=bundle_dir) == []
+
+    ok, text = render_proof(bundle_dir)
+    assert not ok
+    assert "TOWN-TESTED" not in text
+    assert "coverage is incomplete" in text
+    assert "descriptor_consistency" in text
 
 
 def test_stale_evidence_refuses_a_badge(tmp_path):


### PR DESCRIPTION
## Summary

Town Proof previously required at least one tested stage but did not reject a nonempty `coverage.not_tested` list. A passing direct A2A run without a pinned AgentCard digest could therefore leave `descriptor_consistency` untested while still rendering `TOWN-TESTED`.

This change makes Town Proof ineligible whenever the receipt records any untested stage and names those stages in the refusal reason. It also fails closed when the `not_tested` field is missing or malformed.

Partial receipts remain valid evidence: `make_receipt()` still records and signs partial coverage, and `verify_receipt()` still verifies its signature and bundle binding. Only the higher-level badge eligibility policy changes.

## Regression coverage

- A normal unpinned A2A run still passes and produces a valid, verifiable receipt, but cannot render `TOWN-TESTED`; the reason names `descriptor_consistency`.
- A normal pinned, fully covered, passing, fresh, verified run still renders `TOWN-TESTED`.
- Missing and non-string `coverage.not_tested` metadata fail closed instead of raising.
- Existing failed-verdict, stale-evidence, tampering, and CLI behavior tests remain covered.

## Verification

- `.venv/bin/python -m pytest -q tests/test_receipt.py` — 8 passed on Python 3.11.15.
- `.venv/bin/python -m pytest -q` — 185 passed on Python 3.11.15.
- `uv run --python 3.12 --with-editable . --with pytest python -m pytest -q` — 185 passed on Python 3.12.13.
- `nandatown run marketplace --out /tmp/runs` — PASSED on Python 3.11 and 3.12.
- `nandatown run quote-crash-restart --out /tmp/runs` — PASSED on Python 3.11 and 3.12.
- `git diff --check` — passed.

Current CI defines no separate lint or formatting command.