### PR TITLE
fix(imports): preserve pinned snapshots and disclose incomplete imports

### DIFF
--- a/src/nandatown/onramp.py
+++ b/src/nandatown/onramp.py
@@ -215,10 +215,29 @@ def onramp(spec_path: str, name: str | None = None,
     subject = f"{name}@{snapshot_fp}"
 
     candidate_dir = os.path.join(out_dir, name)
-    os.makedirs(candidate_dir, exist_ok=True)
     ext = "yaml" if spec_path.endswith((".yaml", ".yml")) else "json"
-    with open(os.path.join(candidate_dir, f"snapshot.{ext}"), "w") as f:
-        f.write(raw)
+    if os.path.lexists(candidate_dir):
+        try:
+            if os.path.islink(candidate_dir) or not os.path.isdir(candidate_dir):
+                raise ValueError("not a candidate directory")
+            release_path = os.path.join(candidate_dir, "release.json")
+            snapshot_path = os.path.join(candidate_dir, f"snapshot.{ext}")
+            if os.path.islink(release_path) or os.path.islink(snapshot_path):
+                raise ValueError("candidate contains a symbolic link")
+            with open(release_path) as f:
+                previous = ReleaseRef.model_validate_json(f.read())
+            if previous.content_fingerprint != snapshot_fp:
+                raise OnrampError(
+                    f"{name!r} already has a different pinned snapshot;"
+                    " choose a new --name or --out directory")
+            with open(snapshot_path) as f:
+                if f.read() != raw:
+                    raise ValueError("snapshot differs from its release")
+        except (OSError, ValueError) as exc:
+            raise OnrampError(
+                f"{candidate_dir} already exists and cannot be reused: {exc};"
+                " choose a new --name or --out directory") from exc
+        return candidate_dir
 
     skill_text = generate_skillmd(name, analysis)
     from .skills import validate_skill
@@ -226,6 +245,13 @@ def onramp(spec_path: str, name: str | None = None,
     if problems:
         raise OnrampError(f"generated SKILL.md failed validation:"
                           f" {problems}")
+    try:
+        os.makedirs(candidate_dir, exist_ok=False)
+    except FileExistsError as exc:
+        raise OnrampError(f"{candidate_dir} already exists; retry with a"
+                          " new --name or --out directory") from exc
+    with open(os.path.join(candidate_dir, f"snapshot.{ext}"), "w") as f:
+        f.write(raw)
     with open(os.path.join(candidate_dir, "SKILL.md"), "w") as f:
         f.write(skill_text)
 

--- a/src/nandatown/onramp.py
+++ b/src/nandatown/onramp.py
@@ -213,6 +213,9 @@ def onramp(spec_path: str, name: str | None = None,
     name = slugify(name or analysis["title"])
     snapshot_fp = fingerprint(raw)
     subject = f"{name}@{snapshot_fp}"
+    release = ReleaseRef(kind="service", name=name,
+                         version=analysis["version"],
+                         content_fingerprint=snapshot_fp)
 
     candidate_dir = os.path.join(out_dir, name)
     ext = "yaml" if spec_path.endswith((".yaml", ".yml")) else "json"
@@ -230,6 +233,8 @@ def onramp(spec_path: str, name: str | None = None,
                 raise OnrampError(
                     f"{name!r} already has a different pinned snapshot;"
                     " choose a new --name or --out directory")
+            if previous != release:
+                raise ValueError("release does not match the requested candidate")
             with open(snapshot_path) as f:
                 if f.read() != raw:
                     raise ValueError("snapshot differs from its release")
@@ -255,9 +260,6 @@ def onramp(spec_path: str, name: str | None = None,
     with open(os.path.join(candidate_dir, "SKILL.md"), "w") as f:
         f.write(skill_text)
 
-    release = ReleaseRef(kind="service", name=name,
-                         version=analysis["version"],
-                         content_fingerprint=snapshot_fp)
     with open(os.path.join(candidate_dir, "release.json"), "w") as f:
         f.write(release.model_dump_json(indent=2))
 

--- a/src/nandatown/protocols.py
+++ b/src/nandatown/protocols.py
@@ -16,6 +16,7 @@ import base64
 import json
 import os
 import re
+import shlex
 import time
 from typing import Any
 
@@ -189,17 +190,18 @@ def usage_recipe(protocol_dir: str,
                  classification: dict[str, list[dict]]) -> list[str]:
     lines = []
     for plugin in classification["plugins"]:
-        flags = f"--plugin {os.path.join(protocol_dir, plugin['path'])}"
+        argv = ["nandatown", "run", "marketplace", "--plugin",
+                os.path.join(protocol_dir, plugin["path"])]
         for reg in plugin["registrations"]:
-            flags += f" --layer {reg['layer']}={reg['plugin_id']}"
-        lines.append(f"nandatown run marketplace {flags}")
+            argv.extend(["--layer", f"{reg['layer']}={reg['plugin_id']}"])
+        lines.append(shlex.join(argv))
     for scenario in classification["scenarios"]:
-        lines.append(
-            f"nandatown run {os.path.join(protocol_dir, scenario['path'])}")
+        lines.append(shlex.join([
+            "nandatown", "run", os.path.join(protocol_dir, scenario["path"])]))
     for skill in classification["skills"]:
-        lines.append(
-            "nandatown skills --validate"
-            f" {os.path.join(protocol_dir, skill['path'])}")
+        lines.append(shlex.join([
+            "nandatown", "skills", "--validate",
+            os.path.join(protocol_dir, skill["path"])]))
     return lines
 
 
@@ -207,25 +209,42 @@ def import_pr(number: int, repo: str = DEFAULT_REPO,
               out_dir: str = "protocols",
               http: httpx.Client | None = None) -> str:
     pr = fetch_pr(repo, number, http=http)
-    classification = classify(pr["files"])
-    checks = structural_checks(pr, classification)
     name = f"{number}-{slugify(pr['title'])[:40]}"
     protocol_dir = os.path.join(out_dir, name)
+    if os.path.islink(protocol_dir):
+        raise ProtocolImportError("snapshot directory is a symbolic link")
+    for metadata_name in ("metadata.json", "checks.jsonl"):
+        if os.path.islink(os.path.join(protocol_dir, metadata_name)):
+            raise ProtocolImportError("snapshot metadata is a symbolic link")
+    if os.path.islink(os.path.join(out_dir, "catalog.json")):
+        raise ProtocolImportError("catalog is a symbolic link")
     os.makedirs(protocol_dir, exist_ok=True)
 
     root = os.path.abspath(protocol_dir)
     safe_files = []
     for f in pr["files"]:
         dest = os.path.abspath(os.path.join(root, f["path"]))
-        if os.path.commonpath([root, dest]) != root:
+        if (os.path.isabs(f["path"]) or dest == root
+                or os.path.commonpath([root, dest]) != root):
             pr["skipped"].append(f"{f['path']} (path escapes the"
                                  " snapshot directory)")
+            continue
+        relative = os.path.relpath(dest, root)
+        parts = relative.split(os.sep)
+        if parts[0] in {"metadata.json", "checks.jsonl"}:
+            pr["skipped"].append(f"{f['path']} (reserved snapshot metadata)")
+            continue
+        if any(os.path.islink(os.path.join(root, *parts[:n]))
+               for n in range(1, len(parts) + 1)):
+            pr["skipped"].append(f"{f['path']} (symbolic link in snapshot path)")
             continue
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         with open(dest, "w") as fh:
             fh.write(f["content"])
         safe_files.append(f)
     pr["files"] = safe_files
+    classification = classify(pr["files"])
+    checks = structural_checks(pr, classification)
 
     content_fp = fingerprint([{f["path"]: f["content"]}
                               for f in pr["files"]])

--- a/src/nandatown/protocols.py
+++ b/src/nandatown/protocols.py
@@ -52,6 +52,14 @@ def _client(http: httpx.Client | None) -> httpx.Client:
 def fetch_pr(repo: str, number: int,
              http: httpx.Client | None = None) -> dict[str, Any]:
     client = _client(http)
+    try:
+        return _fetch_pr(repo, number, client)
+    finally:
+        if http is None:
+            client.close()
+
+
+def _fetch_pr(repo: str, number: int, client: httpx.Client) -> dict[str, Any]:
     r = client.get(f"/repos/{repo}/pulls/{number}")
     if r.status_code == 404:
         raise ProtocolImportError(f"no PR #{number} in {repo}")
@@ -61,7 +69,7 @@ def fetch_pr(repo: str, number: int,
     head_repo = (pr["head"].get("repo") or {}).get("full_name", repo)
 
     files_response = client.get(f"/repos/{repo}/pulls/{number}/files",
-                                params={"per_page": MAX_FILES})
+                                params={"per_page": MAX_FILES + 1})
     files_response.raise_for_status()
     listed = files_response.json()
     skipped = []
@@ -88,9 +96,13 @@ def fetch_pr(repo: str, number: int,
             skipped.append(f"{path} (not text)")
             continue
         files.append({"path": path, "content": content})
-    if len(listed) > MAX_FILES:
-        skipped.append(f"{len(listed) - MAX_FILES} further files beyond"
-                       f" the {MAX_FILES} file cap")
+    total = pr.get("changed_files")
+    if isinstance(total, int) and not isinstance(total, bool) and total > MAX_FILES:
+        skipped.append(f"{total - MAX_FILES} further files beyond"
+                       f" the {MAX_FILES} file cap; snapshot is partial")
+    elif len(listed) > MAX_FILES:
+        skipped.append(f"additional files beyond the {MAX_FILES} file cap;"
+                       " snapshot is partial")
     return {
         "repo": repo,
         "number": number,
@@ -143,7 +155,8 @@ def structural_checks(pr: dict[str, Any],
             at=time.time(), evidence=evidence[:8]))
 
     add("files-fetched",
-        "passed" if pr["files"] else "failed",
+        ("failed" if not pr["files"] else
+         "not_enough_evidence" if pr["skipped"] else "passed"),
         [f"{len(pr['files'])} files at {pr['head_sha'][:12]}"]
         + pr["skipped"])
 

--- a/tests/test_onramp.py
+++ b/tests/test_onramp.py
@@ -126,6 +126,24 @@ def test_onramp_does_not_write_through_a_candidate_symlink(tmp_path):
     assert list(other.iterdir()) == []
 
 
+@pytest.mark.parametrize("field,value", [("kind", "profile"), ("name", "other"),
+                                         ("version", "999")])
+def test_onramp_reuse_binds_the_complete_release(tmp_path, field, value):
+    candidate = Path(onramp(FIXTURE, out_dir=str(tmp_path)))
+    path = candidate / "release.json"
+    release = json.loads(path.read_text())
+    release[field] = value
+    path.write_text(json.dumps(release))
+    before = {file.relative_to(tmp_path): file.read_bytes()
+              for file in tmp_path.rglob("*") if file.is_file()}
+
+    with pytest.raises(OnrampError, match="release"):
+        onramp(FIXTURE, out_dir=str(tmp_path))
+
+    assert before == {file.relative_to(tmp_path): file.read_bytes()
+                      for file in tmp_path.rglob("*") if file.is_file()}
+
+
 def test_embedded_secret_is_caught(tmp_path):
     with open(FIXTURE) as f:
         spec = json.load(f)

--- a/tests/test_onramp.py
+++ b/tests/test_onramp.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 
 import pytest
 
@@ -59,6 +60,70 @@ def test_fingerprint_stability_and_catalog(tmp_path):
     assert len(entries) == 1
     assert entries[0]["fingerprint"] == first
     assert entries[0]["status"] == "candidate-unclaimed"
+
+
+def test_onramp_refuses_to_replace_a_different_pinned_snapshot(tmp_path):
+    output = tmp_path / "services"
+    candidate = Path(onramp(FIXTURE, out_dir=str(output)))
+    before = {path.relative_to(output): path.read_bytes()
+              for path in output.rglob("*") if path.is_file()}
+    changed = json.loads(Path(FIXTURE).read_text())
+    changed["info"]["version"] = "2.0"
+    source = tmp_path / "changed.json"
+    source.write_text(json.dumps(changed))
+
+    with pytest.raises(OnrampError, match="different.*snapshot"):
+        onramp(str(source), name="paylite", out_dir=str(output))
+
+    assert candidate.is_dir()
+    assert before == {path.relative_to(output): path.read_bytes()
+                      for path in output.rglob("*") if path.is_file()}
+
+
+def test_identical_onramp_is_read_only(tmp_path):
+    output = tmp_path / "services"
+    candidate = onramp(FIXTURE, out_dir=str(output))
+    before = {path.relative_to(output): path.read_bytes()
+              for path in output.rglob("*") if path.is_file()}
+
+    assert onramp(FIXTURE, out_dir=str(output)) == candidate
+
+    assert before == {path.relative_to(output): path.read_bytes()
+                      for path in output.rglob("*") if path.is_file()}
+
+
+def test_onramp_refuses_an_existing_unrecognized_directory(tmp_path):
+    candidate = tmp_path / "paylite"
+    candidate.mkdir()
+    (candidate / "SKILL.md").write_text("user work")
+
+    with pytest.raises(OnrampError, match="already exists"):
+        onramp(FIXTURE, out_dir=str(tmp_path))
+
+    assert (candidate / "SKILL.md").read_text() == "user work"
+
+
+def test_onramp_refuses_a_changed_snapshot_even_with_matching_release(tmp_path):
+    candidate = Path(onramp(FIXTURE, out_dir=str(tmp_path)))
+    (candidate / "snapshot.json").write_text("changed after import")
+
+    with pytest.raises(OnrampError, match="snapshot differs"):
+        onramp(FIXTURE, out_dir=str(tmp_path))
+
+    assert (candidate / "snapshot.json").read_text() == "changed after import"
+
+
+def test_onramp_does_not_write_through_a_candidate_symlink(tmp_path):
+    other = tmp_path / "user-files"
+    other.mkdir()
+    output = tmp_path / "services"
+    output.mkdir()
+    (output / "paylite").symlink_to(other, target_is_directory=True)
+
+    with pytest.raises(OnrampError, match="already exists"):
+        onramp(FIXTURE, out_dir=str(output))
+
+    assert list(other.iterdir()) == []
 
 
 def test_embedded_secret_is_caught(tmp_path):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -147,3 +147,64 @@ def test_path_traversal_is_blocked(tmp_path, monkeypatch):
 def test_missing_pr_fails_cleanly():
     with pytest.raises(ProtocolImportError):
         fetch_pr("projnanda/nandatown", 404, http=fake_github(FILES))
+
+
+def test_fetch_discloses_files_beyond_github_page_limit():
+    contents_requested = []
+
+    def responder(request):
+        path = request.url.path
+        if path.endswith("/pulls/321"):
+            return httpx.Response(200, json={
+                "title": "Large contribution", "state": "open", "changed_files": 100,
+                "user": {"login": "contributor"},
+                "head": {"sha": "abc123", "repo": {"full_name": "contributor/nandatown"}},
+            })
+        if path.endswith("/files"):
+            page_size = int(request.url.params["per_page"])
+            return httpx.Response(200, json=[
+                {"filename": f"file-{n}.py", "status": "added"}
+                for n in range(page_size)])
+        contents_requested.append(path)
+        return httpx.Response(200, json={"size": 3, "content": "eD0x"})
+
+    with httpx.Client(transport=httpx.MockTransport(responder),
+                      base_url="https://api.github.com") as client:
+        pr = fetch_pr("projnanda/nandatown", 321, http=client)
+
+    assert len(pr["files"]) == 50
+    assert len(contents_requested) == 50
+    assert any("50" in reason and "beyond" in reason for reason in pr["skipped"])
+
+
+def test_import_check_does_not_call_partial_snapshot_complete():
+    from nandatown.protocols import structural_checks
+
+    pr = {"repo": "projnanda/nandatown", "number": 321, "head_sha": "abc123",
+          "files": [{"path": "ok.py", "content": "x=1"}],
+          "skipped": ["unreadable.py (unreadable at the head commit)"]}
+    checks = structural_checks(pr, classify(pr["files"]))
+
+    fetched = next(check for check in checks if check.test == "files-fetched")
+    assert fetched.result == "not_enough_evidence"
+    assert "unreadable.py" in str(fetched.evidence)
+
+
+@pytest.mark.parametrize("number", [321, 404])
+def test_fetch_closes_only_the_http_client_it_owns(monkeypatch, number):
+    owned = fake_github(FILES)
+    monkeypatch.setattr("nandatown.protocols._client", lambda supplied: owned)
+    try:
+        fetch_pr("projnanda/nandatown", number)
+    except ProtocolImportError:
+        assert number == 404
+    assert owned.is_closed
+
+    borrowed = fake_github(FILES)
+    monkeypatch.setattr("nandatown.protocols._client", lambda supplied: supplied)
+    with borrowed:
+        try:
+            fetch_pr("projnanda/nandatown", number, http=borrowed)
+        except ProtocolImportError:
+            assert number == 404
+        assert not borrowed.is_closed

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -130,7 +130,7 @@ def test_path_traversal_is_blocked(tmp_path, monkeypatch):
         "repo": "projnanda/nandatown", "number": 321, "title": "evil",
         "author": "attacker", "state": "open",
         "head_sha": "abc123def4567890", "head_repo": "a/n",
-        "files": [{"path": "../../escape.py", "content": "print('out')"},
+        "files": [{"path": "../../escape.py", "content": PLUGIN_SOURCE},
                   {"path": "ok.py", "content": "x = 1"}],
         "skipped": [],
     }
@@ -142,6 +142,64 @@ def test_path_traversal_is_blocked(tmp_path, monkeypatch):
     with open(os.path.join(protocol_dir, "metadata.json")) as f:
         metadata = json.load(f)
     assert any("escapes the snapshot" in s for s in metadata["skipped"])
+    assert metadata["classification"]["plugins"] == []
+    assert metadata["usage"] == []
+    with open(os.path.join(protocol_dir, "checks.jsonl")) as f:
+        checks = [json.loads(line) for line in f]
+    assert next(check for check in checks if check["test"] == "files-fetched")["result"] == "not_enough_evidence"
+    assert protocol_entries(str(tmp_path / "protocols"))[0]["checks"]["unknown"] > 0
+
+
+def test_import_usage_quotes_literal_file_paths(tmp_path):
+    import shlex
+    name = "plugins/odd name;echo nope.py"
+    directory = import_pr(321, out_dir=str(tmp_path), http=fake_github({name: PLUGIN_SOURCE}))
+    with open(os.path.join(directory, "metadata.json")) as f:
+        metadata = json.load(f)
+
+    command = shlex.split(metadata["usage"][0])
+    assert command == ["nandatown", "run", "marketplace", "--plugin",
+                       os.path.join(directory, name), "--layer", "trust=webweight.v2"]
+
+
+def test_import_does_not_follow_existing_snapshot_symlinks(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    output = tmp_path / "protocols"
+    snapshot = output / "321-add-webweight-trust"
+    snapshot.mkdir(parents=True)
+    (snapshot / "plugins").symlink_to(outside, target_is_directory=True)
+
+    directory = import_pr(321, out_dir=str(output), http=fake_github(FILES))
+
+    assert list(outside.iterdir()) == []
+    with open(os.path.join(directory, "metadata.json")) as f:
+        metadata = json.load(f)
+    assert metadata["classification"]["plugins"] == []
+    assert any("symbolic link" in reason for reason in metadata["skipped"])
+
+
+@pytest.mark.parametrize("path", ["metadata.json", "checks.jsonl", "metadata.json/evil.py"])
+def test_import_reserves_its_metadata_paths(tmp_path, path):
+    directory = import_pr(321, out_dir=str(tmp_path),
+                          http=fake_github({path: PLUGIN_SOURCE, "ok.py": "x=1"}))
+    with open(os.path.join(directory, "metadata.json")) as f:
+        metadata = json.load(f)
+    assert metadata["classification"]["plugins"] == []
+    assert any("reserved snapshot metadata" in reason for reason in metadata["skipped"])
+
+
+@pytest.mark.parametrize("path", ["metadata.json", "checks.jsonl", "../catalog.json"])
+def test_import_does_not_write_through_metadata_symlinks(tmp_path, path):
+    outside = tmp_path / "outside"
+    outside.write_text("preserve")
+    output = tmp_path / "protocols"
+    snapshot = output / "321-add-webweight-trust"
+    snapshot.mkdir(parents=True)
+    (snapshot / path).symlink_to(outside)
+    with pytest.raises(ProtocolImportError, match="symbolic link"):
+        import_pr(321, out_dir=str(output), http=fake_github(FILES))
+    assert outside.read_text() == "preserve"
 
 
 def test_missing_pr_fails_cleanly():


### PR DESCRIPTION
## Summary

- Refuse silent replacement of an on-ramp snapshot and validate the full pinned release reference on an idempotent re-import.
- Disclose omitted PR files and inconclusive partial coverage instead of describing a bounded snapshot as complete.
- Derive classifications, checks and suggested commands only from safely retained files; quote command paths and reject unsafe filesystem/metadata targets.
- Close owned HTTP clients without closing caller-owned clients.

Importing remains review/discovery, not authorization to execute untrusted plugins or a claim that a legacy contribution works in current Town.

## Verification

Fresh standalone base: `53178b9c780d7a7dd6ce723131c4250de03908dd`.
- `python -m pytest -q` on Python 3.12 — fresh full rerun 675 passed, 8 existing warnings.
- Initial run: `tests/test_participants.py::test_buyer_and_seller_complete_clean_run` observed zero seller acknowledgments where one was expected (`1 failed, 674 passed`). The unchanged test then passed 10/10 in isolation and the fresh full suite passed 675/675, consistent with its existing unjoined-thread timing race. No out-of-scope test or runtime change was made in this PR.
- `git diff --check` — clean.
- Added regressions failed before implementation; independent review also caught and verified corrections for rejected files influencing commands and incomplete release-reference checks.

Combined remediation separately passed 817 tests on Python 3.12 and a clean Python 3.11 wheel. No upstream PR content is executed merely by importing it.
