### PR TITLE
fix: bind Lab auction settlement to its task and payee

### DIFF
--- a/src/nandatown/sim/validators.py
+++ b/src/nandatown/sim/validators.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 from ..records import EvidenceResult, StageResult, TownEvent
 
-LAB_EVALUATOR_VERSION = "lab-0.2.4"
+LAB_EVALUATOR_VERSION = "lab-0.2.5"
 
 VALIDATORS: dict[str, Callable] = {}
 
@@ -272,6 +272,80 @@ def marketplace(spec, trace: Trace) -> list[StageResult]:
     return stages
 
 
+def auction_settlement(spec, trace: Trace) -> StageResult:
+    """Bind the single-auction payment to its recorded award and issuer.
+
+    Conservation alone cannot detect crediting the wrong participant. These
+    are correlated Lab records, not independent external account read-back;
+    the separate award stage evaluates the bidding outcome.
+    """
+    issuers = [a for a in spec.agents if a.role == "auctioneer"]
+    if len(issuers) != 1 or "item" not in issuers[0].config:
+        return _missing("settlement", "requires one configured auctioneer and item")
+    issuer = issuers[0]
+    item = issuer.config["item"]
+    task = f"auction-{item}"
+    bidders = {a.name for a in spec.agents if a.role == "bidder"}
+    kinds = ("run_created", "task_announced", "task_awarded", "payment_settled")
+    records, problems, gaps = {}, [], []
+    for kind in kinds:
+        matches = trace.find(kind)
+        if not matches:
+            gaps.append(f"missing {kind} evidence")
+        else:
+            records[kind] = matches[0]
+            if len(matches) != 1:
+                problems.append(f"expected exactly one {kind} record")
+    present = list(records.values())
+    evidence = [e.event_id for e in present]
+    if len(set(evidence)) != len(evidence):
+        problems.append("auction records have ambiguous event IDs")
+
+    for kind, event in records.items():
+        expected_observer = ("town" if kind in {"run_created", "payment_settled"}
+                             else issuer.name)
+        expected_subject = event.run_id if kind == "run_created" else task
+        if event.observer != expected_observer or event.subject != expected_subject:
+            problems.append(f"{kind} names the wrong observer or task")
+    for before, after in zip(present, present[1:]):
+        if (before.run_id != after.run_id
+                or trace.index(before) >= trace.index(after)
+                or not before.at <= after.at):
+            problems.append("auction records must be from one run and in causal order")
+
+    announced = records.get("task_announced")
+    if announced is not None:
+        terms = announced.detail.get("spec")
+        if (announced.detail.get("rule") != "highest"
+                or not isinstance(terms, dict) or terms.get("item") != item):
+            problems.append("announcement does not describe the configured auction")
+    award = records.get("task_awarded")
+    if award is not None:
+        winner = award.detail.get("winner")
+        if (not isinstance(winner, str) or winner not in bidders
+                or type(award.detail.get("cents")) is not int
+                or award.detail.get("rule") != "highest"):
+            problems.append("award must name a configured bidder and integer amount")
+    payment = records.get("payment_settled")
+    if payment is not None:
+        payer = payment.detail.get("from")
+        if (payment.detail.get("to") != issuer.name
+                or not isinstance(payer, str) or payer not in bidders
+                or type(payment.detail.get("cents")) is not int):
+            problems.append("payment must credit the auctioneer from a bidder in integer cents")
+        if award is not None and (
+                payer != award.detail.get("winner")
+                or payment.detail.get("cents") != award.detail.get("cents")):
+            problems.append("payment does not match the recorded winner and amount")
+    # Known contradictions must not be hidden by a different missing record.
+    if problems:
+        return _failed("settlement", evidence, problems[0])
+    if gaps:
+        return _missing("settlement", gaps[0])
+    return _passed("settlement", evidence,
+                   "one payment to the auctioneer for this task's recorded award")
+
+
 @validator("auction")
 def auction(spec, trace: Trace) -> list[StageResult]:
     stages = []
@@ -296,13 +370,7 @@ def auction(spec, trace: Trace) -> list[StageResult]:
         "award", ok, [e.event_id for e in awards],
         "the award must go to the highest on-time bid"))
 
-    payments = trace.find("payment_settled")
-    pay_ok = (len(payments) == 1 and awards
-              and payments[0].detail["cents"] == awards[0].detail["cents"]
-              and payments[0].detail["from"] == awards[0].detail["winner"])
-    stages.append(_check(
-        "settlement", pay_ok, [e.event_id for e in payments],
-        "exactly one payment, by the winner, for the winning amount"))
+    stages.append(auction_settlement(spec, trace))
 
     delivered = trace.find("message_delivered", kind="item_delivery")
     stages.append(_check(

--- a/tests/test_lab_auction.py
+++ b/tests/test_lab_auction.py
@@ -1,0 +1,177 @@
+"""Conserving a total does not prove the intended payee received it.
+
+Retains the correct-recipient distinction from legacy PR #136
+(KaranSinghBisht); does not implement its weighted fan-out protocol.
+"""
+
+import pytest
+
+from nandatown.bundle import load_bundle, verify_bundle
+from nandatown.records import TownEvent
+from nandatown.sim.runner import build_engine, run_lab
+from nandatown.sim.scenario import load_bundled
+from nandatown.sim.validators import Trace, auction, evaluate_scenario
+
+
+def settlement(spec, events):
+    return next(s for s in auction(spec, Trace(events))
+                if s.name == "settlement")
+
+
+def literal_payment_chain():
+    """Hand-written bindings, independent of the simulator and evaluator."""
+    rows = [
+        ("town", "run_created", "run-a", {"scenario": "auction"}),
+        ("auctioneer", "task_announced", "auction-print-001",
+         {"rule": "highest", "spec": {"item": "print-001"}}),
+        ("auctioneer", "task_awarded", "auction-print-001",
+         {"winner": "bidder-y", "cents": 900, "rule": "highest"}),
+        ("town", "payment_settled", "auction-print-001",
+         {"from": "bidder-y", "to": "auctioneer", "cents": 900}),
+    ]
+    return [TownEvent(event_id=f"event-{i}", run_id="run-a", at=i,
+                      observer=who, kind=kind, subject=subject, detail=detail)
+            for i, (who, kind, subject, detail) in enumerate(rows)]
+
+
+@pytest.mark.parametrize("target,field,value", [
+    (3, "to", "bidder-x"),
+    (3, "from", "bidder-x"),
+    (3, "cents", 899),
+    (3, "cents", 900.0),
+    (2, "winner", "not-a-bidder"),
+    (2, "cents", 900.0),
+    (2, "rule", "lowest"),
+    (1, "rule", "lowest"),
+    (1, "spec", {"item": "different-item"}),
+])
+def test_settlement_rejects_conflicting_terms(target, field, value):
+    """Dropping the individual binding must make its case pass incorrectly."""
+    events = literal_payment_chain()
+    events[target].detail[field] = value
+    assert settlement(load_bundled("auction"), events).status == "failed"
+
+
+@pytest.mark.parametrize("target", [1, 2, 3])
+@pytest.mark.parametrize("field,value", [
+    ("subject", "unrelated-task"),
+    ("observer", "unrelated-observer"),
+    ("run_id", "unrelated-run"),
+])
+def test_settlement_binds_each_record_to_the_task_and_run(target, field, value):
+    events = literal_payment_chain()
+    setattr(events[target], field, value)
+    assert settlement(load_bundled("auction"), events).status == "failed"
+
+
+@pytest.mark.parametrize("target", [0, 1, 2, 3])
+def test_settlement_requires_each_record(target):
+    events = literal_payment_chain()
+    del events[target]
+    assert settlement(load_bundled("auction"), events).status == "not_enough_evidence"
+
+
+@pytest.mark.parametrize("target", [0, 1, 2, 3])
+def test_settlement_rejects_duplicate_records(target):
+    events = literal_payment_chain()
+    repeated = events[target].model_copy(deep=True)
+    repeated.event_id = "duplicate-record"
+    events.insert(target + 1, repeated)
+    assert settlement(load_bundled("auction"), events).status == "failed"
+
+
+@pytest.mark.parametrize("target", [1, 2, 3])
+@pytest.mark.parametrize("reverse_time", [False, True])
+def test_settlement_requires_prior_evidence(target, reverse_time):
+    events = literal_payment_chain()
+    if reverse_time:
+        events[target].at = events[target - 1].at - 1
+    else:
+        events[target], events[target - 1] = events[target - 1], events[target]
+    assert settlement(load_bundled("auction"), events).status == "failed"
+
+
+def test_wrong_payee_is_not_hidden_by_missing_award():
+    events = literal_payment_chain()
+    events[3].detail["to"] = "bidder-x"
+    del events[2]
+    assert settlement(load_bundled("auction"), events).status == "failed"
+
+
+def test_matching_payment_and_award_do_not_admit_an_unconfigured_bidder():
+    events = literal_payment_chain()
+    events[2].detail["winner"] = events[3].detail["from"] = "outsider"
+    assert settlement(load_bundled("auction"), events).status == "failed"
+
+
+def test_distinct_records_cannot_share_an_evidence_id():
+    events = literal_payment_chain()
+    events[3].event_id = events[2].event_id
+    assert settlement(load_bundled("auction"), events).status == "failed"
+
+
+@pytest.mark.parametrize("field,value", [
+    ("observer", "not-town"), ("subject", "wrong-run")])
+def test_run_creation_record_must_identify_the_run(field, value):
+    events = literal_payment_chain()
+    setattr(events[0], field, value)
+    assert settlement(load_bundled("auction"), events).status == "failed"
+
+
+def test_equal_logical_timestamps_keep_recorded_order():
+    events = literal_payment_chain()
+    for event in events:
+        event.at = 0
+    assert settlement(load_bundled("auction"), events).status == "passed"
+
+
+def test_literal_settlement_cites_its_evidence():
+    events = literal_payment_chain()
+    result = settlement(load_bundled("auction"), events)
+    assert result.status == "passed"
+    assert set(result.evidence) == {"event-0", "event-1", "event-2", "event-3"}
+
+
+def test_configured_seller_and_item_are_not_hardcoded():
+    spec = load_bundled("auction")
+    spec.agents[0] = spec.agents[0].model_copy(update={
+        "name": "another-seller", "config": {"item": "another-item"}})
+    events = literal_payment_chain()
+    for e in events[1:]:
+        e.subject = "auction-another-item"
+    events[1].observer = events[2].observer = "another-seller"
+    events[1].detail["spec"] = {"item": "another-item"}
+    events[3].detail["to"] = "another-seller"
+    assert settlement(spec, events).status == "passed"
+
+
+def test_real_wrong_recipient_transfer_fails_even_when_money_is_conserved():
+    spec = load_bundled("auction")
+    engine = build_engine(spec)
+    ledger = engine.layers["payments"]
+    original = ledger.transfer
+
+    def wrong_recipient(frm, to, cents, memo):
+        original(frm, "bidder-x", cents, memo)
+
+    ledger.transfer = wrong_recipient
+    engine.run()
+    assert ledger.balances == {"auctioneer": 0, "bidder-x": 2900,
+                               "bidder-y": 1100, "bidder-late": 2000}
+    result = evaluate_scenario(spec, engine.run_id, engine.events)
+    stages = {s.name: s.status for s in result.stages}
+    assert stages["ledger_conserved"] == "passed"
+    assert stages["settlement"] == "failed"
+    assert result.verdict == "failed"
+
+
+def test_healthy_auction_runs_and_replays(tmp_path):
+    directory, result = run_lab("auction", str(tmp_path))
+    assert result.verdict == "passed"
+    assert verify_bundle(directory) == []
+    bundle = load_bundle(directory)
+    payment = next(e for e in bundle["events"] if e.kind == "payment_settled")
+    assert payment.detail == {"from": "bidder-y", "to": "auctioneer", "cents": 900}
+    stage = next(s for s in result.stages if s.name == "settlement")
+    assert {e.kind for e in bundle["events"] if e.event_id in stage.evidence} == {
+        "run_created", "task_announced", "task_awarded", "payment_settled"}

--- a/tests/test_lab_coverage.py
+++ b/tests/test_lab_coverage.py
@@ -171,7 +171,8 @@ def test_weak_auth_remains_a_deliberately_failing_native_control():
     assert stage(result, "containment").status == "failed"
 
 
-@pytest.mark.parametrize("old_version", ["lab-0.2.0", "lab-0.2.1", "lab-0.2.2", "lab-0.2.3"])
+@pytest.mark.parametrize("old_version", [
+    "lab-0.2.0", "lab-0.2.1", "lab-0.2.2", "lab-0.2.3", "lab-0.2.4"])
 def test_new_lab_bundles_replay_and_old_lab_versions_do_not(tmp_path, old_version):
     """The evaluator bump makes old Lab bundles explicitly non-reproducible."""
     bundle_dir, result = run_lab("marketplace", str(tmp_path))


### PR DESCRIPTION
## Summary

Current Lab auction settlement checks the payer and amount but not the payee or task. A real local run with the ledger transfer redirected to a losing bidder still reports `passed`, even though the auctioneer receives zero.

This change binds the single-auction settlement evidence to the configured auctioneer/item, recorded task announcement and award, winner, integer amount, run and causal order. Duplicate/ambiguous records and known contradictions fail. Missing records remain `not_enough_evidence`; missing evidence cannot hide a known wrong payee.

## Source and scope

Retains the correct-recipient distinction raised by #136, by @KaranSinghBisht: conservation alone does not prove that the intended parties received the intended allocation. This is a selected-scope adaptation to the existing bilateral auction, not a port of the weighted fan-out implementation.

The weighted allocator/property corpus, independent payee-observed balances and broader split/refund workflow remain future profile candidates. These are correlated Lab records, not external settlement verification. No payment runtime, provider, default authority policy, amount-validation runtime, wire schema or new dependency changes. The separate award stage still evaluates the bidding result; this patch binds payment to the recorded award.

## Verification

- Clean baseline: 342 tests passed.
- Initial regression pass: 30 expected failures.
- Final focused auction/coverage checks: 60 passed.
- Full final suite: 385 passed, 8 existing warnings.
- Real healthy auction: passed; real wrong-recipient transfer: settlement failed while ledger conservation remained passed.
- Six in-memory omitted-check mutations were rejected by their corresponding regressions.
- Genuine pre-change bundle reports `lab-0.2.4` versus `lab-0.2.5` and explicitly declines replay equivalence.
- New healthy auction bundles verify and replay.

Review was local self-review. No contributor code or external payment service was executed. Source #136 will be closed only after this selected correction merges, with the unported scope recorded.