### PR TITLE
fix(lab): disclose untested scope of imported scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ Same agents, same scenario, same seed; only the rules differ. The comparison rep
 
 ## Upstream scenarios run here
 
-Scenario files from the projnanda/nandatown repository (agent populations declared as roles with counts, tick durations, rate-based failures) are detected and adapted automatically: roles map onto the reference agents per task type, upstream layer plugins substitute to local defaults, and every substitution is disclosed in the report as an adaptation. `nandatown import-pr N` then `nandatown run <imported scenario>` just works, judged by the generic adapted validator: population active, discovery worked, messages flowed, the task completed, money conserved.
+Legacy scenario files (agent populations declared as roles with counts, tick durations, rate-based failures) are detected and adapted automatically. `nandatown import-pr N` then `nandatown run <imported scenario>` runs a local reference flow: roles map onto Town's reference agents and upstream layer plugins are replaced by local defaults. The generic checks cover population activity, discovery, message flow, a completion fact, and money conservation.
+
+**A passing adapted run is not a pass for the original contribution.** The report and exported result include `original_scenario: not_tested`; the verdict applies only to the adapted reference flow. Original agent configuration, plugin code and validators are not executed. Duration becomes bounded local logical time, not a reproduction of legacy event-count ticks. `message_drop` maps to seeded drops, capped at 0.2 with the cap disclosed. Every other declared failure key, including `network_partition` and `byzantine_agents`, is explicitly reported as not modeled, even when its value is zero or disabled. These notes travel in `profile.json` and the human report; unsupported payload values are not copied into the notes. Testing streaming-payment or gossip-partition invariants requires a scenario and implementation that actually exercise those semantics.
+
+The coverage change is versioned as Lab evaluator `lab-0.2.2`. Older Lab bundles retain their recorded results, but verification reports an evaluator-version mismatch rather than replaying them as if the checks were unchanged.
 
 ## Lab scenarios
 

--- a/src/nandatown/report.py
+++ b/src/nandatown/report.py
@@ -112,7 +112,10 @@ def render_report(bundle: dict[str, Any]) -> str:
         created = time.strftime("%Y-%m-%d %H:%M:%S UTC",
                                 time.gmtime(run.created_at))
         add(f"Started:   {created}")
-    add(f"Verdict:   {result.verdict.upper()}")
+    scope = (" (adapted reference flow only)"
+             if bundle.get("mode") == "lab" and profile.validator == "adapted"
+             else "")
+    add(f"Verdict:   {result.verdict.upper()}{scope}")
     if result.verdict != "passed":
         broken = next((s for s in result.stages
                        if s.status in ("failed", "error")), None)

--- a/src/nandatown/sim/upstream.py
+++ b/src/nandatown/sim/upstream.py
@@ -5,9 +5,10 @@ uses different layer keys and plugin ids, tick durations, and rate
 based failures. This adapter translates any of that into a runnable
 local ScenarioSpec, mapping upstream roles onto the town's reference
 roles per task type and substituting upstream layer plugins with the
-local defaults. Every substitution and fill-in is recorded as an
-adaptation, and adapted runs are judged by the generic adapted
-validator, so the report says exactly what was translated.
+local defaults. Adaptation notes disclose mapped roles, substituted
+plugins, and unsupported failure declarations. The generic adapted
+validator judges the local reference flow, not the original scenario's
+agent configuration, protocol implementation, or validators.
 """
 
 from __future__ import annotations
@@ -218,10 +219,13 @@ def adapt_upstream(data: dict[str, Any]) -> ScenarioSpec:
         if drop > 0.2:
             adaptations.append(f"message_drop {drop} capped at 0.2 so"
                                " the flow can still complete")
-    byzantine = float(failures.get("byzantine_agents", 0) or 0)
-    if byzantine > 0:
-        adaptations.append(f"byzantine_agents {byzantine} not modeled;"
-                           " the population runs honest")
+    for key in failures:
+        if key != "message_drop":
+            # Do not interpret unsupported values or copy their payloads
+            # into public evidence. Even a zero/disabled declaration needs
+            # disclosure: accepting it does not establish support for it.
+            adaptations.append(f"failures.{key} not modeled by the"
+                               " adapted reference flow")
 
     return ScenarioSpec(
         name=f"upstream-{name}",

--- a/src/nandatown/sim/validators.py
+++ b/src/nandatown/sim/validators.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 from ..records import EvidenceResult, StageResult, TownEvent
 
-LAB_EVALUATOR_VERSION = "lab-0.2.1"
+LAB_EVALUATOR_VERSION = "lab-0.2.2"
 
 VALIDATORS: dict[str, Callable] = {}
 
@@ -412,8 +412,15 @@ COMPLETION_KINDS = ["offer_accepted", "vote_result",
 def adapted(spec, trace: Trace) -> list[StageResult]:
     """Generic system fitness for scenarios adapted from upstream:
     the population came up, discovery worked, messages moved, and the
-    task flow reached a completion fact."""
-    stages = []
+    task flow reached a completion fact. These checks do not establish
+    the original upstream scenario's protocol or failure semantics."""
+    stages = [StageResult(
+        name="original_scenario", status="not_tested",
+        note=("Only the adapted reference flow is evaluated. Original"
+              " agent configuration, plugins, validators, and declared"
+              " failure semantics are not validated by this run; see"
+              " the profile's adaptation notes and effective faults."),
+    )]
     joined = trace.find("participant_joined")
     stages.append(_check(
         "population_active", len(joined) == len(spec.agents),

--- a/tests/test_lab_coverage.py
+++ b/tests/test_lab_coverage.py
@@ -38,6 +38,7 @@ NATIVE_SCENARIO_STAGES = {
 }
 ADAPTED_STAGES = {
     "population_active", "discovery", "messages_flowed", "task_completed",
+    "original_scenario",
 }
 GENERIC_STAGES = {"ledger_conserved", "privacy"}
 UPSTREAM_FIXTURES = os.path.join(
@@ -170,7 +171,8 @@ def test_weak_auth_remains_a_deliberately_failing_native_control():
     assert stage(result, "containment").status == "failed"
 
 
-def test_new_lab_bundles_replay_and_old_lab_versions_do_not(tmp_path):
+@pytest.mark.parametrize("old_version", ["lab-0.2.0", "lab-0.2.1"])
+def test_new_lab_bundles_replay_and_old_lab_versions_do_not(tmp_path, old_version):
     """The evaluator bump makes old Lab bundles explicitly non-reproducible."""
     bundle_dir, result = run_lab("marketplace", str(tmp_path))
     assert result.evaluator_version == LAB_EVALUATOR_VERSION
@@ -178,7 +180,7 @@ def test_new_lab_bundles_replay_and_old_lab_versions_do_not(tmp_path):
 
     result_path = os.path.join(bundle_dir, "result.json")
     recorded = json.loads(open(result_path).read())
-    recorded["evaluator_version"] = "lab-0.2.0"
+    recorded["evaluator_version"] = old_version
     with open(result_path, "w") as handle:
         json.dump(recorded, handle)
     manifest_path = os.path.join(bundle_dir, "manifest.json")
@@ -191,6 +193,6 @@ def test_new_lab_bundles_replay_and_old_lab_versions_do_not(tmp_path):
         json.dump(manifest, handle)
 
     assert verify_bundle(bundle_dir) == [
-        "evaluator version differs: bundle lab-0.2.0, local "
-        "lab-0.2.1; reproducibility not checked",
+        f"evaluator version differs: bundle {old_version}, local "
+        "lab-0.2.2; reproducibility not checked",
     ]

--- a/tests/test_upstream.py
+++ b/tests/test_upstream.py
@@ -1,9 +1,14 @@
 import os
+from pathlib import Path
+
+import pytest
+import yaml
 
 from nandatown.bundle import load_bundle, verify_bundle
 from nandatown.sim.runner import run_lab
 from nandatown.sim.scenario import load_scenario_file
 from nandatown.sim.upstream import adapt_upstream
+from nandatown.sim.validators import evaluate_scenario
 
 FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "upstream")
 
@@ -85,3 +90,76 @@ def test_unknown_task_falls_back_to_exchange():
     })
     assert {a.role for a in spec.agents} == {"buyer", "seller"}
     assert any("alpha adapted as buyer" in a for a in spec.adaptations)
+
+
+@pytest.mark.parametrize("key, value", [
+    ("network_partition", {"groups": [["private-peer-marker"]]}),
+    ("network_partition", False),
+    ("reasoning_timeout", 0),
+    ("byzantine_agents", 0),
+    ("byzantine_agents", 0.1),
+])
+def test_unsupported_failure_declarations_never_disappear(key, value):
+    """Even a disabled unknown condition is not silently treated as supported."""
+    spec = adapt_upstream({"failures": {key: value}})
+    disclosure = "\n".join(spec.adaptations)
+    assert f"failures.{key}" in disclosure
+    assert "not modeled" in disclosure
+    assert "private-peer-marker" not in disclosure
+    assert spec.faults == []
+
+
+@pytest.mark.parametrize("task_type, failure", [
+    ("streaming_payments", {"network_partition": {"groups": [["payer"], ["payee"]]}}),
+    ("gossip_registry", {"network_partition": {"groups": [["peer_a"], ["peer_b"]]}}),
+])
+def test_adapted_run_exports_original_scope_as_untested(tmp_path, task_type, failure):
+    """A passing reference exchange cannot certify streaming or partition semantics."""
+    source = tmp_path / "legacy.yaml"
+    source.write_text(yaml.safe_dump({
+        "name": task_type,
+        "task": {"type": task_type},
+        "agents": {"roles": [{"name": "buyer"}, {"name": "seller"}]},
+        "failures": failure,
+        # The importer must not execute upstream plugin code.
+        "plugin_files": [str(tmp_path / "not-a-local-plugin.py")],
+    }))
+    directory, result = run_lab(str(source), str(tmp_path / "runs"))
+    assert result.verdict == "passed"
+    assert stage(result, "task_completed").status == "passed"
+    original = stage(result, "original_scenario")
+    assert original.status == "not_tested"
+    assert original.evidence == []
+    assert "original" in original.note.lower()
+    bundle = load_bundle(directory)
+    assert bundle["profile"].plugin_files == []
+    assert any("failures.network_partition" in note
+               for note in bundle["profile"].adaptations)
+    assert verify_bundle(directory) == []
+    report = (Path(directory) / "report.md").read_text()
+    assert "failures.network_partition" in report
+    assert "original_scenario" in report
+    source_line = next(line for line in report.splitlines()
+                       if "original_scenario" in line)
+    assert "not tested" in source_line.lower()
+    assert "adapted reference flow only" in report
+
+
+def test_empty_adapted_trace_still_cannot_pass():
+    """An explicit untested-source marker cannot hide missing local evidence."""
+    result = evaluate_scenario(adapt_upstream({}), "empty-adaptation", [])
+    assert result.verdict == "incomplete"
+    assert stage(result, "original_scenario").status == "not_tested"
+    assert stage(result, "task_completed").status == "not_enough_evidence"
+
+
+@pytest.mark.parametrize("requested, effective", [(0, 0), (0.1, 0.1), (0.5, 0.2)])
+def test_supported_drop_translation_is_unchanged(requested, effective):
+    """Disclosing unsupported conditions must not change supported drop policy."""
+    spec = adapt_upstream({"failures": {"message_drop": requested}})
+    assert [(fault.action, fault.rate) for fault in spec.faults] == (
+        [("drop_rate", effective)] if effective else []
+    )
+    assert not any("not modeled" in note for note in spec.adaptations)
+    if requested > effective:
+        assert any("0.5 capped at 0.2" in note for note in spec.adaptations)


### PR DESCRIPTION
## Summary

Imported legacy scenarios run Town reference agents, not their original plugins or validators. Previously a declared `network_partition` disappeared silently, and a generic adapted exchange could pass without any result saying that the original protocol was untested.

- Disclose every unsupported `failures` key in the exported profile and report, including zero/disabled declarations. Unsupported payload values are not copied into these notes.
- Add `original_scenario: not_tested` to adapted results, with no supporting event IDs. Keep the existing generic local-flow checks and their outcomes.
- Label the human verdict as applying to the adapted reference flow only.
- Bump the Lab evaluator to `lab-0.2.2`; old bundles report a version mismatch instead of silently acquiring different checks.

No new dependency, profile schema field, execution backend, payment system or partition simulator is introduced. Existing `message_drop` behavior, including its disclosed 0.2 cap, remains unchanged. Original agent configuration, plugin code, and validators are still not executed.

## Source ideas and scope

This current-main change was motivated by the actual-run discipline in @stanleyoz's #153 and the declared-condition/non-vacuity checks in @ang101's #190. Their tests highlighted why completing a substituted marketplace flow must not be presented as proving streaming payments or gossip isolation.

This is a focused coverage/disclosure replacement, not a port of either original implementation. Streaming lifecycle idempotency, cancellation/refunds and conservation require a separately selected streaming scenario. Per-node partition isolation and legitimate bridge relay require an actual partition-capable registry fixture. Those remain useful future suites, not capabilities established by this PR. No source code from either legacy PR was copied.

## Verification

- Clean baseline: 236 passed.
- Regression-first checks reproduced missing unsupported-condition notes and missing original-scenario coverage before the fix.
- Full local suite: 248 passed, 9 pre-existing warnings, Python 3.12.
- Actual `run_lab` round trips for synthetic streaming and gossip imports: reference task passes, original scenario remains untested, omissions survive export, and bundles verify/replay.
- Empty adapted trace remains incomplete; native scenario stage expectations and existing fault controls remain green.
- A genuine pre-change `lab-0.2.1` bundle was generated and verified before the edit; the new code retains its recorded verdict and reports the expected evaluator-version mismatch.
- Self-reviewed against the bounded requirements; no new independent-agent review was performed for this batch.

Reproduce with `python -m pytest -q`. CI also runs Python 3.11/3.12 and the existing Lab/Track smoke commands.
