### PR TITLE
fix(lab): verify receipt-backed reputation arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ Legacy scenario files (agent populations declared as roles with counts, tick dur
 
 **A passing adapted run is not a pass for the original contribution.** The report and exported result include `original_scenario: not_tested`; the verdict applies only to the adapted reference flow. Original agent configuration, plugin code and validators are not executed. Duration becomes bounded local logical time, not a reproduction of legacy event-count ticks. `message_drop` maps to seeded drops, capped at 0.2 with the cap disclosed. Every other declared failure key, including `network_partition` and `byzantine_agents`, is explicitly reported as not modeled, even when its value is zero or disabled. These notes travel in `profile.json` and the human report; unsupported payload values are not copied into the notes. Testing streaming-payment or gossip-partition invariants requires a scenario and implementation that actually exercise those semantics.
 
-The coverage change is versioned as Lab evaluator `lab-0.2.2`. Older Lab bundles retain their recorded results, but verification reports an evaluator-version mismatch rather than replaying them as if the checks were unchanged.
+The current Lab evaluator is `lab-0.2.3`. Marketplace reputation checks now match each score update to a prior receipt event from the same observer, about the same subject and outcome, and replay the reference +1/-1 arithmetic. Missing receipts mean insufficient evidence; conflicting attribution, repeated receipt use or incorrect arithmetic fail. This validates recorded claims, not their truth, reporter authority or receipt signatures. A bad outcome can reduce a still-positive total. Other scoring algorithms need their own declared evaluator.
+
+Older Lab bundles retain their recorded results, but verification reports an evaluator-version mismatch rather than replaying them as if the checks were unchanged.
 
 ## Lab scenarios
 

--- a/src/nandatown/sim/validators.py
+++ b/src/nandatown/sim/validators.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 from ..records import EvidenceResult, StageResult, TownEvent
 
-LAB_EVALUATOR_VERSION = "lab-0.2.2"
+LAB_EVALUATOR_VERSION = "lab-0.2.3"
 
 VALIDATORS: dict[str, Callable] = {}
 
@@ -145,6 +145,76 @@ def privacy_clean(trace: Trace, redact_fields: list[str]) -> StageResult:
                    f"fields {sorted(redact_fields)} never left the run")
 
 
+def reputation_consistent(trace: Trace) -> StageResult:
+    """Replay the reference +1/-1 formula against attributed receipt events.
+
+    This checks the recorded claim, not whether the reporter told the truth,
+    held authority, or proved misconduct. Receipt signatures are not present
+    in these events and are not cryptographically verified by this check.
+    """
+    receipts: dict[str, list[tuple[int, TownEvent]]] = {}
+    for index, event in enumerate(trace.events):
+        if event.kind == "receipt_attested":
+            record_id = event.detail.get("record_id")
+            if isinstance(record_id, str) and record_id:
+                receipts.setdefault(record_id, []).append((index, event))
+
+    scores: dict[str, int] = {}
+    used: set[str] = set()
+    evidence: list[str] = []
+    missing_receipt = False
+    for index, event in enumerate(trace.events):
+        if event.kind != "reputation_updated":
+            continue
+        detail = event.detail
+        outcome = detail.get("outcome")
+        delta = 1 if outcome == "good" else -1
+        score = scores.get(event.subject, 0) + delta
+        if (outcome not in ("good", "bad")
+                or type(detail.get("delta")) is not int
+                or detail["delta"] != delta
+                or type(detail.get("score")) is not int
+                or detail["score"] != score):
+            return _failed("reputation", [event.event_id],
+                           "score update does not follow the reference +1/-1 formula")
+        scores[event.subject] = score
+        evidence.append(event.event_id)
+
+        record_id = detail.get("receipt")
+        if not isinstance(record_id, str) or not record_id:
+            return _failed("reputation", [event.event_id],
+                           "score update has no valid receipt reference")
+        if record_id in used:
+            return _failed("reputation", [event.event_id],
+                           "one receipt was counted more than once")
+        used.add(record_id)
+        matches = receipts.get(record_id, [])
+        if not matches:
+            missing_receipt = True
+            continue
+        if len(matches) != 1:
+            return _failed("reputation", [event.event_id],
+                           "receipt reference is ambiguous")
+        receipt_index, receipt = matches[0]
+        refs = [receipt.event_id, event.event_id]
+        if (receipt_index >= index or receipt.at > event.at
+                or receipt.run_id != event.run_id
+                or receipt.observer != event.observer
+                or receipt.subject != event.subject
+                or receipt.observer == receipt.subject
+                or receipt.detail.get("claim") != "trade.outcome"
+                or receipt.detail.get("value") != outcome):
+            return _failed("reputation", refs,
+                           "score update does not match a prior attributed trade receipt")
+        evidence.append(receipt.event_id)
+
+    if not evidence or missing_receipt:
+        return _missing("reputation", "score updates or their receipt events are missing")
+    return _passed("reputation", evidence,
+                   "recorded receipt claims and reference score arithmetic agree; "
+                   "claim truth and reporter authority are not tested")
+
+
 @validator("marketplace")
 def marketplace(spec, trace: Trace) -> list[StageResult]:
     stages = []
@@ -185,11 +255,13 @@ def marketplace(spec, trace: Trace) -> list[StageResult]:
         "the duplicated delivery must be recognized and released once"))
 
     reps = trace.find("reputation_updated")
-    stages.append(_check(
-        "reputation", len(reps) == 2 and reps[-1].detail["score"] == 2,
-        [e.event_id for e in reps],
-        "expected the winning seller to end with reputation 2 from two"
-        " good receipts"))
+    reputation = reputation_consistent(trace)
+    if reputation.status != "failed" and reps and not (
+            len(reps) == 2 and reps[-1].detail["score"] == 2):
+        reputation = _failed(
+            "reputation", reputation.evidence,
+            "expected the winning seller to end with reputation 2 from two good receipts")
+    stages.append(reputation)
 
     remembered = trace.ids("memory_written")
     stages.append(_check(

--- a/tests/test_lab_coverage.py
+++ b/tests/test_lab_coverage.py
@@ -171,7 +171,7 @@ def test_weak_auth_remains_a_deliberately_failing_native_control():
     assert stage(result, "containment").status == "failed"
 
 
-@pytest.mark.parametrize("old_version", ["lab-0.2.0", "lab-0.2.1"])
+@pytest.mark.parametrize("old_version", ["lab-0.2.0", "lab-0.2.1", "lab-0.2.2"])
 def test_new_lab_bundles_replay_and_old_lab_versions_do_not(tmp_path, old_version):
     """The evaluator bump makes old Lab bundles explicitly non-reproducible."""
     bundle_dir, result = run_lab("marketplace", str(tmp_path))
@@ -194,5 +194,5 @@ def test_new_lab_bundles_replay_and_old_lab_versions_do_not(tmp_path, old_versio
 
     assert verify_bundle(bundle_dir) == [
         f"evaluator version differs: bundle {old_version}, local "
-        "lab-0.2.2; reproducibility not checked",
+        "lab-0.2.3; reproducibility not checked",
     ]

--- a/tests/test_lab_reputation.py
+++ b/tests/test_lab_reputation.py
@@ -1,0 +1,163 @@
+"""A final score alone must not stand in for attributable score changes.
+
+Retains the report/outcome and per-update (not lifetime-negative) distinction
+raised by legacy PRs #129 (Anurag17-2005) and #178 (RoarHX).
+"""
+
+import pytest
+
+from nandatown.sim.runner import build_engine, run_lab
+from nandatown.sim.scenario import load_bundled
+from nandatown.sim.api import TownAPI
+from nandatown.sim.engine import Engine
+from nandatown.sim.validators import (
+    Trace, evaluate_scenario, marketplace, reputation_consistent,
+)
+from nandatown.bundle import verify_bundle
+
+
+def marketplace_trace():
+    spec = load_bundled("marketplace")
+    engine = build_engine(spec)
+    engine.run()
+    return spec, [event.model_copy(deep=True) for event in engine.events]
+
+
+def reputation_stage(spec, events):
+    return next(stage for stage in marketplace(spec, Trace(events))
+                if stage.name == "reputation")
+
+
+@pytest.mark.parametrize("case,want", [
+    ("missing_receipts", "not_enough_evidence"),
+    ("missing_one_receipt", "not_enough_evidence"),
+    ("wrong_subject", "failed"),
+    ("wrong_observer", "failed"),
+    ("self_report", "failed"),
+    ("wrong_claim", "failed"),
+    ("wrong_outcome", "failed"),
+    ("future_receipt", "failed"),
+    ("future_timestamp", "failed"),
+    ("different_run", "failed"),
+    ("duplicate_receipt_id", "failed"),
+    ("reused_receipt", "failed"),
+    ("wrong_intermediate_score", "failed"),
+    ("wrong_delta", "failed"),
+    ("unknown_outcome", "failed"),
+    ("bool_delta", "failed"),
+    ("bool_score", "failed"),
+    ("missing_score", "failed"),
+    ("malformed_receipt_ref", "failed"),
+])
+def test_marketplace_reputation_requires_receipt_backed_arithmetic(case, want):
+    """Removing attribution/arithmetic checks must break these regressions."""
+    spec, events = marketplace_trace()
+    receipts = [e for e in events if e.kind == "receipt_attested"]
+    updates = [e for e in events if e.kind == "reputation_updated"]
+    assert len(receipts) == len(updates) == 2
+    if case == "missing_receipts":
+        events = [e for e in events if e.kind != "receipt_attested"]
+    elif case == "missing_one_receipt":
+        events.remove(receipts[0])
+    elif case == "wrong_subject":
+        receipts[0].subject = "unrelated-seller"
+    elif case == "wrong_observer":
+        receipts[0].observer = "unrelated-buyer"
+    elif case == "self_report":
+        receipts[0].observer = updates[0].observer = updates[0].subject
+    elif case == "wrong_claim":
+        receipts[0].detail["claim"] = "endpoint.live"
+    elif case == "wrong_outcome":
+        receipts[0].detail["value"] = "bad"
+    elif case == "future_receipt":
+        events.remove(receipts[0])
+        events.append(receipts[0])
+    elif case == "future_timestamp":
+        receipts[0].at = updates[0].at + 1
+    elif case == "different_run":
+        receipts[0].run_id = "different-run"
+    elif case == "duplicate_receipt_id":
+        receipts[1].detail["record_id"] = receipts[0].detail["record_id"]
+    elif case == "reused_receipt":
+        updates[1].detail["receipt"] = updates[0].detail["receipt"]
+    elif case == "wrong_intermediate_score":
+        updates[0].detail["score"] = 999
+    elif case == "wrong_delta":
+        updates[0].detail["delta"] = -1
+    elif case == "unknown_outcome":
+        updates[0].detail["outcome"] = "uncertain"
+    elif case == "bool_delta":
+        updates[0].detail["delta"] = True
+    elif case == "bool_score":
+        updates[0].detail["score"] = True
+    elif case == "missing_score":
+        del updates[0].detail["score"]
+    elif case == "malformed_receipt_ref":
+        updates[0].detail["receipt"] = []
+    result = evaluate_scenario(spec, events[0].run_id, events)
+    stage = next(s for s in result.stages if s.name == "reputation")
+    assert stage.status == want
+    assert result.verdict != "passed"
+
+
+def test_healthy_marketplace_cites_receipts_and_replays(tmp_path):
+    spec, events = marketplace_trace()
+    stage = reputation_stage(spec, events)
+    assert stage.status == "passed"
+    cited_kinds = {e.kind for e in events if e.event_id in stage.evidence}
+    assert cited_kinds == {"receipt_attested", "reputation_updated"}
+    bundle_dir, result = run_lab("marketplace", str(tmp_path))
+    assert result.verdict == "passed"
+    assert verify_bundle(bundle_dir) == []
+
+
+def test_empty_reputation_is_missing_not_success():
+    spec = load_bundled("marketplace")
+    assert reputation_stage(spec, []).status == "not_enough_evidence"
+
+
+@pytest.mark.parametrize("case,want", [
+    ("recorded_bad", "passed"),
+    ("bad_raises_score", "failed"),
+    ("bad_missing_receipt", "not_enough_evidence"),
+])
+def test_real_bad_report_decrements_without_requiring_negative_total(case, want):
+    """Do not confuse a negative delta with a negative lifetime reputation."""
+    engine = Engine(load_bundled("marketplace"))
+    engine.layers["identity"].create("buyer")
+    api = TownAPI(engine, "buyer")
+    for outcome in ("good", "good", "good", "bad"):
+        api.rate("seller", outcome)
+    assert api.reputation("seller") == 2
+    updates = [e for e in engine.events if e.kind == "reputation_updated"]
+    assert [e.detail["score"] for e in updates] == [1, 2, 3, 2]
+    assert [e.detail["delta"] for e in updates] == [1, 1, 1, -1]
+    if case == "bad_raises_score":
+        updates[-1].detail.update(delta=1, score=4)
+    elif case == "bad_missing_receipt":
+        engine.events = [e for e in engine.events
+                         if not (e.kind == "receipt_attested"
+                                 and e.detail["value"] == "bad")]
+    stage = reputation_consistent(Trace(engine.events))
+    assert stage.status == want
+    # These are attributed reports, not an independently observed cheating test.
+    assert not any(e.kind == "cheat" for e in engine.events)
+
+
+def test_known_arithmetic_failure_is_not_hidden_by_another_missing_receipt():
+    _, events = marketplace_trace()
+    receipts = [e for e in events if e.kind == "receipt_attested"]
+    updates = [e for e in events if e.kind == "reputation_updated"]
+    events.remove(receipts[0])
+    updates[1].detail["score"] = 999
+    assert reputation_consistent(Trace(events)).status == "failed"
+
+
+def test_missing_receipt_does_not_hide_wrong_marketplace_update_count():
+    spec, events = marketplace_trace()
+    events = [e for e in events if e.kind != "receipt_attested"]
+    last = [e for e in events if e.kind == "reputation_updated"][-1]
+    extra = last.model_copy(deep=True, update={"event_id": "extra-update"})
+    extra.detail.update(score=3, receipt="absent-third-receipt")
+    events.append(extra)
+    assert reputation_stage(spec, events).status == "failed"


### PR DESCRIPTION
## What changes

The marketplace reputation stage previously accepted two updates ending at score 2, even if receipt events were absent, a receipt named a different seller, or the first score was 999.

Now it checks the recorded reference reputation path:

- Each update identifies one unambiguous, prior `trade.outcome` receipt event in the same run, with matching observer, subject and outcome.
- A receipt cannot be counted twice; self-written receipt events are inconsistent with the data-facts contract.
- The +1 good / -1 bad formula is recomputed per subject, including each intermediate score. Booleans, unknown outcomes and malformed references do not qualify.
- Missing updates/receipts remain insufficient evidence; a known arithmetic or marketplace-count failure is not hidden by missing evidence elsewhere.
- Passing evidence cites receipts as well as score updates. The existing marketplace stage set and expected two-update result remain intact.

Lab evaluation is versioned as `lab-0.2.3`; older bundles retain their recorded result and produce an explicit evaluator-version mismatch. The README names the exact scope.

## Source ideas and limits

This preserves selected requirements from #129 by @Anurag17-2005 and #178 by @RoarHX: a report is not the underlying observed behavior, and a bad outcome should decrement a score without requiring the lifetime total to be negative. It uses current Town records, not either legacy plugin/validator patch.

This is an evaluator consistency check, not a trust-system redesign. It does **not** verify reporter authority, receipt signatures (not present in these trace events), truth of a reported outcome, independent misconduct, or a transaction-to-receipt binding. Those need a separately specified scenario/admission boundary. `ReceiptReputation.update` is not changed. Other scoring algorithms need their own evaluator.

## Verification

- Initial base (`d26ca5a`): 248 tests passed; the first candidate passed 275 tests with 9 pre-existing warnings. Targeted reputation/coverage checks: **42 passed**.
- After integrating current main (`5cbae9d`, including #234–#237), reviewed head `c9c4b221fefb77e22ea75514ed5c9f8ef2119154`: **303 tests passed**, 8 warnings.
- The first regression pass produced 15 expected failures before the implementation.
- Actual Town API good/good/good/bad calls give literal scores `[1, 2, 3, 2]`; wrong-delta and missing-receipt controls discriminate the outcomes.
- Real marketplace runs export and replay successfully; mutation cases cover attribution, ordering, repeated/ambiguous references, malformed fields and arithmetic.
- A genuine pre-change `lab-0.2.2` bundle was verified before the change and correctly reports only the version mismatch afterward.
- Self-review caught and fixed a case where a missing receipt could hide the existing marketplace update-count failure.

CI will be verified on the submitted head before merge. No legacy source PR will be closed until this replacement is confirmed merged, and any closure will state the selected and deferred scope.
