### PR TITLE
fix(bundle): verify the declared bundle fingerprint

### DIFF
--- a/src/nandatown/bundle.py
+++ b/src/nandatown/bundle.py
@@ -148,6 +148,12 @@ def verify_bundle(directory: str) -> list[str]:
             manifest = json.load(f)
     except OSError as exc:
         return [f"manifest.json unreadable: {exc}"]
+    calculated_fingerprint = fingerprint(manifest.get("files", {}))
+    if manifest.get("bundle_fingerprint") != calculated_fingerprint:
+        problems.append(
+            "bundle fingerprint mismatch: manifest "
+            f"{manifest.get('bundle_fingerprint')}, calculated "
+            f"{calculated_fingerprint}")
     for name, expected in manifest.get("files", {}).items():
         path = os.path.join(directory, name)
         if not os.path.exists(path):

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,9 +1,16 @@
+import hashlib
 import json
 
-from nandatown.bundle import load_bundle, verify_bundle, write_bundle
+from nandatown.bundle import (
+    attest_bundle,
+    load_bundle,
+    verify_bundle,
+    write_bundle,
+)
+from nandatown.identity_portable import Keystore
 from nandatown.report import render_report
 from nandatown.evaluator import evaluate
-from nandatown.records import RunRecord, TestProfile
+from nandatown.records import RunRecord, fingerprint
 
 from test_evaluator import clean_events, profile
 
@@ -31,8 +38,19 @@ def make_bundle(tmp_path):
     return str(out), result
 
 
-def test_write_then_verify_is_clean(tmp_path):
+def refresh_file_hash(manifest, name, path):
+    manifest["files"][name] = "sha256:" + hashlib.sha256(
+        path.read_bytes()).hexdigest()
+
+
+def test_clean_unsigned_bundle_remains_allowed(tmp_path):
     path, _ = make_bundle(tmp_path)
+    assert verify_bundle(path) == []
+
+
+def test_clean_signed_bundle_is_valid(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    attest_bundle(path, keystore=Keystore(str(tmp_path / "keys")))
     assert verify_bundle(path) == []
     bundle = load_bundle(path)
     assert bundle["profile"].name == "quote-none"
@@ -76,12 +94,80 @@ def test_evaluator_mismatch_is_detected_even_with_valid_hashes(tmp_path):
     result_file.write_text(json.dumps(data))
     manifest_file = tmp_path / "bundle" / "manifest.json"
     manifest = json.loads(manifest_file.read_text())
-    import hashlib
-    manifest["files"]["result.json"] = "sha256:" + hashlib.sha256(
-        result_file.read_bytes()).hexdigest()
+    refresh_file_hash(manifest, "result.json", result_file)
+    manifest["bundle_fingerprint"] = fingerprint(manifest["files"])
     manifest_file.write_text(json.dumps(manifest))
     problems = verify_bundle(path)
     assert any("evaluator" in p for p in problems)
+
+
+def test_refreshed_file_hash_with_stale_root_is_detected(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    run_file = tmp_path / "bundle" / "run.json"
+    run = json.loads(run_file.read_text())
+    run["participants"][0]["name"] = "attacker"
+    run_file.write_text(json.dumps(run))
+    manifest_file = tmp_path / "bundle" / "manifest.json"
+    manifest = json.loads(manifest_file.read_text())
+    refresh_file_hash(manifest, "run.json", run_file)
+    manifest_file.write_text(json.dumps(manifest))
+
+    problems = verify_bundle(path)
+
+    assert any("bundle fingerprint mismatch" in p for p in problems)
+
+
+def test_refreshed_root_rejects_unchanged_attestation(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    attest_bundle(path, keystore=Keystore(str(tmp_path / "keys")))
+    run_file = tmp_path / "bundle" / "run.json"
+    run = json.loads(run_file.read_text())
+    run["participants"][0]["name"] = "attacker"
+    run_file.write_text(json.dumps(run))
+    manifest_file = tmp_path / "bundle" / "manifest.json"
+    manifest = json.loads(manifest_file.read_text())
+    refresh_file_hash(manifest, "run.json", run_file)
+    manifest["bundle_fingerprint"] = fingerprint(manifest["files"])
+    manifest_file.write_text(json.dumps(manifest))
+
+    problems = verify_bundle(path)
+
+    assert "attestation names a different bundle fingerprint" in problems
+
+
+def test_updated_attestation_root_with_original_signature_is_rejected(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    attest_bundle(path, keystore=Keystore(str(tmp_path / "keys")))
+    run_file = tmp_path / "bundle" / "run.json"
+    run = json.loads(run_file.read_text())
+    run["participants"][0]["name"] = "attacker"
+    run_file.write_text(json.dumps(run))
+    manifest_file = tmp_path / "bundle" / "manifest.json"
+    manifest = json.loads(manifest_file.read_text())
+    refresh_file_hash(manifest, "run.json", run_file)
+    manifest["bundle_fingerprint"] = fingerprint(manifest["files"])
+    manifest_file.write_text(json.dumps(manifest))
+    attestation_file = tmp_path / "bundle" / "attestation.json"
+    attestation = json.loads(attestation_file.read_text())
+    attestation["payload"]["bundle_fingerprint"] = \
+        manifest["bundle_fingerprint"]
+    attestation_file.write_text(json.dumps(attestation))
+
+    problems = verify_bundle(path)
+
+    assert "attestation signature does not verify" in problems
+
+
+def test_root_only_edit_is_detected(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    manifest_file = tmp_path / "bundle" / "manifest.json"
+    manifest = json.loads(manifest_file.read_text())
+    manifest["bundle_fingerprint"] = "sha256:attacker"
+    manifest_file.write_text(json.dumps(manifest))
+
+    problems = verify_bundle(path)
+
+    assert any("bundle fingerprint mismatch" in p for p in problems)
 
 
 def test_report_contains_scope_and_stages(tmp_path):


### PR DESCRIPTION
## Summary

Verify that the manifest's declared `bundle_fingerprint` matches the canonical fingerprint of its file-hash map before accepting a bundle.

Previously, an edited record plus an updated per-file hash could pass verification while retaining the original bundle fingerprint and unchanged signed attestation. Verification compared the attestation against the declared fingerprint without recomputing that fingerprint from the file hashes.

This closes that missing link using the existing fingerprint algorithm. It preserves unsigned-bundle support, per-file checks, evaluator replay, and attestation verification. Signatures still establish a key's commitment to bytes, not truth, independence, safety, or endorsement.

## Regression coverage

- Clean unsigned and signed bundles still verify.
- Edited record plus refreshed file hash is rejected against the stale root.
- A refreshed root is rejected against an unchanged attestation.
- Changing the attestation payload without re-signing is rejected.
- A root-only edit is rejected.
- The existing replay-mismatch fixture now refreshes the root so it continues testing replay rather than failing the new integrity check first.

## Verification

- `.venv/bin/python -m pytest -q tests/test_bundle.py`: 10 passed.
- `.venv/bin/python -m pytest -q`: 187 passed.
- `.venv/bin/nandatown run marketplace --out <temporary-dir>`: PASSED.
- `.venv/bin/nandatown run quote-crash-restart --out <temporary-dir>`: PASSED.
- `git diff --check`: passed.
- Python 3.12.13 locally; current CI also exercises Python 3.11. CI has no separate lint/format step.
- Test-driven development: both stale-root regressions failed before the production fix.
- Independent expert correctness and scope review completed.
- Combined integration with #233 and the other three correctness fixes: 213 tests passed on both Python 3.11.15 and 3.12.13.

Companion #235 applies the bundle verifier as a gate before rendering Town Proof. Merge this PR first; both PRs target main independently.

Base: `projnanda/nandatown:main` at `4d57012a3dfb6b7aeee5ab429b26513a5eef4505`. This is a current-main fix, not a legacy port or a comprehensive bundle-format redesign.
