### PR TITLE
Reject malformed ledger amounts before mutation

### DIFF
--- a/src/nandatown/layers/payments.py
+++ b/src/nandatown/layers/payments.py
@@ -16,6 +16,11 @@ class PaymentError(Exception):
     pass
 
 
+def _require_cents(cents: int, minimum: int) -> None:
+    if type(cents) is not int or cents < minimum:
+        raise PaymentError(f"cents must be an integer >= {minimum}")
+
+
 @register("payments", "ledger.v1")
 class Ledger:
     """Balances, transfers, and escrow hold, release, refund."""
@@ -26,6 +31,7 @@ class Ledger:
         self.escrow: dict[str, dict[str, Any]] = {}
 
     def open_account(self, name: str, cents: int) -> None:
+        _require_cents(cents, 0)
         if name not in self.balances:
             self.balances[name] = cents
             self.engine.emit("town", "account_opened", name,
@@ -40,6 +46,7 @@ class Ledger:
                       if h["state"] == "held"))
 
     def transfer(self, frm: str, to: str, cents: int, memo: str) -> None:
+        _require_cents(cents, 1)
         if self.balance(frm) < cents:
             self.engine.emit("town", "payment_rejected", frm,
                              {"to": to, "cents": cents, "memo": memo,
@@ -51,6 +58,7 @@ class Ledger:
                          {"from": frm, "to": to, "cents": cents})
 
     def hold(self, frm: str, cents: int, ref: str) -> None:
+        _require_cents(cents, 1)
         if ref in self.escrow:
             raise PaymentError(f"escrow ref {ref} reused")
         if self.balance(frm) < cents:

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -1,0 +1,81 @@
+from copy import deepcopy
+
+import pytest
+
+from nandatown.layers.payments import Ledger, PaymentError
+
+
+class IntSubclass(int):
+    pass
+
+
+class RecordingEngine:
+    def __init__(self):
+        self.events = []
+
+    def emit(self, observer, kind, subject, detail=None):
+        self.events.append(
+            {
+                "observer": observer,
+                "kind": kind,
+                "subject": subject,
+                "detail": detail or {},
+            }
+        )
+
+
+@pytest.fixture()
+def ledger():
+    engine = RecordingEngine()
+    return Ledger(engine), engine
+
+
+INVALID_CENTS = [True, False, 1.0, 1.5, "1", IntSubclass(1)]
+
+
+@pytest.mark.parametrize("name", ["new-account", "existing-account"])
+@pytest.mark.parametrize("cents", [*INVALID_CENTS, -1])
+def test_open_account_rejects_invalid_cents_without_mutation(ledger, name, cents):
+    pay, engine = ledger
+    pay.open_account("existing-account", 100)
+    before = (deepcopy(pay.balances), deepcopy(pay.escrow), deepcopy(engine.events))
+
+    with pytest.raises(PaymentError):
+        pay.open_account(name, cents)
+
+    assert (pay.balances, pay.escrow, engine.events) == before
+
+
+def test_open_account_accepts_zero_and_remains_idempotent(ledger):
+    pay, engine = ledger
+
+    pay.open_account("buyer", 0)
+    pay.open_account("buyer", 100)
+
+    assert pay.balance("buyer") == 0
+    assert [event["kind"] for event in engine.events] == ["account_opened"]
+
+
+@pytest.mark.parametrize("cents", [*INVALID_CENTS, 0, -1])
+def test_transfer_rejects_invalid_cents_without_mutation(ledger, cents):
+    pay, engine = ledger
+    pay.open_account("buyer", 100)
+    pay.open_account("seller", 25)
+    before = (deepcopy(pay.balances), deepcopy(pay.escrow), deepcopy(engine.events))
+
+    with pytest.raises(PaymentError):
+        pay.transfer("buyer", "seller", cents, memo="order-1")
+
+    assert (pay.balances, pay.escrow, engine.events) == before
+
+
+@pytest.mark.parametrize("cents", [*INVALID_CENTS, 0, -1])
+def test_hold_rejects_invalid_cents_without_mutation(ledger, cents):
+    pay, engine = ledger
+    pay.open_account("buyer", 100)
+    before = (deepcopy(pay.balances), deepcopy(pay.escrow), deepcopy(engine.events))
+
+    with pytest.raises(PaymentError):
+        pay.hold("buyer", cents, ref="order-1")
+
+    assert (pay.balances, pay.escrow, engine.events) == before


### PR DESCRIPTION
## Summary

- Enforce the declared integer-cent domain at every current ledger entry boundary.
- Allow non-negative account-opening balances and require positive transfer and escrow-hold amounts.
- Reject booleans, floats, strings, integer subclasses, zero where disallowed, and negative values before balances, escrow, or trace events can change.

## Why

The current ledger accepts malformed amounts. A negative transfer or hold can move balances in the wrong direction while the generic conservation check still passes. This keeps the existing ledger model and fixes that current correctness gap.

The retained positive-amount invariant was surfaced while reviewing legacy PR #123 by @kishankannanblr-cell and legacy PR #7 by @mariagorskikh. This is a fresh implementation against current `main`; no contributor code was executed or copied.

## Scope boundary

This PR does not adopt AgentCourt, juror arbitration, persistent memory, HTLCs, hashlocks, timelocks, or a new payment policy. Those remain separate profile/design decisions.

## Verification

- `PYTHONPATH=$PWD/src .venv/bin/pytest -q tests/test_payments.py` — 31 passed
- `PYTHONPATH=$PWD/src .venv/bin/pytest -q` — 531 passed, 8 existing warnings
- Independent review: no critical, important, or minor findings
