### PR TITLE
fix(path): require exact fulfillment request correlation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ nandatown visualize runs/<id>
 
 `verify` recomputes every hash and replays the pinned evaluator over the recorded events; edits to the result or the events are caught. `visualize` writes a single HTML file: agents on a town map, messages animating along the timeline, the event log, and the stage table.
 
+Path evaluators are versioned. Replay a `path-0.1` bundle with its matching
+`path-0.1` evaluator; a newer evaluator reports the version difference rather
+than treating the bundle as corrupt. The bundle's existing signature remains
+valid for its recorded bytes.
+
 Stages are separate claims with separate failure boundaries. An HTTP success is never proof an agent understood or completed a task. Missing evidence stays missing. Every event names its observer, and the town cannot synthesize a participant's assertions.
 
 ## Tier two: real model participants

--- a/src/nandatown/path_runner.py
+++ b/src/nandatown/path_runner.py
@@ -36,7 +36,7 @@ from .records import (
     fingerprint,
 )
 
-PATH_EVALUATOR_VERSION = "path-0.1"
+PATH_EVALUATOR_VERSION = "path-0.2"
 
 STAGE_ORDER = ["resolution", "agent_card_retrieval",
                "descriptor_consistency", "protocol_invocation",
@@ -336,19 +336,28 @@ def evaluate_path(profile: PathProfile, run_id: str,
     if first_fulfillment:
         detail = first_fulfillment[0].detail
         observed_total = detail.get("total_cents")
-        request_ok = str(detail.get("request_id", "")).startswith("order-")
+        expected_request_id = first_fulfillment[0].subject
+        observed_request_id = detail.get("request_id")
+        request_ok = (isinstance(expected_request_id, str)
+                      and bool(expected_request_id)
+                      and isinstance(observed_request_id, str)
+                      and observed_request_id == expected_request_id)
         if observed_total == expected_total and request_ok:
             stages.append(StageResult(
                 name="semantic_result", status="passed",
                 evidence=[first_fulfillment[0].event_id],
                 note=f"exactly one fulfillment, total {observed_total}"))
         else:
+            note = (f"protocol passed but the result is wrong:"
+                    f" expected total {expected_total}, observed"
+                    f" {observed_total}")
+            if not request_ok:
+                note += (f"; expected request_id {expected_request_id!r},"
+                         f" observed request_id {observed_request_id!r}")
             stages.append(StageResult(
                 name="semantic_result", status="failed",
                 evidence=[first_fulfillment[0].event_id],
-                note=f"protocol passed but the result is wrong:"
-                     f" expected total {expected_total}, observed"
-                     f" {observed_total}"))
+                note=note))
     elif find("fulfillment_unparseable", attempt=1):
         bad = find("fulfillment_unparseable", attempt=1)[0]
         stages.append(StageResult(

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -7,8 +7,8 @@ from fastapi.testclient import TestClient
 from nandatown.a2a_adapter import build_a2a_app, build_agent_card
 from nandatown.bundle import load_bundle, verify_bundle
 from nandatown.path_profiles import get_path_profile
-from nandatown.path_runner import run_path_test
-from nandatown.records import fingerprint
+from nandatown.path_runner import evaluate_path, run_path_test
+from nandatown.records import TownEvent, fingerprint
 from nandatown.report import render_report
 
 SUBJECT = "http://testserver"
@@ -117,8 +117,12 @@ def test_wrong_total_fails_semantics_only(tmp_path):
         ("unrelated-request", False),
         (MISSING_REQUEST_ID, False),
         (None, False),
+        (123, False),
+        (["order-from-an-earlier-run"], False),
+        ({"request_id": "order-from-an-earlier-run"}, False),
     ],
-    ids=["matching", "stale-order", "other", "missing", "null"],
+    ids=["matching", "stale-order", "other", "missing", "null",
+         "integer", "list", "object"],
 )
 def test_fulfillment_request_id_must_exactly_match_issued_order_and_replay(
         tmp_path, returned_request_id, passes):
@@ -139,7 +143,24 @@ def test_fulfillment_request_id_must_exactly_match_issued_order_and_replay(
     assert semantic.status == "failed"
     assert result.verdict == "failed"
     assert f"expected request_id {fulfillment.subject!r}" in semantic.note
-    assert "observed request_id" in semantic.note
+    assert (f"observed request_id"
+            f" {fulfillment.detail.get('request_id')!r}" in semantic.note)
+
+
+def test_empty_fulfillment_subject_cannot_establish_request_correlation():
+    profile = get_path_profile("a2a-capability-fulfillment@0.1")
+    result = evaluate_path(profile, "path-empty-subject", [TownEvent(
+        event_id="ev-1", run_id="path-empty-subject", at=0,
+        observer="town-requester", kind="fulfillment_observed", subject="",
+        detail={"attempt": 1, "total_cents": 3990,
+                "request_id": "order-issued"},
+    )])
+
+    semantic = stage(result, "semantic_result")
+    assert semantic.status == "failed"
+    assert result.verdict == "failed"
+    assert "expected request_id ''" in semantic.note
+    assert "observed request_id 'order-issued'" in semantic.note
 
 
 def test_duplicate_fulfillment_exposes_idempotency_defect(tmp_path):

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -153,14 +153,14 @@ def test_empty_fulfillment_subject_cannot_establish_request_correlation():
         event_id="ev-1", run_id="path-empty-subject", at=0,
         observer="town-requester", kind="fulfillment_observed", subject="",
         detail={"attempt": 1, "total_cents": 3990,
-                "request_id": "order-issued"},
+                "request_id": ""},
     )])
 
     semantic = stage(result, "semantic_result")
     assert semantic.status == "failed"
     assert result.verdict == "failed"
     assert "expected request_id ''" in semantic.note
-    assert "observed request_id 'order-issued'" in semantic.note
+    assert "observed request_id ''" in semantic.note
 
 
 def test_duplicate_fulfillment_exposes_idempotency_defect(tmp_path):

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,5 +1,6 @@
 import json
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -11,10 +12,41 @@ from nandatown.records import fingerprint
 from nandatown.report import render_report
 
 SUBJECT = "http://testserver"
+MISSING_REQUEST_ID = object()
 
 
 def client(defect=None):
     return TestClient(build_a2a_app(SUBJECT, defect=defect))
+
+
+def fulfillment_id_client(returned_request_id):
+    """In-process A2A service whose fulfillment ID may differ from its order."""
+    def handler(request):
+        if request.method == "GET":
+            return httpx.Response(200, json=build_agent_card(SUBJECT))
+
+        message = json.loads(request.content)
+        text = message["params"]["message"]["parts"][0]["text"]
+        order = json.loads(text)
+        fulfillment = {"total_cents": 3990}
+        if returned_request_id is not MISSING_REQUEST_ID:
+            fulfillment["request_id"] = (
+                order["request_id"]
+                if returned_request_id == "matching"
+                else returned_request_id
+            )
+        task = {
+            "id": "task-1",
+            "kind": "task",
+            "status": {"state": "completed"},
+            "artifacts": [{"parts": [{"kind": "text",
+                                         "text": json.dumps(fulfillment)}]}],
+        }
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1,
+                                         "result": task})
+
+    return httpx.Client(base_url=SUBJECT,
+                        transport=httpx.MockTransport(handler))
 
 
 def stage(result, name):
@@ -75,6 +107,39 @@ def test_wrong_total_fails_semantics_only(tmp_path):
     assert semantic.status == "failed"
     assert "expected total 3990, observed 4090" in semantic.note
     assert result.verdict == "failed"
+
+
+@pytest.mark.parametrize(
+    ("returned_request_id", "passes"),
+    [
+        ("matching", True),
+        ("order-from-an-earlier-run", False),
+        ("unrelated-request", False),
+        (MISSING_REQUEST_ID, False),
+        (None, False),
+    ],
+    ids=["matching", "stale-order", "other", "missing", "null"],
+)
+def test_fulfillment_request_id_must_exactly_match_issued_order_and_replay(
+        tmp_path, returned_request_id, passes):
+    bundle_dir, result = run_path_test(
+        SUBJECT, str(tmp_path), http=fulfillment_id_client(returned_request_id))
+
+    semantic = stage(result, "semantic_result")
+    assert verify_bundle(bundle_dir) == []
+    if passes:
+        assert semantic.status == "passed"
+        assert result.verdict == "passed"
+        return
+
+    bundle = load_bundle(bundle_dir)
+    fulfillment = next(event for event in bundle["events"]
+                       if event.kind == "fulfillment_observed"
+                       and event.detail["attempt"] == 1)
+    assert semantic.status == "failed"
+    assert result.verdict == "failed"
+    assert f"expected request_id {fulfillment.subject!r}" in semantic.note
+    assert "observed request_id" in semantic.note
 
 
 def test_duplicate_fulfillment_exposes_idempotency_defect(tmp_path):


### PR DESCRIPTION
## Summary

Require a fulfillment's returned `request_id` to match the exact, nonempty order identifier Town issued and recorded as the event subject.

Previously, semantic evaluation accepted any identifier beginning with `order-`. A cached answer for a different run, with the expected total, could pass all six Path stages. The comparison now uses the actual issued identifier without coercion, and mismatch diagnostics include both expected and observed IDs while preserving the total check.

## Compatibility

The judgment change advances `PATH_EVALUATOR_VERSION` to `path-0.2`; the frozen profile is unchanged. Existing `path-0.1` bundles need their matching evaluator for replay. Their signatures are not invalidated by this revision, but the newer bundle verifier stops at the evaluator-version mismatch and does not complete their verification. A Proof gate requiring successful bundle verification will therefore refuse them until verified with the matching evaluator or replaced by a fresh run.

## Regression coverage

- Normal matching responses pass through the run and bundle-verification APIs.
- Stale `order-*`, unrelated, missing, null, and non-string response identifiers fail.
- Empty issued identifiers cannot satisfy correlation.
- Failure notes identify the actual observed value.
- Passing and failed results replay consistently.

## Verification

- `.venv/bin/python -m pytest -q tests/test_path.py`: 18 passed.
- `.venv/bin/python -m pytest -q`: 191 passed.
- `.venv/bin/nandatown run marketplace --out <temporary-dir>`: PASSED.
- `.venv/bin/nandatown run quote-crash-restart --out <temporary-dir>`: PASSED.
- `git diff --check`: passed.
- Python 3.12.13 locally; current CI also exercises Python 3.11. CI has no separate lint/format step.
- TDD reproduced the stale-order false pass before the fix. Independent expert correctness and vision review completed; review feedback strengthened edge-case tests.
- Combined integration with #233 and the other three correctness fixes: 213 tests passed on both Python 3.11.15 and 3.12.13.

Base: `projnanda/nandatown:main` at `4d57012a3dfb6b7aeee5ab429b26513a5eef4505`. This is an exact-request correctness fix, not a general A2A conformance or external-adoption claim.
