### PR TITLE
fix(packaging): ship runtime assets and verify built distributions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,10 @@ runs
 __pycache__
 *.egg-info
 .pytest_cache
+build
+dist
+**/node_modules
+**/.next
+**/.env
+**/.env.local
+**/.env.*.local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,28 @@ jobs:
         run: nandatown run marketplace --out /tmp/runs
       - name: Smoke run (Track)
         run: nandatown run quote-crash-restart --out /tmp/runs
+
+  distribution:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build source and wheel artifacts
+        run: |
+          python -m pip install build
+          python -m build
+          python scripts/check_distributions.py dist
+      - name: Install the wheel outside the checkout
+        run: |
+          python -m venv "$RUNNER_TEMP/town-wheel-env"
+          "$RUNNER_TEMP/town-wheel-env/bin/python" -m pip install dist/*.whl
+      - name: Installed-wheel controls
+        working-directory: ${{ runner.temp }}
+        env:
+          NANDATOWN_HOME: ${{ runner.temp }}/town-wheel-state
+        run: |
+          "$RUNNER_TEMP/town-wheel-env/bin/nandatown" run marketplace --out "$RUNNER_TEMP/town-wheel-runs"
+          "$RUNNER_TEMP/town-wheel-env/bin/nandatown" run quote-crash-restart --out "$RUNNER_TEMP/town-wheel-runs"
+          "$RUNNER_TEMP/town-wheel-env/bin/nandatown" skills

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include tests/fixtures *.json *.yaml
 recursive-include schemas *.json
+recursive-include examples *.py
 include scripts/check_distributions.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include tests/fixtures *.json *.yaml
+recursive-include schemas *.json
+include scripts/check_distributions.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,7 @@ name = "nandatown"
 version = "0.2.0"
 description = "Local-first NANDA Town sandbox and test harness. Bring an agent, give it a task, break something on purpose, leave with evidence."
 requires-python = ">=3.11"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 dependencies = [
     "fastapi>=0.110",
     "uvicorn>=0.29",

--- a/schemas/evidence_result.schema.json
+++ b/schemas/evidence_result.schema.json
@@ -24,7 +24,8 @@
             "passed",
             "failed",
             "not_enough_evidence",
-            "not_tested"
+            "not_tested",
+            "error"
           ],
           "title": "Status",
           "type": "string"
@@ -64,7 +65,8 @@
       "enum": [
         "passed",
         "failed",
-        "incomplete"
+        "incomplete",
+        "error"
       ],
       "title": "Verdict",
       "type": "string"

--- a/schemas/release_ref.schema.json
+++ b/schemas/release_ref.schema.json
@@ -12,7 +12,8 @@
         "scenario",
         "plugin",
         "package",
-        "profile"
+        "profile",
+        "service"
       ],
       "title": "Kind",
       "type": "string"

--- a/schemas/run_plan.schema.json
+++ b/schemas/run_plan.schema.json
@@ -58,7 +58,9 @@
         "drop_wakeup",
         "duplicate_delivery",
         "lost_ack",
-        "crash_after_claim"
+        "crash_after_claim",
+        "context_truncation",
+        "tool_error"
       ],
       "title": "Fault",
       "type": "string"
@@ -76,6 +78,14 @@
         "type": "string"
       },
       "title": "Roles",
+      "type": "object"
+    },
+    "runtimes": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {},
+      "title": "Runtimes",
       "type": "object"
     },
     "task": {

--- a/scripts/check_distributions.py
+++ b/scripts/check_distributions.py
@@ -23,7 +23,7 @@ def check(directory: Path) -> None:
     }
     test_data = {
         str(path.relative_to(root))
-        for pattern in ("tests/fixtures/**/*", "schemas/*.json")
+        for pattern in ("tests/fixtures/**/*", "schemas/*.json", "examples/*.py")
         for path in root.glob(pattern) if path.is_file()
     }
     with zipfile.ZipFile(wheels[0]) as wheel:

--- a/scripts/check_distributions.py
+++ b/scripts/check_distributions.py
@@ -1,0 +1,44 @@
+"""Check the artifacts, not the checkout, for runtime and shipped-test data.
+
+Usage: python scripts/check_distributions.py dist
+"""
+
+from pathlib import Path
+import sys
+import tarfile
+import zipfile
+
+
+def check(directory: Path) -> None:
+    wheels = list(directory.glob("*.whl"))
+    sources = list(directory.glob("*.tar.gz"))
+    if len(wheels) != 1 or len(sources) != 1:
+        raise SystemExit("expected exactly one wheel and one sdist")
+    root = Path(__file__).resolve().parents[1]
+    runtime = {
+        str(path.relative_to(root / "src"))
+        for pattern in ("src/nandatown/sim/scenarios/*.yaml",
+                        "src/nandatown/skills/builtin/*.md")
+        for path in root.glob(pattern)
+    }
+    test_data = {
+        str(path.relative_to(root))
+        for pattern in ("tests/fixtures/**/*", "schemas/*.json")
+        for path in root.glob(pattern) if path.is_file()
+    }
+    with zipfile.ZipFile(wheels[0]) as wheel:
+        missing = runtime - set(wheel.namelist())
+        if missing:
+            raise SystemExit(f"wheel missing runtime data: {sorted(missing)}")
+    with tarfile.open(sources[0]) as source:
+        names = {name.partition("/")[2] for name in source.getnames()}
+        expected = test_data | {f"src/{name}" for name in runtime}
+        missing = expected - names
+        if missing:
+            raise SystemExit(f"sdist missing data: {sorted(missing)}")
+    print(f"Distribution data verified: {len(runtime)} runtime files,"
+          f" {len(test_data)} fixture/schema files")
+
+
+if __name__ == "__main__":
+    check(Path(sys.argv[1] if len(sys.argv) > 1 else "dist"))

--- a/tests/test_schema_sync.py
+++ b/tests/test_schema_sync.py
@@ -1,0 +1,14 @@
+import json
+from pathlib import Path
+
+from nandatown.schemas import export_schemas
+
+
+def test_checked_in_schemas_match_exported_contracts(tmp_path):
+    generated = [Path(path) for path in export_schemas(str(tmp_path))]
+    committed = Path(__file__).resolve().parents[1] / "schemas"
+    assert {path.name for path in generated} == {
+        path.name for path in committed.glob("*.schema.json")}
+    for path in generated:
+        assert json.loads(path.read_text()) == json.loads(
+            (committed / path.name).read_text()), f"regenerate schemas: {path.name} drifted"


### PR DESCRIPTION
## Summary

- Regenerate stale exported record schemas and test them against the live models.
- Include fixtures, schemas and the BYOA example needed by shipped source-distribution tests; check wheel and sdist assets explicitly.
- Add CI that builds artifacts, installs the wheel in a clean environment outside the checkout, and runs Lab/Track/skills controls.
- Use the supported SPDX license declaration and exclude dependency/build/local-environment artifacts from Docker context.

## Verification

Fresh standalone base: `53178b9c780d7a7dd6ce723131c4250de03908dd`.
- `python -m pytest -q tests/test_schema_sync.py` — 1 passed.
- `python -m build --installer uv` — wheel and source archive built.
- `python scripts/check_distributions.py <artifact-directory>` — 13 runtime files and 12 fixture/schema/example files verified.
- Fresh installed-wheel `nandatown run marketplace` and `nandatown run quote-crash-restart` outside the checkout — both passed; `nandatown skills` listed all six bundled skills.
- `git diff --check` — clean.

The guard first failed against incomplete archives, then passed after the packaging repairs. Independent review rebuilt an exact source archive offline. Separately, the final combined remediation's source-archive tests all passed (817) against its clean installed Python 3.11 wheel.

This job is independent of the companion dashboard lint/build CI additions; their workflow edits are disjoint.
