### PR TITLE
Stop fetching untrusted catalog URLs on submission

### DIFF
--- a/apps/nest-dashboard/README.md
+++ b/apps/nest-dashboard/README.md
@@ -31,9 +31,10 @@ npm run typecheck
 ```
 
 The tests exercise the real API handler, form action and rendered page with
-external persistence, request context and fetch responses replaced by test
-doubles. They require no database, credentials or live endpoint. They do not
-prove database transactions, browser hydration or a deployed Next server.
+external persistence and request context replaced by test doubles. Unexpected
+network access is blocked. They require no database, credentials or live
+endpoint. They do not prove database transactions, browser hydration or a
+deployed Next server.
 
 The form lifecycle tests use the real React action queue and a DOM environment,
 with only the server action replaced. They cover repeated submit events, pending
@@ -43,10 +44,10 @@ HTTP retries or concurrent server requests. Server idempotency needs a separate
 contract with an explicit operation key and atomic persistence. A time-window
 lookup before insertion is not that guarantee.
 
-URL validation checks source syntax only. API submissions do not probe links
-and keep `reachable: null`; the page labels those links as not checked.
-The existing form's best-effort probe is unchanged. These observations are not
-capability, endorsement or permission to execute a submitted skill.
+URL validation checks source syntax only. API and form submissions do not probe
+links and keep `reachable: null`; the page labels those links as not checked.
+A saved catalog record is not evidence that a link is live or safe, an
+endorsement, or permission to execute a submitted skill.
 
 ## Learn More
 

--- a/apps/nest-dashboard/src/app/docs/page.tsx
+++ b/apps/nest-dashboard/src/app/docs/page.tsx
@@ -505,8 +505,11 @@ export default function DocsPage() {
                 <a href="/skills" className="text-rust hover:text-rust/80 underline underline-offset-2">
                   Skills page
                 </a>
-                . Agents can discover your service there and call it in sandbox
-                runs today, and in the live town once it is running.
+                . Registration only makes the catalog entry discoverable. It
+                does not verify, install, authorize, endorse, or execute the
+                submitted skill, agent, or service. For new URL and GitHub
+                entries, the catalog stores the source link without fetching or
+                hosting the linked content, agent, or service.
               </li>
             </ol>
 

--- a/apps/nest-dashboard/src/app/llms.txt/route.ts
+++ b/apps/nest-dashboard/src/app/llms.txt/route.ts
@@ -15,7 +15,7 @@ Key facts:
 - The simulator is deterministic: same seed, same trace. Scenarios are plain YAML; validators check protocol invariants on every run.
 - Twelve protocol layers cover identity, trust, payments, registry, comms, memory, coordination, and more; each layer accepts community plugins via a pull request to the repo.
 - Community contributions arrive as pull requests to https://github.com/projnanda/nandatown and appear in the PR gallery, organized by layer.
-- The SkillMD registry hosts Markdown skill files that teach agents how to call live APIs; browse or submit at ${SITE_URL}/skills (JSON API at /api/skills).
+- The SkillMD registry catalogs submissions at ${SITE_URL}/skills (JSON API at /api/skills). Registration only makes the catalog entry discoverable. It does not verify, install, authorize, endorse, or execute the submitted skill, agent, or service. For new URL and GitHub entries, the catalog stores the source link without fetching or hosting the linked content, agent, or service.
 - Agents can also run in the cloud instead of locally: Maritime (https://maritime.sh) is the preferred partner for hosting agents (CLI: \`npm install -g maritime-cli\`; SDK: \`pip install maritime\` / \`npm install maritime-sdk\`). Nanda Town builders get 20 agents free with promo code NANDATOWN.
 - Nanda Town hosts hackathons (NandaHacks): the NandaHack x HCLTech skills event and the Agentic Commerce Hackathon (Prava payments track).
 

--- a/apps/nest-dashboard/src/app/skills/actions.ts
+++ b/apps/nest-dashboard/src/app/skills/actions.ts
@@ -43,26 +43,6 @@ async function clientIp(): Promise<string | null> {
   return h.get("x-real-ip");
 }
 
-/**
- * Best-effort check that a submitted URL actually answers. Never throws — a
- * failed or slow request just means we record `false`, we don't block the save.
- */
-async function checkReachable(url: string): Promise<boolean> {
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 5000);
-    const res = await fetch(url, {
-      signal: controller.signal,
-      redirect: "follow",
-      headers: { "user-agent": "NandaTown-SkillMD-Checker" },
-    });
-    clearTimeout(timer);
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
-
 export async function submitSkill(
   _prev: SubmitState,
   formData: FormData,
@@ -107,12 +87,6 @@ export async function submitSkill(
     };
   }
 
-  // --- Best-effort reachability check for hosted links --------------------
-  let reachable: boolean | null = null;
-  if (sourceType === "url" || sourceType === "github") {
-    reachable = await checkReachable(sourceUrl);
-  }
-
   // --- Save ---------------------------------------------------------------
   try {
     const submitterIp = await clientIp();
@@ -125,7 +99,7 @@ export async function submitSkill(
       content: sourceType === "content" ? content : null,
       endpoints: endpoints || null,
       tags: tags || null,
-      reachable,
+      reachable: null,
       email: email || null,
       github_username: githubUsername || null,
       submitter_ip: submitterIp,

--- a/apps/nest-dashboard/tests/catalog-discovery-copy.test.tsx
+++ b/apps/nest-dashboard/tests/catalog-discovery-copy.test.tsx
@@ -1,0 +1,43 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, test } from "vitest";
+import DocsPage from "../src/app/docs/page";
+import { GET as getLlmsTxt } from "../src/app/llms.txt/route";
+
+function expectDiscoveryOnlyCopy(copy: string): void {
+  expect(copy).toContain("only makes the catalog entry discoverable");
+  expect(copy).toContain(
+    "does not verify, install, authorize, endorse, or execute",
+  );
+  expect(copy).toContain(
+    "For new URL and GitHub entries, the catalog stores the source link without fetching or hosting the linked content, agent, or service",
+  );
+  expect(copy).not.toMatch(
+    /\b(?:registry|registration|catalog(?:ing)?|entry)\s+(?:installs?|authorizes?|endorses?|verifies?|hosts?|executes?)\b/i,
+  );
+  expect(copy).not.toMatch(/\bagents can .*call it in sandbox/i);
+}
+
+test("public docs describe SkillMD registration as discovery only", () => {
+  const markup = renderToStaticMarkup(<DocsPage />);
+  const start = markup.indexOf('<section id="startups"');
+  const end = markup.indexOf("</section>", start);
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  const sectionText = markup
+    .slice(start, end)
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ");
+  expectDiscoveryOnlyCopy(sectionText);
+});
+
+test("llms.txt describes the SkillMD registry as discovery only", async () => {
+  const response = getLlmsTxt();
+  const registryLine = (await response.text())
+    .split("\n")
+    .find((line) => line.startsWith("- The SkillMD registry"));
+
+  expect(registryLine).toBeTypeOf("string");
+  expectDiscoveryOnlyCopy(registryLine ?? "");
+});

--- a/apps/nest-dashboard/tests/skill-catalog.test.tsx
+++ b/apps/nest-dashboard/tests/skill-catalog.test.tsx
@@ -104,17 +104,16 @@ for (const sourceType of ["url", "github"]) {
       expect(fetch).not.toHaveBeenCalled();
     });
 
-    test(`form retains its existing successful probe for ${sourceType} ${sourceUrl}`, async () => {
-      vi.mocked(fetch).mockResolvedValueOnce(new Response("ok"));
+    test(`form saves ${sourceType} ${sourceUrl} without claiming a probe`, async () => {
       const result = await submitSkill(initialSubmitState, form({
         name: skill.name, source_type: sourceType, source_url: `  ${sourceUrl}  `,
       }));
       expect(result.ok).toBe(true);
       expect(result.createdId).toBe(skill.id);
       expect(external.createSkill).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
-        source_type: sourceType, source_url: sourceUrl, reachable: true,
+        source_type: sourceType, source_url: sourceUrl, reachable: null,
       }));
-      expect(fetch).toHaveBeenCalledExactlyOnceWith(sourceUrl, expect.any(Object));
+      expect(fetch).not.toHaveBeenCalled();
     });
   }
 }


### PR DESCRIPTION
## Summary

- Stop the catalog form from fetching user-submitted URL and GitHub sources.
- Store new link submissions with `reachable: null`, matching the existing API behavior and making uncertainty explicit.
- State in human and machine-readable docs that catalog registration is discovery only: it does not verify, install, authorize, endorse, host, or execute the submitted target.

## Why

The server action followed redirects while fetching an arbitrary submitted URL. That exposed a present SSRF boundary: a submission could target loopback, private, link-local, or metadata-network resources directly or through redirects. Submission-time liveness is not required to create a catalog entry, so this fix removes the untrusted server-side request instead of relying on an incomplete address denylist or a DNS check that can race the connection.

The server-fetch boundary was surfaced by legacy PR #80 from @athiye. This is a fresh implementation against current `main`; no contributor code was executed or copied.

## Scope boundary

This PR does not port the legacy reputation scenario, establish endpoint liveness, inspect linked content, or imply that a discoverable entry is safe, installed, authorized, endorsed, hosted, or running. Any future live probe belongs in an isolated observer with explicit network policy and timestamped evidence.

## Verification

- Dashboard tests: 44 passed
- Dashboard typecheck: passed
- Changed-file lint and diff check: passed
- Independent re-review: no critical, important, or minor findings
