### PR TITLE
Reject duplicate bids in sealed-bid auctions

### DIFF
--- a/src/nandatown/layers/coordination.py
+++ b/src/nandatown/layers/coordination.py
@@ -34,6 +34,11 @@ class ContractNet:
                              {"bidder": bidder, "cents": cents,
                               "reason": "task closed"})
             return False
+        if bidder in task["bids"]:
+            self.engine.emit("town", "bid_rejected", task_id,
+                             {"bidder": bidder, "cents": cents,
+                              "reason": "duplicate bid"})
+            return False
         task["bids"][bidder] = cents
         self.engine.emit(bidder, "bid_placed", task_id, {"cents": cents})
         return True

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -187,6 +187,26 @@ def test_contract_net_rules_and_late_bids(eng):
     assert coord.award("task-2") == ("y", 900)
 
 
+def test_contract_net_rejects_duplicate_bid_and_preserves_first_amount(eng):
+    """Sealed-bid contract retained from legacy PR #5 (@mariagorskikh)."""
+    coord = eng.layers["coordination"]
+    coord.announce("auctioneer", "sealed-task", {"item": "print"},
+                   rule="highest")
+
+    assert coord.bid("sealed-task", "bidder", 700) is True
+    assert coord.bid("sealed-task", "bidder", 900) is False
+
+    assert coord.award("sealed-task") == ("bidder", 700)
+    placed = [event for event in eng.events
+              if event["kind"] == "bid_placed"]
+    assert len(placed) == 1
+    rejected = [event for event in eng.events
+                if event["kind"] == "bid_rejected"]
+    assert rejected[-1]["detail"] == {
+        "bidder": "bidder", "cents": 900, "reason": "duplicate bid",
+    }
+
+
 def test_memory_and_communication(eng):
     mem = eng.layers["memory"]
     mem.remember("buyer", "preferred_seller", "seller-b")


### PR DESCRIPTION
## Summary

- Make the current advertised sealed-bid auction accept at most one bid from each bidder before award.
- Reject a duplicate bid without mutating the first accepted bid.
- Emit an attributed `bid_rejected` event with the duplicate-bid reason so the trace explains the decision.

## Why

The current coordination layer stores bids in a dictionary and silently overwrites an earlier bid from the same bidder. In a sealed-bid workflow, that lets a bidder revise its bid after submission and makes the trace claim stronger semantics than the implementation provides.

The one-shot bid requirement was surfaced by legacy PR #5 from @mariagorskikh. This is a fresh implementation against current `main`; no contributor code was executed or copied.

## Scope boundary

This PR preserves the current first-price `highest` and `lowest` award rules. It does not add Vickrey pricing, reserve prices, bid encryption, a new coordination plugin, or other auction policy.

## Verification

- Coordination tests: 11 passed
- Full suite: 532 passed, 8 existing warnings
- Diff check passed
- Independent review: no findings for this isolated change
