### PR TITLE
fix(lab): require scenario coverage before a passing verdict

### DIFF
--- a/src/nandatown/sim/validators.py
+++ b/src/nandatown/sim/validators.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 from ..records import EvidenceResult, StageResult, TownEvent
 
-LAB_EVALUATOR_VERSION = "lab-0.2.0"
+LAB_EVALUATOR_VERSION = "lab-0.2.1"
 
 VALIDATORS: dict[str, Callable] = {}
 
@@ -103,8 +103,14 @@ def ledger_conserved(trace: Trace) -> StageResult:
                            f"negative balance after {e.event_id}")
     total = sum(balances.values()) + sum(escrow.values())
     if opened == 0 and not evidence:
-        return _passed("ledger_conserved", trace.ids("run_created"),
-                       "no money moved")
+        finished = trace.ids("run_finished")
+        if not finished:
+            return _missing(
+                "ledger_conserved",
+                "no completed-run evidence for a no-money ledger claim",
+            )
+        return _passed("ledger_conserved", finished,
+                       "complete run recorded no money moved")
     if total != opened:
         return _failed("ledger_conserved", evidence,
                        f"opened {opened} cents but ended with {total}")
@@ -129,7 +135,13 @@ def privacy_clean(trace: Trace, redact_fields: list[str]) -> StageResult:
     bad = [e.event_id for e in trace.events if leaks(e.detail)]
     if bad:
         return _failed("privacy", bad, "redacted fields leaked into events")
-    return _passed("privacy", trace.ids("run_created"),
+    finished = trace.ids("run_finished")
+    if not finished:
+        return _missing(
+            "privacy",
+            "no completed-run evidence for a declared-privacy claim",
+        )
+    return _passed("privacy", finished,
                    f"fields {sorted(redact_fields)} never left the run")
 
 
@@ -441,6 +453,18 @@ def evaluate_scenario(spec, run_id: str,
                            f" {spec.validator!r}")]
     else:
         stages = fn(spec, trace)
+        if not stages:
+            stages = [StageResult(
+                name="scenario_coverage", status="error",
+                note=(f"selected validator {spec.validator!r} produced no"
+                      " scenario checks"),
+            )]
+        elif all(stage.status == "not_tested" for stage in stages):
+            stages.append(_missing(
+                "scenario_coverage",
+                f"selected validator {spec.validator!r} produced only"
+                " not_tested checks",
+            ))
     stages.append(ledger_conserved(trace))
     stages.append(privacy_clean(trace, spec.redact_fields))
     from ..evaluator import stage_verdict

--- a/tests/test_lab_coverage.py
+++ b/tests/test_lab_coverage.py
@@ -7,7 +7,7 @@ import os
 import pytest
 
 from nandatown.bundle import verify_bundle
-from nandatown.records import StageResult, TownEvent
+from nandatown.records import StageResult, TownEvent, fingerprint
 from nandatown.sim.runner import build_engine, run_lab
 from nandatown.sim.scenario import load_bundled, load_scenario_file
 from nandatown.sim.validators import (
@@ -186,6 +186,7 @@ def test_new_lab_bundles_replay_and_old_lab_versions_do_not(tmp_path):
     manifest["files"]["result.json"] = "sha256:" + hashlib.sha256(
         open(result_path, "rb").read()
     ).hexdigest()
+    manifest["bundle_fingerprint"] = fingerprint(manifest["files"])
     with open(manifest_path, "w") as handle:
         json.dump(manifest, handle)
 

--- a/tests/test_lab_coverage.py
+++ b/tests/test_lab_coverage.py
@@ -1,0 +1,195 @@
+"""Regression coverage for Lab scenario evaluation boundaries."""
+
+import hashlib
+import json
+import os
+
+import pytest
+
+from nandatown.bundle import verify_bundle
+from nandatown.records import StageResult, TownEvent
+from nandatown.sim.runner import build_engine, run_lab
+from nandatown.sim.scenario import load_bundled, load_scenario_file
+from nandatown.sim.validators import (
+    LAB_EVALUATOR_VERSION,
+    VALIDATORS,
+    Trace,
+    evaluate_scenario,
+    ledger_conserved,
+    privacy_clean,
+)
+
+
+NATIVE_SCENARIO_STAGES = {
+    "marketplace": {
+        "discovery", "negotiation", "settlement", "duplicate_recognized",
+        "reputation", "memory_reuse",
+    },
+    "auction": {"announced", "bidding", "award", "settlement", "delivery"},
+    "voting": {"ballots", "one_agent_one_vote", "tally", "result_broadcast"},
+    "consensus": {"quorum_commit", "agreement", "fault_recovered"},
+    "supply_chain": {
+        "procurement", "milestones", "assembly_order", "customer_settled",
+    },
+    "capability_spoofing": {
+        "spoof_detected", "honest_verified", "containment",
+        "honest_trade_completed",
+    },
+}
+ADAPTED_STAGES = {
+    "population_active", "discovery", "messages_flowed", "task_completed",
+}
+GENERIC_STAGES = {"ledger_conserved", "privacy"}
+UPSTREAM_FIXTURES = os.path.join(
+    os.path.dirname(__file__), "fixtures", "upstream", "voting.yaml",
+)
+
+
+def stage(result, name):
+    return next(item for item in result.stages if item.name == name)
+
+
+def complete_run_event():
+    return TownEvent(
+        event_id="finished", run_id="run", at=1.0, observer="town",
+        kind="run_finished", subject="run", detail={},
+    )
+
+
+def test_empty_selected_validator_is_a_town_error(monkeypatch):
+    """Removing a selected scenario's checks cannot inherit generic PASS."""
+    spec = load_bundled("marketplace")
+    engine = build_engine(spec)
+    engine.run()
+    monkeypatch.setitem(VALIDATORS, "marketplace", lambda spec, trace: [])
+
+    for events in ([], engine.events):
+        result = evaluate_scenario(spec, "coverage-check", events)
+        assert result.verdict == "error"
+        coverage = stage(result, "scenario_coverage")
+        assert coverage.status == "error"
+        assert coverage.note == (
+            "selected validator 'marketplace' produced no scenario checks"
+        )
+
+
+def test_unknown_and_untested_selected_validators_remain_incomplete(monkeypatch):
+    """Missing coverage is not a subject failure or a generic-pass shortcut."""
+    spec = load_bundled("marketplace")
+    spec.validator = "not-registered"
+    unknown = evaluate_scenario(spec, "unknown", [])
+    assert unknown.verdict == "incomplete"
+    assert stage(unknown, "validator").status == "not_enough_evidence"
+
+    monkeypatch.setitem(
+        VALIDATORS, "marketplace",
+        lambda spec, trace: [StageResult(name="source", status="not_tested")],
+    )
+    spec.validator = "marketplace"
+    untested = evaluate_scenario(spec, "untested", [complete_run_event()])
+    assert untested.verdict == "incomplete"
+    coverage = stage(untested, "scenario_coverage")
+    assert coverage.status == "not_enough_evidence"
+    assert coverage.note == (
+        "selected validator 'marketplace' produced only not_tested checks"
+    )
+
+
+def test_empty_generic_claims_are_missing_but_complete_no_money_is_valid():
+    """An empty trace cannot prove ledger or declared-privacy claims."""
+    empty = Trace([])
+    assert ledger_conserved(empty).status == "not_enough_evidence"
+    assert privacy_clean(empty, ["secret"]).status == "not_enough_evidence"
+    assert privacy_clean(empty, []).status == "not_tested"
+
+    complete = Trace([complete_run_event()])
+    assert ledger_conserved(complete).status == "passed"
+
+
+def test_declared_privacy_rejects_an_unredacted_event():
+    """A declared field with its literal value is a privacy failure."""
+    leaked = TownEvent(
+        event_id="leak", run_id="run", at=1.0, observer="town",
+        kind="note", subject="run", detail={"nested": {"secret": "raw"}},
+    )
+    result = privacy_clean(Trace([leaked]), ["secret"])
+    assert result.status == "failed"
+    assert result.evidence == ["leak"]
+
+
+@pytest.mark.parametrize("name, expected", [
+    ("marketplace", NATIVE_SCENARIO_STAGES["marketplace"]),
+    ("auction", NATIVE_SCENARIO_STAGES["auction"]),
+    ("voting", NATIVE_SCENARIO_STAGES["voting"]),
+    ("consensus", NATIVE_SCENARIO_STAGES["consensus"]),
+    ("supply_chain", NATIVE_SCENARIO_STAGES["supply_chain"]),
+    ("capability_spoofing", NATIVE_SCENARIO_STAGES["capability_spoofing"]),
+])
+def test_healthy_native_scenarios_emit_their_literal_stage_set(name, expected):
+    """Deleting a required native check must fail against this fixed matrix."""
+    spec = load_bundled(name)
+    engine = build_engine(spec)
+    engine.run()
+    result = evaluate_scenario(spec, engine.run_id, engine.events)
+    assert {item.name for item in result.stages} == expected | GENERIC_STAGES
+    assert {item.name for item in result.stages} - GENERIC_STAGES == expected
+    assert result.verdict == "passed"
+
+
+def test_adapted_reference_run_emits_its_literal_stage_set():
+    """Adapted coverage is explicit and remains separate from native checks."""
+    spec = load_scenario_file(UPSTREAM_FIXTURES)
+    engine = build_engine(spec)
+    engine.run()
+    result = evaluate_scenario(spec, engine.run_id, engine.events)
+    assert {item.name for item in result.stages} == ADAPTED_STAGES | GENERIC_STAGES
+    assert result.verdict == "passed"
+
+
+def test_bundled_empty_and_irrelevant_traces_remain_incomplete():
+    """Scenario checks need evidence; this does not claim arbitrary truncation detection."""
+    irrelevant = TownEvent(
+        event_id="irrelevant", run_id="run", at=1.0, observer="town",
+        kind="irrelevant", subject="run", detail={},
+    )
+    for name in NATIVE_SCENARIO_STAGES:
+        spec = load_bundled(name)
+        assert evaluate_scenario(spec, "empty", []).verdict == "incomplete"
+        assert evaluate_scenario(spec, "irrelevant", [irrelevant]).verdict == "incomplete"
+
+
+def test_weak_auth_remains_a_deliberately_failing_native_control():
+    spec = load_bundled("capability_spoofing_weak_auth")
+    engine = build_engine(spec)
+    engine.run()
+    result = evaluate_scenario(spec, engine.run_id, engine.events)
+    assert {item.name for item in result.stages} == (
+        NATIVE_SCENARIO_STAGES["capability_spoofing"] | GENERIC_STAGES
+    )
+    assert result.verdict == "failed"
+    assert stage(result, "containment").status == "failed"
+
+
+def test_new_lab_bundles_replay_and_old_lab_versions_do_not(tmp_path):
+    """The evaluator bump makes old Lab bundles explicitly non-reproducible."""
+    bundle_dir, result = run_lab("marketplace", str(tmp_path))
+    assert result.evaluator_version == LAB_EVALUATOR_VERSION
+    assert verify_bundle(bundle_dir) == []
+
+    result_path = os.path.join(bundle_dir, "result.json")
+    recorded = json.loads(open(result_path).read())
+    recorded["evaluator_version"] = "lab-0.2.0"
+    with open(result_path, "w") as handle:
+        json.dump(recorded, handle)
+    manifest_path = os.path.join(bundle_dir, "manifest.json")
+    manifest = json.loads(open(manifest_path).read())
+    manifest["files"]["result.json"] = "sha256:" + hashlib.sha256(
+        open(result_path, "rb").read()
+    ).hexdigest()
+    with open(manifest_path, "w") as handle:
+        json.dump(manifest, handle)
+
+    assert verify_bundle(bundle_dir) == [
+        "evaluator version differs: bundle lab-0.2.0, local "
+        "lab-0.2.1; reproducibility not checked",
+    ]

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -108,12 +108,23 @@ def test_marketplace_key_events(tmp_path):
 
 def test_marketplace_redaction_applied(tmp_path):
     bundle_dir, _ = run_lab("marketplace", str(tmp_path))
-    with open(f"{bundle_dir}/profile.json") as f:
-        text = f.read()
-    assert "10000" not in text.split("budget_cents")[1].split(",")[0]
-    with open(f"{bundle_dir}/events.jsonl") as f:
-        assert "budget_cents" not in f.read() or True
     bundle = load_bundle(bundle_dir)
+
+    def assert_declared_fields_redacted(value, fields):
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                if key in fields:
+                    assert nested == "[redacted]"
+                assert_declared_fields_redacted(nested, fields)
+        elif isinstance(value, list):
+            for nested in value:
+                assert_declared_fields_redacted(nested, fields)
+
+    assert_declared_fields_redacted(
+        bundle["profile"].model_dump(), {"budget_cents"},
+    )
+    for event in bundle["events"]:
+        assert_declared_fields_redacted(event.model_dump(), {"budget_cents"})
     buyer = next(a for a in bundle["profile"].agents if a.role == "buyer")
     assert buyer.config["budget_cents"] == "[redacted]"
 


### PR DESCRIPTION
## Summary

A registered Lab validator can return no scenario checks and still receive a passing verdict from generic checks. This change makes missing scenario coverage explicit before those generic checks are appended.

- Zero selected-validator results become a Town evaluator error; entirely untested scenario results remain incomplete.
- Empty ledger and declared-privacy evidence no longer pass. Completed no-money runs remain valid.
- Literal native/adapted stage-set regressions detect coverage drift, and the redaction test now examines actual nested values instead of an always-true assertion.
- Lab evaluator version becomes `lab-0.2.1`. New bundles replay; older Lab evaluator versions explicitly report that reproducibility was not checked rather than silently using changed rules.

## Attribution and scope

Preserves useful coverage requirements from #219 by `dhyantsoni` (reviewed head `8135ab72ef7d27b310fada582346d381481ee8a2`) and empty-evidence requirements from #164 by `rajpatilrobotics` (reviewed head `0071ae80d0e3be50eb53c7ef20b2222009ece57b`), reimplemented for current `main`. No legacy code was copied. Both original PRs remain open pending the broader rescue/disposition review.

This is separate from #233's receipt eligibility rule. It does not add a general required-stage manifest or claim to detect every truncated trace.

## Verification

- Regression RED before production changes: 4 failed, 27 passed.
- Focused GREEN: 31 passed.
- Independent full-suite run on Python 3.12: 196 passed, nine pre-existing warnings.
- Independent spec/quality review approved with no findings.
- Combined with the pending correctness fixes #233–#237, response limits and rerun correction: 267 tests passed. The old-version fixture was adjusted to preserve the bundle root fingerprint; verification rules were not weakened.

Run from the checkout with development dependencies installed:

```sh
python -m pytest -q tests/test_lab_coverage.py tests/test_sim.py
python -m pytest -q
```
