### PR TITLE
fix(receipt): verify evidence before rendering Town Proof

### DIFF
--- a/src/nandatown/receipt.py
+++ b/src/nandatown/receipt.py
@@ -131,7 +131,15 @@ def verify_receipt(receipt_path: str,
 def render_proof(bundle_dir: str,
                  freshness_days: float = 30.0) -> tuple[bool, str]:
     """The TOWN-TESTED badge, rendered only when the evidence is
-    conclusive, covered, fresh, and the receipt verifies."""
+    conclusive, covered, fresh, and the bundle and receipt verify."""
+    from .bundle import verify_bundle
+
+    bundle_problems = verify_bundle(bundle_dir)
+    if bundle_problems:
+        lines = ["No Town Proof. Bundle verification failed:"]
+        lines += [f"  {problem}" for problem in bundle_problems]
+        return False, "\n".join(lines) + "\n"
+
     receipt_path = os.path.join(bundle_dir, "receipt.json")
     if not os.path.exists(receipt_path):
         make_receipt(bundle_dir)

--- a/tests/test_proof_integrity.py
+++ b/tests/test_proof_integrity.py
@@ -1,0 +1,117 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from nandatown.a2a_adapter import build_a2a_app, build_agent_card
+from nandatown.bundle import attest_bundle, verify_bundle
+from nandatown.cli import main
+from nandatown.path_runner import run_path_test
+from nandatown.receipt import make_receipt, render_proof, verify_receipt
+from nandatown.records import fingerprint
+
+
+def complete_bundle(tmp_path):
+    url = "http://testserver"
+    with TestClient(build_a2a_app(url)) as client:
+        directory, result = run_path_test(
+            url, str(tmp_path), http=client,
+            pin_card_digest=fingerprint(build_agent_card(url)))
+    assert result.verdict == "passed"
+    assert all(stage.status == "passed" for stage in result.stages)
+    return Path(directory)
+
+
+def test_verified_complete_bundle_still_renders_proof(tmp_path):
+    directory = complete_bundle(tmp_path)
+    assert verify_bundle(str(directory)) == []
+
+    ok, text = render_proof(str(directory))
+
+    assert ok, text
+    assert "TOWN-TESTED" in text
+    assert verify_receipt(str(directory / "receipt.json")) == []
+
+
+@pytest.mark.parametrize("existing_receipt", [False, True])
+def test_proof_rejects_changed_evidence_before_issuing_receipt(
+        tmp_path, existing_receipt):
+    directory = complete_bundle(tmp_path)
+    receipt_path = directory / "receipt.json"
+    if existing_receipt:
+        make_receipt(str(directory))
+        original_receipt = receipt_path.read_bytes()
+
+    run_path = directory / "run.json"
+    run = json.loads(run_path.read_text())
+    run["config"]["subject"] = "https://different-agent.invalid"
+    run_path.write_text(json.dumps(run))
+    assert any("run.json hash mismatch" in problem
+               for problem in verify_bundle(str(directory)))
+
+    ok, text = render_proof(str(directory))
+
+    assert not ok
+    assert "TOWN-TESTED" not in text
+    assert "run.json hash mismatch" in text
+    if existing_receipt:
+        assert receipt_path.read_bytes() == original_receipt
+        assert verify_receipt(str(receipt_path)) == []
+    else:
+        assert not receipt_path.exists()
+
+
+def test_cli_proof_rejects_missing_evidence(tmp_path, capsys):
+    directory = complete_bundle(tmp_path)
+    (directory / "events.jsonl").unlink()
+
+    assert main(["proof", str(directory)]) == 1
+
+    text = capsys.readouterr().out
+    assert "events.jsonl missing" in text
+    assert "TOWN-TESTED" not in text
+    assert not (directory / "receipt.json").exists()
+
+
+def test_proof_requires_evaluator_replay_not_just_valid_signatures(tmp_path):
+    directory = complete_bundle(tmp_path)
+    events_path = directory / "events.jsonl"
+    events = [json.loads(line) for line in events_path.read_text().splitlines()]
+    for event in events:
+        if event["kind"] == "fulfillment_observed":
+            event["detail"]["total_cents"] = 4090
+    events_path.write_text("".join(json.dumps(event) + "\n" for event in events))
+    manifest_path = directory / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["files"]["events.jsonl"] = (
+        "sha256:" + hashlib.sha256(events_path.read_bytes()).hexdigest())
+    manifest["bundle_fingerprint"] = fingerprint(manifest["files"])
+    manifest_path.write_text(json.dumps(manifest))
+    # Valid signatures commit to these bytes; they do not make the
+    # recorded passing verdict agree with the changed observations.
+    attest_bundle(str(directory))
+    path = make_receipt(str(directory))
+    assert verify_receipt(path, str(directory)) == []
+    assert any("evaluator replay mismatch" in problem
+               for problem in verify_bundle(str(directory)))
+
+    ok, text = render_proof(str(directory))
+
+    assert not ok
+    assert "evaluator replay mismatch" in text
+    assert "TOWN-TESTED" not in text
+
+
+def test_partial_receipt_remains_independently_verifiable(tmp_path):
+    url = "http://testserver"
+    with TestClient(build_a2a_app(url)) as client:
+        directory, result = run_path_test(url, str(tmp_path), http=client)
+    assert result.verdict == "passed"
+    assert any(stage.status == "not_tested" for stage in result.stages)
+
+    path = make_receipt(directory)
+
+    assert verify_receipt(path) == []
+    assert verify_receipt(path, directory) == []


### PR DESCRIPTION
## Summary

Require successful bundle verification before rendering Town Proof or automatically creating its receipt.

Previously, `proof` checked receipt signatures and two references but did not call `verify_bundle`. It could render `TOWN-TESTED` beside evidence that `verify` correctly rejected for tampering or evaluator-replay disagreement.

The new gate returns a clear “No Town Proof” reason when verification reports problems, leaves existing receipts untouched, and does not create a new receipt on rejection.

## Semantic boundary

`make_receipt` and `verify_receipt` are unchanged. Signed partial and failed receipts remain valid, independently verifiable commitments. Only the higher-level badge now requires the underlying bundle to pass verification. Signatures do not establish truth, observer independence, safety, or endorsement.

This is separate from #233, which refuses badges for incomplete coverage. The new positive fixture is fully covered through a normal pinned-card Path run, so the fixes compose without weakening that policy.

Companion #234 strengthens the bundle verifier's fingerprint binding. Merge #234 before this PR for the complete integrity chain; both PRs target main independently.

## Regression coverage

- Fully covered, fresh, verified evidence still renders the badge.
- Edited evidence is rejected with and without an existing receipt; existing bytes remain unchanged and no new receipt is created.
- Missing evidence returns CLI exit 1 with a reason, rather than attempting receipt creation.
- A bundle with valid signatures but an unreproducible verdict receives no badge.
- Partial receipts still verify independently.

## Verification

- `.venv/bin/python -m pytest -q tests/test_proof_integrity.py tests/test_receipt.py`: 11 passed.
- `.venv/bin/python -m pytest -q`: 188 passed.
- `.venv/bin/nandatown run marketplace --out <temporary-dir>`: PASSED.
- `.venv/bin/nandatown run quote-crash-restart --out <temporary-dir>`: PASSED.
- `git diff --check`: passed.
- Python 3.12.13 locally; current CI also exercises Python 3.11. CI has no separate lint/format step.
- TDD: the new regressions produced three false-badge failures and one missing-file failure before the production change.
- Independent expert correctness and scope review completed.
- Combined integration with #233 and the other three correctness fixes: 213 tests passed on both Python 3.11.15 and 3.12.13.

Base: `projnanda/nandatown:main` at `4d57012a3dfb6b7aeee5ab429b26513a5eef4505`. This gate inherits `verify_bundle`'s checks; it is not a comprehensive new validator.
