### PR TITLE
fix: verify correlated majority evidence in Lab consensus

### DIFF
--- a/src/nandatown/sim/validators.py
+++ b/src/nandatown/sim/validators.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 from ..records import EvidenceResult, StageResult, TownEvent
 
-LAB_EVALUATOR_VERSION = "lab-0.2.3"
+LAB_EVALUATOR_VERSION = "lab-0.2.4"
 
 VALIDATORS: dict[str, Callable] = {}
 
@@ -350,32 +350,147 @@ def voting(spec, trace: Trace) -> list[StageResult]:
     return stages
 
 
+def quorum_commit(spec, trace: Trace) -> StageResult:
+    """Check the Lab's single-proposer majority, not a BFT certificate.
+
+    Delivery events omit sender/body, so follow message IDs back to sends
+    and conversation IDs back to delivered prepares. Counting deliveries or
+    trusting the proposer's acknowledgement list alone is insufficient.
+    """
+    committed = trace.find("consensus_committed")
+    if not committed:
+        return _missing("quorum_commit", "no consensus commit recorded")
+    proposers = [a for a in spec.agents if a.role == "proposer"]
+    acceptors = {a.name for a in spec.agents if a.role == "acceptor"}
+    if len(proposers) != 1 or not acceptors or "value" not in proposers[0].config:
+        return _missing("quorum_commit", "requires one configured proposer and acceptors")
+    proposer, value = proposers[0].name, proposers[0].config["value"]
+    quorum = len(acceptors) // 2 + 1
+    sends = trace.find("message_sent")
+    deliveries = trace.find("message_delivered")
+    problems, gaps, evidence = [], [], [e.event_id for e in committed]
+
+    def problem(event, note):
+        problems.append(note)
+        evidence.append(event.event_id)
+
+    def precedes(first, second):
+        return (first.run_id == second.run_id
+                and trace.index(first) < trace.index(second)
+                and first.at <= second.at)
+
+    def delivered_send(delivery, kind, to, before):
+        matches = [s for s in sends if s.subject == delivery.subject]
+        if not matches:
+            gaps.append(f"missing send for {delivery.subject}")
+            return None
+        if len(matches) != 1:
+            problem(delivery, f"ambiguous send ID {delivery.subject}")
+            return None
+        sent = matches[0]
+        if (not precedes(sent, delivery) or not precedes(delivery, before)
+                or delivery.observer != "town"
+                or delivery.detail.get("kind") != kind
+                or delivery.detail.get("to") != to
+                or sent.detail.get("kind") != kind
+                or sent.detail.get("to") != to):
+            problem(delivery, f"inconsistent or late {kind} delivery {delivery.subject}")
+            return None
+        rejected = [e for e in trace.events
+                    if e.subject == sent.subject
+                    and e.kind in {"signature_invalid", "delivery_failed"}
+                    and precedes(sent, e) and precedes(e, before)]
+        if rejected:
+            problem(rejected[0], f"rejected message {sent.subject} cannot support quorum")
+            return None
+        return sent
+
+    for commit in committed:
+        claimed = commit.detail.get("acks")
+        if (commit.observer != proposer or commit.subject != value
+                or type(commit.detail.get("quorum")) is not int
+                or commit.detail["quorum"] != quorum
+                or not isinstance(claimed, list)
+                or any(not isinstance(v, str) for v in claimed)
+                or len(set(claimed)) != len(claimed)
+                or not set(claimed) <= acceptors or len(claimed) < quorum):
+            problem(commit, "commit must name the configured value and a distinct eligible majority")
+            continue
+        voters = set()
+        for delivery in deliveries:
+            referenced = [s for s in sends if s.subject == delivery.subject]
+            # An uncounted response is not evidence for this commit. In
+            # particular, noise from an outsider must not spoil a real quorum.
+            if len(referenced) == 1 and referenced[0].observer not in claimed:
+                continue
+            if (trace.index(delivery) >= trace.index(commit)
+                    or not (delivery.detail.get("kind") == "prepare_ack"
+                            or any(s.detail.get("kind") == "prepare_ack" for s in referenced))):
+                continue
+            ack = delivered_send(delivery, "prepare_ack", proposer, commit)
+            if ack is None:
+                continue
+            if (ack.observer not in acceptors
+                    or not isinstance(ack.detail.get("body"), dict)
+                    or ack.detail["body"].get("value") != value):
+                problem(ack, "acknowledgement must come from an eligible voter for the proposed value")
+                continue
+            conversation = ack.detail.get("conversation")
+            if not isinstance(conversation, str) or not conversation:
+                problem(ack, "acknowledgement has no valid prepare conversation")
+                continue
+            matches = [s for s in sends if s.detail.get("kind") == "prepare"
+                       and s.detail.get("conversation") == conversation]
+            if not matches:
+                gaps.append(f"missing prepare for conversation {conversation}")
+                continue
+            if len(matches) != 1:
+                problem(ack, "acknowledgement has an ambiguous prepare conversation")
+                continue
+            prepare = matches[0]
+            if (prepare.observer != proposer
+                    or prepare.detail.get("to") != ack.observer
+                    or not isinstance(prepare.detail.get("body"), dict)
+                    or prepare.detail["body"].get("value") != value):
+                problem(prepare, "prepare must carry the configured proposer's value")
+                continue
+            arrivals = [d for d in deliveries if d.subject == prepare.subject]
+            if not arrivals:
+                gaps.append(f"missing prior prepare delivery to {ack.observer}")
+                continue
+            if delivered_send(arrivals[0], "prepare", ack.observer, ack) is not None:
+                voters.add(ack.observer)
+        if not set(claimed) <= voters:
+            late = [d for d in deliveries if trace.index(d) >= trace.index(commit)
+                    and any(s.subject == d.subject and s.observer in set(claimed) - voters
+                            and s.detail.get("kind") == "prepare_ack" for s in sends)]
+            if late:
+                problem(late[0], "claimed acknowledgement arrived after commit")
+            else:
+                gaps.append("not every claimed voter has a complete prepare/ack delivery chain")
+    if problems:
+        return _failed("quorum_commit", evidence, problems[0])
+    if gaps:
+        return _missing("quorum_commit", gaps[0])
+    return _passed("quorum_commit", evidence,
+                   f"each commit follows {quorum} distinct eligible acknowledgements for its value")
+
+
 @validator("consensus")
 def consensus(spec, trace: Trace) -> list[StageResult]:
-    stages = []
+    stages = [quorum_commit(spec, trace)]
     acceptors = [a.name for a in spec.agents if a.role == "acceptor"]
-    quorum = len(acceptors) // 2 + 1
-
-    committed = trace.find("consensus_committed")
-    quorum_ok = False
-    if committed:
-        idx = trace.index(committed[0])
-        acks_before = [e for e in trace.events[:idx]
-                       if e.kind == "message_delivered"
-                       and e.detail.get("kind") == "prepare_ack"]
-        quorum_ok = (len(acks_before) >= quorum
-                     and len(committed[0].detail["acks"]) >= quorum)
-    stages.append(_check(
-        "quorum_commit", quorum_ok,
-        [e.event_id for e in committed],
-        f"commit must follow at least {quorum} acknowledged prepares"))
+    proposers = [a for a in spec.agents if a.role == "proposer"]
 
     values = trace.find("value_committed")
-    agree = ({e.subject for e in values} == set(acceptors)
-             and len({e.detail["value"] for e in values}) == 1)
+    agree = (len(proposers) == 1 and "value" in proposers[0].config
+             and {e.subject for e in values} == set(acceptors)
+             and all(e.observer == e.subject
+                     and e.detail.get("value") == proposers[0].config["value"]
+                     for e in values))
     stages.append(_check(
         "agreement", agree, [e.event_id for e in values],
-        "every acceptor must commit the same value"))
+        "every acceptor must commit the configured proposed value"))
 
     dropped = trace.ids("message_dropped")
     retries = trace.ids("proposal_retry")

--- a/tests/test_lab_consensus.py
+++ b/tests/test_lab_consensus.py
@@ -1,0 +1,198 @@
+"""Quorum evidence must count voters, not transport events.
+
+Retains the distinct-voter/evidence requirement from legacy #171
+(saurabhvmagdum), without importing its BFT protocol or fault model.
+"""
+
+import pytest
+
+from nandatown.bundle import verify_bundle
+from nandatown.records import TownEvent
+from nandatown.sim.runner import build_engine, run_lab
+from nandatown.sim.scenario import load_bundled
+from nandatown.sim.validators import Trace, consensus
+
+
+def fixture():
+    """Literal trace, independent of the simulator and evaluator algorithms."""
+    rows = [
+        ("proposer", "message_sent", "p1", {"to": "acceptor-1", "kind": "prepare", "conversation": "c1", "body": {"value": "v42"}}),
+        ("town", "message_delivered", "p1", {"to": "acceptor-1", "kind": "prepare"}),
+        ("acceptor-1", "message_sent", "a1", {"to": "proposer", "kind": "prepare_ack", "conversation": "c1", "body": {"value": "v42"}}),
+        ("town", "message_delivered", "a1", {"to": "proposer", "kind": "prepare_ack"}),
+        ("proposer", "message_sent", "p2", {"to": "acceptor-2", "kind": "prepare", "conversation": "c2", "body": {"value": "v42"}}),
+        ("town", "message_delivered", "p2", {"to": "acceptor-2", "kind": "prepare"}),
+        ("acceptor-2", "message_sent", "a2", {"to": "proposer", "kind": "prepare_ack", "conversation": "c2", "body": {"value": "v42"}}),
+        ("town", "message_delivered", "a2", {"to": "proposer", "kind": "prepare_ack"}),
+        ("proposer", "consensus_committed", "v42", {"acks": ["acceptor-1", "acceptor-2"], "quorum": 2}),
+        ("acceptor-1", "value_committed", "acceptor-1", {"value": "v42"}),
+        ("acceptor-2", "value_committed", "acceptor-2", {"value": "v42"}),
+        ("acceptor-3", "value_committed", "acceptor-3", {"value": "v42"}),
+    ]
+    return load_bundled("consensus"), [
+        TownEvent(event_id=f"e{i}", run_id="literal", at=i,
+                  observer=o, kind=k, subject=s, detail=d)
+        for i, (o, k, s, d) in enumerate(rows)
+    ]
+
+
+def stage(spec, events, name="quorum_commit"):
+    return next(s for s in consensus(spec, Trace(events)) if s.name == name)
+
+
+@pytest.mark.parametrize("case,want", [
+    ("duplicate_claim", "failed"),
+    ("repeated_voter", "failed"),
+    ("unknown_voter", "failed"),
+    ("wrong_ack_value", "failed"),
+    ("wrong_ack_recipient", "failed"),
+    ("wrong_delivery_recipient", "failed"),
+    ("wrong_delivery_kind", "failed"),
+    ("wrong_delivery_observer", "failed"),
+    ("wrong_proposal_value", "failed"),
+    ("wrong_proposal_sender", "failed"),
+    ("wrong_conversation", "failed"),
+    ("late_ack", "failed"),
+    ("late_prepare_delivery", "failed"),
+    ("future_timestamp", "failed"),
+    ("different_run", "failed"),
+    ("duplicate_send_id", "failed"),
+    ("failed_delivery", "failed"),
+    ("wrong_committer", "failed"),
+    ("wrong_commit_value", "failed"),
+    ("wrong_quorum", "failed"),
+    ("malformed_claim", "failed"),
+    ("malformed_body", "failed"),
+    ("missing_ack_send", "not_enough_evidence"),
+    ("missing_ack_delivery", "not_enough_evidence"),
+    ("missing_prepare_send", "not_enough_evidence"),
+    ("missing_prepare_delivery", "not_enough_evidence"),
+])
+def test_quorum_requires_correlated_distinct_eligible_voters(case, want):
+    spec, events = fixture()
+    prepare, delivered_prepare, ack, delivery, commit = (
+        events[4], events[5], events[6], events[7], events[8])
+    if case == "duplicate_claim":
+        commit.detail["acks"] = ["acceptor-1", "acceptor-1"]
+    elif case == "repeated_voter":
+        ack.observer = "acceptor-1"
+    elif case == "unknown_voter":
+        ack.observer = "outsider"
+        commit.detail["acks"][1] = "outsider"
+    elif case == "wrong_ack_value":
+        ack.detail["body"]["value"] = "other"
+    elif case == "wrong_ack_recipient":
+        ack.detail["to"] = "another-proposer"
+    elif case == "wrong_delivery_recipient":
+        delivery.detail["to"] = "another-proposer"
+    elif case == "wrong_delivery_kind":
+        delivery.detail["kind"] = "not-an-ack"
+    elif case == "wrong_delivery_observer":
+        delivery.observer = "acceptor-2"
+    elif case == "wrong_proposal_value":
+        prepare.detail["body"]["value"] = "other"
+    elif case == "wrong_proposal_sender":
+        prepare.observer = "another-proposer"
+    elif case == "wrong_conversation":
+        ack.detail["conversation"] = "c1"
+    elif case == "late_ack":
+        events.remove(delivery)
+        events.append(delivery)
+    elif case == "late_prepare_delivery":
+        events.remove(delivered_prepare)
+        events.insert(7, delivered_prepare)
+    elif case == "future_timestamp":
+        ack.at = commit.at + 1
+    elif case == "different_run":
+        ack.run_id = "other-run"
+    elif case == "duplicate_send_id":
+        duplicate = ack.model_copy(deep=True)
+        duplicate.event_id = "ambiguous-send"
+        events.insert(6, duplicate)
+    elif case == "failed_delivery":
+        rejection = delivery.model_copy(deep=True)
+        rejection.event_id = "rejected"
+        rejection.kind = "delivery_failed"
+        events.insert(8, rejection)
+    elif case == "wrong_committer":
+        commit.observer = "another-proposer"
+    elif case == "wrong_commit_value":
+        commit.subject = "other"
+    elif case == "wrong_quorum":
+        commit.detail["quorum"] = 1
+    elif case == "malformed_claim":
+        commit.detail["acks"] = {"acceptor-1": 1, "acceptor-2": 1}
+    elif case == "malformed_body":
+        ack.detail["body"] = []
+    elif case == "missing_ack_send":
+        events.remove(ack)
+    elif case == "missing_ack_delivery":
+        events.remove(delivery)
+    elif case == "missing_prepare_send":
+        events.remove(prepare)
+    elif case == "missing_prepare_delivery":
+        events.remove(delivered_prepare)
+    assert stage(spec, events).status == want
+
+
+def test_healthy_literal_and_repeated_delivery_with_real_quorum():
+    spec, events = fixture()
+    assert stage(spec, events).status == "passed"
+    duplicate = events[3].model_copy(deep=True)
+    duplicate.event_id = "redelivered"
+    events.insert(4, duplicate)
+    assert stage(spec, events).status == "passed"
+
+
+def test_known_invalid_claim_is_not_hidden_by_missing_evidence():
+    spec, events = fixture()
+    events[8].detail["acks"] = ["acceptor-1", "outsider"]
+    events.pop(2)
+    assert stage(spec, events).status == "failed"
+
+
+def test_later_invalid_commit_cannot_hide_behind_first_valid_commit():
+    spec, events = fixture()
+    invalid = events[8].model_copy(deep=True)
+    invalid.event_id = "later-commit"
+    invalid.detail["acks"] = ["acceptor-1", "acceptor-1"]
+    events.append(invalid)
+    assert stage(spec, events).status == "failed"
+
+
+def test_agreement_must_be_for_the_proposed_value():
+    spec, events = fixture()
+    for event in events[9:]:
+        event.detail["value"] = "unproposed"
+    assert stage(spec, events, "agreement").status == "failed"
+
+
+def test_empty_trace_does_not_certify_consensus():
+    spec, _ = fixture()
+    assert stage(spec, []).status == "not_enough_evidence"
+
+
+def test_unrelated_retry_does_not_fill_a_missing_prepare_record():
+    spec, events = fixture()
+    events[4].detail["conversation"] = "another-attempt"
+    assert stage(spec, events).status == "not_enough_evidence"
+
+
+def test_unclaimed_outsider_ack_does_not_invalidate_a_real_quorum():
+    spec, events = fixture()
+    sent = events[2].model_copy(deep=True)
+    sent.event_id, sent.subject, sent.observer = "noise-sent", "noise", "outsider"
+    delivered = events[3].model_copy(deep=True)
+    delivered.event_id, delivered.subject = "noise-delivered", "noise"
+    events[8:8] = [sent, delivered]
+    assert stage(spec, events).status == "passed"
+
+
+def test_actual_consensus_and_exported_bundle_replay(tmp_path):
+    spec = load_bundled("consensus")
+    engine = build_engine(spec)
+    engine.run()
+    assert all(s.status == "passed" for s in consensus(spec, Trace(engine.events)))
+    bundle, result = run_lab("consensus", str(tmp_path))
+    assert result.verdict == "passed"
+    assert verify_bundle(bundle) == []

--- a/tests/test_lab_coverage.py
+++ b/tests/test_lab_coverage.py
@@ -171,7 +171,7 @@ def test_weak_auth_remains_a_deliberately_failing_native_control():
     assert stage(result, "containment").status == "failed"
 
 
-@pytest.mark.parametrize("old_version", ["lab-0.2.0", "lab-0.2.1", "lab-0.2.2"])
+@pytest.mark.parametrize("old_version", ["lab-0.2.0", "lab-0.2.1", "lab-0.2.2", "lab-0.2.3"])
 def test_new_lab_bundles_replay_and_old_lab_versions_do_not(tmp_path, old_version):
     """The evaluator bump makes old Lab bundles explicitly non-reproducible."""
     bundle_dir, result = run_lab("marketplace", str(tmp_path))
@@ -194,5 +194,5 @@ def test_new_lab_bundles_replay_and_old_lab_versions_do_not(tmp_path, old_versio
 
     assert verify_bundle(bundle_dir) == [
         f"evaluator version differs: bundle {old_version}, local "
-        "lab-0.2.3; reproducibility not checked",
+        f"{LAB_EVALUATOR_VERSION}; reproducibility not checked",
     ]


### PR DESCRIPTION
## Summary

Fix a false-positive in the current Lab consensus evaluator. It previously counted delivered prepare_ack events and entries in the proposer’s acks list without independently establishing distinct eligible voters or binding the acknowledgements to the proposed value.

The evaluator now:
- Checks every commit against the configured single proposer, value, and majority threshold.
- Correlates each counted voter through message IDs, delivery observations, and the original prepare conversation, including recipient, run, time/order and recorded delivery rejection.
- Rejects duplicate voter claims, ambiguous send records and contradictory evidence. Missing chain records remain not_enough_evidence.
- Preserves valid duplicate deliveries and ignores responses from uncounted outsiders.
- Requires acceptor agreement on the configured proposed value, rather than any common value.
- Advances the Lab evaluator to lab-0.2.4 so previous evaluator results are not silently replayed as equivalent.

## Scope and credit

Selected requirement rescue from #171 by @saurabhvmagdum: distinct-voter quorum evidence must be checked rather than inferred from event counts. Related historical quorum/lock evidence discussion also appears in #191.

This is newly implemented for current main’s single-proposer majority simulation. It does not port the old BFT plugin, add peer-signature verification, provide a BFT certificate, change agent runtime behavior, or establish cross-view Byzantine safety. Broader signed-vote, fixed-membership, equivocation and view-change profiles remain separate design work. The source PR will be closed with precise partial-scope credit only after this replacement lands.

## Verification

- Baseline: 307 tests passed.
- Initial new regressions: 25 failed and 5 passed against the old evaluator.
- Final candidate: 342 tests passed, 8 existing warnings.
- Focused final scenario/coverage/upstream/bundle checks: 95 passed.
- Includes an independent literal trace, real bundled consensus run, valid duplicate-delivery control, missing-evidence controls, later-invalid-commit check, uncounted outsider control and bundle replay.
- A genuine consensus bundle produced before this change reports: evaluator version differs: bundle lab-0.2.3, local lab-0.2.4; reproducibility not checked.
- Local self-review, not an independent-agent review.

Run: `PYTHONPATH=src python -m pytest -q -p no:cacheprovider`
