### PR TITLE
fix(path): preserve the explicit profile in rerun commands

### DIFF
--- a/src/nandatown/path_runner.py
+++ b/src/nandatown/path_runner.py
@@ -194,7 +194,7 @@ def run_path_test(subject_url: str | None, out_dir: str,
         rerun += f" --index {index_file} --agent-name {agent_name}"
     else:
         rerun += f" --url {subject_url}"
-    rerun += f" --profile {profile.ref}"
+    rerun += f" --path-profile {profile.ref}"
     if pin_card_digest:
         rerun += f" --pin-card-digest {pin_card_digest}"
 

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,11 +1,18 @@
+import argparse
 import json
+import os
+import shlex
+import socket
+import subprocess
+import sys
+import time
 
 import pytest
 from fastapi.testclient import TestClient
 
 from nandatown.a2a_adapter import build_a2a_app, build_agent_card
 from nandatown.bundle import load_bundle, verify_bundle
-from nandatown.path_profiles import get_path_profile
+from nandatown.path_profiles import PATH_PROFILES, get_path_profile
 from nandatown.path_runner import run_path_test
 from nandatown.records import fingerprint
 from nandatown.report import render_report
@@ -23,6 +30,31 @@ def stage(result, name):
 
 def statuses(result):
     return {s.name: s.status for s in result.stages}
+
+
+def start_reference_agent():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    source_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    environment = dict(os.environ, PYTHONDONTWRITEBYTECODE="1",
+                       PYTHONPATH=os.path.join(source_root, "src"))
+    process = subprocess.Popen(
+        [sys.executable, "-m", "nandatown.cli", "a2a", "serve",
+         "--port", str(port)], env=environment,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    url = f"http://127.0.0.1:{port}"
+    import httpx
+
+    for _ in range(50):
+        try:
+            if httpx.get(url + "/.well-known/agent-card.json").status_code == 200:
+                return process, url
+        except httpx.HTTPError:
+            time.sleep(0.05)
+    process.terminate()
+    process.wait()
+    raise RuntimeError("reference A2A agent did not start")
 
 
 def test_healthy_agent_passes_the_path(tmp_path):
@@ -142,3 +174,42 @@ def test_profile_is_frozen_and_fingerprinted():
     assert profile.fingerprint().startswith("sha256:")
     with pytest.raises(KeyError):
         get_path_profile("nonsense@9.9")
+
+
+def test_generated_rerun_keeps_explicit_path_profile_when_default_changes(
+        tmp_path, monkeypatch):
+    """Catches a generated --profile being parsed as the Track flag."""
+    fallback = get_path_profile("a2a-capability-fulfillment@0.1").model_copy(
+        update={"version": "0.2"})
+    monkeypatch.setitem(PATH_PROFILES, fallback.ref, fallback)
+    original_add_argument = argparse.ArgumentParser.add_argument
+
+    def different_path_default(parser, *names, **kwargs):
+        if "--path-profile" in names:
+            kwargs["default"] = fallback.ref
+        return original_add_argument(parser, *names, **kwargs)
+
+    monkeypatch.setattr(argparse.ArgumentParser, "add_argument",
+                        different_path_default)
+    process, url = start_reference_agent()
+    try:
+        expected_digest = fingerprint(build_agent_card(url))
+        bundle_dir, _ = run_path_test(
+            url, str(tmp_path),
+            profile_ref="a2a-capability-fulfillment@0.1",
+            pin_card_digest=expected_digest)
+        rerun = load_bundle(bundle_dir)["run"].config["rerun_command"]
+        assert url in rerun
+        assert "--pin-card-digest " + expected_digest in rerun
+
+        monkeypatch.chdir(tmp_path)
+        from nandatown.cli import main
+
+        assert main(shlex.split(rerun)[1:]) == 0
+        rerun_bundle = next((tmp_path / "runs").iterdir())
+        replayed = load_bundle(str(rerun_bundle))
+        assert replayed["run"].profile_name == "a2a-capability-fulfillment@0.1"
+        assert replayed["run"].config["pinned_card_digest"] == expected_digest
+    finally:
+        process.terminate()
+        process.wait()

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -48,7 +48,8 @@ def start_reference_agent():
 
     for _ in range(50):
         try:
-            if httpx.get(url + "/.well-known/agent-card.json").status_code == 200:
+            if httpx.get(url + "/.well-known/agent-card.json",
+                         trust_env=False).status_code == 200:
                 return process, url
         except httpx.HTTPError:
             time.sleep(0.05)


### PR DESCRIPTION
## Summary

Generated Path rerun commands used `--profile`, but the already-running-agent CLI consumes `--path-profile`. A rerun therefore used the current default instead of the profile recorded in the evidence bundle.

This changes the generated flag and adds a regression that runs the generated command through the actual CLI against a local reference agent after changing the test's default. The resulting bundle must retain the original profile, endpoint and pinned-card guard.

This is a prerequisite for changing the default Path transport profile. It does not change the evaluator, transport or protocol.

## Verification

- RED: Path suite 9 passed, 1 failed. The generated rerun silently selected the changed default.
- GREEN: Path suite 10 passed.
- Full suite: 183 passed, nine pre-existing warnings.
- Independent spec/quality review approved. Combined with pending #233–#237, coverage and new transport profile: 267 tests passed.

```sh
python -m pytest -q tests/test_path.py
python -m pytest -q
```
