### PR TITLE
Make message acceptance atomic and bind the complete envelope

### DIFF
--- a/src/nandatown/db.py
+++ b/src/nandatown/db.py
@@ -297,19 +297,23 @@ class TownDB:
     ) -> tuple[float, bool]:
         """Accept work durably. Returns (accepted_at, replay).
 
-        The message row and its notification row are written in one
-        transaction. Retrying the same identity with identical content
-        returns the original acceptance; different content raises
-        IdentityReuse.
+        Lookup, message, notification and event writes share one write
+        transaction. Retrying the same identity with the same sender,
+        recipient, kind and body fingerprint returns the original
+        acceptance; a different envelope raises IdentityReuse.
         """
         with self._conn() as conn:
+            conn.execute("BEGIN IMMEDIATE")
             row = conn.execute(
-                "SELECT accepted_at, content_fingerprint FROM messages"
+                "SELECT accepted_at, sender, recipient, kind,"
+                " content_fingerprint FROM messages"
                 " WHERE run_id=? AND message_id=?",
                 (run_id, message_id),
             ).fetchone()
             if row is not None:
-                if row["content_fingerprint"] != content_fingerprint:
+                if (row["sender"], row["recipient"], row["kind"],
+                    row["content_fingerprint"]) != (sender, to, kind,
+                                                    content_fingerprint):
                     self._event(conn, run_id, now, "town",
                                 "identity_reuse_rejected", message_id,
                                 {"sender": sender})
@@ -319,30 +323,28 @@ class TownDB:
                                 message_id, {"sender": sender})
                     reject = False
             else:
-                reject = None
-        if reject is True:
+                conn.execute(
+                    "INSERT INTO messages (run_id, message_id, sender, recipient,"
+                    " kind, body_json, content_fingerprint, accepted_at)"
+                    " VALUES (?,?,?,?,?,?,?,?)",
+                    (run_id, message_id, sender, to, kind,
+                     json.dumps(body), content_fingerprint, now),
+                )
+                conn.execute(
+                    "INSERT INTO notifications (run_id, recipient, message_id,"
+                    " status) VALUES (?,?,?,?)",
+                    (run_id, to, message_id,
+                     "suppressed" if suppress_notify else "pending"),
+                )
+                self._event(conn, run_id, now, "town", "message_accepted",
+                            message_id,
+                            {"sender": sender, "to": to, "kind": kind,
+                             "content_fingerprint": content_fingerprint})
+                return now, False
+        # Leave the transaction normally so rejection evidence commits.
+        if reject:
             raise IdentityReuse(message_id)
-        if reject is False:
-            return row["accepted_at"], True
-        with self._conn() as conn:
-            conn.execute(
-                "INSERT INTO messages (run_id, message_id, sender, recipient,"
-                " kind, body_json, content_fingerprint, accepted_at)"
-                " VALUES (?,?,?,?,?,?,?,?)",
-                (run_id, message_id, sender, to, kind,
-                 json.dumps(body), content_fingerprint, now),
-            )
-            conn.execute(
-                "INSERT INTO notifications (run_id, recipient, message_id,"
-                " status) VALUES (?,?,?,?)",
-                (run_id, to, message_id,
-                 "suppressed" if suppress_notify else "pending"),
-            )
-            self._event(conn, run_id, now, "town", "message_accepted",
-                        message_id,
-                        {"sender": sender, "to": to, "kind": kind,
-                         "content_fingerprint": content_fingerprint})
-            return now, False
+        return row["accepted_at"], True
 
     def message_kind(self, run_id: str, message_id: str) -> str | None:
         with self._conn() as conn:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -137,6 +137,44 @@ def test_replay_and_identity_reuse(client):
     assert r3.json()["detail"]["error"] == "identity_reuse"
 
 
+@pytest.mark.parametrize("field", ["sender", "to", "kind", "body"])
+@pytest.mark.parametrize("fault", ["none", "drop_wakeup"])
+def test_envelope_conflicts_and_completed_replay_do_not_reschedule(client, field, fault):
+    run_id, sessions, _ = make_run(client, fault=fault)
+    first = send_q1(client, run_id, sessions)
+    assert first.status_code == 202 and first.json()["replay"] is False
+    notify_url = f"/runs/{run_id}/inbox/notify"
+    claim_url = f"/runs/{run_id}/inbox/claim"
+    assert client.get(notify_url, params={"wait": 0}, headers=sessions["seller"]).json() == {
+        "hint": fault == "none"}
+    claim = client.post(claim_url, headers=sessions["seller"]).json()
+    ack = client.post(f"/runs/{run_id}/inbox/ack", headers=sessions["seller"],
+                      json={"message_id": "q-1", "fence": claim["fence"],
+                            "status": "processed", "note": {"applied": True}})
+    assert ack.status_code == 200
+
+    replay = send_q1(client, run_id, sessions)
+    assert replay.status_code == 202
+    assert replay.json() == {**first.json(), "replay": True}
+    payload = {"message_id": "q-1", "to": "seller", "kind": "quote_request", "body": BODY}
+    if field != "sender":
+        payload[field] = {"to": "buyer", "kind": "quote_response", "body": {"quantity": 3}}[field]
+    conflict = client.post(f"/runs/{run_id}/messages", json=payload,
+                           headers=sessions["seller" if field == "sender" else "buyer"])
+    assert conflict.status_code == 409
+    assert conflict.json()["detail"] == {"error": "identity_reuse", "message_id": "q-1"}
+    for name in ["buyer", "seller"]:
+        assert client.get(notify_url, params={"wait": 0}, headers=sessions[name]).json() == {"hint": False}
+        assert client.post(claim_url, headers=sessions[name]).status_code == 204
+    kinds = event_kinds(client, run_id)
+    assert kinds.count("message_accepted") == 1
+    assert kinds.count("replay_returned") == 1
+    assert kinds.count("identity_reuse_rejected") == 1
+    assert kinds.count("message_claimed") == 1
+    assert kinds.count("ack_recorded") == 1
+    assert kinds.count("notify_suppressed") == (1 if fault == "drop_wakeup" else 0)
+
+
 def test_stale_fence_over_http(client):
     run_id, sessions, _ = make_run(client, lease=0.0)
     send_q1(client, run_id, sessions)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,3 +1,11 @@
+import json
+import sqlite3
+import subprocess
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+
 import pytest
 
 from nandatown.db import IdentityReuse, StaleFence, TownDB
@@ -21,11 +29,192 @@ BODY = {"sku": "widget", "quantity": 2, "unit_price_cents": 1995}
 FP = fingerprint(BODY)
 
 
-def accept(db, run_id, now=100.0):
-    return db.accept_message(
-        run_id, sender="buyer", message_id="q-1", to="seller",
-        kind="quote_request", body=BODY, content_fingerprint=FP, now=now,
-    )
+def accept(db, run_id, now=100.0, **changes):
+    envelope = dict(sender="buyer", message_id="q-1", to="seller",
+                    kind="quote_request", body=BODY, now=now)
+    envelope.update(changes)
+    envelope["content_fingerprint"] = fingerprint(envelope["body"])
+    return db.accept_message(run_id, **envelope)
+
+
+def stored_rows(db, table):
+    with db._conn() as conn:
+        return [dict(row) for row in conn.execute(f"SELECT * FROM {table}")]
+
+
+IDENTITY_CHANGES = [
+    {"sender": "other-buyer"},
+    {"to": "other-seller"},
+    {"kind": "quote_response"},
+    {"body": {"quantity": 3}},
+]
+
+
+@pytest.mark.parametrize("changes", IDENTITY_CHANGES,
+                         ids=["sender", "recipient", "kind", "body"])
+def test_complete_envelope_conflict_preserves_original_and_commits_rejection(db, run, changes):
+    assert accept(db, run) == (100.0, False)
+    original = stored_rows(db, "messages")
+    notifications = stored_rows(db, "notifications")
+    with pytest.raises(IdentityReuse):
+        accept(db, run, now=200.0, **changes)
+    reopened = TownDB(db.path)
+    assert stored_rows(reopened, "messages") == original
+    assert stored_rows(reopened, "notifications") == notifications
+    events = reopened.events(run)
+    assert [e["kind"] for e in events] == ["message_accepted", "identity_reuse_rejected"]
+    assert events[-1]["at"] == 200.0
+    assert events[-1]["subject"] == "q-1"
+    assert events[-1]["detail"] == {"sender": changes.get("sender", "buyer")}
+
+
+@pytest.mark.parametrize("state", ["accepted", "claimed", "done"])
+@pytest.mark.parametrize("notification", ["pending", "consumed", "suppressed"])
+def test_replay_preserves_work_and_notification_state(db, run, state, notification):
+    accept(db, run, suppress_notify=notification == "suppressed")
+    if notification == "consumed":
+        assert db.pop_notify(run, "seller") is True
+    if state != "accepted":
+        claim = db.claim_next(run, "seller", lease_seconds=500.0, now=101.0)
+        if state == "done":
+            db.ack(run, "seller", "q-1", claim["fence"], "processed", {}, now=102.0)
+    before = {t: stored_rows(db, t) for t in ("messages", "notifications", "claims", "acks")}
+    reordered = {"unit_price_cents": 1995, "quantity": 2, "sku": "widget"}
+    reopened = TownDB(db.path)
+    assert accept(reopened, run, now=200.0, body=reordered,
+                  suppress_notify=notification != "suppressed") == (100.0, True)
+    assert {t: stored_rows(reopened, t) for t in before} == before
+    assert before["messages"][0]["status"] == state
+    assert before["messages"][0]["attempts"] == (0 if state == "accepted" else 1)
+    assert before["messages"][0]["content_fingerprint"] == FP
+    assert before["notifications"][0]["status"] == notification
+    assert [e["kind"] for e in reopened.events(run)].count("message_accepted") == 1
+    assert reopened.events(run)[-1]["kind"] == "replay_returned"
+    if state != "accepted":
+        assert reopened.claim_next(run, "seller", lease_seconds=5.0, now=201.0) is None
+
+
+def test_same_message_id_is_independent_between_runs(db, run):
+    other_run = db.create_run('{}')
+    assert accept(db, run) == (100.0, False)
+    assert accept(db, other_run, now=200.0, sender="other-buyer") == (200.0, False)
+    assert len(stored_rows(db, "messages")) == 2
+    assert len(stored_rows(db, "notifications")) == 2
+    assert [e["kind"] for e in db.events(run)] == ["message_accepted"]
+    assert [e["kind"] for e in db.events(other_run)] == ["message_accepted"]
+
+
+def test_retry_from_fresh_process_preserves_acceptance(db, run):
+    accept(db, run)
+    script = """
+import json, sys
+from nandatown.db import TownDB
+from nandatown.records import fingerprint
+body = {"quantity": 2, "sku": "widget", "unit_price_cents": 1995}
+print(json.dumps(TownDB(sys.argv[1]).accept_message(
+    sys.argv[2], "buyer", "q-1", "seller", "quote_request", body,
+    fingerprint(body), 200.0, suppress_notify=True)))
+"""
+    result = subprocess.run([sys.executable, "-c", script, db.path, run],
+                            capture_output=True, text=True, timeout=20)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == [100.0, True]
+    assert len(stored_rows(db, "messages")) == 1
+    assert [r["status"] for r in stored_rows(db, "notifications")] == ["pending"]
+    assert [e["kind"] for e in db.events(run)] == ["message_accepted", "replay_returned"]
+
+
+@pytest.mark.parametrize("table", ["notifications", "events"])
+def test_acceptance_rolls_back_if_notification_or_event_insert_fails(db, run, table):
+    with db._conn() as conn:
+        conn.execute(f"CREATE TRIGGER fail_insert BEFORE INSERT ON {table} "
+                     "BEGIN SELECT RAISE(ABORT, 'injected insert failure'); END")
+    with pytest.raises(sqlite3.IntegrityError, match="injected insert failure"):
+        accept(db, run)
+    assert stored_rows(db, "messages") == []
+    assert stored_rows(db, "notifications") == []
+    assert db.events(run) == []
+    with db._conn() as conn:
+        conn.execute("DROP TRIGGER fail_insert")
+    assert accept(db, run, now=200.0) == (200.0, False)
+
+
+@pytest.mark.parametrize("changes", [{}] + IDENTITY_CHANGES,
+                         ids=["identical", "sender", "recipient", "kind", "body"])
+def test_concurrent_acceptance_serializes_lookup_and_preserves_winner(db, run, monkeypatch, changes):
+    # Start independent real SQLite connections together. For an unprotected
+    # lookup only, finish both reads before either insert: this deterministically
+    # exposes the old check/insert race. Never wait at a barrier while holding
+    # a transaction/write lock; BEGIN IMMEDIATE makes the second barrier unused.
+    start = threading.Barrier(2, timeout=10)
+    unprotected_reads = threading.Barrier(2, timeout=10)
+
+    class LookupCursor:
+        def __init__(self, cursor, conn):
+            self.cursor, self.conn = cursor, conn
+
+        def fetchone(self):
+            row = self.cursor.fetchone()
+            if not self.conn.in_transaction:
+                unprotected_reads.wait()
+            return row
+
+    class RacingConnection:
+        def __init__(self, conn):
+            self.conn = conn
+
+        def execute(self, sql, *args):
+            cursor = self.conn.execute(sql, *args)
+            if sql.startswith("SELECT") and "FROM messages" in sql:
+                return LookupCursor(cursor, self.conn)
+            return cursor
+
+    def synchronize_first_connection(instance):
+        original = instance._conn
+        first = True
+
+        @contextmanager
+        def connection():
+            nonlocal first
+            with original() as conn:
+                if first:
+                    first = False
+                    assert not conn.in_transaction
+                    start.wait()
+                yield RacingConnection(conn)
+        monkeypatch.setattr(instance, "_conn", connection)
+
+    contenders = [TownDB(db.path), TownDB(db.path)]
+    for instance in contenders:
+        synchronize_first_connection(instance)
+
+    def send(index):
+        try:
+            return accept(contenders[index], run, now=100.0 + 100.0 * index,
+                          suppress_notify=index == 0, **(changes if index else {}))
+        except IdentityReuse:
+            return "rejected"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(send, i) for i in range(2)]
+        outcomes = [future.result(timeout=20) for future in futures]
+    row, = stored_rows(db, "messages")
+    winner = 0 if row["accepted_at"] == 100.0 else 1
+    assert outcomes[winner] == (100.0 + 100.0 * winner, False)
+    assert outcomes[1 - winner] == ("rejected" if changes else (row["accepted_at"], True))
+    expected = dict(sender="buyer", to="seller", kind="quote_request", body=BODY)
+    if winner:
+        expected.update(changes)
+    assert (row["sender"], row["recipient"], row["kind"], json.loads(row["body_json"])) == (
+        expected["sender"], expected["to"], expected["kind"], expected["body"])
+    assert row["status"] == "accepted" and row["attempts"] == 0
+    notification, = stored_rows(db, "notifications")
+    assert notification == dict(run_id=run, recipient=expected["to"], message_id="q-1",
+                                status="suppressed" if winner == 0 else "pending")
+    events = db.events(run)
+    assert [e["kind"] for e in events] == ["message_accepted",
+        "identity_reuse_rejected" if changes else "replay_returned"]
+    assert events[0]["at"] == row["accepted_at"]
 
 
 def test_accept_then_claim_returns_work_with_fence(db, run):


### PR DESCRIPTION
## Summary

Make current Town's durable message acceptance atomic and bind replay to the complete message envelope.

This carries forward the concurrent-retry and request-identity requirement identified while reviewing [#211 by ChiJian28](https://github.com/projnanda/nandatown/pull/211), at `a39b0f0adff59ea9bfebcdf7010ec317a1ac27f1`. It is a fresh fix for the current coordinator, not a port of the legacy Prava payment adapter.

## Behavior

- Begin one SQLite write transaction before looking up a message ID. Lookup, insertion, notification and event writes use that connection.
- Exact retries match sender, recipient, kind and body fingerprint and return the original acceptance time. Completed work and consumed or suppressed notifications are not reset.
- Reusing the ID with a changed envelope commits rejection evidence and returns the existing HTTP 409 response.
- Initial acceptance rolls back completely if notification or event insertion fails.
- Preserve schemas, body-only fingerprint meaning, canonical payloads, permissions and claim/ack behavior.

## Verification

- TDD: 14 failures / 34 passes before the fix; 48 focused tests pass afterward.
- Full suite independently rerun by the controller: **461 passed**, 8 existing warnings.
- Real independent SQLite connections exercise identical and conflicting simultaneous acceptance with deterministic race setup, without sleeps or barriers behind a write lock.
- Coverage includes each envelope field, reordered body keys, separate runs, fresh-process retries, state preservation, transaction rollback and HTTP 202/409 behavior.
- Independent expert review passed spec compliance and code quality with no actionable findings. Concurrency tests use threads with separate connections; fresh-process coverage checks sequential retry, not a load test.

## Scope and credit

This fixes exactly-once **local acceptance**, not exactly-once external effects. Existing SQLite busy-timeout behavior and claim/ack concurrency are unchanged.

The broader provider integration from #211 remains separate: durable outbound-effect journals, uncertain-response reconciliation, provider authorization, currency/principal binding, refunds and independently observed merchant completion need their own profile and tests. No live payments or contributor code were executed. The source PR remains open until this replacement is merged and its selected/deferred scope is documented.
