### PR TITLE
fix(a2a): bound streamed responses and version transport policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ nandatown test-agent --index my-index.json --agent-name maya-seller --pin-card-d
 
 Your agent is already running; you migrate nothing and supply no model
 key. Town acts as a deterministic counterpart and observer, walking an
-exact versioned profile (`a2a-capability-fulfillment@0.1`): resolve
+exact versioned profile (`a2a-capability-fulfillment@0.2`): resolve
 the subject, fetch and digest the agent card, check it against the
 pinned descriptor, make a native protocol exchange, check the semantic
 result (a two-widget order with a run nonce, exactly one terminal
@@ -311,6 +311,52 @@ ERROR, where ERROR means Town itself malfunctioned and is never blamed
 on your agent. Try the failure modes against the reference seller:
 `nandatown a2a serve --defect wrong_total` (or `duplicate_fulfillment`
 or `card_drift`).
+
+The default Path profile pins a **1,048,576-byte (1 MiB) response budget**
+for both AgentCard and JSON-RPC envelopes. The shared native A2A client
+requests identity encoding, rejects other content encodings before
+decompression, checks any declared length, and counts actual streamed
+bytes before retaining or parsing them. Malformed/non-object JSON and
+transport, HTTP, or RPC failures produce bounded diagnostic categories,
+not remote error bodies. An oversized response means this run exceeded
+the selected local budget; it does not establish maliciousness or general
+agent incapability. Later stages remain untested when retrieval fails.
+
+Redirects are refused per request. Internally owned clients ignore ambient
+proxy/environment configuration, use zero transport retries, and are closed
+after each native operation or complete Path run (which retains one session);
+card fallback is only for HTTP 404/410. This also
+disables environment-supplied corporate proxy and CA configuration. Trusted
+injected clients remain caller-owned and can supply explicit transport/TLS
+configuration; their proxy and retry behavior is recorded as caller-controlled,
+and allocations made by their already-buffered responses are outside the
+streaming guarantee. The deliberate second logical order is a test condition,
+not an automatic POST retry. Explicit localhost and LAN agents remain allowed.
+
+Each new bundle records `config.a2a_transport_policy`: policy ID
+`a2a-bounded-json@0.1`, effective byte limit and its basis, encoding,
+redirect/environment/retry settings, client ownership, phase timeout, and
+`total_deadline_seconds: null`. Path uses a 15-second HTTPX phase timeout;
+direct native card/RPC calls default to 15/30 seconds respectively. These
+are not hard wall-clock deadlines: a peer that keeps making progress may
+take longer. Cancellable total deadlines and connection-bound address
+policy remain follow-ups. This is not a public-hosted arbitrary-fetch policy,
+input URL sanitization, or business-output sanitization.
+
+The original `a2a-capability-fulfillment@0.1` profile and fingerprint remain
+unchanged, as does the evaluator version. Select it explicitly with
+`--path-profile a2a-capability-fulfillment@0.1`; newly executed old-profile
+runs disclose the same 1 MiB implementation ceiling rather than claiming
+the old profile specified it. Existing stored evidence is not reinterpreted.
+The generated rerun command currently uses `--profile` rather than
+`--path-profile`; correcting that separate defect is still a follow-up.
+
+Requirements credit: [#145 by abhishekeb211](https://github.com/projnanda/nandatown/pull/145)
+(`ddc5f4c5ee67db7b9784b1198446eee596facf53`), and bounded-read technique
+credit: [James's #222](https://github.com/projnanda/nandatown/pull/222)
+(`77c9ff3a39260e31640360be7ccb23652a13d307`). This replacement does not
+adopt their legacy middleware, Town-specific handshake, deployment code,
+or loopback-only origin restrictions.
 
 ## Receipts and Town Proof
 

--- a/README.md
+++ b/README.md
@@ -348,8 +348,6 @@ unchanged, as does the evaluator version. Select it explicitly with
 `--path-profile a2a-capability-fulfillment@0.1`; newly executed old-profile
 runs disclose the same 1 MiB implementation ceiling rather than claiming
 the old profile specified it. Existing stored evidence is not reinterpreted.
-The generated rerun command currently uses `--profile` rather than
-`--path-profile`; correcting that separate defect is still a follow-up.
 
 Requirements credit: [#145 by abhishekeb211](https://github.com/projnanda/nandatown/pull/145)
 (`ddc5f4c5ee67db7b9784b1198446eee596facf53`), and bounded-read technique

--- a/README.md
+++ b/README.md
@@ -344,7 +344,8 @@ policy remain follow-ups. This is not a public-hosted arbitrary-fetch policy,
 input URL sanitization, or business-output sanitization.
 
 The original `a2a-capability-fulfillment@0.1` profile and fingerprint remain
-unchanged, as does the evaluator version. Select it explicitly with
+unchanged. This transport-policy change does not change the evaluator version.
+Select the original profile explicitly with
 `--path-profile a2a-capability-fulfillment@0.1`; newly executed old-profile
 runs disclose the same 1 MiB implementation ceiling rather than claiming
 the old profile specified it. Existing stored evidence is not reinterpreted.

--- a/src/nandatown/a2a_adapter.py
+++ b/src/nandatown/a2a_adapter.py
@@ -18,6 +18,13 @@ import httpx
 from fastapi import FastAPI, Request
 
 from . import __version__
+from .a2a_transport import (
+    DEFAULT_MAX_RESPONSE_BYTES,
+    HTTPStatusError,
+    a2a_client,
+    read_json,
+    validate_response_budget,
+)
 
 CARD_PATHS = ["/.well-known/agent-card.json", "/.well-known/agent.json"]
 
@@ -131,29 +138,42 @@ def build_a2a_app(base_url: str = "http://127.0.0.1:8940",
 
 
 def fetch_card(base_url: str,
-               http: httpx.Client | None = None) -> dict[str, Any]:
-    client = http or httpx.Client(base_url=base_url, timeout=15.0)
-    for path in CARD_PATHS:
-        response = client.get(path)
-        if response.status_code == 200:
-            return response.json()
-    raise ValueError(f"no agent card at {base_url} under"
-                     f" {' or '.join(CARD_PATHS)}")
+               http: httpx.Client | None = None, *,
+               max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+               timeout_seconds: float = 15.0) -> dict[str, Any]:
+    budget = validate_response_budget(max_response_bytes)
+    with a2a_client(base_url, http, timeout_seconds) as client:
+        for path in CARD_PATHS:
+            try:
+                return read_json(client, "GET", path,
+                                 max_response_bytes=budget,
+                                 timeout_seconds=timeout_seconds)
+            except HTTPStatusError as exc:
+                if exc.status_code not in (404, 410):
+                    raise
+    raise ValueError("a2a_card_missing")
 
 
 def send_message(base_url: str, text: str,
-                 http: httpx.Client | None = None) -> dict[str, Any]:
-    client = http or httpx.Client(base_url=base_url, timeout=30.0)
-    response = client.post("/", json={
+                 http: httpx.Client | None = None, *,
+                 max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+                 timeout_seconds: float = 30.0) -> dict[str, Any]:
+    budget = validate_response_budget(max_response_bytes)
+    request = {
         "jsonrpc": "2.0", "id": 1, "method": "message/send",
         "params": {"message": {
             "role": "user",
             "messageId": "m-" + uuid.uuid4().hex[:8],
-            "parts": [{"kind": "text", "text": text}]}}})
-    response.raise_for_status()
-    payload = response.json()
+            "parts": [{"kind": "text", "text": text}]}}}
+    with a2a_client(base_url, http, timeout_seconds) as client:
+        payload = read_json(client, "POST", "/", payload=request,
+                            max_response_bytes=budget,
+                            timeout_seconds=timeout_seconds,
+                            success_statuses=range(200, 300))
     if "error" in payload:
-        raise ValueError(f"message/send failed: {payload['error']}")
+        raise ValueError("a2a_rpc_error")
+    if not isinstance(payload.get("result"), dict):
+        raise ValueError("a2a_rpc_invalid_result")
     return payload["result"]
 
 

--- a/src/nandatown/a2a_transport.py
+++ b/src/nandatown/a2a_transport.py
@@ -1,0 +1,111 @@
+"""Bounded synchronous JSON transport, not a total-deadline or address policy."""
+
+from __future__ import annotations
+
+import json
+import math
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+import httpx
+
+DEFAULT_MAX_RESPONSE_BYTES = 1_048_576
+POLICY_ID = "a2a-bounded-json@0.1"
+BUDGET_EXCEEDED = (
+    "a2a_response_budget_exceeded: selected local byte budget exceeded for this run"
+)
+
+
+class HTTPStatusError(ValueError):
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        super().__init__(f"a2a_http_status_{status_code}")
+
+
+def validate_response_budget(value: int | float) -> int:
+    # Profiles currently serialize numeric limits as floats; integral floats
+    # are valid, but booleans and coercible strings are not byte counts.
+    if (isinstance(value, bool) or not isinstance(value, (int, float))
+            or (isinstance(value, float) and not math.isfinite(value))
+            or value <= 0 or int(value) != value):
+        raise ValueError("a2a_invalid_response_budget")
+    return int(value)
+
+
+@contextmanager
+def a2a_client(base_url: str, http: httpx.Client | None,
+               timeout_seconds: float) -> Iterator[httpx.Client]:
+    if http is not None:
+        yield http
+    else:
+        with httpx.Client(
+            base_url=base_url, timeout=timeout_seconds,
+            follow_redirects=False, trust_env=False,
+            transport=httpx.HTTPTransport(retries=0, trust_env=False),
+        ) as client:
+            yield client
+
+
+def read_json(client: httpx.Client, method: str, path: str, *,
+              max_response_bytes: int, timeout_seconds: float,
+              payload: dict[str, Any] | None = None,
+              success_statuses: tuple[int, ...] | range = (200,)
+              ) -> dict[str, Any]:
+    """Count identity bytes before retention/parsing; always close responses.
+
+    A trusted injected transport may already have materialized its response.
+    That seam still gets checked, but its earlier allocations are caller-owned.
+    """
+    try:
+        with client.stream(method, path, json=payload,
+                           headers={"Accept-Encoding": "identity"},
+                           follow_redirects=False,
+                           timeout=timeout_seconds) as response:
+            if response.status_code not in success_statuses:
+                raise HTTPStatusError(response.status_code)
+            encoding = response.headers.get("content-encoding", "identity")
+            if encoding.strip().lower() != "identity":
+                raise ValueError("a2a_unsupported_encoding")
+            length = response.headers.get("content-length")
+            if length is not None:
+                # Invalid/dishonest lengths never replace actual byte counting.
+                try:
+                    declared_length = int(length)
+                except ValueError:
+                    declared_length = None
+                if declared_length is not None and declared_length > max_response_bytes:
+                    raise ValueError(BUDGET_EXCEEDED)
+            chunks = ([response.content] if response.is_stream_consumed
+                      else response.iter_raw())
+            body = bytearray()
+            for chunk in chunks:
+                if len(chunk) > max_response_bytes - len(body):
+                    raise ValueError(BUDGET_EXCEEDED)
+                body.extend(chunk)
+            try:
+                result = json.loads(body)
+            except (ValueError, UnicodeError, RecursionError):
+                raise ValueError("a2a_invalid_json") from None
+            if not isinstance(result, dict):
+                raise ValueError("a2a_json_not_object")
+            return result
+    except httpx.TimeoutException:
+        raise ValueError("a2a_timeout") from None
+    except httpx.HTTPError:
+        raise ValueError("a2a_transport_error") from None
+
+
+def effective_policy(max_response_bytes: int, timeout_seconds: float, *,
+                     injected: bool, profile_budget: bool) -> dict[str, Any]:
+    return {
+        "policy_id": POLICY_ID,
+        "max_response_bytes": max_response_bytes,
+        "budget_basis": "profile" if profile_budget else "implementation_ceiling",
+        "accept_encoding": "identity",
+        "follow_redirects": False,
+        "trust_env": "caller_controlled" if injected else False,
+        "transport_retries": "caller_controlled" if injected else 0,
+        "client_ownership": "injected" if injected else "owned",
+        "phase_timeout_seconds": timeout_seconds,
+        "total_deadline_seconds": None,
+    }

--- a/src/nandatown/cli.py
+++ b/src/nandatown/cli.py
@@ -12,6 +12,7 @@ import argparse
 import sys
 
 from . import __version__
+from .path_profiles import DEFAULT_PATH_PROFILE
 
 
 def _is_lab(name: str) -> bool:
@@ -725,7 +726,7 @@ def main(argv: list[str] | None = None) -> int:
                              " Town acts as deterministic counterpart"
                              " and observer")
     p_test.add_argument("--path-profile",
-                        default="a2a-capability-fulfillment@0.1",
+                        default=DEFAULT_PATH_PROFILE,
                         help="the exact versioned path profile")
     p_test.add_argument("--pin-card-digest", default=None,
                         help="expected agent card fingerprint; a"

--- a/src/nandatown/path_profiles.py
+++ b/src/nandatown/path_profiles.py
@@ -50,9 +50,21 @@ PATH_PROFILES: dict[str, PathProfile] = {
         limits={"timeout_seconds": 15.0},
         evaluator="path-evaluator@0.1",
     ),
+    "a2a-capability-fulfillment@0.2": PathProfile(
+        profile_id="a2a-capability-fulfillment",
+        version="0.2",
+        protocol="a2a",
+        capability="quote",
+        request={"sku": "widget", "quantity": 2,
+                 "unit_price_cents": 1995},
+        expected={"total_cents": 3990, "terminal_fulfillments": 1},
+        controlled_condition="duplicate_request",
+        limits={"timeout_seconds": 15.0, "max_response_bytes": 1_048_576},
+        evaluator="path-evaluator@0.1",
+    ),
 }
 
-DEFAULT_PATH_PROFILE = "a2a-capability-fulfillment@0.1"
+DEFAULT_PATH_PROFILE = "a2a-capability-fulfillment@0.2"
 
 
 def get_path_profile(ref: str) -> PathProfile:

--- a/src/nandatown/path_runner.py
+++ b/src/nandatown/path_runner.py
@@ -20,6 +20,7 @@ import os
 import sys
 import time
 import uuid
+from contextlib import ExitStack
 from typing import Any
 
 import httpx
@@ -27,7 +28,11 @@ import httpx
 from . import __version__
 from .bundle import attest_bundle, write_bundle
 from .evaluator import cascade_unreached, stage_verdict
-from .path_profiles import PathProfile, get_path_profile
+from .a2a_transport import (
+    DEFAULT_MAX_RESPONSE_BYTES, a2a_client, effective_policy,
+    validate_response_budget,
+)
+from .path_profiles import DEFAULT_PATH_PROFILE, PathProfile, get_path_profile
 from .records import (
     EvidenceResult,
     RunRecord,
@@ -106,86 +111,92 @@ def run_path_test(subject_url: str | None, out_dir: str,
                   ) -> tuple[str, EvidenceResult]:
     from .a2a_adapter import artifact_text, fetch_card, send_message
 
-    profile = get_path_profile(profile_ref
-                               or "a2a-capability-fulfillment@0.1")
+    profile = get_path_profile(profile_ref or DEFAULT_PATH_PROFILE)
     run_id = "path-" + uuid.uuid4().hex[:12]
     nonce = uuid.uuid4().hex[:10]
     recorder = _Recorder(run_id)
     timeout = profile.limits.get("timeout_seconds", 15.0)
+    response_budget = validate_response_budget(profile.limits.get(
+        "max_response_bytes", DEFAULT_MAX_RESPONSE_BYTES))
 
     url, index_digest = _resolve(recorder, subject_url, index_file,
                                  agent_name)
     pinned = pin_card_digest or index_digest
 
-    card_ok = False
-    descriptor_mismatch = False
-    if url is not None:
-        recorder.intend("town-requester", "fetch_card", {"url": url})
-        try:
-            client = http or httpx.Client(base_url=url, timeout=timeout)
-            card = fetch_card(url, http=client)
-            observed_digest = fingerprint(card)
-            recorder.emit("town-requester", "card_retrieved", url,
-                          {"digest": observed_digest,
-                           "name": card.get("name"),
-                           "version": card.get("version")})
-            card_ok = True
-            if pinned:
-                recorder.emit("town-requester", "descriptor_expected",
-                              url, {"digest": pinned})
-                descriptor_mismatch = pinned != observed_digest
-        except (ValueError, httpx.HTTPError) as exc:
-            recorder.emit("town-requester", "card_fetch_failed", url,
-                          {"reason": str(exc)})
-
-    if card_ok and not descriptor_mismatch:
-        order_id = f"order-{nonce}"
-        request_body = dict(profile.request, request_id=order_id,
-                            nonce=nonce)
-        for attempt in (1, 2):
-            if attempt == 2 and profile.controlled_condition \
-                    != "duplicate_request":
-                break
-            recorder.intend("town-requester", "message_send",
-                            {"attempt": attempt, "body": request_body})
+    with ExitStack() as clients:
+        card_ok = False
+        descriptor_mismatch = False
+        if url is not None:
+            recorder.intend("town-requester", "fetch_card", {"url": url})
             try:
-                task = send_message(url, json.dumps(request_body),
-                                    http=client)
-                state = task.get("status", {}).get("state")
-                recorder.emit("town-requester", "protocol_exchange",
-                              order_id,
-                              {"attempt": attempt, "ok": True,
-                               "task_id": task.get("id"),
-                               "kind": task.get("kind"),
-                               "state": state})
-                text = artifact_text(task)
-                try:
-                    fulfillment = json.loads(text)
-                    recorder.emit(
-                        "town-requester", "fulfillment_observed",
-                        order_id,
-                        {"attempt": attempt,
-                         "total_cents": fulfillment.get("total_cents"),
-                         "request_id": fulfillment.get("request_id"),
-                         "content_digest": fingerprint(fulfillment)})
-                except json.JSONDecodeError:
-                    recorder.emit("town-requester",
-                                  "fulfillment_unparseable", order_id,
-                                  {"attempt": attempt,
-                                   "text": text[:200]})
+                client = clients.enter_context(a2a_client(url, http, timeout))
+                card = fetch_card(url, http=client,
+                                  max_response_bytes=response_budget,
+                                  timeout_seconds=timeout)
+                observed_digest = fingerprint(card)
+                recorder.emit("town-requester", "card_retrieved", url,
+                              {"digest": observed_digest,
+                               "name": card.get("name"),
+                               "version": card.get("version")})
+                card_ok = True
+                if pinned:
+                    recorder.emit("town-requester", "descriptor_expected",
+                                  url, {"digest": pinned})
+                    descriptor_mismatch = pinned != observed_digest
             except (ValueError, httpx.HTTPError) as exc:
-                recorder.emit("town-requester", "protocol_exchange",
-                              order_id,
-                              {"attempt": attempt, "ok": False,
-                               "reason": str(exc)})
-                break
-            except Exception as exc:
-                # Town's own driver misbehaved. That is Town's fault
-                # and must never read as a subject failure.
-                recorder.emit("town", "town_driver_error", order_id,
-                              {"attempt": attempt,
-                               "reason": f"{type(exc).__name__}: {exc}"})
-                break
+                recorder.emit("town-requester", "card_fetch_failed", url,
+                              {"reason": str(exc)})
+
+        if card_ok and not descriptor_mismatch:
+            order_id = f"order-{nonce}"
+            request_body = dict(profile.request, request_id=order_id,
+                                nonce=nonce)
+            for attempt in (1, 2):
+                if attempt == 2 and profile.controlled_condition \
+                        != "duplicate_request":
+                    break
+                recorder.intend("town-requester", "message_send",
+                                {"attempt": attempt, "body": request_body})
+                try:
+                    task = send_message(url, json.dumps(request_body),
+                                        http=client,
+                                        max_response_bytes=response_budget,
+                                        timeout_seconds=timeout)
+                    state = task.get("status", {}).get("state")
+                    recorder.emit("town-requester", "protocol_exchange",
+                                  order_id,
+                                  {"attempt": attempt, "ok": True,
+                                   "task_id": task.get("id"),
+                                   "kind": task.get("kind"),
+                                   "state": state})
+                    text = artifact_text(task)
+                    try:
+                        fulfillment = json.loads(text)
+                        recorder.emit(
+                            "town-requester", "fulfillment_observed",
+                            order_id,
+                            {"attempt": attempt,
+                             "total_cents": fulfillment.get("total_cents"),
+                             "request_id": fulfillment.get("request_id"),
+                             "content_digest": fingerprint(fulfillment)})
+                    except json.JSONDecodeError:
+                        recorder.emit("town-requester",
+                                      "fulfillment_unparseable", order_id,
+                                      {"attempt": attempt,
+                                       "text": text[:200]})
+                except (ValueError, httpx.HTTPError) as exc:
+                    recorder.emit("town-requester", "protocol_exchange",
+                                  order_id,
+                                  {"attempt": attempt, "ok": False,
+                                   "reason": str(exc)})
+                    break
+                except Exception as exc:
+                    # Town's own driver misbehaved. That is Town's fault
+                    # and must never read as a subject failure.
+                    recorder.emit("town", "town_driver_error", order_id,
+                                  {"attempt": attempt,
+                                   "reason": f"{type(exc).__name__}: {exc}"})
+                    break
 
     result = evaluate_path(profile, run_id, recorder.events)
 
@@ -215,6 +226,9 @@ def run_path_test(subject_url: str | None, out_dir: str,
                 "profile": profile.ref,
                 "pinned_card_digest": pinned,
                 "nonce": nonce,
+                "a2a_transport_policy": effective_policy(
+                    response_budget, timeout, injected=http is not None,
+                    profile_budget="max_response_bytes" in profile.limits),
                 "rerun_command": rerun},
     )
     bundle_dir = os.path.join(out_dir, run_id)

--- a/tests/test_a2a_transport.py
+++ b/tests/test_a2a_transport.py
@@ -1,0 +1,281 @@
+"""External bytes are faked; parsing, policy and client ownership are real."""
+
+import json
+import socket
+import subprocess
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpx
+import pytest
+
+from nandatown.a2a_adapter import fetch_card, send_message
+
+
+class Chunks(httpx.SyncByteStream):
+    def __init__(self, chunks):
+        self.chunks = chunks
+        self.reads = 0
+        self.closed = False
+
+    def __iter__(self):
+        for chunk in self.chunks:
+            self.reads += 1
+            if isinstance(chunk, Exception):
+                raise chunk
+            yield chunk
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.parametrize("operation", ["card", "rpc"])
+@pytest.mark.parametrize("extra", [0, 1])
+@pytest.mark.parametrize("length", [None, "1"])
+def test_actual_bytes_enforce_exact_cap(operation, extra, length):
+    body = b'{"result":{}}' if operation == "rpc" else b'{}'
+    budget = len(body) + 4
+    stream = Chunks([body, b' ' * (4 + extra)])
+    headers = {} if length is None else {"content-length": length}
+    requests = []
+
+    def handle(request):
+        requests.append(request)
+        return httpx.Response(200, headers=headers, stream=stream)
+
+    with httpx.Client(base_url="http://fixture.invalid", transport=httpx.MockTransport(handle)) as client:
+        def invoke():
+            if operation == "rpc":
+                return send_message("http://fixture.invalid", "hello", http=client, max_response_bytes=budget)
+            return fetch_card("http://fixture.invalid", http=client, max_response_bytes=budget)
+        if extra:
+            with pytest.raises(ValueError, match="^a2a_response_budget_exceeded: selected local byte budget exceeded for this run$"):
+                invoke()
+        else:
+            assert invoke() == {}
+        assert not client.is_closed
+    assert stream.closed
+    assert len(requests) == 1
+    assert requests[0].headers["accept-encoding"] == "identity"
+
+
+@pytest.mark.parametrize("headers,category", [
+    ({"content-length": "1048577"}, "a2a_response_budget_exceeded"),
+    ({"content-encoding": "gzip"}, "a2a_unsupported_encoding"),
+])
+def test_header_rejection_does_not_read_body(headers, category):
+    stream = Chunks([b"remote-secret-marker"])
+    with httpx.Client(base_url="http://fixture.invalid", transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, headers=headers, stream=stream))) as client:
+        with pytest.raises(ValueError, match="^" + category) as error:
+            fetch_card("http://fixture.invalid", http=client)
+    assert "remote-secret-marker" not in str(error.value)
+    assert stream.reads == 0
+    assert stream.closed
+
+
+@pytest.mark.parametrize("body,category", [
+    (b'[]', "a2a_json_not_object"),
+    (b'null', "a2a_json_not_object"),
+    (b'bad remote-secret-marker', "a2a_invalid_json"),
+    (b'{"error":{"message":"remote-secret-marker"}}', "a2a_rpc_error"),
+    (b'{"result":[]}', "a2a_rpc_invalid_result"),
+    (b'{}', "a2a_rpc_invalid_result"),
+])
+def test_rpc_parse_errors_are_stable_and_private(body, category):
+    stream = Chunks([body])
+    with httpx.Client(base_url="http://fixture.invalid", transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, stream=stream))) as client:
+        with pytest.raises(ValueError, match="^" + category + "$"):
+            send_message("http://fixture.invalid", "hello", http=client)
+    assert stream.closed
+
+
+@pytest.mark.parametrize("status", [301, 403, 500])
+def test_http_error_does_not_fallback_or_read_remote_body(status):
+    stream = Chunks([b"remote-secret-marker"])
+    calls = []
+    def handle(request):
+        calls.append(request)
+        return httpx.Response(status, headers={"location": "/elsewhere"}, stream=stream)
+    with httpx.Client(base_url="http://fixture.invalid", follow_redirects=True,
+                      transport=httpx.MockTransport(handle)) as client:
+        with pytest.raises(ValueError, match="^a2a_http_status_" + str(status) + "$"):
+            fetch_card("http://fixture.invalid", http=client)
+    assert len(calls) == 1
+    assert stream.closed and stream.reads == 0
+
+
+def test_only_missing_cards_fall_back_and_close_each_response():
+    streams = [Chunks([b"missing"]), Chunks([b'{"name":"local"}'])]
+    paths = []
+    def handle(request):
+        paths.append(request.url.path)
+        return httpx.Response(404 if len(paths) == 1 else 200, stream=streams[len(paths)-1])
+    with httpx.Client(base_url="http://fixture.invalid", transport=httpx.MockTransport(handle)) as client:
+        assert fetch_card("http://fixture.invalid", http=client) == {"name": "local"}
+    assert paths == ["/.well-known/agent-card.json", "/.well-known/agent.json"]
+    assert all(s.closed for s in streams)
+    assert streams[0].reads == 0
+
+
+@pytest.mark.parametrize("limit", [0, -1, 1.5, float("inf"), float("nan"), True, "12", None])
+def test_invalid_byte_limit_is_rejected_before_request(limit):
+    def handle(request):
+        pytest.fail("invalid local budget reached transport")
+    with httpx.Client(base_url="http://fixture.invalid", transport=httpx.MockTransport(handle)) as client:
+        with pytest.raises(ValueError, match="^a2a_invalid_response_budget$"):
+            fetch_card("http://fixture.invalid", http=client, max_response_bytes=limit)
+
+
+def test_interrupted_stream_closes_and_hides_transport_exception():
+    stream = Chunks([b'{', httpx.ReadError("remote-secret-marker")])
+    with httpx.Client(base_url="http://fixture.invalid", transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, stream=stream))) as client:
+        with pytest.raises(ValueError, match="^a2a_transport_error$"):
+            send_message("http://fixture.invalid", "hello", http=client)
+    assert stream.closed
+
+
+def test_native_rpc_preserves_successful_non_200_status():
+    stream = Chunks([b'{"result":{"kind":"task"}}'])
+    with httpx.Client(base_url="http://fixture.invalid", transport=httpx.MockTransport(
+            lambda request: httpx.Response(201, stream=stream))) as client:
+        assert send_message("http://fixture.invalid", "hello", http=client) == {"kind": "task"}
+    assert stream.closed
+
+
+@contextmanager
+def loopback(handler):
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+class QuietHandler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+
+def test_owned_client_bypasses_ambient_proxy_and_accepts_local_agent(monkeypatch):
+    proxy_hits = []
+    requests = []
+    class Proxy(QuietHandler):
+        def do_GET(self):
+            proxy_hits.append(self.path)
+            self.send_error(502)
+        do_POST = do_GET
+    class Agent(QuietHandler):
+        def do_GET(self):
+            requests.append(("GET", self.headers.get("Accept-Encoding")))
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{"name":"loopback"}')
+        def do_POST(self):
+            requests.append(("POST", self.headers.get("Accept-Encoding")))
+            self.rfile.read(int(self.headers["Content-Length"]))
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{"result":{"kind":"task"}}')
+    with loopback(Proxy) as proxy, loopback(Agent) as url:
+        for key in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"):
+            monkeypatch.setenv(key, proxy)
+        for key in ("NO_PROXY", "no_proxy"):
+            monkeypatch.setenv(key, "")
+        assert fetch_card(url) == {"name": "loopback"}
+        assert send_message(url, "hello") == {"kind": "task"}
+    assert proxy_hits == []
+    assert requests == [("GET", "identity"), ("POST", "identity")]
+
+
+def test_owned_client_refuses_redirect_and_does_not_retry_interrupted_post():
+    requests = []
+    class Agent(QuietHandler):
+        def do_GET(self):
+            requests.append(self.path)
+            self.send_response(302)
+            self.send_header("Location", "/redirected")
+            self.end_headers()
+        def do_POST(self):
+            requests.append("POST")
+            self.rfile.read(int(self.headers["Content-Length"]))
+            self.connection.shutdown(socket.SHUT_RDWR)
+            self.connection.close()
+    with loopback(Agent) as url:
+        with pytest.raises(ValueError, match="^a2a_http_status_302$"):
+            fetch_card(url)
+        with pytest.raises(ValueError, match="^a2a_transport_error$"):
+            send_message(url, "hello")
+    assert requests == ["/.well-known/agent-card.json", "POST"]
+
+
+def test_slow_read_hits_phase_timeout_without_claiming_total_deadline():
+    class Agent(QuietHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.end_headers()
+            time.sleep(0.15)
+    with loopback(Agent) as url:
+        with pytest.raises(ValueError, match="^a2a_timeout$"):
+            fetch_card(url, timeout_seconds=0.02)
+
+
+def test_real_cli_selects_shared_default_and_records_owned_policy(tmp_path):
+    from nandatown.bundle import load_bundle, verify_bundle
+    class Agent(QuietHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{"name":"loopback"}')
+        def do_POST(self):
+            request = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            order = json.loads(request["params"]["message"]["parts"][0]["text"])
+            task = {"kind": "task", "id": "local-task", "status": {"state": "completed"},
+                    "artifacts": [{"parts": [{"kind": "text", "text": json.dumps({
+                        "request_id": order["request_id"], "total_cents": 3990})}]}]}
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps({"result": task}).encode())
+    with loopback(Agent) as url:
+        result = subprocess.run([sys.executable, "-m", "nandatown.cli", "test-agent", "--url", url,
+                                 "--out", str(tmp_path)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    directory, = tmp_path.glob("path-*")
+    bundle = load_bundle(str(directory))
+    assert bundle["run"].profile_name == "a2a-capability-fulfillment@0.2"
+    policy = bundle["run"].config["a2a_transport_policy"]
+    assert policy["trust_env"] is False
+    assert policy["transport_retries"] == 0
+    assert policy["client_ownership"] == "owned"
+    assert policy["total_deadline_seconds"] is None
+    assert verify_bundle(str(directory)) == []
+
+
+@pytest.mark.parametrize("body", [b'{}', b'bad-json'])
+def test_internally_owned_client_is_closed_on_success_and_failure(monkeypatch, body):
+    import nandatown.a2a_transport as transport
+    clients = []
+    real_client = httpx.Client
+    def client_factory(**kwargs):
+        # Keep the real HTTPX client lifecycle; only external I/O is replaced.
+        kwargs.pop("transport", None)
+        client = real_client(**kwargs, transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, stream=Chunks([body]))))
+        clients.append(client)
+        return client
+    monkeypatch.setattr(transport.httpx, "Client", client_factory)
+    if body == b'{}':
+        assert fetch_card("http://fixture.invalid") == {}
+    else:
+        with pytest.raises(ValueError, match="a2a_invalid_json"):
+            fetch_card("http://fixture.invalid")
+    assert len(clients) == 1 and clients[0].is_closed

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,5 +1,6 @@
 import json
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -142,3 +143,79 @@ def test_profile_is_frozen_and_fingerprinted():
     assert profile.fingerprint().startswith("sha256:")
     with pytest.raises(KeyError):
         get_path_profile("nonsense@9.9")
+
+
+def test_oversized_card_does_not_reach_path_invocation(tmp_path):
+    url = "http://fixture.invalid"
+    card = build_agent_card(url)
+    card["description"] = "x" * 1_048_576
+    methods = []
+    def handle(request):
+        methods.append(request.method)
+        return httpx.Response(200, json=card)
+    with httpx.Client(base_url=url, transport=httpx.MockTransport(handle)) as http:
+        bundle_dir, result = run_path_test(url, str(tmp_path), http=http)
+        assert not http.is_closed
+    assert methods == ["GET"]
+    assert stage(result, "agent_card_retrieval").status == "failed"
+    assert stage(result, "agent_card_retrieval").note == (
+        "a2a_response_budget_exceeded: selected local byte budget exceeded for this run")
+    assert stage(result, "semantic_result").status == "not_tested"
+    bundle = load_bundle(bundle_dir)
+    assert bundle["run"].profile_name == "a2a-capability-fulfillment@0.2"
+    assert bundle["run"].config["a2a_transport_policy"] == {
+        "policy_id": "a2a-bounded-json@0.1",
+        "max_response_bytes": 1_048_576,
+        "budget_basis": "profile",
+        "accept_encoding": "identity",
+        "follow_redirects": False,
+        "trust_env": "caller_controlled",
+        "transport_retries": "caller_controlled",
+        "client_ownership": "injected",
+        "phase_timeout_seconds": 15.0,
+        "total_deadline_seconds": None,
+    }
+    assert verify_bundle(bundle_dir) == []
+
+
+def test_old_profile_is_unchanged_and_new_bundles_replay(tmp_path):
+    old = get_path_profile("a2a-capability-fulfillment@0.1")
+    assert old.fingerprint() == "sha256:80d238c2de68dbe3de577ad88ae5eb742daeaf2628dc7802be2b11e68b8d4b83"
+    assert old.limits == {"timeout_seconds": 15.0}
+    new = get_path_profile("a2a-capability-fulfillment@0.2")
+    assert new.limits == {"timeout_seconds": 15.0, "max_response_bytes": 1_048_576}
+    assert old.fingerprint() != new.fingerprint()
+    for profile in (old, new):
+        with client() as http:
+            directory, result = run_path_test(SUBJECT, str(tmp_path), profile_ref=profile.ref, http=http)
+        assert result.verdict == "passed"
+        bundle = load_bundle(directory)
+        assert bundle["run"].profile_fingerprint == profile.fingerprint()
+        assert bundle["run"].config["a2a_transport_policy"]["budget_basis"] == (
+            "implementation_ceiling" if profile.version == "0.1" else "profile")
+        assert verify_bundle(directory) == []
+
+
+def test_owned_path_keeps_card_session_for_both_logical_requests(tmp_path, monkeypatch):
+    import nandatown.a2a_transport as transport
+    real_client = httpx.Client
+    clients = []
+    def handle(request):
+        if request.method == "GET":
+            return httpx.Response(200, json=build_agent_card(SUBJECT),
+                                  headers={"set-cookie": "session=local; Path=/"})
+        assert request.headers.get("cookie") == "session=local"
+        order = json.loads(json.loads(request.content)["params"]["message"]["parts"][0]["text"])
+        return httpx.Response(200, json={"result": {
+            "kind": "task", "id": "local", "status": {"state": "completed"},
+            "artifacts": [{"parts": [{"kind": "text", "text": json.dumps({
+                "request_id": order["request_id"], "total_cents": 3990})}]}]}})
+    def client_factory(**kwargs):
+        kwargs.pop("transport", None)
+        http = real_client(**kwargs, transport=httpx.MockTransport(handle))
+        clients.append(http)
+        return http
+    monkeypatch.setattr(transport.httpx, "Client", client_factory)
+    _, result = run_path_test(SUBJECT, str(tmp_path))
+    assert result.verdict == "passed"
+    assert len(clients) == 1 and clients[0].is_closed


### PR DESCRIPTION
## Summary

Bound external AgentCard and native A2A JSON responses before parsing, and record the effective transport policy in each Path run.

- Stream with a 1 MiB default byte limit, checking actual bytes even without an honest Content-Length. Request identity encoding and reject unsupported encodings.
- Close owned clients and every response; preserve injected-client ownership and the same owned session across a run.
- Make no redirects, no ambient proxies/environment settings, and no automatic transport retries explicit for owned clients. The deliberate duplicate logical request remains part of the test.
- Use bounded error categories instead of retaining arbitrary remote error bodies or exception strings.
- Add `a2a-capability-fulfillment@0.2` as the shared default. Preserve the old `@0.1` profile and its fingerprint; record implementation policy separately for old-profile runs.

## Attribution and scope

Carries forward bounded external-invocation requirements from #145 by `abhishekeb211` (reviewed head `ddc5f4c5ee67db7b9784b1198446eee596facf53`) and techniques from James's historical #222 (source commit `77c9ff3a39260e31640360be7ccb23652a13d307`), reimplemented for current `main`. It does not port the legacy middleware/deployment rewrite or alter the legacy branches. This transport change leaves the evaluator and its version unchanged.

This caps response bytes, not total runtime. HTTPX phase timeouts are not a cancellable overall deadline. Connection-bound address/DNS policy is a separate follow-up; intentional localhost/LAN agents remain supported. Injected client proxy/retry settings remain caller-controlled and are disclosed as such.

Disabling environment settings also affects corporate proxies and custom certificate configuration. The README describes this tradeoff. Explicit profile selection uses `--path-profile`.

## Merge order

**Prerequisite landed:** #238 (`f8489d7`) corrects the generated rerun flag so old-profile reruns retain their selected version. This branch has been refreshed with that change and #239 (`7af8084`, scenario coverage). The transport diff against current `main` remains separate from those fixes.

## Verification

Behavioral tests cover byte boundaries, length/encoding/JSON errors, cleanup, native success, real loopback redirects/proxy bypass/no POST retry/phase timeout, CLI profile selection, and bundle replay.

- Focused RED: 37 failed, 9 passed before production changes. Two additional self-review regressions failed before their compatibility fixes.
- Focused GREEN: 48 passed.
- Independent full-suite verification on Python 3.12: 221 passed, nine pre-existing warnings.
- Final candidate `0d7ed81` including landed #238 and #239: 236 passed, nine pre-existing warnings. Independent integration review confirmed all appended tests were retained unchanged.
- Combined with pending #233–#237, coverage and rerun changes: 267 tests passed.
- A genuine baseline `@0.1` bundle verifies and replays with this transport branch. The separate evaluator update in #236 explicitly reports its version mismatch rather than silently replaying with changed rules.
- Independent task and whole-batch reviews approved the combination; dependency ordering is intentional.

```sh
python -m pytest -q tests/test_a2a_transport.py tests/test_path.py
python -m pytest -q
```
