### PR TITLE
Add optional quote-intent profile for cheaper wrong-item failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,49 @@ credit: [James's #222](https://github.com/projnanda/nandatown/pull/222)
 adopt their legacy middleware, Town-specific handshake, deployment code,
 or loopback-only origin restrictions.
 
+#### Check the item, not only the price
+
+Select `--path-profile a2a-quote-intent@0.1` to test an explicit quote:
+two blue widgets from `town-reference`, denominated in USD, with a maximum
+total of 3,990 cents. The response must contain the exact `sku`, `color`,
+`quantity`, `merchant_id`, `currency`, and current `request_id`.
+`total_cents` must be a JSON integer from 0 through 3990; discounts and free
+quotes are allowed, strings, floats and booleans are not. Missing terms fail;
+Town never substitutes request values for an agent's missing response fields.
+
+In two terminals:
+
+```bash
+nandatown a2a serve --defect wrong_item
+nandatown test-agent --url http://127.0.0.1:8940 --path-profile a2a-quote-intent@0.1
+```
+
+The reference seller deliberately offers a red item for 3,000 cents. The price
+is within budget, but the report names `color` as the semantic mismatch.
+Restart the seller without `--defect wrong_item` and rerun for the healthy
+control. Other A2A agents can implement this same JSON contract; no specific
+agent runtime, model key or payment provider is required by Town.
+
+The bundle stores the selected profile, observed quote fields, request
+correlation, response digest and `path-quote-intent-0.1` evaluator version.
+`nandatown verify BUNDLE_DIR` replays the judgment offline. The controlled
+duplicate checks whether the returned quote changes, not whether a merchant
+performed a second purchase. A matching merchant identifier is a returned
+claim, not independent proof of merchant ownership. This is a synthetic quote
+conformance test, not purchase authorization, payment settlement, physical
+delivery verification or outside-user adoption evidence.
+
+The default remains `a2a-capability-fulfillment@0.2`; both earlier price-only
+profiles and their `path-0.2` evaluator remain unchanged. Non-object quote
+artifacts are now recorded as unparseable subject output rather than a Town
+driver exception. Older recorded events retain their original interpretation.
+
+Requirements credit: [#215 by chainaim-sathya](https://github.com/projnanda/nandatown/pull/215)
+(`0b7667d5896bedd80f237a188f7cd0607d46237f`) identified the cheaper-but-wrong-item
+gap. This fresh implementation preserves that narrow requirement; it does not
+port the legacy Prava client, live charges, intent certificates, FX conversions,
+return policy or hosted service.
+
 ## Receipts and Town Proof
 
 ```

--- a/src/nandatown/a2a_adapter.py
+++ b/src/nandatown/a2a_adapter.py
@@ -18,6 +18,7 @@ import httpx
 from fastapi import FastAPI, Request
 
 from . import __version__
+from .path_profiles import QUOTE_INTENT_FIELDS
 from .a2a_transport import (
     DEFAULT_MAX_RESPONSE_BYTES,
     HTTPStatusError,
@@ -46,7 +47,10 @@ def build_agent_card(base_url: str) -> dict[str, Any]:
             "name": "Quote",
             "description": "Given JSON {sku, quantity,"
                            " unit_price_cents}, returns JSON"
-                           " {request_id, total_cents}.",
+                           " {request_id, total_cents}. Optional item terms"
+                           " {color, merchant_id, currency} request an explicit"
+                           " quote echoing sku, quantity and those terms."
+                           " This reference fixture performs no purchase.",
             "tags": ["quote", "commerce", "nandatown"],
         }],
     }
@@ -55,7 +59,7 @@ def build_agent_card(base_url: str) -> dict[str, Any]:
 def build_a2a_app(base_url: str = "http://127.0.0.1:8940",
                   defect: str | None = None):
     """The reference A2A seller, optionally with one planted defect:
-    wrong_total, duplicate_fulfillment, or card_drift. Planted defects
+    wrong_total, wrong_item, duplicate_fulfillment, or card_drift. Planted defects
     are how the path test's failure cases are demonstrated for real."""
     app = FastAPI(title="nandatown a2a seller", version=__version__)
     tasks: dict[str, dict[str, Any]] = {}
@@ -84,8 +88,13 @@ def build_a2a_app(base_url: str = "http://127.0.0.1:8940",
                 return "completed", {"request_id": request_id,
                                      "total_cents": total,
                                      "fulfillment_number": count}
-        return "completed", {"request_id": request_id,
-                             "total_cents": total}
+        quote = {"request_id": request_id, "total_cents": total}
+        if any(field in request for field in ("color", "merchant_id", "currency")):
+            quote.update({field: request[field] for field in QUOTE_INTENT_FIELDS
+                          if field in request})
+        if defect == "wrong_item":
+            quote.update({"color": "red", "total_cents": 3000})
+        return "completed", quote
 
     @app.post("/")
     async def rpc(request: Request):

--- a/src/nandatown/bundle.py
+++ b/src/nandatown/bundle.py
@@ -173,8 +173,8 @@ def verify_bundle(directory: str) -> list[str]:
         expected_version = LAB_EVALUATOR_VERSION
         replay_fn = evaluate_scenario
     elif bundle["mode"] == "path":
-        from .path_runner import PATH_EVALUATOR_VERSION, evaluate_path
-        expected_version = PATH_EVALUATOR_VERSION
+        from .path_runner import evaluate_path, path_evaluator_version
+        expected_version = path_evaluator_version(bundle["profile"])
         replay_fn = evaluate_path
     else:
         expected_version = EVALUATOR_VERSION

--- a/src/nandatown/cli.py
+++ b/src/nandatown/cli.py
@@ -939,7 +939,7 @@ def main(argv: list[str] | None = None) -> int:
     p_a2a.add_argument("--host", default="127.0.0.1")
     p_a2a.add_argument("--port", type=int, default=8940)
     p_a2a.add_argument("--defect", default=None,
-                       choices=["wrong_total", "duplicate_fulfillment",
+                       choices=["wrong_total", "wrong_item", "duplicate_fulfillment",
                                 "card_drift"],
                        help="plant one defect in the reference seller"
                             " to demonstrate a failing path test")

--- a/src/nandatown/path_profiles.py
+++ b/src/nandatown/path_profiles.py
@@ -15,6 +15,9 @@ from pydantic import BaseModel, ConfigDict
 
 from .records import fingerprint
 
+QUOTE_INTENT_EVALUATOR = "quote-intent-evaluator@0.1"
+QUOTE_INTENT_FIELDS = ("sku", "color", "quantity", "merchant_id", "currency")
+
 
 class PathProfile(BaseModel):
     model_config = ConfigDict(frozen=True)
@@ -38,6 +41,20 @@ class PathProfile(BaseModel):
 
 
 PATH_PROFILES: dict[str, PathProfile] = {
+    "a2a-quote-intent@0.1": PathProfile(
+        profile_id="a2a-quote-intent",
+        version="0.1",
+        protocol="a2a",
+        capability="quote",
+        request={"sku": "widget", "quantity": 2, "unit_price_cents": 1995,
+                 "color": "blue", "merchant_id": "town-reference", "currency": "USD"},
+        expected={"max_total_cents": 3990,
+                  "quote": {"sku": "widget", "quantity": 2, "color": "blue",
+                            "merchant_id": "town-reference", "currency": "USD"}},
+        controlled_condition="duplicate_request",
+        limits={"timeout_seconds": 15.0, "max_response_bytes": 1_048_576},
+        evaluator=QUOTE_INTENT_EVALUATOR,
+    ),
     "a2a-capability-fulfillment@0.1": PathProfile(
         profile_id="a2a-capability-fulfillment",
         version="0.1",

--- a/src/nandatown/path_runner.py
+++ b/src/nandatown/path_runner.py
@@ -32,7 +32,10 @@ from .a2a_transport import (
     DEFAULT_MAX_RESPONSE_BYTES, a2a_client, effective_policy,
     validate_response_budget,
 )
-from .path_profiles import DEFAULT_PATH_PROFILE, PathProfile, get_path_profile
+from .path_profiles import (
+    DEFAULT_PATH_PROFILE, QUOTE_INTENT_EVALUATOR, QUOTE_INTENT_FIELDS,
+    PathProfile, get_path_profile,
+)
 from .records import (
     EvidenceResult,
     RunRecord,
@@ -42,6 +45,35 @@ from .records import (
 )
 
 PATH_EVALUATOR_VERSION = "path-0.2"
+
+
+def path_evaluator_version(profile: PathProfile) -> str:
+    # Existing price-only profiles retain their evaluator and replay semantics.
+    if profile.evaluator == QUOTE_INTENT_EVALUATOR:
+        return "path-quote-intent-0.1"
+    return PATH_EVALUATOR_VERSION
+
+
+def _quote_intent_errors(profile: PathProfile, detail: dict[str, Any]) -> list[str]:
+    """Compare observed quote terms, never filling omissions from the request."""
+    errors = []
+    observed = detail.get("quote")
+    if not isinstance(observed, dict):
+        observed = {}
+    expected = profile.expected["quote"]
+    for field in QUOTE_INTENT_FIELDS:
+        value = observed.get(field)
+        wanted = expected[field]
+        # JSON booleans and floats are not integer item counts.
+        if type(value) is not type(wanted) or value != wanted:
+            errors.append(f"{field}: expected {wanted!r}, observed {value!r}")
+    total = detail.get("total_cents")
+    maximum = profile.expected["max_total_cents"]
+    if type(total) is not int or not 0 <= total <= maximum:
+        errors.append(f"total_cents: expected integer in [0, {maximum}],"
+                      f" observed {total!r}")
+    return errors
+
 
 STAGE_ORDER = ["resolution", "agent_card_retrieval",
                "descriptor_consistency", "protocol_invocation",
@@ -172,13 +204,23 @@ def run_path_test(subject_url: str | None, out_dir: str,
                     text = artifact_text(task)
                     try:
                         fulfillment = json.loads(text)
+                        if not isinstance(fulfillment, dict):
+                            recorder.emit("town-requester", "fulfillment_unparseable",
+                                          order_id, {"attempt": attempt,
+                                                     "reason": "quote is not a JSON object"})
+                            continue
+                        detail = {
+                            "attempt": attempt,
+                            "total_cents": fulfillment.get("total_cents"),
+                            "request_id": fulfillment.get("request_id"),
+                            "content_digest": fingerprint(fulfillment)}
+                        if profile.evaluator == QUOTE_INTENT_EVALUATOR:
+                            detail["quote"] = {
+                                field: fulfillment[field] for field in QUOTE_INTENT_FIELDS
+                                if field in fulfillment}
                         recorder.emit(
                             "town-requester", "fulfillment_observed",
-                            order_id,
-                            {"attempt": attempt,
-                             "total_cents": fulfillment.get("total_cents"),
-                             "request_id": fulfillment.get("request_id"),
-                             "content_digest": fingerprint(fulfillment)})
+                            order_id, detail)
                     except json.JSONDecodeError:
                         recorder.emit("town-requester",
                                       "fulfillment_unparseable", order_id,
@@ -220,7 +262,7 @@ def run_path_test(subject_url: str | None, out_dir: str,
              "role": "subject"},
         ],
         releases={"nandatown": __version__,
-                  "evaluator": PATH_EVALUATOR_VERSION,
+                  "evaluator": path_evaluator_version(profile),
                   "python": sys.version.split()[0]},
         config={"mode": "path", "subject": subject_url or agent_name,
                 "profile": profile.ref,
@@ -356,15 +398,22 @@ def evaluate_path(profile: PathProfile, run_id: str,
                       and bool(expected_request_id)
                       and isinstance(observed_request_id, str)
                       and observed_request_id == expected_request_id)
-        if observed_total == expected_total and request_ok:
+        quote_intent = profile.evaluator == QUOTE_INTENT_EVALUATOR
+        errors = _quote_intent_errors(profile, detail) if quote_intent else []
+        result_ok = not errors if quote_intent else observed_total == expected_total
+        if result_ok and request_ok:
             stages.append(StageResult(
                 name="semantic_result", status="passed",
                 evidence=[first_fulfillment[0].event_id],
-                note=f"exactly one fulfillment, total {observed_total}"))
+                note=(f"observed quote matches the item terms and budget;"
+                      f" total_cents {observed_total}; no purchase or delivery tested"
+                      if quote_intent else
+                      f"exactly one fulfillment, total {observed_total}")))
         else:
-            note = (f"protocol passed but the result is wrong:"
-                    f" expected total {expected_total}, observed"
-                    f" {observed_total}")
+            note = ("quote does not match the selected profile: " + "; ".join(errors)
+                    if quote_intent else
+                    f"protocol passed but the result is wrong:"
+                    f" expected total {expected_total}, observed {observed_total}")
             if not request_ok:
                 note += (f"; expected request_id {expected_request_id!r},"
                          f" observed request_id {observed_request_id!r}")
@@ -407,6 +456,6 @@ def evaluate_path(profile: PathProfile, run_id: str,
 
     cascade_unreached(stages)
     return EvidenceResult(run_id=run_id,
-                          evaluator_version=PATH_EVALUATOR_VERSION,
+                          evaluator_version=path_evaluator_version(profile),
                           stages=stages, verdict=stage_verdict(stages),
                           evaluated_at=time.time())

--- a/tests/test_quote_intent.py
+++ b/tests/test_quote_intent.py
@@ -1,0 +1,192 @@
+"""Quote-intent regressions inspired by legacy PR #215, without payment rails."""
+
+import json
+import os
+import subprocess
+import sys
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from nandatown.a2a_adapter import build_agent_card, build_a2a_app
+from nandatown.bundle import load_bundle, verify_bundle
+from nandatown.path_runner import evaluate_path, run_path_test
+from nandatown.records import fingerprint
+from nandatown.report import render_report
+
+SUBJECT = "http://testserver"
+PROFILE = "a2a-quote-intent@0.1"
+MISSING = object()
+
+
+def quote_client(changes=None, *, artifact=MISSING, duplicate=False):
+    """A deterministic peer at the HTTP boundary, not a mocked evaluator."""
+    attempts = 0
+
+    def handle(request):
+        nonlocal attempts
+        if request.method == "GET":
+            return httpx.Response(200, json=build_agent_card(SUBJECT))
+        envelope = json.loads(request.content)
+        order = json.loads(envelope["params"]["message"]["parts"][0]["text"])
+        attempts += 1
+        quote = {"request_id": order["request_id"], "total_cents": 3990,
+                 "sku": "widget", "quantity": 2, "color": "blue",
+                 "merchant_id": "town-reference", "currency": "USD"}
+        for key, value in (changes or {}).items():
+            if value is MISSING:
+                quote.pop(key)
+            else:
+                quote[key] = value
+        if duplicate and attempts == 2:
+            quote["quote_revision"] = "different"
+        payload = quote if artifact is MISSING else artifact
+        task = {"id": f"task-{attempts}", "kind": "task",
+                "status": {"state": "completed"},
+                "artifacts": [{"artifactId": "quote", "parts": [
+                    {"kind": "text", "text": json.dumps(payload)}]}]}
+        return httpx.Response(200, json={"jsonrpc": "2.0",
+                                        "id": envelope["id"], "result": task})
+
+    return httpx.Client(base_url=SUBJECT, transport=httpx.MockTransport(handle))
+
+
+def run_quote(tmp_path, **kwargs):
+    with quote_client(**kwargs) as http:
+        return run_path_test(SUBJECT, str(tmp_path), profile_ref=PROFILE,
+                             pin_card_digest=fingerprint(build_agent_card(SUBJECT)),
+                             http=http)
+
+
+@pytest.mark.parametrize(("field", "value"), [
+    ("sku", "other-widget"), ("color", "red"), ("quantity", 1),
+    ("quantity", True), ("quantity", 2.0), ("merchant_id", "other-merchant"),
+    ("currency", "EUR"), ("sku", None), ("color", MISSING),
+    ("merchant_id", MISSING), ("currency", MISSING), ("quantity", MISSING),
+])
+def test_wrong_or_missing_quote_term_fails_even_at_the_expected_price(
+        tmp_path, field, value):
+    # Removing any one field comparison must let its wrong/missing case escape.
+    directory, result = run_quote(tmp_path, changes={field: value})
+    stages = {s.name: s for s in result.stages}
+    assert stages["protocol_invocation"].status == "passed"
+    assert stages["semantic_result"].status == "failed"
+    assert field in stages["semantic_result"].note
+    assert result.verdict == "failed"
+    assert verify_bundle(directory) == []
+    assert "First broken stage: semantic_result" in render_report(load_bundle(directory))
+
+
+@pytest.mark.parametrize("total", [0, 1, 3000, 3990])
+def test_matching_quote_within_budget_passes_and_replays(tmp_path, total):
+    directory, result = run_quote(tmp_path, changes={"total_cents": total})
+    assert result.verdict == "passed"
+    assert verify_bundle(directory) == []
+    bundle = load_bundle(directory)
+    event = next(e for e in bundle["events"]
+                 if e.kind == "fulfillment_observed" and e.detail["attempt"] == 1)
+    assert event.detail["quote"] == {
+        "sku": "widget", "color": "blue", "quantity": 2,
+        "merchant_id": "town-reference", "currency": "USD"}
+    assert event.detail["total_cents"] == total
+    assert "--path-profile a2a-quote-intent@0.1" in bundle["run"].config["rerun_command"]
+
+
+def test_cheaper_wrong_item_is_not_a_successful_discount(tmp_path):
+    directory, result = run_quote(
+        tmp_path, changes={"sku": "other-widget", "color": "red", "total_cents": 3000})
+    semantic = next(s for s in result.stages if s.name == "semantic_result")
+    assert semantic.status == "failed"
+    assert "sku" in semantic.note and "color" in semantic.note
+    assert verify_bundle(directory) == []
+
+
+@pytest.mark.parametrize("total", [3991, -1, True, False, 3990.0, "3990", None, MISSING])
+def test_quote_budget_requires_nonnegative_integer_cents(tmp_path, total):
+    directory, result = run_quote(tmp_path, changes={"total_cents": total})
+    semantic = next(s for s in result.stages if s.name == "semantic_result")
+    assert semantic.status == "failed"
+    assert "total_cents" in semantic.note
+    assert verify_bundle(directory) == []
+
+
+@pytest.mark.parametrize("request_id", ["old-order", "", None, MISSING])
+def test_intent_quote_still_requires_current_request_id(tmp_path, request_id):
+    directory, result = run_quote(tmp_path, changes={"request_id": request_id})
+    semantic = next(s for s in result.stages if s.name == "semantic_result")
+    assert semantic.status == "failed"
+    assert "request_id" in semantic.note
+    assert verify_bundle(directory) == []
+
+
+@pytest.mark.parametrize("artifact", [None, [], 1, "not a quote"])
+def test_nonobject_quote_artifact_is_subject_semantic_failure(tmp_path, artifact):
+    directory, result = run_quote(tmp_path, artifact=artifact)
+    stages = {s.name: s.status for s in result.stages}
+    assert stages["protocol_invocation"] == "passed"
+    assert stages["semantic_result"] == "failed"
+    assert result.verdict == "failed"
+    assert verify_bundle(directory) == []
+
+
+def test_second_distinct_quote_remains_a_duplicate_failure(tmp_path):
+    directory, result = run_quote(tmp_path, duplicate=True)
+    stages = {s.name: s.status for s in result.stages}
+    assert stages["semantic_result"] == "passed"
+    assert stages["duplicate_request"] == "failed"
+    assert verify_bundle(directory) == []
+
+
+@pytest.mark.parametrize("profile", [
+    "a2a-capability-fulfillment@0.1", "a2a-capability-fulfillment@0.2"])
+def test_price_only_profiles_keep_their_old_contract_and_replay(tmp_path, profile):
+    with quote_client({"sku": "different", "color": "red"}) as http:
+        directory, result = run_path_test(
+            SUBJECT, str(tmp_path), profile_ref=profile, http=http)
+    assert result.verdict == "passed"
+    assert result.evaluator_version == "path-0.2"
+    assert verify_bundle(directory) == []
+
+
+def test_reference_seller_supports_the_explicit_item_quote(tmp_path):
+    with TestClient(build_a2a_app(SUBJECT)) as http:
+        directory, result = run_path_test(
+            SUBJECT, str(tmp_path), profile_ref=PROFILE, http=http)
+    assert result.verdict == "passed"
+    assert verify_bundle(directory) == []
+
+
+def test_reference_wrong_item_demonstrates_cheaper_substitution(tmp_path):
+    with TestClient(build_a2a_app(SUBJECT, defect="wrong_item")) as http:
+        directory, result = run_path_test(
+            SUBJECT, str(tmp_path), profile_ref=PROFILE, http=http)
+    bundle = load_bundle(directory)
+    observed = next(e for e in bundle["events"]
+                    if e.kind == "fulfillment_observed")
+    assert observed.detail["total_cents"] == 3000
+    assert observed.detail["quote"]["color"] == "red"
+    semantic = next(s for s in result.stages if s.name == "semantic_result")
+    assert semantic.status == "failed"
+    assert "color" in semantic.note
+    assert verify_bundle(directory) == []
+
+
+def test_quote_evidence_replays_without_a_running_peer(tmp_path):
+    directory, result = run_quote(tmp_path)
+    # The client is closed. A fresh interpreter must load the shipped profile
+    # and select the matching evaluator, rather than rely on this process.
+    checked = subprocess.run([
+        sys.executable, "-c",
+        "import json,sys; from nandatown.bundle import verify_bundle; "
+        "print(json.dumps(verify_bundle(sys.argv[1])))", directory,
+    ], capture_output=True, text=True, check=True, env=dict(os.environ))
+    assert json.loads(checked.stdout) == []
+    bundle = load_bundle(directory)
+    assert bundle["run"].releases["evaluator"] == result.evaluator_version
+    assert result.evaluator_version != "path-0.2"
+    events = [event.model_copy(deep=True) for event in bundle["events"]]
+    first = next(e for e in events if e.kind == "fulfillment_observed")
+    first.detail["quote"]["color"] = "red"
+    replay = evaluate_path(bundle["profile"], result.run_id, events)
+    assert next(s for s in replay.stages if s.name == "semantic_result").status == "failed"


### PR DESCRIPTION
## Summary

Add the optional `a2a-quote-intent@0.1` profile to the existing Path runner. A quote within the price ceiling is not enough if it describes the wrong item.

This carries forward one requirement from [#215 by chainaim-sathya](https://github.com/projnanda/nandatown/pull/215), reviewed at `0b7667d5896bedd80f237a188f7cd0607d46237f`. It is a fresh implementation for current main, not a merge of the legacy payment plugin.

## Behavior

- Require observed SKU, color, integer quantity, merchant identifier, currency and current request ID to match the selected synthetic quote contract.
- Accept integer totals from 0 through 3990 cents, including discounts. Reject missing, negative, over-budget, floating-point, boolean and string amounts.
- Persist response-derived fields, not request-filled assumptions; report each mismatched term and replay from the evidence bundle.
- Keep both price-only profiles, their fingerprints, the default selection and `path-0.2` replay semantics unchanged. The opt-in profile selects `path-quote-intent-0.1`.
- Add a reference `wrong_item` CLI demonstration: a 3000-cent red quote fails the blue-item requirement.
- Record non-object quote artifacts as unparseable subject output instead of a Town driver exception.

## Verification

- Full suite: **431 passed**, 8 pre-existing warnings.
- New profile suite: **39 passed**.
- TDD: after correcting the test client's base URL, **29 failed / 5 passed** against unchanged production code, including wrong-item cases incorrectly passing. Reference-agent support then had its own two failing tests before implementation.
- Mutation checks: omitting item checks causes **13 failures**; omitting the amount check causes **8 failures**. Mutations were in disposable processes, not committed files.
- Real localhost CLI healthy run: exit 0 / PASS. Wrong-item run: exit 1 / semantic color failure. Both independently verify through the CLI.
- Fresh-process offline replay and both old-profile compatibility checks pass.
- Local self-review only; no separate reviewer agent was contacted.

## Scope and credit

This tests an observed **quote**, not purchase authorization, payment settlement, merchant ownership or physical delivery. The duplicate condition compares returned quote content, not external merchant effects. This Town-authored fixture is not proof of outside adoption.

The broader Prava client, hosted service, live charges, intent-certification, FX and return-policy work from #215 is not ported or claimed implemented. Its source remains the reference for a separately designed provider integration. #215 stays open until this replacement is merged and its final disposition is documented.
