### PR TITLE
Fail closed on invalid fault-rule numbers

### DIFF
--- a/schemas/scenario.schema.json
+++ b/schemas/scenario.schema.json
@@ -30,29 +30,39 @@
           "enum": [
             "drop",
             "duplicate",
-            "delay"
+            "delay",
+            "drop_rate"
           ],
           "title": "Action",
           "type": "string"
         },
         "delay": {
           "default": 0.0,
+          "minimum": 0,
           "title": "Delay",
           "type": "number"
         },
         "kind": {
+          "default": "",
           "title": "Kind",
           "type": "string"
         },
         "nth": {
           "default": 1,
+          "minimum": 1,
           "title": "Nth",
           "type": "integer"
+        },
+        "rate": {
+          "default": 0.0,
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Rate",
+          "type": "number"
         }
       },
       "required": [
-        "action",
-        "kind"
+        "action"
       ],
       "title": "FaultRule",
       "type": "object"
@@ -60,6 +70,14 @@
   },
   "$id": "https://nandatown.local/schemas/scenario.schema.json",
   "properties": {
+    "adaptations": {
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "title": "Adaptations",
+      "type": "array"
+    },
     "agents": {
       "items": {
         "$ref": "#/$defs/AgentSpec"
@@ -96,6 +114,14 @@
     "name": {
       "title": "Name",
       "type": "string"
+    },
+    "plugin_files": {
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "title": "Plugin Files",
+      "type": "array"
     },
     "redact_fields": {
       "default": [],

--- a/src/nandatown/sim/scenario.py
+++ b/src/nandatown/sim/scenario.py
@@ -8,10 +8,11 @@ dropped messages or adversarial agents, and the seed.
 from __future__ import annotations
 
 import importlib.resources
+import math
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from ..layers import DEFAULT_PLUGINS, LAYER_NAMES
 
@@ -29,9 +30,23 @@ class FaultRule(BaseModel):
 
     action: Literal["drop", "duplicate", "delay", "drop_rate"]
     kind: str = ""
-    nth: int = 1
-    delay: float = 0.0
-    rate: float = 0.0
+    nth: int = Field(default=1, ge=1)
+    delay: float = Field(default=0.0, ge=0)
+    rate: float = Field(default=0.0, ge=0, le=1)
+
+    @field_validator("nth", mode="before")
+    @classmethod
+    def _validate_nth(cls, value):
+        if type(value) is not int:
+            raise ValueError("nth must be an integer")
+        return value
+
+    @field_validator("delay", "rate", mode="before")
+    @classmethod
+    def _validate_real_number(cls, value):
+        if type(value) not in (int, float) or not math.isfinite(value):
+            raise ValueError("must be a finite real number")
+        return value
 
 
 class ScenarioSpec(BaseModel):

--- a/tests/test_scenario_faults.py
+++ b/tests/test_scenario_faults.py
@@ -1,0 +1,68 @@
+"""Fault declaration contract from legacy PR #8 (@mariagorskikh).
+
+Legacy PRs #10 and #11 remain future latency and topology profiles; these
+tests only harden the numeric declarations the current transport consumes.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from nandatown.sim.scenario import FaultRule, ScenarioSpec, load_scenario_text
+
+
+@pytest.mark.parametrize(("field", "action", "value"), [
+    ("nth", "drop_rate", 0),
+    ("nth", "drop_rate", -1),
+    ("nth", "drop_rate", True),
+    ("nth", "drop_rate", 1.0),
+    ("nth", "drop_rate", 1.5),
+    ("nth", "drop_rate", "1"),
+    ("delay", "drop", -0.1),
+    ("delay", "drop", True),
+    ("delay", "drop", "0.5"),
+    ("delay", "drop", float("nan")),
+    ("delay", "drop", float("inf")),
+    ("delay", "drop", float("-inf")),
+    ("rate", "delay", -0.1),
+    ("rate", "delay", 1.1),
+    ("rate", "delay", True),
+    ("rate", "delay", "0.5"),
+    ("rate", "delay", float("nan")),
+    ("rate", "delay", float("inf")),
+    ("rate", "delay", float("-inf")),
+])
+def test_fault_numbers_reject_malformed_values_even_when_unused(
+        field, action, value):
+    with pytest.raises(ValidationError):
+        FaultRule.model_validate({"action": action, field: value})
+
+
+def test_integer_yaml_values_remain_valid_for_float_fault_fields():
+    spec = load_scenario_text("""
+name: integer-fault-values
+agents: []
+faults:
+  - {action: delay, kind: ping, nth: 1, delay: 2, rate: 1}
+""")
+
+    rule = spec.faults[0]
+    assert rule.nth == 1 and type(rule.nth) is int
+    assert rule.delay == 2.0 and type(rule.delay) is float
+    assert rule.rate == 1.0 and type(rule.rate) is float
+
+
+def test_shipped_scenario_schema_matches_generated_numeric_contract():
+    path = Path(__file__).parents[1] / "schemas" / "scenario.schema.json"
+    shipped = json.loads(path.read_text())
+    generated = ScenarioSpec.model_json_schema()
+    generated["$id"] = "https://nandatown.local/schemas/scenario.schema.json"
+
+    assert shipped == generated
+    fault = shipped["$defs"]["FaultRule"]["properties"]
+    assert fault["nth"]["minimum"] == 1
+    assert fault["delay"]["minimum"] == 0
+    assert fault["rate"]["minimum"] == 0
+    assert fault["rate"]["maximum"] == 1


### PR DESCRIPTION
## Summary

- Validate every current fault-rule numeric field before a run starts.
- Require exact integer `nth >= 1`, finite non-negative delay, and finite drop rate in `[0, 1]`.
- Reject booleans, strings, negative values, NaN, infinity, and out-of-range values even when a field is unused by the chosen action.
- Keep the shipped JSON schema synchronized with the runtime model.

## Why

Malformed fault values could silently change test meaning: negative delays were clamped, out-of-range rates became always-or-never behavior, and positive infinity could enter the event queue. A test harness must fail closed on invalid fault configuration rather than produce a misleading run.

This fail-closed requirement was surfaced while reviewing legacy PR #8 from @mariagorskikh. This is a fresh implementation against current `main`; no contributor code was executed or copied.

## Scope boundary

This PR validates the existing drop, duplicate, delay, and drop-rate rules. It does not adopt the legacy latency-model plugin, jitter distributions, bandwidth, queue, partition, or SLO policy.

## Verification

- Fault/schema/tooling tests: 31 passed
- Full suite: 552 passed, 8 existing warnings
- Diff check passed
- Independent review: no findings for this isolated change
