### PR TITLE
fix(runtime): serialize mailbox work and settle participant processes

### DIFF
--- a/src/nandatown/coordinator.py
+++ b/src/nandatown/coordinator.py
@@ -286,10 +286,6 @@ def build_app(db_path: str, admin_token: str) -> FastAPI:
                                     lease_seconds=state["lease"], now=now)
                 if result is not None:
                     state["fired"] = True
-                    db.record_event(run_id, observer="town",
-                                    kind="duplicate_offered", subject=done,
-                                    at=now, detail={"fault":
-                                                    "duplicate_delivery"})
         if result is None:
             from fastapi import Response
             return Response(status_code=204)

--- a/src/nandatown/coordinator.py
+++ b/src/nandatown/coordinator.py
@@ -21,9 +21,10 @@ import uuid
 from typing import Any
 
 from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from .db import IdentityReuse, StaleFence, TownDB
+from .db import IdentityReuse, RunFinished, StaleFence, TownDB
 from .records import TestProfile, fingerprint
 
 ACK_STATUSES = {"received", "processed", "rejected", "retryable", "failed"}
@@ -69,6 +70,14 @@ def build_app(db_path: str, admin_token: str) -> FastAPI:
     db = TownDB(db_path)
     # Fault bookkeeping per run: each fault fires at most once.
     faults: dict[str, dict[str, Any]] = {}
+
+    @app.exception_handler(RunFinished)
+    async def run_finished(_request, exc: RunFinished):
+        return JSONResponse(
+            status_code=409,
+            content={"detail": {"error": "run_finished",
+                                "run_id": exc.run_id}},
+        )
 
     def deny(run_id: str, name: str, permission: str, now: float) -> None:
         """A refused action is evidence: record it, then refuse."""
@@ -336,9 +345,10 @@ def build_app(db_path: str, admin_token: str) -> FastAPI:
 
     @app.post("/runs/{run_id}/finish", dependencies=[Depends(require_admin)])
     def finish(run_id: str):
-        db.set_run_status(run_id, "finished")
-        db.record_event(run_id, observer="town", kind="run_finished",
-                        subject=run_id, at=time.time())
+        try:
+            db.finish_run(run_id, now=time.time())
+        except KeyError:
+            raise HTTPException(status_code=404, detail="unknown run")
         return {"finished": True}
 
     return app

--- a/src/nandatown/db.py
+++ b/src/nandatown/db.py
@@ -392,6 +392,7 @@ class TownDB:
                    now: float) -> dict[str, Any] | None:
         """Claim one bounded piece of work for a limited time."""
         with self._conn() as conn:
+            conn.execute("BEGIN IMMEDIATE")
             self._expire_stale_claims(conn, run_id, now)
             row = conn.execute(
                 "SELECT * FROM messages WHERE run_id=? AND recipient=?"
@@ -403,11 +404,13 @@ class TownDB:
             attempt = row["attempts"] + 1
             fence = "fence-" + uuid.uuid4().hex
             lease_expires_at = now + lease_seconds
-            conn.execute(
+            updated = conn.execute(
                 "UPDATE messages SET status='claimed', attempts=? WHERE run_id=?"
-                " AND message_id=?",
+                " AND message_id=? AND status='accepted'",
                 (attempt, run_id, row["message_id"]),
             )
+            if updated.rowcount != 1:
+                return None
             conn.execute(
                 "INSERT INTO claims (run_id, message_id, claimant, fence,"
                 " lease_expires_at, attempt) VALUES (?,?,?,?,?,?)",
@@ -467,6 +470,7 @@ class TownDB:
             status: str, note: dict, now: float) -> None:
         """Acknowledge claimed work. A stale or expired fence is rejected."""
         with self._conn() as conn:
+            conn.execute("BEGIN IMMEDIATE")
             claim = conn.execute(
                 "SELECT * FROM claims WHERE run_id=? AND message_id=?"
                 " AND fence=? AND claimant=?",
@@ -491,30 +495,44 @@ class TownDB:
                 self._event(conn, run_id, now, "town", "stale_fence_rejected",
                             message_id,
                             {"participant": participant, "fence": fence})
-        if stale:
-            raise StaleFence(fence)
-        with self._conn() as conn:
-            conn.execute("UPDATE claims SET active=0 WHERE claim_seq=?",
-                         (claim["claim_seq"],))
-            if status == "retryable":
-                new_status, done = "accepted", None
             else:
-                new_status, done = "done", status
-            conn.execute(
-                "UPDATE messages SET status=?, done_status=? WHERE run_id=?"
-                " AND message_id=? AND status IN ('claimed','done')",
-                (new_status, done, run_id, message_id),
-            )
-            conn.execute(
-                "INSERT INTO acks (run_id, message_id, participant, fence,"
-                " status, note_json, at) VALUES (?,?,?,?,?,?,?)",
-                (run_id, message_id, participant, fence, status,
-                 json.dumps(note), now),
-            )
-            self._event(conn, run_id, now, participant, "ack_recorded",
+                deactivated = conn.execute(
+                    "UPDATE claims SET active=0 WHERE claim_seq=? AND active=1"
+                    " AND lease_expires_at>=?",
+                    (claim["claim_seq"], now),
+                )
+                if deactivated.rowcount != 1:
+                    stale = True
+                    self._event(
+                        conn, run_id, now, "town", "stale_fence_rejected",
+                        message_id,
+                        {"participant": participant, "fence": fence},
+                    )
+                else:
+                    if status == "retryable":
+                        new_status, done = "accepted", None
+                    else:
+                        new_status, done = "done", status
+                    conn.execute(
+                        "UPDATE messages SET status=?, done_status=?"
+                        " WHERE run_id=? AND message_id=?"
+                        " AND status IN ('claimed','done')",
+                        (new_status, done, run_id, message_id),
+                    )
+                    conn.execute(
+                        "INSERT INTO acks (run_id, message_id, participant,"
+                        " fence, status, note_json, at) VALUES (?,?,?,?,?,?,?)",
+                        (run_id, message_id, participant, fence, status,
+                         json.dumps(note), now),
+                    )
+                    self._event(
+                        conn, run_id, now, participant, "ack_recorded",
                         message_id,
                         {"status": status, "note": note, "fence": fence,
-                         "attempt": claim["attempt"]})
+                         "attempt": claim["attempt"]},
+                    )
+        if stale:
+            raise StaleFence(fence)
 
     # -- events and intents ---------------------------------------------
 

--- a/src/nandatown/db.py
+++ b/src/nandatown/db.py
@@ -26,6 +26,14 @@ class StaleFence(Exception):
     """An acknowledgement carried a fence that is no longer current."""
 
 
+class RunFinished(Exception):
+    """A mutation targeted a run whose terminal event already committed."""
+
+    def __init__(self, run_id: str):
+        super().__init__(run_id)
+        self.run_id = run_id
+
+
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS runs (
     run_id TEXT PRIMARY KEY,
@@ -152,6 +160,14 @@ class TownDB:
 
     # -- runs and participants ------------------------------------------
 
+    @staticmethod
+    def _require_open(conn, run_id: str) -> None:
+        row = conn.execute(
+            "SELECT status FROM runs WHERE run_id=?", (run_id,)
+        ).fetchone()
+        if row is not None and row["status"] == "finished":
+            raise RunFinished(run_id)
+
     def create_run(self, profile_json: str, now: float = 0.0) -> str:
         run_id = "run-" + uuid.uuid4().hex[:12]
         with self._conn() as conn:
@@ -168,9 +184,22 @@ class TownDB:
             ).fetchone()
         return json.loads(row["profile_json"]) if row else None
 
-    def set_run_status(self, run_id: str, status: str) -> None:
+    def finish_run(self, run_id: str, now: float) -> bool:
+        """Commit the finished state and sole terminal event together."""
         with self._conn() as conn:
-            conn.execute("UPDATE runs SET status=? WHERE run_id=?", (status, run_id))
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT status FROM runs WHERE run_id=?", (run_id,)
+            ).fetchone()
+            if row is None:
+                raise KeyError(run_id)
+            if row["status"] == "finished":
+                return False
+            conn.execute(
+                "UPDATE runs SET status='finished' WHERE run_id=?", (run_id,)
+            )
+            self._event(conn, run_id, now, "town", "run_finished", run_id, {})
+            return True
 
     def add_participant(
         self, run_id: str, name: str, role: str,
@@ -197,6 +226,8 @@ class TownDB:
         permissions_json = (None if permissions is None
                             else json.dumps(sorted(permissions)))
         with self._conn() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            self._require_open(conn, run_id)
             row = conn.execute(
                 "SELECT join_token, session, grant_issued_at"
                 " FROM participants WHERE run_id=? AND name=?",
@@ -304,6 +335,7 @@ class TownDB:
         """
         with self._conn() as conn:
             conn.execute("BEGIN IMMEDIATE")
+            self._require_open(conn, run_id)
             row = conn.execute(
                 "SELECT accepted_at, sender, recipient, kind,"
                 " content_fingerprint FROM messages"
@@ -357,6 +389,8 @@ class TownDB:
     def pop_notify(self, run_id: str, recipient: str) -> bool:
         """Consume one pending wake-up hint, if any."""
         with self._conn() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            self._require_open(conn, run_id)
             row = conn.execute(
                 "SELECT rowid FROM notifications WHERE run_id=? AND recipient=?"
                 " AND status='pending' LIMIT 1",
@@ -393,6 +427,7 @@ class TownDB:
         """Claim one bounded piece of work for a limited time."""
         with self._conn() as conn:
             conn.execute("BEGIN IMMEDIATE")
+            self._require_open(conn, run_id)
             self._expire_stale_claims(conn, run_id, now)
             row = conn.execute(
                 "SELECT * FROM messages WHERE run_id=? AND recipient=?"
@@ -436,6 +471,8 @@ class TownDB:
                 lease_seconds: float, now: float) -> dict[str, Any] | None:
         """Offer already-completed work one more time (duplicate delivery)."""
         with self._conn() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            self._require_open(conn, run_id)
             row = conn.execute(
                 "SELECT * FROM messages WHERE run_id=? AND message_id=?"
                 " AND recipient=?",
@@ -471,6 +508,7 @@ class TownDB:
         """Acknowledge claimed work. A stale or expired fence is rejected."""
         with self._conn() as conn:
             conn.execute("BEGIN IMMEDIATE")
+            self._require_open(conn, run_id)
             claim = conn.execute(
                 "SELECT * FROM claims WHERE run_id=? AND message_id=?"
                 " AND fence=? AND claimant=?",
@@ -548,6 +586,8 @@ class TownDB:
     def record_event(self, run_id: str, observer: str, kind: str, subject: str,
                      at: float, detail: dict | None = None) -> str:
         with self._conn() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            self._require_open(conn, run_id)
             return self._event(conn, run_id, at, observer, kind, subject,
                                detail or {})
 
@@ -566,6 +606,8 @@ class TownDB:
     def record_intent(self, run_id: str, actor: str, action: str,
                       payload: dict, at: float) -> str:
         with self._conn() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            self._require_open(conn, run_id)
             cur = conn.execute(
                 "INSERT INTO intents (run_id, at, actor, action, payload_json)"
                 " VALUES (?,?,?,?,?)",

--- a/src/nandatown/db.py
+++ b/src/nandatown/db.py
@@ -475,10 +475,20 @@ class TownDB:
             self._require_open(conn, run_id)
             row = conn.execute(
                 "SELECT * FROM messages WHERE run_id=? AND message_id=?"
-                " AND recipient=?",
+                " AND recipient=? AND status='done'",
                 (run_id, message_id, claimant),
             ).fetchone()
             if row is None:
+                return None
+            active = conn.execute(
+                "SELECT 1 FROM claims WHERE run_id=? AND message_id=?"
+                " AND active=1 LIMIT 1", (run_id, message_id),
+            ).fetchone()
+            offered = conn.execute(
+                "SELECT 1 FROM events WHERE run_id=? AND subject=?"
+                " AND kind='duplicate_offered' LIMIT 1", (run_id, message_id),
+            ).fetchone()
+            if active or offered:
                 return None
             attempt = row["attempts"] + 1
             fence = "fence-" + uuid.uuid4().hex
@@ -492,6 +502,10 @@ class TownDB:
                 (run_id, message_id, claimant, fence, now + lease_seconds,
                  attempt),
             )
+            # The event is also the durable one-shot marker. It must commit
+            # with the fence, not through the coordinator's in-memory flag.
+            self._event(conn, run_id, now, "town", "duplicate_offered",
+                        message_id, {"fault": "duplicate_delivery"})
             return {
                 "message_id": row["message_id"],
                 "kind": row["kind"],

--- a/src/nandatown/mcp_adapter.py
+++ b/src/nandatown/mcp_adapter.py
@@ -14,12 +14,19 @@ handshake against any external MCP server and reports what it found.
 from __future__ import annotations
 
 import json
+import os
+import queue
+import signal
+import subprocess
 import sys
+import threading
+import time
 from typing import Any
 
 from . import __version__
 
 PROTOCOL_VERSION = "2025-06-18"
+MAX_PROBE_RESPONSE_BYTES = 1024 * 1024
 
 TOOLS = [
     {"name": "town_status",
@@ -169,21 +176,107 @@ class MCPTownServer:
                 stdout.flush()
 
 
-def probe(command: list[str], timeout: float = 15.0) -> dict[str, Any]:
-    """Client side of the handshake against any external MCP server."""
-    import subprocess
+class _ProbeFailure(Exception):
+    pass
 
+
+def _stop_probe_process(process: subprocess.Popen) -> None:
+    """Stop the probe and its process group on POSIX.
+
+    Non-POSIX platforms fall back to stopping the direct child because
+    Python does not expose one portable descendant-process primitive.
+    """
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    elif process.poll() is None:
+        process.terminate()
+    try:
+        process.wait(timeout=0.2)
+    except subprocess.TimeoutExpired:
+        pass
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    elif process.poll() is None:
+        process.kill()
+    try:
+        process.wait(timeout=1.0)
+    except subprocess.TimeoutExpired:
+        pass
+    for stream in (process.stdin, process.stdout):
+        if stream is not None:
+            stream.close()
+
+
+def probe(command: list[str], timeout: float = 15.0) -> dict[str, Any]:
+    """Client side of the handshake against any external MCP server.
+
+    ``timeout`` is one wall-clock deadline for the entire handshake, not a
+    per-read timeout. Responses are line-delimited and individually bounded.
+    """
     report: dict[str, Any] = {"ok": False, "problems": []}
-    process = subprocess.Popen(command, stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE, text=True)
+    deadline = time.monotonic() + max(timeout, 0.0)
+    process = subprocess.Popen(
+        command, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+        start_new_session=(os.name == "posix"))
+    responses: queue.Queue[bytes | BaseException | None] = queue.Queue()
+
+    def read_responses() -> None:
+        assert process.stdout is not None
+        try:
+            while True:
+                line = process.stdout.readline(MAX_PROBE_RESPONSE_BYTES + 1)
+                if not line:
+                    responses.put(None)
+                    return
+                if len(line) > MAX_PROBE_RESPONSE_BYTES:
+                    responses.put(_ProbeFailure(
+                        "MCP response is too large (limit 1048576 bytes)"))
+                    return
+                responses.put(line)
+        except (OSError, ValueError) as exc:
+            responses.put(exc)
+
+    reader = threading.Thread(target=read_responses, daemon=True)
+    reader.start()
 
     def rpc(message: dict[str, Any]) -> dict[str, Any] | None:
-        process.stdin.write(json.dumps(message) + "\n")
-        process.stdin.flush()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise _ProbeFailure("MCP probe timed out")
+        assert process.stdin is not None
+        try:
+            process.stdin.write((json.dumps(message) + "\n").encode())
+            process.stdin.flush()
+        except (BrokenPipeError, OSError) as exc:
+            raise _ProbeFailure("MCP server closed stdin") from exc
         if "id" not in message:
             return None
-        line = process.stdout.readline()
-        return json.loads(line) if line else None
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise _ProbeFailure("MCP probe timed out")
+        try:
+            response = responses.get(timeout=remaining)
+        except queue.Empty as exc:
+            raise _ProbeFailure("MCP probe timed out") from exc
+        if isinstance(response, BaseException):
+            if isinstance(response, _ProbeFailure):
+                raise response
+            raise _ProbeFailure("could not read MCP response") from response
+        if response is None:
+            raise _ProbeFailure("MCP server closed stdout")
+        try:
+            decoded = json.loads(response)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise _ProbeFailure("MCP server returned malformed JSON") from exc
+        if not isinstance(decoded, dict):
+            raise _ProbeFailure("MCP server returned non-object JSON")
+        return decoded
 
     try:
         init = rpc({"jsonrpc": "2.0", "id": 1, "method": "initialize",
@@ -217,12 +310,12 @@ def probe(command: list[str], timeout: float = 15.0) -> dict[str, Any]:
                     f"tool {tool.get('name')} has no input schema")
         report["ok"] = not report["problems"]
         return report
+    except _ProbeFailure as exc:
+        report["problems"].append(str(exc))
+        return report
     finally:
-        process.terminate()
-        try:
-            process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            process.kill()
+        _stop_probe_process(process)
+        reader.join(timeout=0.2)
 
 
 def main() -> None:

--- a/src/nandatown/mcp_adapter.py
+++ b/src/nandatown/mcp_adapter.py
@@ -186,6 +186,8 @@ def _stop_probe_process(process: subprocess.Popen) -> None:
     Non-POSIX platforms fall back to stopping the direct child because
     Python does not expose one portable descendant-process primitive.
     """
+    # Reap an already-exited group leader before addressing its process group.
+    process.poll()
     if os.name == "posix":
         try:
             os.killpg(process.pid, signal.SIGTERM)

--- a/src/nandatown/runner.py
+++ b/src/nandatown/runner.py
@@ -94,6 +94,9 @@ def _stop_process(process: subprocess.Popen, grace: float = 0.5) -> int | None:
     Other platforms use a direct-child fallback; Python has no portable
     descendant-process primitive.
     """
+    # Reap an already-exited group leader first. Darwin reports EPERM when
+    # killpg targets a group containing only an unreaped (defunct) leader.
+    process.poll()
     if os.name == "posix":
         try:
             os.killpg(process.pid, signal.SIGTERM)

--- a/src/nandatown/runner.py
+++ b/src/nandatown/runner.py
@@ -221,6 +221,130 @@ def _participant_command(profile: TestProfile, role: str,
             {}, kind)
 
 
+def _participant_provenance(role: str, kind: str
+                            ) -> tuple[str, dict[str, Any]]:
+    """Describe who supplied a harness without inventing its release.
+
+    Town can name the bundled module bytes it launched. An operator command,
+    manually connected participant, or remote A2A endpoint does not supply an
+    immutable participant release through the current connector contract, so
+    the record says that directly. The A2A bridge is still recorded separately
+    as the adapter Town did launch.
+    """
+    if kind in ("scripted", "llm"):
+        module = role if kind == "scripted" else "llm"
+        release = f"nandatown.participants.{module} {__version__}"
+        return release, {
+            "kind": kind,
+            "identity_basis": "bundled NANDA Town harness",
+            "release_basis": release,
+        }
+
+    external = {
+        "cmd": (
+            "external command; immutable release not recorded",
+            "operator-supplied command (command not recorded)",
+        ),
+        "external": (
+            "external participant; immutable release not recorded",
+            "operator-connected participant (software identity not supplied)",
+        ),
+        "a2a": (
+            "external A2A participant; immutable release not recorded",
+            "operator-supplied A2A endpoint (URL not recorded)",
+        ),
+    }
+    release, identity_basis = external[kind]
+    provenance: dict[str, Any] = {
+        "kind": kind,
+        "identity_basis": identity_basis,
+        "release_basis": None,
+        "release_basis_note": "immutable external release not supplied",
+    }
+    if kind == "a2a":
+        provenance["adapter_release"] = (
+            f"nandatown.participants.a2a_bridge {__version__}")
+    return release, provenance
+
+
+def _redacted_harness_spec(kind: str, supplied: str | None = None) -> str:
+    """Return connector metadata that is safe to put in run.json."""
+    if kind == "cmd":
+        return "cmd:<operator-supplied-command>"
+    if kind == "a2a":
+        return "a2a:<operator-supplied-endpoint>"
+    if kind in ("scripted", "llm", "external"):
+        return supplied or kind
+    raise RunnerError(f"unknown resolved harness kind {kind!r}")
+
+
+def _recorded_harnesses(
+        profile: TestProfile,
+        participant_kinds: dict[str, str],
+        harnesses: dict[str, str] | None,
+        external: dict[str, list[str] | None] | None) -> dict[str, str]:
+    """Record effective overrides while omitting commands and endpoints."""
+    recorded: dict[str, str] = {}
+    for role in profile.roles:
+        if harnesses and role in harnesses:
+            supplied = harnesses[role]
+        elif external and role in external:
+            supplied = None
+        else:
+            continue
+        recorded[role] = _redacted_harness_spec(
+            participant_kinds[role], supplied)
+    return recorded
+
+
+def _rerun_metadata(
+        profile: TestProfile,
+        recorded_harnesses: dict[str, str],
+        participant_kinds: dict[str, str],
+        external: dict[str, list[str] | None] | None,
+        harnesses: dict[str, str] | None,
+        identity_dir: str | None,
+        uses_llm: bool,
+        model: str) -> tuple[str, dict[str, str]]:
+    """Build a non-secret rerun recipe and list inputs Town omitted."""
+    import shlex
+
+    required = {
+        role: {
+            "cmd": "original command (not recorded)",
+            "a2a": "original A2A endpoint (URL not recorded)",
+            "external": (
+                "external participant must reconnect with fresh credentials"),
+        }[kind]
+        for role, kind in participant_kinds.items()
+        if kind in ("cmd", "a2a", "external")
+    }
+
+    # This is the public CLI path used by `test-agent --cmd/--wait`. Preserve
+    # it when possible instead of converting the rerun into a stock Track run.
+    if external and not harnesses and len(external) == 1 and not identity_dir:
+        role, command = next(iter(external.items()))
+        parts = ["nandatown", "test-agent", "--profile", profile.name,
+                 "--role", role]
+        if command is None:
+            parts.append("--wait")
+        else:
+            parts.extend(["--cmd", "<operator-supplied-command>"])
+        rerun = " ".join(shlex.quote(part) for part in parts)
+        if uses_llm and model != "mock:v1":
+            rerun = f"TOWN_MODEL={shlex.quote(model)} {rerun}"
+        return rerun, required
+
+    parts = ["nandatown", "run", profile.name]
+    for role, spec in recorded_harnesses.items():
+        parts.extend(["--agent", f"{role}={spec}"])
+    if identity_dir:
+        parts.append("--identity")
+    if uses_llm and model != "mock:v1":
+        parts.extend(["--model", model])
+    return " ".join(shlex.quote(part) for part in parts), required
+
+
 def _validate_role_overrides(
         profile: TestProfile,
         harnesses: dict[str, str] | None,
@@ -445,16 +569,20 @@ def run_town(profile_name: str, out_dir: str, port: int = 0,
         raw_events = get_events()
         events = [TownEvent.model_validate(e) for e in raw_events]
         intents = admin.get(f"/runs/{run_id}/intents").json()["intents"]
-        directory = [
-            {"name": p["name"], "role": p["role"],
-             "capabilities": p["capabilities"],
-             "release": f"nandatown.participants.{p['role']} {__version__}"}
-            for p in [
-                {"name": "buyer", "role": "buyer", "capabilities": []},
-                {"name": "seller", "role": "seller",
-                 "capabilities": ["quote.read"]},
-            ]
-        ]
+        participant_kinds = {"buyer": buyer_kind, "seller": seller_kind}
+        participant_provenance: dict[str, dict[str, Any]] = {}
+        directory = []
+        for name, role in profile.roles.items():
+            release, provenance = _participant_provenance(
+                role, participant_kinds[name])
+            participant_provenance[name] = provenance
+            directory.append({
+                "name": name,
+                "role": role,
+                "capabilities": profile.capabilities.get(name, []),
+                "runtime": participant_kinds[name],
+                "release": release,
+            })
         created_at = next((e.at for e in events if e.kind == "run_created"),
                           time.time())
         from .skills import skill_source
@@ -463,25 +591,23 @@ def run_town(profile_name: str, out_dir: str, port: int = 0,
              "content_fingerprint": fingerprint(skill_source(name))}
             for name in ("town-protocol", "quote.read", "quote.request")
         ]
-        uses_llm = ("llm" in profile.runtimes.values()
-                    or any(spec.startswith("llm")
-                           for spec in (harnesses or {}).values()))
+        uses_llm = "llm" in participant_kinds.values()
+        recorded_harnesses = _recorded_harnesses(
+            profile, participant_kinds, harnesses, external)
         config: dict[str, Any] = {"port": port,
                                   "restarted_seller": restarted,
-                                  "runtimes": profile.runtimes or
-                                  {"buyer": "scripted",
-                                   "seller": "scripted"},
+                                  "runtimes": participant_kinds,
+                                  "participant_provenance":
+                                  participant_provenance,
                                   "skill_releases": skill_releases}
-        if harnesses:
-            config["harnesses"] = harnesses
-        rerun = f"nandatown run {profile.name}"
-        for role, spec_text in (harnesses or {}).items():
-            rerun += f" --agent {role}={spec_text}"
-        if identity_dir:
-            rerun += " --identity"
-        if uses_llm and model != "mock:v1":
-            rerun += f" --model {model}"
+        if recorded_harnesses:
+            config["harnesses"] = recorded_harnesses
+        rerun, rerun_required_inputs = _rerun_metadata(
+            profile, recorded_harnesses, participant_kinds, external,
+            harnesses, identity_dir, uses_llm, model)
         config["rerun_command"] = rerun
+        if rerun_required_inputs:
+            config["rerun_required_inputs"] = rerun_required_inputs
         if uses_llm:
             config["model"] = model
             if not model.startswith("mock:"):

--- a/src/nandatown/runner.py
+++ b/src/nandatown/runner.py
@@ -94,6 +94,8 @@ def _stop_process(process: subprocess.Popen, grace: float = 0.5) -> int | None:
     Other platforms use a direct-child fallback; Python has no portable
     descendant-process primitive.
     """
+    if getattr(process, "_town_cleanup_complete", False):
+        return process.returncode
     # Reap an already-exited group leader first. Darwin reports EPERM when
     # killpg targets a group containing only an unreaped (defunct) leader.
     process.poll()
@@ -101,7 +103,10 @@ def _stop_process(process: subprocess.Popen, grace: float = 0.5) -> int | None:
         try:
             os.killpg(process.pid, signal.SIGTERM)
         except ProcessLookupError:
-            pass
+            # Do not address this numeric PGID again: after ESRCH it could
+            # belong to an unrelated group before a defensive finally pass.
+            process._town_cleanup_complete = True
+            return process.wait(timeout=grace)
     elif process.poll() is None:
         process.terminate()
     try:
@@ -116,9 +121,13 @@ def _stop_process(process: subprocess.Popen, grace: float = 0.5) -> int | None:
     elif process.poll() is None:
         process.kill()
     try:
-        return process.wait(timeout=grace)
+        result = process.wait(timeout=grace)
     except subprocess.TimeoutExpired:
         return process.poll()
+    # SIGKILL has been issued to any remaining POSIX descendants. A zombie
+    # descendant may await its own parent's reap, but needs no second signal.
+    process._town_cleanup_complete = True
+    return result
 
 
 def _participant_extra_env(kind: str, explicit: dict[str, str],
@@ -132,6 +141,11 @@ def _participant_extra_env(kind: str, explicit: dict[str, str],
         # commands inherit ambient variables in _spawn_participant regardless.
         if kind == "cmd" or not effective_model.startswith("mock:"):
             for key in ("TOWN_MODEL_URL", "TOWN_MODEL_KEY"):
+                if key in os.environ:
+                    env[key] = os.environ[key]
+        if kind == "llm" and not effective_model.startswith("mock:"):
+            for key in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+                        "http_proxy", "https_proxy", "all_proxy", "no_proxy"):
                 if key in os.environ:
                     env[key] = os.environ[key]
     env.update(explicit)

--- a/src/nandatown/runner.py
+++ b/src/nandatown/runner.py
@@ -123,10 +123,11 @@ def _stop_process(process: subprocess.Popen, grace: float = 0.5) -> int | None:
     try:
         result = process.wait(timeout=grace)
     except subprocess.TimeoutExpired:
-        return process.poll()
+        result = process.poll()
     # SIGKILL has been issued to any remaining POSIX descendants. A zombie
     # descendant may await its own parent's reap, but needs no second signal.
-    process._town_cleanup_complete = True
+    if result is not None:
+        process._town_cleanup_complete = True
     return result
 
 

--- a/src/nandatown/runner.py
+++ b/src/nandatown/runner.py
@@ -1,17 +1,21 @@
 """Full-run orchestration: one command, one run, one evidence bundle.
 
 The runner starts a coordinator subprocess, spawns the buyer and seller
-as isolated subprocesses with their own state directories, restarts the
-seller once if it crashes, finishes the run, evaluates the event log,
-and writes the portable bundle. Runner observations (crash, restart,
-exit) are posted as attributed events; the runner never synthesizes
-participant assertions.
+as separate subprocesses with their own state directories, restarts the
+seller once if it crashes, finishes the run, evaluates the event log, and
+writes the portable bundle. Bundled harnesses receive a narrow environment;
+an operator-supplied ``cmd:`` harness is trusted code and retains the
+operator's ambient environment. This is process lifecycle containment, not a
+filesystem or network sandbox. Runner observations (crash, restart, exit) are
+posted as attributed events; the runner never synthesizes participant
+assertions.
 """
 
 from __future__ import annotations
 
 import os
 import secrets
+import signal
 import shutil
 import socket
 import subprocess
@@ -28,6 +32,14 @@ from .records import RunRecord, TestProfile, TownEvent, fingerprint
 from .profiles import PROFILES
 
 SELLER_CRASH_EXIT = 3
+
+_BUILTIN_ENV_KEYS = (
+    "PATH", "PYTHONPATH", "PYTHONHOME",
+    "LANG", "LC_ALL", "LC_CTYPE",
+    "TMPDIR", "TMP", "TEMP",
+    "SYSTEMROOT", "WINDIR",
+    "SSL_CERT_FILE", "SSL_CERT_DIR",
+)
 
 
 class RunnerError(Exception):
@@ -59,17 +71,68 @@ def _wait_health(http: httpx.Client, timeout: float = 10.0) -> None:
 def _spawn_participant(command: list[str], url: str, run_id: str, name: str,
                        token: str, state_dir: str, fault: str,
                        deadline: str,
-                       extra_env: dict[str, str] | None = None
+                       extra_env: dict[str, str] | None = None,
+                       inherit_env: bool = False,
                        ) -> subprocess.Popen:
     os.makedirs(state_dir, exist_ok=True)
-    env = dict(os.environ)
+    env = (dict(os.environ) if inherit_env else
+           {key: os.environ[key] for key in _BUILTIN_ENV_KEYS
+            if key in os.environ})
     env.update({"TOWN_URL": url, "RUN_ID": run_id, "NAME": name,
                 "TOKEN": token, "STATE_DIR": state_dir, "FAULT": fault,
                 "DEADLINE": deadline})
     env.update(extra_env or {})
     return subprocess.Popen(command, env=env,
                             stdout=subprocess.DEVNULL,
-                            stderr=subprocess.DEVNULL)
+                            stderr=subprocess.DEVNULL,
+                            start_new_session=(os.name == "posix"))
+
+
+def _stop_process(process: subprocess.Popen, grace: float = 0.5) -> int | None:
+    """Settle a child and, on POSIX, every descendant in its process group.
+
+    Other platforms use a direct-child fallback; Python has no portable
+    descendant-process primitive.
+    """
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    elif process.poll() is None:
+        process.terminate()
+    try:
+        process.wait(timeout=grace)
+    except subprocess.TimeoutExpired:
+        pass
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    elif process.poll() is None:
+        process.kill()
+    try:
+        return process.wait(timeout=grace)
+    except subprocess.TimeoutExpired:
+        return process.poll()
+
+
+def _participant_extra_env(kind: str, explicit: dict[str, str],
+                           model: str) -> dict[str, str]:
+    """Select model configuration for one harness without broad inheritance."""
+    env: dict[str, str] = {}
+    if kind in ("llm", "cmd"):
+        effective_model = explicit.get("TOWN_MODEL", model)
+        env["TOWN_MODEL"] = effective_model
+        # A mock harness has no reason to receive paid credentials. Trusted
+        # commands inherit ambient variables in _spawn_participant regardless.
+        if kind == "cmd" or not effective_model.startswith("mock:"):
+            for key in ("TOWN_MODEL_URL", "TOWN_MODEL_KEY"):
+                if key in os.environ:
+                    env[key] = os.environ[key]
+    env.update(explicit)
+    return env
 
 
 def parse_harness(spec: str) -> dict[str, Any]:
@@ -109,9 +172,8 @@ def parse_harness(spec: str) -> dict[str, Any]:
 def _participant_command(profile: TestProfile, role: str,
                          external: dict[str, list[str] | None] | None,
                          harnesses: dict[str, str] | None = None
-                         ) -> tuple[list[str] | None, dict[str, str]]:
-    """The command and extra env for one role, or (None, {}) when an
-    outside agent will join with handed-out credentials."""
+                         ) -> tuple[list[str] | None, dict[str, str], str]:
+    """Return the command, explicit environment, and harness kind."""
     if harnesses and role in harnesses:
         harness = parse_harness(harnesses[role])
     elif external and role in external:
@@ -124,19 +186,21 @@ def _participant_command(profile: TestProfile, role: str,
                    "model": None}
     kind = harness["kind"]
     if kind == "external":
-        return None, {}
+        return None, {}, kind
     if kind == "cmd":
-        return harness["command"], {}
+        return harness["command"], {}, kind
     if kind == "llm":
         env = {"ROLE": role}
         if harness.get("model"):
             env["TOWN_MODEL"] = harness["model"]
-        return [sys.executable, "-m", "nandatown.participants.llm"], env
+        return ([sys.executable, "-m", "nandatown.participants.llm"],
+                env, kind)
     if kind == "a2a":
         return ([sys.executable, "-m",
                  "nandatown.participants.a2a_bridge"],
-                {"A2A_URL": harness["url"]})
-    return [sys.executable, "-m", f"nandatown.participants.{role}"], {}
+                {"A2A_URL": harness["url"]}, kind)
+    return ([sys.executable, "-m", f"nandatown.participants.{role}"],
+            {}, kind)
 
 
 def _validate_role_overrides(
@@ -189,7 +253,8 @@ def run_town(profile_name: str, out_dir: str, port: int = 0,
     overrides the profile's runtimes. external is the lower-level form:
     a role mapped to a replacement command, or to None to spawn nothing
     and hand join credentials to on_credentials(role, env) so an
-    outside agent can join.
+    outside agent can join. Command harnesses are trusted operator code and
+    inherit the operator environment; bundled harnesses do not.
     """
     if profile_name not in PROFILES:
         raise RunnerError(f"unknown profile {profile_name!r};"
@@ -206,12 +271,14 @@ def run_town(profile_name: str, out_dir: str, port: int = 0,
     os.makedirs(scratch, exist_ok=True)
     db_path = os.path.join(scratch, "town.db")
 
-    env = dict(os.environ)
+    env = {key: os.environ[key] for key in _BUILTIN_ENV_KEYS
+           if key in os.environ}
     env["TOWN_ADMIN_TOKEN"] = admin_token
     coordinator = subprocess.Popen(
         [sys.executable, "-m", "nandatown.coordinator", "--db", db_path,
          "--port", str(port)],
         env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        start_new_session=(os.name == "posix"),
     )
     procs: list[subprocess.Popen] = [coordinator]
     admin = httpx.Client(base_url=url, timeout=10.0,
@@ -253,17 +320,14 @@ def run_town(profile_name: str, out_dir: str, port: int = 0,
 
         seller_state = os.path.join(scratch, "seller")
         buyer_state = os.path.join(scratch, "buyer")
-        seller_cmd, seller_env = _participant_command(profile, "seller",
-                                                      external, harnesses)
-        buyer_cmd, buyer_env = _participant_command(profile, "buyer",
-                                                    external, harnesses)
-        model_env = {"TOWN_MODEL": model}
-        for key in ("TOWN_MODEL_URL", "TOWN_MODEL_KEY"):
-            if key in os.environ:
-                model_env[key] = os.environ[key]
+        seller_cmd, seller_env, seller_kind = _participant_command(
+            profile, "seller", external, harnesses)
+        buyer_cmd, buyer_env, buyer_kind = _participant_command(
+            profile, "buyer", external, harnesses)
+
         # A per-role harness model outranks the run-level model.
-        seller_env = {**model_env, **seller_env}
-        buyer_env = {**model_env, **buyer_env}
+        seller_env = _participant_extra_env(seller_kind, seller_env, model)
+        buyer_env = _participant_extra_env(buyer_kind, buyer_env, model)
         if "seller" in grants:
             seller_env["TOWN_GRANT"] = grants["seller"]
         if "buyer" in grants:
@@ -293,7 +357,8 @@ def run_town(profile_name: str, out_dir: str, port: int = 0,
             p = _spawn_participant(seller_cmd, url, run_id, "seller",
                                    tokens["seller"], seller_state,
                                    profile.fault, seller_deadline,
-                                   extra_env=seller_env)
+                                   extra_env=seller_env,
+                                   inherit_env=(seller_kind == "cmd"))
             procs.append(p)
             return p
 
@@ -305,7 +370,8 @@ def run_town(profile_name: str, out_dir: str, port: int = 0,
             buyer = _spawn_participant(buyer_cmd, url, run_id, "buyer",
                                        tokens["buyer"], buyer_state,
                                        profile.fault, buyer_deadline,
-                                       extra_env=buyer_env)
+                                       extra_env=buyer_env,
+                                       inherit_env=(buyer_kind == "cmd"))
             procs.append(buyer)
 
         restarted = False
@@ -329,6 +395,7 @@ def run_town(profile_name: str, out_dir: str, port: int = 0,
             if seller is not None:
                 rc = seller.poll()
                 if rc is not None:
+                    _stop_process(seller)
                     if rc == SELLER_CRASH_EXIT and not restarted:
                         post_event("runner", "participant_crashed",
                                    "seller", {"exit_code": rc})
@@ -342,10 +409,9 @@ def run_town(profile_name: str, out_dir: str, port: int = 0,
                         break
             time.sleep(0.1)
         if buyer is not None:
-            if buyer.poll() is None:
-                buyer.terminate()
+            buyer_exit = _stop_process(buyer)
             post_event("runner", "participant_exited", "buyer",
-                       {"exit_code": buyer.poll()})
+                       {"exit_code": buyer_exit})
 
         quiet_deadline = time.time() + (0.0 if refused_role else 8.0)
         while time.time() < quiet_deadline:
@@ -353,9 +419,10 @@ def run_town(profile_name: str, out_dir: str, port: int = 0,
                 break
             time.sleep(0.2)
 
-        if seller is not None and seller.poll() is None:
-            seller.terminate()
-        admin.post(f"/runs/{run_id}/finish")
+        if seller is not None:
+            _stop_process(seller)
+        finished = admin.post(f"/runs/{run_id}/finish")
+        finished.raise_for_status()
 
         raw_events = get_events()
         events = [TownEvent.model_validate(e) for e in raw_events]
@@ -425,13 +492,7 @@ def run_town(profile_name: str, out_dir: str, port: int = 0,
         return bundle_dir, result
     finally:
         for p in procs:
-            if p.poll() is None:
-                p.terminate()
-        for p in procs:
-            try:
-                p.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                p.kill()
+            _stop_process(p)
         admin.close()
         # Keep the operational state (town.db, journals) inspectable
         # inside the bundle once the processes that owned it are gone.

--- a/src/nandatown/tui.py
+++ b/src/nandatown/tui.py
@@ -43,6 +43,15 @@ HARNESS_OPTIONS = [
     ("my own command", "cmd"),
 ]
 
+KIOSK_HOSTED_MODEL_OPT_IN = "NANDATOWN_KIOSK_ALLOW_HOSTED_MODEL"
+
+
+def _track_model(kiosk: bool) -> str | None:
+    """Keep a public kiosk off operator-funded models unless opted in."""
+    if kiosk and os.environ.get(KIOSK_HOSTED_MODEL_OPT_IN) != "1":
+        return "mock:v1"
+    return None
+
 
 def _targets() -> list[tuple[str, str]]:
     from .profiles import PROFILES
@@ -304,7 +313,8 @@ class TownApp(App):
                           + (f" with harnesses {harnesses}"
                              if harnesses else ""))
                 bundle_dir, result = run_town(target, self.out_dir,
-                                              harnesses=harnesses)
+                                              harnesses=harnesses,
+                                              model=_track_model(self.kiosk))
             else:
                 from .sim.runner import run_lab
                 self._log("run-log", f"lab run of {target}")
@@ -355,7 +365,8 @@ class TownApp(App):
         try:
             if target in PROFILES:
                 from .runner import run_town
-                bundle_dir, result = run_town(target, self.out_dir)
+                bundle_dir, result = run_town(
+                    target, self.out_dir, model=_track_model(self.kiosk))
             else:
                 from .sim.runner import run_lab
                 bundle_dir, result = run_lab(target, self.out_dir)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
+from nandatown import __version__
 from nandatown.a2a_adapter import build_a2a_app, probe_endpoint
 from nandatown.client import TownClient
 from nandatown.coordinator import build_app
@@ -214,9 +215,11 @@ def test_a2a_bridge_carries_a_track_run(tmp_path):
         except httpx.HTTPError:
             time.sleep(0.1)
     try:
+        secret = "a2a-query-secret-must-not-enter-evidence"
         bundle_dir, result = run_town(
             "quote-clean", str(tmp_path),
-            harnesses={"seller": f"a2a:http://127.0.0.1:{port}"})
+            harnesses={
+                "seller": f"a2a:http://127.0.0.1:{port}?token={secret}"})
         detail = [(s.name, s.status, s.note) for s in result.stages]
         assert result.verdict == "passed", detail
         from nandatown.bundle import load_bundle
@@ -225,6 +228,26 @@ def test_a2a_bridge_carries_a_track_run(tmp_path):
                        if e.kind == "ack_recorded"
                        and e.observer == "seller"]
         assert seller_acks[0].detail["note"]["runtime"] == "a2a-bridge"
+        run = bundle["run"]
+        seller = next(p for p in run.participants
+                      if p["name"] == "seller")
+        assert seller["runtime"] == "a2a"
+        assert seller["release"] == (
+            "external A2A participant; immutable release not recorded")
+        assert run.config["harnesses"] == {
+            "seller": "a2a:<operator-supplied-endpoint>"}
+        assert run.config["participant_provenance"]["seller"] == {
+            "kind": "a2a",
+            "identity_basis": (
+                "operator-supplied A2A endpoint (URL not recorded)"),
+            "release_basis": None,
+            "release_basis_note": "immutable external release not supplied",
+            "adapter_release": (
+                f"nandatown.participants.a2a_bridge {__version__}"),
+        }
+        assert secret not in json.dumps(run.model_dump())
+        assert "<operator-supplied-endpoint>" in (
+            run.config["rerun_command"])
     finally:
         server.should_exit = True
         thread.join(timeout=5)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,4 +1,5 @@
 import json
+import os
 import socket
 import sys
 import threading
@@ -121,6 +122,46 @@ def test_mcp_probe_against_own_server():
     assert report["ok"], report
     assert report["protocolVersion"] == PROTOCOL_VERSION
     assert "town_claim" in report["tools"]
+
+
+@pytest.mark.parametrize("partial", [False, True])
+def test_mcp_probe_enforces_wall_deadline_and_reaps_child(
+        tmp_path, partial):
+    pid_path = tmp_path / ("partial.pid" if partial else "silent.pid")
+    prelude = (
+        "import os,pathlib,sys,time;"
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid()));"
+    )
+    if partial:
+        prelude += "sys.stdout.write('{');sys.stdout.flush();"
+    command = [sys.executable, "-c", prelude + "time.sleep(0.8)",
+               str(pid_path)]
+
+    started = time.monotonic()
+    report = probe(command, timeout=0.15)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.65
+    assert report["ok"] is False
+    assert any("timed out" in problem for problem in report["problems"])
+    pid = int(pid_path.read_text())
+    if os.name == "posix":
+        with pytest.raises(ProcessLookupError):
+            os.kill(pid, 0)
+
+
+def test_mcp_probe_rejects_oversized_response_without_crashing():
+    script = (
+        "import sys;"
+        "sys.stdin.readline();"
+        "sys.stdout.write('x' * (1024 * 1024 + 1) + '\\n');"
+        "sys.stdout.flush()"
+    )
+
+    report = probe([sys.executable, "-c", script], timeout=1.0)
+
+    assert report["ok"] is False
+    assert any("too large" in problem for problem in report["problems"])
 
 
 def test_a2a_card_and_quote():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -229,6 +229,35 @@ def test_duplicate_delivery_fault(client):
     assert "duplicate_offered" in event_kinds(client, run_id)
 
 
+def test_concurrent_duplicate_claims_have_one_winner(client, monkeypatch):
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+    from nandatown.db import TownDB
+
+    run_id, sessions, _ = make_run(client, fault="duplicate_delivery")
+    send_q1(client, run_id, sessions)
+    claim_url = f"/runs/{run_id}/inbox/claim"
+    first = client.post(claim_url, headers=sessions["seller"]).json()
+    assert client.post(
+        f"/runs/{run_id}/inbox/ack", headers=sessions["seller"],
+        json={"message_id": "q-1", "fence": first["fence"],
+              "status": "processed", "note": {}}).status_code == 200
+    original = TownDB.reoffer
+    barrier = threading.Barrier(2)
+
+    def synchronized(self, *args, **kwargs):
+        barrier.wait(timeout=5)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(TownDB, "reoffer", synchronized)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(client.post, claim_url, headers=sessions["seller"])
+                   for _ in range(2)]
+        replies = [future.result(timeout=10) for future in futures]
+    assert sorted(reply.status_code for reply in replies) == [200, 204]
+    assert event_kinds(client, run_id).count("duplicate_offered") == 1
+
+
 def test_lost_ack_fault(client):
     run_id, sessions, _ = make_run(client, fault="lost_ack")
     send_q1(client, run_id, sessions)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -256,3 +258,129 @@ def test_finish_and_runner_event(client):
     assert f.status_code == 200
     kinds = event_kinds(client, run_id)
     assert "participant_crashed" in kinds and "run_finished" in kinds
+
+
+def test_finish_is_idempotent_and_records_one_terminal_event(client):
+    run_id, _, _ = make_run(client)
+
+    first = client.post(f"/runs/{run_id}/finish", headers=ADMIN)
+    second = client.post(f"/runs/{run_id}/finish", headers=ADMIN)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    kinds = event_kinds(client, run_id)
+    assert kinds.count("run_finished") == 1
+    assert kinds[-1] == "run_finished"
+
+
+def test_finish_rolls_back_status_when_terminal_event_fails(tmp_path):
+    db_path = tmp_path / "town.db"
+    app = build_app(str(db_path), admin_token="secret")
+    with TestClient(app) as client:
+        run_id, _, _ = make_run(client)
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "CREATE TRIGGER fail_run_finished BEFORE INSERT ON events "
+                "WHEN NEW.kind='run_finished' BEGIN "
+                "SELECT RAISE(ABORT, 'injected finish failure'); END"
+            )
+
+        with pytest.raises(sqlite3.IntegrityError,
+                           match="injected finish failure"):
+            client.post(f"/runs/{run_id}/finish", headers=ADMIN)
+
+        with sqlite3.connect(db_path) as conn:
+            status, = conn.execute(
+                "SELECT status FROM runs WHERE run_id=?", (run_id,)
+            ).fetchone()
+        assert status == "created"
+
+
+@pytest.mark.parametrize(
+    "operation", ["send", "notify", "claim", "ack", "join", "admin_event"]
+)
+def test_finished_run_rejects_further_mutations(client, operation):
+    run_id, sessions, data = make_run(client)
+    claim = None
+    if operation in {"notify", "claim", "ack"}:
+        assert send_q1(client, run_id, sessions).status_code == 202
+    if operation == "ack":
+        claimed = client.post(
+            f"/runs/{run_id}/inbox/claim", headers=sessions["seller"]
+        )
+        assert claimed.status_code == 200
+        claim = claimed.json()
+
+    finished = client.post(f"/runs/{run_id}/finish", headers=ADMIN)
+    assert finished.status_code == 200
+    events_before = client.get(
+        f"/runs/{run_id}/events", headers=ADMIN
+    ).json()["events"]
+    intents_before = client.get(
+        f"/runs/{run_id}/intents", headers=ADMIN
+    ).json()["intents"]
+
+    if operation == "send":
+        response = client.post(
+            f"/runs/{run_id}/messages",
+            json={"message_id": "after-finish", "to": "seller",
+                  "kind": "quote_request", "body": BODY},
+            headers=sessions["buyer"],
+        )
+    elif operation == "notify":
+        response = client.get(
+            f"/runs/{run_id}/inbox/notify", params={"wait": 0},
+            headers=sessions["seller"],
+        )
+    elif operation == "claim":
+        response = client.post(
+            f"/runs/{run_id}/inbox/claim", headers=sessions["seller"]
+        )
+    elif operation == "ack":
+        response = client.post(
+            f"/runs/{run_id}/inbox/ack",
+            json={"message_id": "q-1", "fence": claim["fence"],
+                  "status": "processed", "note": {}},
+            headers=sessions["seller"],
+        )
+    elif operation == "join":
+        response = client.post(
+            f"/runs/{run_id}/join",
+            json={"name": "buyer", "token": data["join_tokens"]["buyer"]},
+        )
+    else:
+        response = client.post(
+            f"/runs/{run_id}/events",
+            json={"observer": "runner", "kind": "late_event",
+                  "subject": run_id, "detail": {}},
+            headers=ADMIN,
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "error": "run_finished", "run_id": run_id
+    }
+    events_after = client.get(
+        f"/runs/{run_id}/events", headers=ADMIN
+    ).json()["events"]
+    intents_after = client.get(
+        f"/runs/{run_id}/intents", headers=ADMIN
+    ).json()["intents"]
+    assert events_after == events_before
+    assert intents_after == intents_before
+    assert events_after[-1]["kind"] == "run_finished"
+
+
+def test_finished_run_keeps_read_routes_available(client):
+    run_id, sessions, _ = make_run(client)
+    assert client.post(f"/runs/{run_id}/finish", headers=ADMIN).status_code == 200
+
+    directory = client.get(
+        f"/runs/{run_id}/participants", headers=sessions["buyer"]
+    )
+    events = client.get(f"/runs/{run_id}/events", headers=ADMIN)
+    intents = client.get(f"/runs/{run_id}/intents", headers=ADMIN)
+
+    assert directory.status_code == 200
+    assert events.status_code == 200
+    assert intents.status_code == 200

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -229,6 +229,73 @@ def test_accept_then_claim_returns_work_with_fence(db, run):
     assert claim["fence"]
 
 
+def test_concurrent_claim_issues_one_active_fence(db, run, monkeypatch):
+    """Two SQLite connections must not both claim the same accepted work."""
+    accept(db, run)
+    start = threading.Barrier(2, timeout=10)
+    unprotected_reads = threading.Barrier(2, timeout=10)
+
+    class ClaimCursor:
+        def __init__(self, cursor, conn):
+            self.cursor, self.conn = cursor, conn
+
+        def fetchone(self):
+            row = self.cursor.fetchone()
+            # On the broken implementation, both real connections finish the
+            # accepted-row lookup before either writes. An immediate write
+            # transaction deliberately makes this barrier unnecessary.
+            if not self.conn.in_transaction:
+                unprotected_reads.wait()
+            return row
+
+    class RacingConnection:
+        def __init__(self, conn):
+            self.conn = conn
+
+        def execute(self, sql, *args):
+            cursor = self.conn.execute(sql, *args)
+            if sql.startswith("SELECT * FROM messages") \
+                    and "status='accepted'" in sql:
+                return ClaimCursor(cursor, self.conn)
+            return cursor
+
+    def synchronize(instance):
+        original = instance._conn
+        first = True
+
+        @contextmanager
+        def connection():
+            nonlocal first
+            with original() as conn:
+                if first:
+                    first = False
+                    start.wait()
+                yield RacingConnection(conn)
+
+        monkeypatch.setattr(instance, "_conn", connection)
+
+    contenders = [TownDB(db.path), TownDB(db.path)]
+    for contender in contenders:
+        synchronize(contender)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(contender.claim_next, run, "seller", 5.0, 101.0)
+            for contender in contenders
+        ]
+        outcomes = [future.result(timeout=20) for future in futures]
+
+    assert sum(outcome is not None for outcome in outcomes) == 1
+    message, = stored_rows(db, "messages")
+    assert message["status"] == "claimed"
+    assert message["attempts"] == 1
+    claims = stored_rows(db, "claims")
+    assert len(claims) == 1
+    assert claims[0]["active"] == 1
+    assert [event["kind"] for event in db.events(run)].count(
+        "message_claimed") == 1
+
+
 def test_idempotent_resend_and_identity_reuse(db, run):
     accept(db, run, now=100.0)
     accepted_at, replay = accept(db, run, now=200.0)
@@ -269,6 +336,93 @@ def test_lease_expiry_inside_ack_is_stale(db, run):
         db.ack(run, "seller", "q-1", first["fence"], "processed", {}, now=110.0)
     again = db.claim_next(run, "seller", lease_seconds=2.0, now=111.0)
     assert again["attempt"] == 2
+
+
+def test_ack_and_reclaim_have_only_serial_outcomes(db, run, monkeypatch):
+    """A fence cannot acknowledge after another connection reclaims it."""
+    accept(db, run)
+    first = db.claim_next(run, "seller", lease_seconds=2.0, now=101.0)
+    ack_db = TownDB(db.path)
+    reclaim_db = TownDB(db.path)
+    claim_selected = threading.Event()
+    reclaim_finished = threading.Event()
+
+    class AckCursor:
+        def __init__(self, cursor, conn):
+            self.cursor, self.conn = cursor, conn
+
+        def fetchone(self):
+            row = self.cursor.fetchone()
+            claim_selected.set()
+            # Reproduce the check/use gap only when the lookup is not already
+            # protected by a write transaction. With the repair, ack proceeds
+            # atomically and the competing reclaim observes completed work.
+            if not self.conn.in_transaction:
+                assert reclaim_finished.wait(timeout=10)
+            return row
+
+    class AckConnection:
+        def __init__(self, conn):
+            self.conn = conn
+
+        def execute(self, sql, *args):
+            cursor = self.conn.execute(sql, *args)
+            if sql.startswith("SELECT * FROM claims") and "fence=?" in sql:
+                return AckCursor(cursor, self.conn)
+            return cursor
+
+    original = ack_db._conn
+    first_connection = True
+
+    @contextmanager
+    def synchronized_ack_connection():
+        nonlocal first_connection
+        with original() as conn:
+            if first_connection:
+                first_connection = False
+                yield AckConnection(conn)
+            else:
+                yield conn
+
+    monkeypatch.setattr(ack_db, "_conn", synchronized_ack_connection)
+
+    def acknowledge():
+        try:
+            ack_db.ack(run, "seller", "q-1", first["fence"],
+                       "processed", {}, now=102.0)
+            return "acked"
+        except StaleFence:
+            return "stale"
+
+    def reclaim():
+        assert claim_selected.wait(timeout=10)
+        try:
+            return reclaim_db.claim_next(run, "seller", lease_seconds=2.0,
+                                         now=104.0)
+        finally:
+            reclaim_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        ack_future = pool.submit(acknowledge)
+        reclaim_future = pool.submit(reclaim)
+        ack_outcome = ack_future.result(timeout=20)
+        reclaimed = reclaim_future.result(timeout=20)
+
+    if reclaimed is None:
+        assert ack_outcome == "acked"
+        message, = stored_rows(db, "messages")
+        assert message["status"] == "done"
+        assert not [claim for claim in stored_rows(db, "claims")
+                    if claim["active"]]
+    else:
+        assert ack_outcome == "stale"
+        message, = stored_rows(db, "messages")
+        assert message["status"] == "claimed"
+        active = [claim for claim in stored_rows(db, "claims")
+                  if claim["active"]]
+        assert len(active) == 1
+        assert active[0]["fence"] == reclaimed["fence"]
+        assert stored_rows(db, "acks") == []
 
 
 def test_ack_completes_message(db, run):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -42,6 +42,40 @@ def stored_rows(db, table):
         return [dict(row) for row in conn.execute(f"SELECT * FROM {table}")]
 
 
+@pytest.mark.parametrize("state", ["accepted", "claimed"])
+def test_reoffer_requires_completed_work(db, run, state):
+    accept(db, run)
+    if state == "claimed":
+        db.claim_next(run, "seller", 5.0, 101.0)
+    before = stored_rows(db, "claims")
+    assert db.reoffer(run, "q-1", "seller", 5.0, 102.0) is None
+    assert stored_rows(db, "claims") == before
+
+
+def test_concurrent_reoffers_issue_one_durable_duplicate(db, run):
+    accept(db, run)
+    first = db.claim_next(run, "seller", 5.0, 101.0)
+    db.ack(run, "seller", "q-1", first["fence"], "processed", {}, 102.0)
+    barrier = threading.Barrier(2)
+
+    def offer():
+        other = TownDB(db.path)
+        barrier.wait(timeout=5)
+        return other.reoffer(run, "q-1", "seller", 5.0, 103.0)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(offer) for _ in range(2)]
+        results = [future.result(timeout=10) for future in futures]
+    assert sum(result is not None for result in results) == 1
+    winner = next(result for result in results if result)
+    assert winner["attempt"] == 2
+    assert sum(row["active"] for row in stored_rows(db, "claims")) == 1
+    assert stored_rows(db, "messages")[0]["attempts"] == 2
+    assert sum(event["kind"] == "duplicate_offered" for event in db.events(run)) == 1
+    db.ack(run, "seller", "q-1", winner["fence"], "processed", {}, 104.0)
+    assert TownDB(db.path).reoffer(run, "q-1", "seller", 5.0, 105.0) is None
+
+
 IDENTITY_CHANGES = [
     {"sender": "other-buyer"},
     {"to": "other-seller"},

--- a/tests/test_harness_overrides.py
+++ b/tests/test_harness_overrides.py
@@ -1,9 +1,12 @@
+import json
 import os
 import shlex
+import subprocess
 import sys
 
 import pytest
 
+from nandatown import __version__
 import nandatown.runner as runner_module
 from nandatown.bundle import load_bundle
 from nandatown.cli import main
@@ -74,14 +77,81 @@ def test_cli_reports_unknown_harness_role_as_usage_error(
 
 
 def test_cmd_harness_runs_external_agent(tmp_path):
+    secret = "command-secret-must-not-enter-evidence"
     spec = "cmd:" + " ".join(shlex.quote(p)
-                             for p in [sys.executable, EXAMPLE])
+                             for p in [sys.executable, EXAMPLE, secret])
     bundle_dir, result = run_town("quote-clean", str(tmp_path),
                                   harnesses={"seller": spec})
     detail = [(s.name, s.status, s.note) for s in result.stages]
     assert result.verdict == "passed", detail
     bundle = load_bundle(bundle_dir)
-    assert bundle["run"].config["harnesses"] == {"seller": spec}
+    run = bundle["run"]
+    seller = next(p for p in run.participants if p["name"] == "seller")
+    buyer = next(p for p in run.participants if p["name"] == "buyer")
+    assert buyer["runtime"] == "scripted"
+    assert buyer["release"] == (
+        f"nandatown.participants.buyer {__version__}")
+    assert seller["runtime"] == "cmd"
+    assert seller["release"] == (
+        "external command; immutable release not recorded")
+    assert run.config["runtimes"]["seller"] == "cmd"
+    assert run.config["harnesses"] == {
+        "seller": "cmd:<operator-supplied-command>"}
+    assert run.config["participant_provenance"]["seller"] == {
+        "kind": "cmd",
+        "identity_basis": "operator-supplied command (command not recorded)",
+        "release_basis": None,
+        "release_basis_note": "immutable external release not supplied",
+    }
+    assert run.config["rerun_required_inputs"] == {
+        "seller": "original command (not recorded)"}
+    assert "<operator-supplied-command>" in run.config["rerun_command"]
+    serialized_run = json.dumps(run.model_dump())
+    assert secret not in serialized_run
+    assert EXAMPLE not in serialized_run
+
+
+def test_wait_handoff_records_external_participant_and_reconnect_rerun(
+        tmp_path):
+    processes: list[subprocess.Popen] = []
+
+    def connect(role, env):
+        assert role == "seller"
+        processes.append(subprocess.Popen(
+            [sys.executable, EXAMPLE], env={**os.environ, **env},
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL))
+
+    try:
+        bundle_dir, result = run_town(
+            "quote-clean", str(tmp_path), external={"seller": None},
+            on_credentials=connect)
+    finally:
+        for process in processes:
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.terminate()
+                process.wait(timeout=5)
+
+    detail = [(s.name, s.status, s.note) for s in result.stages]
+    assert result.verdict == "passed", detail
+    run = load_bundle(bundle_dir)["run"]
+    seller = next(p for p in run.participants if p["name"] == "seller")
+    assert seller["runtime"] == "external"
+    assert seller["release"] == (
+        "external participant; immutable release not recorded")
+    assert run.config["harnesses"] == {"seller": "external"}
+    assert run.config["participant_provenance"]["seller"] == {
+        "kind": "external",
+        "identity_basis": (
+            "operator-connected participant (software identity not supplied)"),
+        "release_basis": None,
+        "release_basis_note": "immutable external release not supplied",
+    }
+    assert run.config["rerun_command"] == (
+        "nandatown test-agent --profile quote-clean --role seller --wait")
+    assert run.config["rerun_required_inputs"] == {
+        "seller": "external participant must reconnect with fresh credentials"}
 
 
 def test_llm_harness_overrides_scripted_profile(tmp_path):
@@ -92,6 +162,10 @@ def test_llm_harness_overrides_scripted_profile(tmp_path):
     bundle = load_bundle(bundle_dir)
     assert bundle["run"].config["model"] == "mock:v1"
     assert bundle["run"].config["harnesses"]["seller"] == "llm:mock:alt"
+    seller = next(p for p in bundle["run"].participants
+                  if p["name"] == "seller")
+    assert seller["runtime"] == "llm"
+    assert seller["release"] == f"nandatown.participants.llm {__version__}"
 
 
 def test_layer_override_reproduces_weak_auth_failure(tmp_path):

--- a/tests/test_llm_and_byoa.py
+++ b/tests/test_llm_and_byoa.py
@@ -1,9 +1,12 @@
 import json
 import os
 import sys
+import time
 
 import httpx
+import pytest
 
+import nandatown.runner as runner_module
 from nandatown.bundle import load_bundle, verify_bundle
 from nandatown.participants.llm import (
     MESSAGE_BUDGET,
@@ -11,7 +14,11 @@ from nandatown.participants.llm import (
     LLMParticipant,
     ModelClient,
 )
-from nandatown.runner import run_town
+from nandatown.runner import (
+    _participant_extra_env,
+    _spawn_participant,
+    run_town,
+)
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -85,3 +92,101 @@ def test_byoa_external_seller_end_to_end(tmp_path):
     seller_acks = [e for e in bundle["events"]
                    if e.kind == "ack_recorded" and e.observer == "seller"]
     assert seller_acks[0].detail["note"].get("runtime") == "byoa-stdlib"
+
+
+def _spawn_environment_probe(tmp_path, inherit_env=False):
+    output = tmp_path / ("inherited.json" if inherit_env else "builtin.json")
+    script = (
+        "import json,os,pathlib,sys;"
+        "pathlib.Path(sys.argv[1]).write_text(json.dumps(dict(os.environ)))"
+    )
+    process = _spawn_participant(
+        [sys.executable, "-c", script, str(output)],
+        "http://town.invalid", "run-1", "seller", "join-token",
+        str(tmp_path / "state"), "none", "1",
+        extra_env={"ROLE": "seller", "TOWN_MODEL_KEY": "explicit-key"},
+        inherit_env=inherit_env)
+    assert process.wait(timeout=5) == 0
+    return json.loads(output.read_text())
+
+
+def test_builtin_participant_gets_only_required_environment(
+        tmp_path, monkeypatch):
+    monkeypatch.setenv("NANDATOWN_TEST_AMBIENT_SECRET", "do-not-copy")
+
+    child_env = _spawn_environment_probe(tmp_path)
+
+    assert "NANDATOWN_TEST_AMBIENT_SECRET" not in child_env
+    assert child_env["TOWN_URL"] == "http://town.invalid"
+    assert child_env["TOKEN"] == "join-token"
+    assert child_env["ROLE"] == "seller"
+    assert child_env["TOWN_MODEL_KEY"] == "explicit-key"
+
+
+def test_trusted_command_can_inherit_operator_environment(
+        tmp_path, monkeypatch):
+    monkeypatch.setenv("NANDATOWN_TEST_AMBIENT_SECRET", "operator-opt-in")
+
+    child_env = _spawn_environment_probe(tmp_path, inherit_env=True)
+
+    assert child_env["NANDATOWN_TEST_AMBIENT_SECRET"] == "operator-opt-in"
+
+
+def test_model_credentials_only_reach_relevant_harnesses(monkeypatch):
+    monkeypatch.setenv("TOWN_MODEL_URL", "https://model.invalid")
+    monkeypatch.setenv("TOWN_MODEL_KEY", "paid-secret")
+
+    scripted = _participant_extra_env("scripted", {}, "hosted:model")
+    mock_llm = _participant_extra_env("llm", {"ROLE": "seller"},
+                                      "mock:v1")
+    hosted_llm = _participant_extra_env("llm", {"ROLE": "seller"},
+                                        "hosted:model")
+
+    assert "TOWN_MODEL_KEY" not in scripted
+    assert "TOWN_MODEL_KEY" not in mock_llm
+    assert hosted_llm["TOWN_MODEL_URL"] == "https://model.invalid"
+    assert hosted_llm["TOWN_MODEL_KEY"] == "paid-secret"
+
+
+@pytest.mark.skipif(os.name != "posix",
+                    reason="descendant cleanup uses POSIX process groups")
+def test_runner_stops_command_descendants_before_bundle_export(
+        tmp_path, monkeypatch):
+    ready = tmp_path / "descendant-ready"
+    export_started = tmp_path / "export-started"
+    late_write = tmp_path / "descendant-wrote-during-export"
+    child = tmp_path / "late_writer.py"
+    child.write_text(
+        "import os, pathlib, sys, time\n"
+        "ready, export_started, late_write = map(pathlib.Path, sys.argv[1:])\n"
+        "ready.write_text(str(os.getpid()))\n"
+        "deadline = time.monotonic() + 20\n"
+        "while not export_started.exists() and time.monotonic() < deadline:\n"
+        "    time.sleep(0.005)\n"
+        "if export_started.exists():\n"
+        "    late_write.write_text('survived')\n"
+    )
+    wrapper = tmp_path / "seller_with_descendant.py"
+    wrapper.write_text(
+        "import subprocess, sys\n"
+        "subprocess.Popen([sys.executable, *sys.argv[1:]])\n"
+        "from nandatown.participants.seller import main\n"
+        "main()\n"
+    )
+    original_write_bundle = runner_module.write_bundle
+
+    def observed_write_bundle(*args, **kwargs):
+        export_started.write_text("started")
+        time.sleep(0.2)
+        return original_write_bundle(*args, **kwargs)
+
+    monkeypatch.setattr(runner_module, "write_bundle", observed_write_bundle)
+    command = [sys.executable, str(wrapper), str(child), str(ready),
+               str(export_started), str(late_write)]
+
+    _, result = run_town("quote-clean", str(tmp_path / "runs"),
+                         external={"seller": command})
+
+    assert result.verdict == "passed"
+    assert ready.exists(), "the real descendant never started"
+    assert not late_write.exists()

--- a/tests/test_llm_and_byoa.py
+++ b/tests/test_llm_and_byoa.py
@@ -83,15 +83,24 @@ def test_llm_truncation_profile_end_to_end(tmp_path):
 
 def test_byoa_external_seller_end_to_end(tmp_path):
     example = os.path.join(REPO_ROOT, "examples", "byoa_seller.py")
+    secret = "external-command-secret-must-not-enter-evidence"
     bundle_dir, result = run_town(
         "quote-clean", str(tmp_path),
-        external={"seller": [sys.executable, example]})
+        external={"seller": [sys.executable, example, secret]})
     detail = [(s.name, s.status, s.note) for s in result.stages]
     assert result.verdict == "passed", detail
     bundle = load_bundle(bundle_dir)
     seller_acks = [e for e in bundle["events"]
                    if e.kind == "ack_recorded" and e.observer == "seller"]
     assert seller_acks[0].detail["note"].get("runtime") == "byoa-stdlib"
+    run = bundle["run"]
+    assert run.config["rerun_command"] == (
+        "nandatown test-agent --profile quote-clean --role seller"
+        " --cmd '<operator-supplied-command>'")
+    serialized_run = json.dumps(run.model_dump())
+    assert secret not in serialized_run
+    assert example not in serialized_run
+    assert verify_bundle(bundle_dir) == []
 
 
 def _spawn_environment_probe(tmp_path, inherit_env=False):

--- a/tests/test_llm_and_byoa.py
+++ b/tests/test_llm_and_byoa.py
@@ -190,3 +190,34 @@ def test_runner_stops_command_descendants_before_bundle_export(
     assert result.verdict == "passed"
     assert ready.exists(), "the real descendant never started"
     assert not late_write.exists()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group ownership")
+def test_process_cleanup_never_resignals_a_settled_group(monkeypatch):
+    import subprocess
+
+    process = subprocess.Popen([sys.executable, "-c", "pass"], start_new_session=True)
+    process.wait(timeout=5)
+    signals = []
+
+    def missing_group(pgid, sig):
+        signals.append((pgid, sig))
+        raise ProcessLookupError
+
+    monkeypatch.setattr(runner_module.os, "killpg", missing_group)
+    assert runner_module._stop_process(process) == 0
+    first_cleanup = list(signals)
+    assert runner_module._stop_process(process) == 0
+    assert signals == first_cleanup
+
+
+def test_only_hosted_model_harness_preserves_explicit_proxy_environment(monkeypatch):
+    keys = ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+            "http_proxy", "https_proxy", "all_proxy", "no_proxy")
+    for key in keys:
+        monkeypatch.setenv(key, "http://proxy.invalid:8080")
+    hosted = _participant_extra_env("llm", {}, "hosted:model")
+    assert all(hosted.get(key) == "http://proxy.invalid:8080" for key in keys)
+    for kind, model in (("scripted", "hosted:model"), ("a2a", "hosted:model"),
+                        ("llm", "mock:v1")):
+        assert all(key not in _participant_extra_env(kind, {}, model) for key in keys)

--- a/tests/test_llm_and_byoa.py
+++ b/tests/test_llm_and_byoa.py
@@ -211,6 +211,33 @@ def test_process_cleanup_never_resignals_a_settled_group(monkeypatch):
     assert signals == first_cleanup
 
 
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group ownership")
+def test_cleanup_records_exit_observed_just_after_wait_timeout(monkeypatch):
+    import subprocess
+
+    class SlowReap:
+        pid = 424242
+        returncode = None
+        polls = 0
+
+        def poll(self):
+            self.polls += 1
+            if self.polls > 1:
+                self.returncode = 0
+            return self.returncode
+
+        def wait(self, timeout):
+            raise subprocess.TimeoutExpired("slow-reap", timeout)
+
+    process = SlowReap()
+    signals = []
+    monkeypatch.setattr(runner_module.os, "killpg", lambda *args: signals.append(args))
+    assert runner_module._stop_process(process) == 0
+    first_cleanup = list(signals)
+    assert runner_module._stop_process(process) == 0
+    assert signals == first_cleanup
+
+
 def test_only_hosted_model_harness_preserves_explicit_proxy_environment(monkeypatch):
     keys = ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
             "http_proxy", "https_proxy", "all_proxy", "no_proxy")

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -93,3 +93,56 @@ def test_kiosk_mode_disables_execution_surfaces(tmp_path):
             await pilot.pause()
 
     run_async(go())
+
+
+def test_kiosk_track_run_forces_mock_model(tmp_path, monkeypatch):
+    import nandatown.runner as runner_module
+
+    captured = {}
+
+    def fake_run_town(*args, **kwargs):
+        captured.update(kwargs)
+        return "unused-bundle", object()
+
+    monkeypatch.setenv("TOWN_MODEL", "hosted:paid")
+    monkeypatch.setenv("TOWN_MODEL_KEY", "paid-secret")
+    monkeypatch.delenv("NANDATOWN_KIOSK_ALLOW_HOSTED_MODEL", raising=False)
+    monkeypatch.setattr(runner_module, "run_town", fake_run_town)
+    monkeypatch.setattr(TownApp, "_show_result",
+                        lambda self, bundle, result, log: None)
+
+    async def go():
+        app = TownApp(out_dir=str(tmp_path), kiosk=True)
+        async with app.run_test() as pilot:
+            app._run_target("quote-clean", None)
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+    run_async(go())
+    assert captured["model"] == "mock:v1"
+
+
+def test_kiosk_hosted_model_requires_operator_opt_in(tmp_path, monkeypatch):
+    import nandatown.runner as runner_module
+
+    captured = {}
+
+    def fake_run_town(*args, **kwargs):
+        captured.update(kwargs)
+        return "unused-bundle", object()
+
+    monkeypatch.setenv("TOWN_MODEL", "hosted:paid")
+    monkeypatch.setenv("NANDATOWN_KIOSK_ALLOW_HOSTED_MODEL", "1")
+    monkeypatch.setattr(runner_module, "run_town", fake_run_town)
+    monkeypatch.setattr(TownApp, "_show_result",
+                        lambda self, bundle, result, log: None)
+
+    async def go():
+        app = TownApp(out_dir=str(tmp_path), kiosk=True)
+        async with app.run_test() as pilot:
+            app._run_target("quote-clean", None)
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+    run_async(go())
+    assert captured.get("model") is None


### PR DESCRIPTION
## Summary

- Serialize mailbox claim/ack/reoffer decisions with their writes and evidence events; finish is atomic/idempotent and terminal runs reject subsequent mutations.
- Bound MCP initialization/tool-list probes by wall time and output size, and settle participant process groups before final export on POSIX.
- Preserve trusted custom-command environments, narrow bundled environments, preserve hosted-model proxy settings, and default kiosk models to mock unless explicitly enabled.
- Record external command/A2A/wait participant provenance honestly. Omit commands/endpoints from rerun metadata and identify inputs the operator must resupply instead of substituting bundled agents.

## Boundaries

This is not a hostile-code sandbox. Non-POSIX cleanup currently covers direct children. Grant expiry remains a join-time check; this does not introduce continuing revocation or a new identity policy. No remote/LAN agent restriction is added.

## Verification

Fresh standalone base: `53178b9c780d7a7dd6ce723131c4250de03908dd`.
- `python -m pytest -q` on Python 3.12 — 683 passed, 8 existing warnings.
- `git diff --check` — clean.
- Regressions include two-connection/concurrent mailbox operations, duplicate reoffers, terminal mutations, real subprocess deadlines/descendants, repeated cleanup and external rerun redaction.
- Independent review reproduced and cleared duplicate reoffer fencing, repeated process-group signaling and hosted proxy regressions. A real loopback ModelClient proxy check passed; planted command/A2A secrets were absent from generated evidence.

Combined remediation separately passed all 817 tests on Python 3.12 and the clean Python 3.11 wheel. This PR is independently based on main; the current-manual PR documents its final boundaries.
