### PR TITLE
fix(runner): reject unknown agent override roles

### DIFF
--- a/src/nandatown/cli.py
+++ b/src/nandatown/cli.py
@@ -46,16 +46,21 @@ def cmd_run(args: argparse.Namespace) -> int:
             print("--plugin and --layer apply to Lab scenarios; Track"
                   " profiles run the fixed coordinator contract")
             return 2
-        from .runner import run_town
+        from .runner import RunnerUsageError, run_town
         print(f"nandatown {__version__}: Track run of {name}"
               " (real subprocess agents)")
         identity_dir = None
         if args.identity:
             from .identity_portable import default_keystore_dir
             identity_dir = args.identity_dir or default_keystore_dir()
-        bundle_dir, result = run_town(name, args.out, model=args.model,
-                                      harnesses=harnesses or None,
-                                      identity_dir=identity_dir)
+        try:
+            bundle_dir, result = run_town(name, args.out,
+                                          model=args.model,
+                                          harnesses=harnesses or None,
+                                          identity_dir=identity_dir)
+        except RunnerUsageError as exc:
+            print(exc)
+            return 2
     elif _is_lab(name):
         if harnesses:
             print("--agent applies to Track profiles; Lab scenarios use"

--- a/src/nandatown/runner.py
+++ b/src/nandatown/runner.py
@@ -34,6 +34,10 @@ class RunnerError(Exception):
     pass
 
 
+class RunnerUsageError(RunnerError):
+    """Invalid caller input that a command-line caller can report as usage."""
+
+
 def _free_port() -> int:
     with socket.socket() as s:
         s.bind(("127.0.0.1", 0))
@@ -135,6 +139,19 @@ def _participant_command(profile: TestProfile, role: str,
     return [sys.executable, "-m", f"nandatown.participants.{role}"], {}
 
 
+def _validate_role_overrides(
+        profile: TestProfile,
+        harnesses: dict[str, str] | None,
+        external: dict[str, list[str] | None] | None) -> None:
+    """Reject override keys that cannot select a profile participant."""
+    for overrides in (harnesses, external):
+        for role in (overrides or {}):
+            if role not in profile.roles:
+                supported = ", ".join(sorted(profile.roles))
+                raise RunnerUsageError(
+                    f"unknown role {role!r}; supported roles: {supported}")
+
+
 def _grant_refused(events: list[dict[str, Any]]) -> str | None:
     """The first role that tried to join a pinned identity with a bare
     token, or None. Such a harness can never join, so waiting on is
@@ -178,6 +195,7 @@ def run_town(profile_name: str, out_dir: str, port: int = 0,
         raise RunnerError(f"unknown profile {profile_name!r};"
                           f" choose from {sorted(PROFILES)}")
     profile = PROFILES[profile_name]
+    _validate_role_overrides(profile, harnesses, external)
     model = model or os.environ.get("TOWN_MODEL", "mock:v1")
     admin_token = secrets.token_hex(16)
     port = port or _free_port()

--- a/tests/test_harness_overrides.py
+++ b/tests/test_harness_overrides.py
@@ -4,6 +4,7 @@ import sys
 
 import pytest
 
+import nandatown.runner as runner_module
 from nandatown.bundle import load_bundle
 from nandatown.cli import main
 from nandatown.runner import RunnerError, parse_harness, run_town
@@ -25,6 +26,51 @@ def test_parse_harness_specs():
         parse_harness("telepathy")
     with pytest.raises(RunnerError):
         parse_harness("cmd:")
+
+
+@pytest.fixture
+def reject_startup(monkeypatch):
+    def fail_if_started():
+        raise AssertionError("invalid role reached port allocation")
+
+    monkeypatch.setattr(runner_module, "_free_port", fail_if_started)
+
+
+@pytest.mark.parametrize(("override_name", "overrides", "role"), [
+    ("harnesses", {"seler": "cmd:/does/not/exist"}, "seler"),
+    ("harnesses", {"": "scripted"}, ""),
+    ("external", {"seler": None}, "seler"),
+    ("external", {"": None}, ""),
+    ("harnesses", {"seller": "scripted", "seler": "external"},
+     "seler"),
+    ("external", {"seller": None, "seler": None}, "seler"),
+])
+def test_run_town_rejects_unknown_override_roles_before_startup(
+        tmp_path, reject_startup, override_name, overrides, role):
+    out_dir = tmp_path / "not-created"
+
+    with pytest.raises(
+            RunnerError,
+            match=rf"unknown role {role!r}; supported roles: buyer, seller"):
+        run_town("quote-clean", str(out_dir), **{override_name: overrides})
+
+    assert not out_dir.exists()
+
+
+@pytest.mark.parametrize(("agent", "role"), [
+    ("seler=cmd:/does/not/exist", "seler"),
+    ("=scripted", ""),
+])
+def test_cli_reports_unknown_harness_role_as_usage_error(
+        tmp_path, capsys, reject_startup, agent, role):
+    out_dir = tmp_path / "not-created"
+
+    assert main(["run", "quote-clean", "--agent",
+                 agent, "--out", str(out_dir)]) == 2
+
+    assert f"unknown role {role!r}; supported roles: buyer, seller" in (
+        capsys.readouterr().out)
+    assert not out_dir.exists()
 
 
 def test_cmd_harness_runs_external_agent(tmp_path):


### PR DESCRIPTION
## Summary

Reject unsupported role keys in both `harnesses` and `external` before starting a Track run.

Previously, `--agent seler=cmd:/does/not/exist` silently left the stock seller selected, produced a passing run, and retained the ignored override in the evidence. A typo could therefore look like a successful test of the user's own agent even though that command never ran.

The runner validates against the selected profile's roles immediately after profile lookup, before allocating ports, creating directories or credentials, invoking callbacks, or starting processes. The CLI reports the unknown and supported roles with exit 2. It catches only the new narrow `RunnerUsageError`, preserving the distinction from runtime failures.

Valid overrides, harness-over-external precedence, external handoff, and stock defaults are unchanged.

## Regression coverage

- Typo and empty roles in each mapping are rejected.
- Mixed valid/invalid mappings and `external` values of `None` are rejected when their key is invalid.
- Startup sentinels and absent output directories confirm rejection precedes side effects.
- CLI returns a usage error rather than a successful reference-agent run.
- Existing real external-command and LLM harness tests remain passing.

## Verification

- `.venv/bin/python -m pytest -q tests/test_harness_overrides.py`: 14 passed.
- `.venv/bin/python -m pytest -q`: 190 passed.
- `.venv/bin/nandatown run marketplace --out <temporary-dir>`: PASSED.
- `.venv/bin/nandatown run quote-crash-restart --out <temporary-dir>`: PASSED.
- `git diff --check`: passed.
- Python 3.12.13 locally; current CI also exercises Python 3.11. CI has no separate lint/format step.
- TDD first reproduced the missing rejection against the real runner. Independent expert correctness and vision review completed.
- Combined integration with #233 and the other three correctness fixes: 213 tests passed on both Python 3.11.15 and 3.12.13.

Base: `projnanda/nandatown:main` at `4d57012a3dfb6b7aeee5ab429b26513a5eef4505`. No new harness or role model is introduced.
