### PR TITLE
fix(catalog): bound submissions and commit history atomically

### DIFF
--- a/apps/nest-dashboard/src/app/api/skills/route.ts
+++ b/apps/nest-dashboard/src/app/api/skills/route.ts
@@ -1,14 +1,14 @@
 import type { NextRequest } from "next/server";
 import { revalidateTag } from "next/cache";
-import { createSkill, listSkillsCached, SKILLS_CACHE_TAG, type SkillSourceType } from "@/lib/skills";
-import { isValidHttpUrl } from "@/lib/skill-source";
+import { createSkill, listSkillsCached, SKILLS_CACHE_TAG } from "@/lib/skills";
+import { readBoundedJson, RequestTooLargeError } from "@/lib/bounded-json";
+import {
+  MAX_SKILL_REQUEST_BYTES,
+  validateSkillSubmission,
+} from "@/lib/skill-submission";
 
 // This registry is read/written at request time, never prerendered.
 export const dynamic = "force-dynamic";
-
-function s(value: unknown): string {
-  return typeof value === "string" ? value.trim() : "";
-}
 
 /**
  * GET /api/skills
@@ -27,65 +27,32 @@ export async function GET() {
  *     author?, description?, endpoints?, tags? }
  */
 export async function POST(request: NextRequest) {
-  let body: Record<string, unknown>;
+  let body: unknown;
   try {
-    body = (await request.json()) as Record<string, unknown>;
-  } catch {
+    body = await readBoundedJson(request, MAX_SKILL_REQUEST_BYTES);
+  } catch (error) {
+    if (error instanceof RequestTooLargeError) {
+      return Response.json({ error: error.message }, { status: 413 });
+    }
     return Response.json({ error: "Send a JSON body." }, { status: 400 });
   }
 
-  const name = s(body.name);
-  const sourceType = s(body.source_type) as SkillSourceType;
-  const sourceUrl = s(body.source_url);
-  const content = typeof body.content === "string" ? body.content : "";
-  const email = s(body.email);
-  const githubUsername = s(body.github_username).replace(/^@/, "");
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return Response.json({ error: "Send a JSON object." }, { status: 400 });
+  }
+
   const forwarded = request.headers.get("x-forwarded-for");
   const submitterIp = forwarded
     ? forwarded.split(",")[0].trim() || null
     : request.headers.get("x-real-ip");
-
-  if (!name) {
-    return Response.json({ error: "name is required" }, { status: 400 });
-  }
-  if (!["url", "github", "content"].includes(sourceType)) {
-    return Response.json(
-      { error: "source_type must be one of: url, github, content" },
-      { status: 400 },
-    );
-  }
-  if ((sourceType === "url" || sourceType === "github") && !sourceUrl) {
-    return Response.json(
-      { error: "source_url is required for url/github submissions" },
-      { status: 400 },
-    );
-  }
-  if ((sourceType === "url" || sourceType === "github") && !isValidHttpUrl(sourceUrl)) {
-    return Response.json(
-      { error: "source_url must be a valid http(s) URL" },
-      { status: 400 },
-    );
-  }
-  if (sourceType === "content" && content.trim().length < 20) {
-    return Response.json(
-      { error: "content is required (and must be the full SkillMD)" },
-      { status: 400 },
-    );
+  const validated = validateSkillSubmission(body as Record<string, unknown>);
+  if (!validated.ok) {
+    return Response.json({ error: validated.error }, { status: 400 });
   }
 
   try {
     const skill = await createSkill({
-      name,
-      author: s(body.author) || null,
-      description: s(body.description) || null,
-      source_type: sourceType,
-      source_url: sourceType === "content" ? null : sourceUrl,
-      content: sourceType === "content" ? content : null,
-      endpoints: s(body.endpoints) || null,
-      tags: s(body.tags) || null,
-      reachable: null,
-      email: email || null,
-      github_username: githubUsername || null,
+      ...validated.value,
       submitter_ip: submitterIp,
     });
     revalidateTag(SKILLS_CACHE_TAG, "max");

--- a/apps/nest-dashboard/src/app/skills/actions.ts
+++ b/apps/nest-dashboard/src/app/skills/actions.ts
@@ -2,35 +2,9 @@
 
 import { revalidatePath, revalidateTag } from "next/cache";
 import { headers } from "next/headers";
-import { createSkill, SKILLS_CACHE_TAG, type SkillSourceType } from "@/lib/skills";
+import { createSkill, SKILLS_CACHE_TAG } from "@/lib/skills";
 import { initialSubmitState, type SubmitState } from "./form-state";
-import { isValidHttpUrl } from "@/lib/skill-source";
-
-function str(value: FormDataEntryValue | null): string {
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function isValidEmail(value: string): boolean {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-}
-
-/**
- * Reduce whatever the user typed to a bare GitHub handle: strip a leading "@",
- * a full "github.com/…" URL, and any trailing slash. Returns "" if nothing
- * usable is left.
- */
-function normalizeGithubUsername(value: string): string {
-  let v = value.trim().replace(/^@/, "");
-  const urlMatch = v.match(/github\.com\/([^/\s?#]+)/i);
-  if (urlMatch) v = urlMatch[1];
-  return v.replace(/\/+$/, "").trim();
-}
-
-function isValidGithubUsername(value: string): boolean {
-  // GitHub handles: 1–39 chars, alphanumeric or single hyphens, no leading/
-  // trailing hyphen.
-  return /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(value);
-}
+import { validateSkillSubmission } from "@/lib/skill-submission";
 
 /**
  * Best-effort client IP from the proxy headers Railway sets. Falls back to
@@ -47,61 +21,17 @@ export async function submitSkill(
   _prev: SubmitState,
   formData: FormData,
 ): Promise<SubmitState> {
-  const name = str(formData.get("name"));
-  const author = str(formData.get("author"));
-  const email = str(formData.get("email"));
-  const githubUsername = normalizeGithubUsername(str(formData.get("github_username")));
-  const description = str(formData.get("description"));
-  const endpoints = str(formData.get("endpoints"));
-  const tags = str(formData.get("tags"));
-  const sourceType = str(formData.get("source_type")) as SkillSourceType;
-  const sourceUrl = str(formData.get("source_url"));
-  const content = str(formData.get("content"));
-
-  // --- Validation ---------------------------------------------------------
-  if (!name) {
-    return { ...initialSubmitState, error: "Give your SkillMD a name." };
-  }
-  if (email && !isValidEmail(email)) {
-    return { ...initialSubmitState, error: "That email doesn't look right." };
-  }
-  if (githubUsername && !isValidGithubUsername(githubUsername)) {
-    return {
-      ...initialSubmitState,
-      error: "Enter just your GitHub username (e.g. octocat).",
-    };
-  }
-  if (!["url", "github", "content"].includes(sourceType)) {
-    return { ...initialSubmitState, error: "Pick how you want to submit it." };
-  }
-  if ((sourceType === "url" || sourceType === "github") && !sourceUrl) {
-    return { ...initialSubmitState, error: "Add the link to your SkillMD." };
-  }
-  if ((sourceType === "url" || sourceType === "github") && !isValidHttpUrl(sourceUrl)) {
-    return { ...initialSubmitState, error: "That link doesn't look like a real URL." };
-  }
-  if (sourceType === "content" && content.length < 20) {
-    return {
-      ...initialSubmitState,
-      error: "Paste the full SkillMD text — that looks too short.",
-    };
+  const fields = Object.fromEntries(formData.entries());
+  const validated = validateSkillSubmission(fields);
+  if (!validated.ok) {
+    return { ...initialSubmitState, error: validated.error };
   }
 
   // --- Save ---------------------------------------------------------------
   try {
     const submitterIp = await clientIp();
     const skill = await createSkill({
-      name,
-      author: author || null,
-      description: description || null,
-      source_type: sourceType,
-      source_url: sourceType === "content" ? null : sourceUrl,
-      content: sourceType === "content" ? content : null,
-      endpoints: endpoints || null,
-      tags: tags || null,
-      reachable: null,
-      email: email || null,
-      github_username: githubUsername || null,
+      ...validated.value,
       submitter_ip: submitterIp,
     });
     revalidateTag(SKILLS_CACHE_TAG, "max");

--- a/apps/nest-dashboard/src/lib/bounded-json.ts
+++ b/apps/nest-dashboard/src/lib/bounded-json.ts
@@ -1,0 +1,46 @@
+export class RequestTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body is too large (maximum ${maxBytes} bytes).`);
+    this.name = "RequestTooLargeError";
+  }
+}
+
+/** Parse JSON without first buffering an unbounded request body. */
+export async function readBoundedJson(
+  request: Request,
+  maxBytes: number,
+): Promise<unknown> {
+  const contentLength = request.headers.get("content-length");
+  if (contentLength && /^\d+$/.test(contentLength.trim())) {
+    if (Number(contentLength) > maxBytes) throw new RequestTooLargeError(maxBytes);
+  }
+
+  if (!request.body) return JSON.parse("");
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new RequestTooLargeError(maxBytes);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+}

--- a/apps/nest-dashboard/src/lib/skill-submission.ts
+++ b/apps/nest-dashboard/src/lib/skill-submission.ts
@@ -1,0 +1,122 @@
+import { isValidHttpUrl } from "./skill-source";
+import type { NewSkill, SkillSourceType } from "./skills";
+
+export const MAX_SKILL_REQUEST_BYTES = 256 * 1024;
+
+const FIELD_LIMITS = {
+  name: 200,
+  author: 200,
+  email: 254,
+  github_username: 39,
+  description: 2_000,
+  source_url: 2_048,
+  content: 200_000,
+  endpoints: 8_192,
+  tags: 512,
+} as const;
+
+type FieldName = keyof typeof FIELD_LIMITS;
+
+export type SkillSubmissionResult =
+  | { ok: true; value: NewSkill }
+  | { ok: false; error: string };
+
+function stringValue(
+  input: Record<string, unknown>,
+  field: FieldName | "source_type",
+  trim = true,
+): string {
+  const value = input[field];
+  if (typeof value !== "string") return "";
+  return trim ? value.trim() : value;
+}
+
+function normalizeGithubUsername(value: string): string {
+  let normalized = value.trim().replace(/^@/, "");
+  const urlMatch = normalized.match(/github\.com\/([^/\s?#]+)/i);
+  if (urlMatch) normalized = urlMatch[1];
+  return normalized.replace(/\/+$/, "").trim();
+}
+
+function isValidGithubUsername(value: string): boolean {
+  return /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(value);
+}
+
+function isValidEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+export function validateSkillSubmission(
+  input: Record<string, unknown>,
+): SkillSubmissionResult {
+  const values = {
+    name: stringValue(input, "name"),
+    author: stringValue(input, "author"),
+    email: stringValue(input, "email"),
+    github_username: normalizeGithubUsername(stringValue(input, "github_username")),
+    description: stringValue(input, "description"),
+    source_url: stringValue(input, "source_url"),
+    content: stringValue(input, "content", false),
+    endpoints: stringValue(input, "endpoints"),
+    tags: stringValue(input, "tags"),
+  };
+
+  for (const field of Object.keys(FIELD_LIMITS) as FieldName[]) {
+    if (values[field].length > FIELD_LIMITS[field]) {
+      return {
+        ok: false,
+        error: `${field} is too long (maximum ${FIELD_LIMITS[field]} characters).`,
+      };
+    }
+  }
+
+  const sourceType = stringValue(input, "source_type") as SkillSourceType;
+  if (!values.name) return { ok: false, error: "name is required" };
+  if (values.email && !isValidEmail(values.email)) {
+    return { ok: false, error: "email must be a valid address" };
+  }
+  if (values.github_username && !isValidGithubUsername(values.github_username)) {
+    return { ok: false, error: "github_username must be a valid GitHub username" };
+  }
+  if (!(["url", "github", "content"] as string[]).includes(sourceType)) {
+    return {
+      ok: false,
+      error: "source_type must be one of: url, github, content",
+    };
+  }
+  if ((sourceType === "url" || sourceType === "github") && !values.source_url) {
+    return {
+      ok: false,
+      error: "source_url is required for url/github submissions",
+    };
+  }
+  if (
+    (sourceType === "url" || sourceType === "github") &&
+    !isValidHttpUrl(values.source_url)
+  ) {
+    return { ok: false, error: "source_url must be a valid http(s) URL" };
+  }
+  if (sourceType === "content" && values.content.trim().length < 20) {
+    return {
+      ok: false,
+      error: "content is required (and must be the full SkillMD)",
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      name: values.name,
+      author: values.author || null,
+      description: values.description || null,
+      source_type: sourceType,
+      source_url: sourceType === "content" ? null : values.source_url,
+      content: sourceType === "content" ? values.content : null,
+      endpoints: values.endpoints || null,
+      tags: values.tags || null,
+      reachable: null,
+      email: values.email || null,
+      github_username: values.github_username || null,
+    },
+  };
+}

--- a/apps/nest-dashboard/src/lib/skills.ts
+++ b/apps/nest-dashboard/src/lib/skills.ts
@@ -88,33 +88,48 @@ export async function getSkill(id: string): Promise<Skill | null> {
 export async function createSkill(input: NewSkill): Promise<Skill> {
   await ensureSchema();
   const db = sql();
-  const rows = await db`
-    insert into skills
-      (name, author, description, source_type, source_url, content,
-       endpoints, tags, reachable, email, github_username, submitter_ip)
-    values
-      (${input.name}, ${input.author ?? null}, ${input.description ?? null},
-       ${input.source_type}, ${input.source_url ?? null}, ${input.content ?? null},
-       ${input.endpoints ?? null}, ${input.tags ?? null}, ${input.reachable ?? null},
-       ${input.email ?? null}, ${input.github_username ?? null}, ${input.submitter_ip ?? null})
-    returning id, name, author, description, source_type, source_url,
-              content, endpoints, tags, reachable, created_at
-  `;
+  const id = crypto.randomUUID();
+  const [rows] = await db.transaction((tx) => [
+    tx`
+      insert into skills
+        (id, name, author, description, source_type, source_url, content,
+         endpoints, tags, reachable, email, github_username, submitter_ip)
+      values
+        (${id}, ${input.name}, ${input.author ?? null}, ${input.description ?? null},
+         ${input.source_type}, ${input.source_url ?? null}, ${input.content ?? null},
+         ${input.endpoints ?? null}, ${input.tags ?? null}, ${input.reachable ?? null},
+         ${input.email ?? null}, ${input.github_username ?? null}, ${input.submitter_ip ?? null})
+      returning id, name, author, description, source_type, source_url,
+                content, endpoints, tags, reachable, created_at
+    `,
+    // The transaction keeps the public row and its private audit snapshot
+    // all-or-nothing. Build the snapshot from the inserted row so its database
+    // timestamp and normalized columns are the committed values.
+    tx`
+      insert into skill_history (skill_id, action, snapshot)
+      select id, 'created', jsonb_build_object(
+        'id', id,
+        'name', name,
+        'author', author,
+        'description', description,
+        'source_type', source_type,
+        'source_url', source_url,
+        'content', content,
+        'endpoints', endpoints,
+        'tags', tags,
+        'reachable', reachable,
+        'created_at', created_at,
+        'email', email,
+        'github_username', github_username,
+        'submitter_ip', submitter_ip
+      )
+      from skills
+      where id = ${id}
+    `,
+  ]);
+
   const skill = (rows as unknown as Skill[])[0];
-
-  // Record the creation in the append-only audit log. The snapshot keeps the
-  // private columns too — skill_history is never exposed by the public API.
-  const snapshot = {
-    ...skill,
-    email: input.email ?? null,
-    github_username: input.github_username ?? null,
-    submitter_ip: input.submitter_ip ?? null,
-  };
-  await db`
-    insert into skill_history (skill_id, action, snapshot)
-    values (${skill.id}, 'created', ${JSON.stringify(snapshot)}::jsonb)
-  `;
-
+  if (!skill) throw new Error("Catalog transaction returned no skill row.");
   return skill;
 }
 

--- a/apps/nest-dashboard/tests/skill-catalog.test.tsx
+++ b/apps/nest-dashboard/tests/skill-catalog.test.tsx
@@ -193,6 +193,7 @@ const overlongFields = [
   ["name", "n".repeat(201)],
   ["author", "a".repeat(201)],
   ["email", `${"e".repeat(243)}@example.test`],
+  ["github_username", "g".repeat(40)],
   ["description", "d".repeat(2_001)],
   ["source_url", `https://example.test/${"u".repeat(2_029)}`],
   ["content", "c".repeat(200_001)],

--- a/apps/nest-dashboard/tests/skill-catalog.test.tsx
+++ b/apps/nest-dashboard/tests/skill-catalog.test.tsx
@@ -2,7 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { NextRequest } from "next/server";
 import { beforeEach, expect, test, vi } from "vitest";
 import type { NewSkill, Skill } from "../src/lib/skills";
-import { POST } from "../src/app/api/skills/route";
+import { GET, POST } from "../src/app/api/skills/route";
 import { submitSkill } from "../src/app/skills/actions";
 import { initialSubmitState } from "../src/app/skills/form-state";
 import SkillsPage from "../src/app/skills/page";
@@ -58,6 +58,29 @@ function request(body: unknown): NextRequest {
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
   });
+}
+
+function streamedRequest(body: string, chunkSize = 16_384): NextRequest {
+  const bytes = new TextEncoder().encode(body);
+  let offset = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (offset >= bytes.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(bytes.slice(offset, offset + chunkSize));
+      offset += chunkSize;
+    },
+  });
+  const init = {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: stream,
+    // Node's Request implementation requires this for a streaming body.
+    duplex: "half",
+  } as unknown as ConstructorParameters<typeof NextRequest>[1];
+  return new NextRequest("http://localhost/api/skills", init);
 }
 
 function form(fields: Record<string, string>): FormData {
@@ -132,6 +155,86 @@ test("pasted content needs no source URL or network check in either path", async
   }));
   expect(fetch).not.toHaveBeenCalled();
 });
+
+test("listing API preserves the complete catalog response", async () => {
+  const pasted: Skill = {
+    ...skill,
+    id: "836fc817-9ca4-4b07-a1b3-a06227e2fa51",
+    name: "Pasted skill",
+    source_type: "content",
+    source_url: null,
+    content: "# Pasted skill\n\nComplete catalog content.",
+  };
+  external.listSkillsCached.mockResolvedValue([skill, pasted]);
+
+  const response = await GET();
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ count: 2, skills: [skill, pasted] });
+});
+
+test("API stops an oversized streamed request before parsing or saving it", async () => {
+  const body = JSON.stringify({
+    name: skill.name,
+    source_type: "url",
+    source_url: skill.source_url,
+    padding: "x".repeat(300_000),
+  });
+
+  const response = await POST(streamedRequest(body));
+
+  expect(response.status).toBe(413);
+  expect((await response.json()).error).toMatch(/too large/i);
+  expect(external.createSkill).not.toHaveBeenCalled();
+  expect(fetch).not.toHaveBeenCalled();
+});
+
+const overlongFields = [
+  ["name", "n".repeat(201)],
+  ["author", "a".repeat(201)],
+  ["email", `${"e".repeat(243)}@example.test`],
+  ["description", "d".repeat(2_001)],
+  ["source_url", `https://example.test/${"u".repeat(2_029)}`],
+  ["content", "c".repeat(200_001)],
+  ["endpoints", "e".repeat(8_193)],
+  ["tags", "t".repeat(513)],
+] as const;
+
+for (const [field, value] of overlongFields) {
+  test(`API rejects overlong ${field} before saving`, async () => {
+    const fields: Record<string, string> = {
+      name: skill.name,
+      source_type: field === "source_url" ? "url" : "content",
+      content: "# Example\n\nA complete SkillMD document.",
+      source_url: skill.source_url!,
+      [field]: value,
+    };
+
+    const response = await POST(request(fields));
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/too long/i);
+    expect(external.createSkill).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test(`form rejects overlong ${field} before saving`, async () => {
+    const fields: Record<string, string> = {
+      name: skill.name,
+      source_type: field === "source_url" ? "url" : "content",
+      content: "# Example\n\nA complete SkillMD document.",
+      source_url: skill.source_url!,
+      [field]: value,
+    };
+
+    const result = await submitSkill(initialSubmitState, form(fields));
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/too long/i);
+    expect(external.createSkill).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+}
 
 for (const sourceType of ["url", "github"] as const) {
   for (const [reachable, expected, excluded] of [

--- a/apps/nest-dashboard/tests/skill-persistence.test.ts
+++ b/apps/nest-dashboard/tests/skill-persistence.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import type { Skill } from "@/lib/skills";
+
+type Query = { text: string; values: unknown[] };
+type State = { skills: Skill[]; history: Record<string, unknown>[] };
+
+const database = vi.hoisted(() => ({
+  ensureSchema: vi.fn(async () => undefined),
+  sql: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => database);
+
+import { createSkill } from "@/lib/skills";
+
+let state: State;
+let failHistory: boolean;
+
+function normalizedSql(strings: TemplateStringsArray): string {
+  return strings.join(" ? ").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function execute(query: Query, target: State): unknown[] {
+  if (query.text.startsWith("insert into skills")) {
+    const explicitId = query.text.includes("(id, name");
+    const values = explicitId ? query.values : ["database-generated-id", ...query.values];
+    const [id, name, author, description, sourceType, sourceUrl, content, endpoints, tags, reachable] = values;
+    const row: Skill = {
+      id: String(id),
+      name: String(name),
+      author: author as string | null,
+      description: description as string | null,
+      source_type: sourceType as Skill["source_type"],
+      source_url: sourceUrl as string | null,
+      content: content as string | null,
+      endpoints: endpoints as string | null,
+      tags: tags as string | null,
+      reachable: reachable as boolean | null,
+      created_at: "2026-09-04T12:00:00.000Z",
+    };
+    target.skills.push(row);
+    return [row];
+  }
+
+  if (query.text.startsWith("insert into skill_history")) {
+    if (failHistory) throw new Error("history unavailable");
+    target.history.push({ skill_id: query.values.at(-1) });
+    return [];
+  }
+
+  throw new Error(`Unexpected query: ${query.text}`);
+}
+
+function fakeDatabase() {
+  const direct = (strings: TemplateStringsArray, ...values: unknown[]) =>
+    Promise.resolve(execute({ text: normalizedSql(strings), values }, state));
+
+  direct.transaction = async (
+    build: (tx: (strings: TemplateStringsArray, ...values: unknown[]) => Query) => Query[],
+  ) => {
+    const pending: State = {
+      skills: [...state.skills],
+      history: [...state.history],
+    };
+    const tx = (strings: TemplateStringsArray, ...values: unknown[]): Query => ({
+      text: normalizedSql(strings),
+      values,
+    });
+    const results = build(tx).map((query) => execute(query, pending));
+    state = pending;
+    return results;
+  };
+
+  return direct;
+}
+
+beforeEach(() => {
+  state = { skills: [], history: [] };
+  failHistory = false;
+  database.sql.mockReturnValue(fakeDatabase());
+});
+
+const input = {
+  name: "Atomic example",
+  source_type: "content" as const,
+  content: "# Atomic example\n\nA complete SkillMD document.",
+};
+
+test("catalog creation and its history record commit together", async () => {
+  const created = await createSkill(input);
+
+  expect(created.name).toBe(input.name);
+  expect(state.skills).toHaveLength(1);
+  expect(state.history).toHaveLength(1);
+});
+
+test("a history failure leaves no catalog row behind", async () => {
+  failHistory = true;
+
+  await expect(createSkill(input)).rejects.toThrow("history unavailable");
+  expect(state.skills).toEqual([]);
+  expect(state.history).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- Bound streamed JSON request bodies and individual catalog fields before any database work, with shared validation for the API and submission form.
- Commit a new catalog entry and its history atomically using the existing Neon transaction API; a history failure cannot leave a partial write.
- Preserve the no-fetch boundary for URL/GitHub entries and the existing complete-response listing API.

## Scope and limits

This fixes the current catalog boundary, not skill installation, authorization, verification or agent execution. Global pagination, admission/rate policy and production database limits remain separate decisions. Tests use a stateful transaction fake; no live Neon database or production catalog was modified.

## Verification

Base: `53178b9c780d7a7dd6ce723131c4250de03908dd` (fresh `origin/main`).

On this standalone branch, Node 22.23.2:
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm test` — 66 passed.
- `npm run typecheck` — passed.
- `git diff --check` — clean.

Regressions were observed failing before the fixes. Independent review checked request bounds, private/public fields, no-fetch behavior and rollback. Combined remediation validation separately passed 71 dashboard tests, typecheck, lint and production build. The current-manual PR introduces the lint/build CI gates; this PR does not suppress existing lint errors.
