### PR TITLE
fix(evidence): bind receipt claims and version strict Path evaluation

### DIFF
--- a/src/nandatown/a2a_adapter.py
+++ b/src/nandatown/a2a_adapter.py
@@ -194,6 +194,30 @@ def artifact_text(task: dict[str, Any]) -> str:
     return ""
 
 
+def artifact_texts(task: dict[str, Any]) -> list[Any]:
+    """Return every text output without silently selecting the first one.
+
+    The strict Path profiles count each text part as a possible fulfillment.
+    Malformed artifact containers produce no text outputs; malformed text
+    values are retained so the caller can report them as unparseable rather
+    than mistaking them for an absent response.
+    """
+    artifacts = task.get("artifacts", [])
+    if not isinstance(artifacts, list):
+        return []
+    texts: list[Any] = []
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        parts = artifact.get("parts", [])
+        if not isinstance(parts, list):
+            continue
+        for part in parts:
+            if isinstance(part, dict) and part.get("kind") == "text":
+                texts.append(part.get("text", ""))
+    return texts
+
+
 def probe_endpoint(base_url: str,
                    http: httpx.Client | None = None) -> dict[str, Any]:
     """Card validation plus one message/send round trip."""

--- a/src/nandatown/bundle.py
+++ b/src/nandatown/bundle.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
+import stat
 import time
 from typing import Any
 
@@ -29,6 +31,8 @@ from .records import (
 
 RECORD_FILES = ["profile.json", "run.json", "intents.jsonl", "events.jsonl",
                 "result.json"]
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+BUNDLE_MODES = {"track", "lab", "path"}
 
 
 def _sha256_file(path: str) -> str:
@@ -37,6 +41,18 @@ def _sha256_file(path: str) -> str:
         for chunk in iter(lambda: f.read(65536), b""):
             digest.update(chunk)
     return "sha256:" + digest.hexdigest()
+
+
+def _regular_file_problem(path: str, name: str) -> str | None:
+    try:
+        metadata = os.lstat(path)
+    except FileNotFoundError:
+        return f"{name} missing"
+    except OSError as exc:
+        return f"{name} unreadable: {exc}"
+    if not stat.S_ISREG(metadata.st_mode):
+        return f"{name} is not a regular file"
+    return None
 
 
 def write_bundle(directory: str, profile, run: RunRecord,
@@ -143,31 +159,91 @@ def load_bundle(directory: str) -> dict[str, Any]:
 def verify_bundle(directory: str) -> list[str]:
     """Check integrity and evaluator reproducibility. Returns problems."""
     problems: list[str] = []
+    manifest_path = os.path.join(directory, "manifest.json")
+    manifest_problem = _regular_file_problem(manifest_path, "manifest.json")
+    if manifest_problem:
+        return [manifest_problem]
     try:
-        with open(os.path.join(directory, "manifest.json")) as f:
+        with open(manifest_path) as f:
             manifest = json.load(f)
-    except OSError as exc:
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         return [f"manifest.json unreadable: {exc}"]
-    calculated_fingerprint = fingerprint(manifest.get("files", {}))
-    if manifest.get("bundle_fingerprint") != calculated_fingerprint:
+    if not isinstance(manifest, dict):
+        return ["manifest.json must contain a JSON object"]
+
+    mode = manifest.get("mode", "track")
+    if mode not in BUNDLE_MODES:
+        problems.append(f"unknown bundle mode {mode!r}")
+    files = manifest.get("files")
+    if not isinstance(files, dict):
+        problems.append("manifest.json files must be a JSON object")
+        return problems
+    actual_names = set(files)
+    canonical_names = set(RECORD_FILES)
+    if actual_names != canonical_names:
+        missing = sorted(canonical_names - actual_names)
+        unexpected = sorted(actual_names - canonical_names, key=repr)
+        problems.append("manifest must name exactly the five canonical records:"
+                        f" missing={missing}, unexpected={unexpected}")
+    for name, expected in files.items():
+        if not isinstance(expected, str) or not DIGEST_RE.fullmatch(expected):
+            problems.append(f"{name} digest is malformed")
+    bundle_fingerprint = manifest.get("bundle_fingerprint")
+    if not isinstance(bundle_fingerprint, str) \
+            or not DIGEST_RE.fullmatch(bundle_fingerprint):
+        problems.append("bundle fingerprint is malformed")
+    if problems:
+        return problems
+
+    for name in RECORD_FILES:
+        problem = _regular_file_problem(os.path.join(directory, name), name)
+        if problem:
+            problems.append(problem)
+    if problems:
+        return problems
+
+    calculated_fingerprint = fingerprint(files)
+    if bundle_fingerprint != calculated_fingerprint:
         problems.append(
             "bundle fingerprint mismatch: manifest "
-            f"{manifest.get('bundle_fingerprint')}, calculated "
+            f"{bundle_fingerprint}, calculated "
             f"{calculated_fingerprint}")
-    for name, expected in manifest.get("files", {}).items():
+    for name, expected in files.items():
         path = os.path.join(directory, name)
-        if not os.path.exists(path):
-            problems.append(f"{name} missing")
+        try:
+            actual = _sha256_file(path)
+        except OSError as exc:
+            problems.append(f"{name} unreadable: {exc}")
             continue
-        actual = _sha256_file(path)
         if actual != expected:
             problems.append(f"{name} hash mismatch: manifest {expected},"
                             f" actual {actual}")
     if problems:
         return problems
 
-    bundle = load_bundle(directory)
+    try:
+        bundle = load_bundle(directory)
+    except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError,
+            ValueError) as exc:
+        return [f"bundle records invalid: {exc}"]
     recorded = bundle["result"]
+    run = bundle["run"]
+    profile = bundle["profile"]
+    profile_name = (profile.ref if bundle["mode"] == "path"
+                    else profile.name)
+    if run.run_id != recorded.run_id:
+        problems.append("run and result name different run ids")
+    if run.profile_name != profile_name:
+        problems.append("run profile name does not match profile")
+    if run.profile_fingerprint != fingerprint(profile.model_dump()):
+        problems.append("run profile fingerprint does not match profile")
+    if any(intent.run_id != run.run_id for intent in bundle["intents"]):
+        problems.append("intent names a different run id")
+    if any(event.run_id != run.run_id for event in bundle["events"]):
+        problems.append("event names a different run id")
+    if problems:
+        return problems
+
     if bundle["mode"] == "lab":
         from .sim.validators import LAB_EVALUATOR_VERSION, evaluate_scenario
         expected_version = LAB_EVALUATOR_VERSION
@@ -184,36 +260,69 @@ def verify_bundle(directory: str) -> list[str]:
             f"evaluator version differs: bundle {recorded.evaluator_version},"
             f" local {expected_version}; reproducibility not checked")
         return problems
+    if manifest.get("evaluator_version") != recorded.evaluator_version:
+        problems.append("manifest evaluator version does not match result")
+        return problems
+    stage_names = [stage.name for stage in recorded.stages]
+    duplicate_names = sorted({name for name in stage_names
+                              if stage_names.count(name) > 1})
+    if duplicate_names:
+        problems.append(f"result has duplicate stage names: {duplicate_names}")
     replay = replay_fn(bundle["profile"], recorded.run_id, bundle["events"])
-    recorded_stages = {s.name: s.status for s in recorded.stages}
-    replay_stages = {s.name: s.status for s in replay.stages}
-    if recorded_stages != replay_stages or recorded.verdict != replay.verdict:
+    recorded_result = recorded.model_dump(exclude={"evaluated_at"})
+    replay_result = replay.model_dump(exclude={"evaluated_at"})
+    if recorded_result != replay_result:
         problems.append(
             "evaluator replay mismatch: result.json does not match a fresh"
-            f" evaluation (recorded {recorded_stages} verdict"
-            f" {recorded.verdict}, replay {replay_stages} verdict"
-            f" {replay.verdict})")
+            " deterministic evaluation")
 
     attestation_path = os.path.join(directory, "attestation.json")
-    if os.path.exists(attestation_path):
+    if os.path.lexists(attestation_path):
         from .identity_portable import verify_signature
         from .records import fingerprint as _fingerprint
 
-        with open(attestation_path) as f:
-            attestation = json.load(f)
+        attestation_problem = _regular_file_problem(
+            attestation_path, "attestation.json")
+        if attestation_problem:
+            problems.append(attestation_problem)
+            return problems
+        try:
+            with open(attestation_path) as f:
+                attestation = json.load(f)
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            problems.append(f"attestation.json unreadable: {exc}")
+            return problems
+        if not isinstance(attestation, dict) \
+                or not isinstance(attestation.get("payload"), dict):
+            problems.append("attestation.json must contain an object payload")
+            return problems
         payload = attestation["payload"]
-        if payload["bundle_fingerprint"] != \
-                bundle["manifest"]["bundle_fingerprint"]:
+        expected_claims = {
+            "bundle_fingerprint": bundle["manifest"]["bundle_fingerprint"],
+            "run_id": recorded.run_id,
+            "verdict": recorded.verdict,
+            "evaluator_version": recorded.evaluator_version,
+        }
+        if payload.get("bundle_fingerprint") != \
+                expected_claims["bundle_fingerprint"]:
             problems.append("attestation names a different bundle"
                             " fingerprint")
-        elif not verify_signature(attestation["controller_public"],
-                                  payload, attestation["signature"]):
+        for name in ("run_id", "verdict", "evaluator_version"):
+            if payload.get(name) != expected_claims[name]:
+                problems.append(
+                    f"attestation {name.replace('_', ' ')} does not match bundle")
+        controller_public = attestation.get("controller_public")
+        signature = attestation.get("signature")
+        if not isinstance(controller_public, str) \
+                or not isinstance(signature, str):
+            problems.append("attestation signature and controller key must be strings")
+        elif not verify_signature(controller_public, payload, signature):
             problems.append("attestation signature does not verify")
-        else:
+        if isinstance(controller_public, str):
             derived = ("did:town:" + _fingerprint(
-                attestation["controller_public"])
+                controller_public)
                 .removeprefix("sha256:")[:24])
-            if derived != payload["signer"]:
+            if derived != payload.get("signer"):
                 problems.append("attestation signer id does not match"
                                 " its controller key")
     return problems

--- a/src/nandatown/bundle.py
+++ b/src/nandatown/bundle.py
@@ -55,6 +55,17 @@ def _regular_file_problem(path: str, name: str) -> str | None:
     return None
 
 
+def _duplicates(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    repeated: set[str] = set()
+    for value in values:
+        if value in seen:
+            repeated.add(value)
+        else:
+            seen.add(value)
+    return sorted(repeated)
+
+
 def write_bundle(directory: str, profile, run: RunRecord,
                  intents: list[dict[str, Any]], events: list[TownEvent],
                  result: EvidenceResult, mode: str = "track") -> dict[str, Any]:
@@ -241,47 +252,76 @@ def verify_bundle(directory: str) -> list[str]:
         problems.append("intent names a different run id")
     if any(event.run_id != run.run_id for event in bundle["events"]):
         problems.append("event names a different run id")
+    participant_problems = []
+    if not run.participants:
+        participant_problems.append("run has no participants")
+    for index, participant in enumerate(run.participants):
+        for field in ("name", "role"):
+            value = participant.get(field)
+            if not isinstance(value, str) or not value.strip():
+                participant_problems.append(
+                    f"run participant {index} has no valid {field}")
+    problems.extend(participant_problems)
+    if manifest.get("nandatown_version") != run.releases.get("nandatown"):
+        problems.append("manifest nandatown version does not match run release")
+    if run.releases.get("evaluator") != recorded.evaluator_version:
+        problems.append("run evaluator release does not match result")
+    if manifest.get("evaluator_version") != recorded.evaluator_version:
+        problems.append("manifest evaluator version does not match result")
+    if bundle["mode"] in {"lab", "path"} \
+            and run.config.get("mode") != bundle["mode"]:
+        problems.append("run mode does not match manifest mode")
+    intent_ids = [intent.intent_id for intent in bundle["intents"]]
+    duplicate_intent_ids = _duplicates(intent_ids)
+    if duplicate_intent_ids:
+        problems.append(f"duplicate intent ids: {duplicate_intent_ids}")
+    event_ids = [event.event_id for event in bundle["events"]]
+    duplicate_event_ids = _duplicates(event_ids)
+    if duplicate_event_ids:
+        problems.append(f"duplicate event ids: {duplicate_event_ids}")
+    stage_names = [stage.name for stage in recorded.stages]
+    duplicate_names = _duplicates(stage_names)
+    if duplicate_names:
+        problems.append(f"result has duplicate stage names: {duplicate_names}")
     if problems:
         return problems
 
-    if bundle["mode"] == "lab":
-        from .sim.validators import LAB_EVALUATOR_VERSION, evaluate_scenario
-        expected_version = LAB_EVALUATOR_VERSION
-        replay_fn = evaluate_scenario
-    elif bundle["mode"] == "path":
-        from .path_runner import evaluate_path, path_evaluator_version
-        expected_version = path_evaluator_version(bundle["profile"])
-        replay_fn = evaluate_path
-    else:
-        expected_version = EVALUATOR_VERSION
-        replay_fn = evaluate
-    if recorded.evaluator_version != expected_version:
+    try:
+        if bundle["mode"] == "lab":
+            from .sim.validators import LAB_EVALUATOR_VERSION, evaluate_scenario
+            expected_version = LAB_EVALUATOR_VERSION
+            replay_fn = evaluate_scenario
+        elif bundle["mode"] == "path":
+            from .path_runner import evaluate_path, path_evaluator_version
+            expected_version = path_evaluator_version(bundle["profile"])
+            replay_fn = evaluate_path
+        else:
+            expected_version = EVALUATOR_VERSION
+            replay_fn = evaluate
+    except (KeyError, ValueError) as exc:
+        expected_version = None
+        replay_fn = None
+        problems.append(str(exc))
+    if expected_version is not None \
+            and recorded.evaluator_version != expected_version:
         problems.append(
             f"evaluator version differs: bundle {recorded.evaluator_version},"
             f" local {expected_version}; reproducibility not checked")
-        return problems
-    if manifest.get("evaluator_version") != recorded.evaluator_version:
-        problems.append("manifest evaluator version does not match result")
-        return problems
-    stage_names = [stage.name for stage in recorded.stages]
-    duplicate_names = sorted({name for name in stage_names
-                              if stage_names.count(name) > 1})
-    if duplicate_names:
-        problems.append(f"result has duplicate stage names: {duplicate_names}")
-    try:
-        replay = replay_fn(
-            bundle["profile"], recorded.run_id, bundle["events"])
-    except Exception as exc:
-        problems.append(
-            "evaluator replay failed on the recorded evidence:"
-            f" {type(exc).__name__}: {exc}")
-        return problems
-    recorded_result = recorded.model_dump(exclude={"evaluated_at"})
-    replay_result = replay.model_dump(exclude={"evaluated_at"})
-    if recorded_result != replay_result:
-        problems.append(
-            "evaluator replay mismatch: result.json does not match a fresh"
-            " deterministic evaluation")
+    elif replay_fn is not None:
+        try:
+            replay = replay_fn(
+                bundle["profile"], recorded.run_id, bundle["events"])
+        except Exception as exc:
+            problems.append(
+                "evaluator replay failed on the recorded evidence:"
+                f" {type(exc).__name__}: {exc}")
+        else:
+            recorded_result = recorded.model_dump(exclude={"evaluated_at"})
+            replay_result = replay.model_dump(exclude={"evaluated_at"})
+            if recorded_result != replay_result:
+                problems.append(
+                    "evaluator replay mismatch: result.json does not match a"
+                    " fresh deterministic evaluation")
 
     attestation_path = os.path.join(directory, "attestation.json")
     if os.path.lexists(attestation_path):

--- a/src/nandatown/bundle.py
+++ b/src/nandatown/bundle.py
@@ -283,8 +283,7 @@ def verify_bundle(directory: str) -> list[str]:
     duplicate_names = _duplicates(stage_names)
     if duplicate_names:
         problems.append(f"result has duplicate stage names: {duplicate_names}")
-    if problems:
-        return problems
+    records_coherent = not problems
 
     try:
         if bundle["mode"] == "lab":
@@ -307,7 +306,7 @@ def verify_bundle(directory: str) -> list[str]:
         problems.append(
             f"evaluator version differs: bundle {recorded.evaluator_version},"
             f" local {expected_version}; reproducibility not checked")
-    elif replay_fn is not None:
+    elif replay_fn is not None and records_coherent:
         try:
             replay = replay_fn(
                 bundle["profile"], recorded.run_id, bundle["events"])

--- a/src/nandatown/bundle.py
+++ b/src/nandatown/bundle.py
@@ -172,7 +172,7 @@ def verify_bundle(directory: str) -> list[str]:
         return ["manifest.json must contain a JSON object"]
 
     mode = manifest.get("mode", "track")
-    if mode not in BUNDLE_MODES:
+    if not isinstance(mode, str) or mode not in BUNDLE_MODES:
         problems.append(f"unknown bundle mode {mode!r}")
     files = manifest.get("files")
     if not isinstance(files, dict):
@@ -268,7 +268,14 @@ def verify_bundle(directory: str) -> list[str]:
                               if stage_names.count(name) > 1})
     if duplicate_names:
         problems.append(f"result has duplicate stage names: {duplicate_names}")
-    replay = replay_fn(bundle["profile"], recorded.run_id, bundle["events"])
+    try:
+        replay = replay_fn(
+            bundle["profile"], recorded.run_id, bundle["events"])
+    except Exception as exc:
+        problems.append(
+            "evaluator replay failed on the recorded evidence:"
+            f" {type(exc).__name__}: {exc}")
+        return problems
     recorded_result = recorded.model_dump(exclude={"evaluated_at"})
     replay_result = replay.model_dump(exclude={"evaluated_at"})
     if recorded_result != replay_result:

--- a/src/nandatown/cli.py
+++ b/src/nandatown/cli.py
@@ -95,6 +95,10 @@ def cmd_test_agent(args: argparse.Namespace) -> int:
     if args.url or args.index:
         from .path_runner import run_path_test
 
+        if args.profile is not None:
+            print("--profile selects a Track profile; use --path-profile"
+                  " with --url or --index")
+            return 2
         print(f"nandatown {__version__}: path test of"
               f" {args.url or args.agent_name} under profile"
               f" {args.path_profile}")
@@ -103,10 +107,10 @@ def cmd_test_agent(args: argparse.Namespace) -> int:
             pin_card_digest=args.pin_card_digest,
             index_file=args.index, agent_name=args.agent_name)
         print(render_report(load_bundle(bundle_dir)))
-        applicable = [s for s in result.stages
-                      if s.status != "not_tested"]
-        passed = sum(1 for s in applicable if s.status == "passed")
-        print(f"{passed} of {len(applicable)} path stages passed.")
+        passed = sum(s.status == "passed" for s in result.stages)
+        untested = sum(s.status == "not_tested" for s in result.stages)
+        print(f"{passed} of {len(result.stages)} path stages passed;"
+              f" {untested} not tested.")
         print(f"Evidence bundle: {bundle_dir}")
         return 0 if result.verdict == "passed" else 1
     if not args.cmd and not args.wait:
@@ -127,16 +131,18 @@ def cmd_test_agent(args: argparse.Namespace) -> int:
             print("then join, claim, work, acknowledge. The town is"
                   " watching.")
 
+    profile = args.profile or "quote-clean"
     print(f"nandatown {__version__}: testing your {args.role} against"
-          f" profile {args.profile}")
-    bundle_dir, result = run_town(args.profile, args.out,
+          f" profile {profile}")
+    bundle_dir, result = run_town(profile, args.out,
                                   external=external,
                                   wait_timeout=args.timeout,
                                   on_credentials=creds_cb)
     print(render_report(load_bundle(bundle_dir)))
-    applicable = [s for s in result.stages if s.status != "not_tested"]
-    passed = sum(1 for s in applicable if s.status == "passed")
-    print(f"{passed} of {len(applicable)} town stages passed.")
+    passed = sum(s.status == "passed" for s in result.stages)
+    untested = sum(s.status == "not_tested" for s in result.stages)
+    print(f"{passed} of {len(result.stages)} town stages passed;"
+          f" {untested} not tested.")
     print(f"Evidence bundle: {bundle_dir}")
     return 0 if result.verdict == "passed" else 1
 
@@ -337,6 +343,9 @@ def cmd_pulse(args: argparse.Namespace) -> int:
         for record in export_records(args.db):
             print(record.model_dump_json())
         return 0
+    if args.count < 1:
+        print("--count must be at least 1")
+        return 2
     targets = {}
     for target in args.target:
         name, _, url = target.partition("=")
@@ -696,7 +705,7 @@ def main(argv: list[str] | None = None) -> int:
                        metavar="ROLE=HARNESS",
                        help="Track only: connect a harness per role:"
                             " scripted, llm, llm:MODEL, cmd:COMMAND,"
-                            " or external")
+                            " a2a:URL, or external")
     p_run.add_argument("--plugin", action="append", default=[],
                        metavar="FILE",
                        help="Lab only: load a plugin/validator file"
@@ -742,7 +751,8 @@ def main(argv: list[str] | None = None) -> int:
     p_test.add_argument("--agent-name", default=None)
     p_test.add_argument("--role", choices=["seller", "buyer"],
                         default="seller")
-    p_test.add_argument("--profile", default="quote-clean")
+    p_test.add_argument("--profile", default=None,
+                        help="Track profile for --cmd/--wait (default: quote-clean)")
     p_test.add_argument("--cmd", default=None,
                         help="command that starts your agent (it receives"
                              " TOWN_URL, RUN_ID, NAME, TOKEN, STATE_DIR"

--- a/src/nandatown/cli.py
+++ b/src/nandatown/cli.py
@@ -426,9 +426,13 @@ def cmd_proof(args: argparse.Namespace) -> int:
 
 
 def cmd_mirror(args: argparse.Namespace) -> int:
-    from .mirror import mirror_bundle
+    from .mirror import MirrorError, mirror_bundle
 
-    destination = mirror_bundle(args.bundle_dir, args.mirror_dir)
+    try:
+        destination = mirror_bundle(args.bundle_dir, args.mirror_dir)
+    except MirrorError as exc:
+        print(f"mirror failed: {exc}")
+        return 1
     print(f"mirrored to {destination}")
     print("the address is the bundle fingerprint; any mirror holding it"
           " can restore the run")

--- a/src/nandatown/mirror.py
+++ b/src/nandatown/mirror.py
@@ -15,7 +15,12 @@ import shutil
 import stat
 import tempfile
 
-from .bundle import DIGEST_RE, verify_bundle
+from .bundle import DIGEST_RE, RECORD_FILES, load_bundle, verify_bundle
+
+
+MIRROR_COPY_FILES = frozenset(
+    [*RECORD_FILES, "manifest.json", "attestation.json", "receipt.json"])
+MIRROR_ALLOWED_FILES = MIRROR_COPY_FILES | {"report.md"}
 
 
 class MirrorError(Exception):
@@ -42,7 +47,7 @@ def _fingerprint_of(bundle_dir: str) -> str:
 
 
 def _tree_problem(bundle_dir: str, *, ignore_state: bool = False) -> str | None:
-    """Reject links and special files without following them."""
+    """Reject links, special files, and unsupported top-level payloads."""
     try:
         root_metadata = os.lstat(bundle_dir)
     except OSError as exc:
@@ -50,29 +55,22 @@ def _tree_problem(bundle_dir: str, *, ignore_state: bool = False) -> str | None:
     if not stat.S_ISDIR(root_metadata.st_mode):
         return "bundle path is not a regular directory"
 
-    def inspect(directory: str, relative: str) -> str | None:
-        try:
-            with os.scandir(directory) as entries:
-                for entry in entries:
-                    if ignore_state and entry.name == "state":
-                        continue
-                    entry_relative = os.path.join(relative, entry.name)
-                    try:
-                        metadata = entry.stat(follow_symlinks=False)
-                    except OSError as exc:
-                        return f"{entry_relative} is unreadable: {exc}"
-                    if stat.S_ISDIR(metadata.st_mode):
-                        problem = inspect(entry.path, entry_relative)
-                        if problem:
-                            return problem
-                    elif not stat.S_ISREG(metadata.st_mode):
-                        return f"{entry_relative} is not a regular file"
-        except OSError as exc:
-            shown = relative or "."
-            return f"{shown} is unreadable: {exc}"
-        return None
-
-    return inspect(bundle_dir, "")
+    try:
+        with os.scandir(bundle_dir) as entries:
+            for entry in entries:
+                if ignore_state and entry.name == "state":
+                    continue
+                if entry.name not in MIRROR_ALLOWED_FILES:
+                    return f"{entry.name} is an unsupported bundle member"
+                try:
+                    metadata = entry.stat(follow_symlinks=False)
+                except OSError as exc:
+                    return f"{entry.name} is unreadable: {exc}"
+                if not stat.S_ISREG(metadata.st_mode):
+                    return f"{entry.name} is not a regular file"
+    except OSError as exc:
+        return f". is unreadable: {exc}"
+    return None
 
 
 def _validate_bundle(bundle_dir: str, label: str, *,
@@ -84,6 +82,14 @@ def _validate_bundle(bundle_dir: str, label: str, *,
     problems = verify_bundle(bundle_dir)
     if problems:
         raise MirrorError(f"{label} bundle fails verification: {problems}")
+    receipt_path = os.path.join(bundle_dir, "receipt.json")
+    if os.path.lexists(receipt_path):
+        from .receipt import verify_receipt
+
+        receipt_problems = verify_receipt(receipt_path, bundle_dir)
+        if receipt_problems:
+            raise MirrorError(
+                f"{label} receipt fails verification: {receipt_problems}")
     fingerprint = _fingerprint_of(bundle_dir)
     if expected_fingerprint is not None \
             and fingerprint != expected_fingerprint:
@@ -92,17 +98,25 @@ def _validate_bundle(bundle_dir: str, label: str, *,
     return fingerprint
 
 
-def _copy_bundle(bundle_dir: str, destination: str, fingerprint: str,
-                 *, ignore_state: bool = False) -> None:
+def _copy_bundle(bundle_dir: str, destination: str, fingerprint: str) -> None:
     parent = os.path.dirname(destination)
     os.makedirs(parent, exist_ok=True)
     staging_root = tempfile.mkdtemp(prefix=".nandatown-copy-", dir=parent)
     staged_bundle = os.path.join(staging_root, "bundle")
     try:
-        ignore = shutil.ignore_patterns("state") if ignore_state else None
-        shutil.copytree(bundle_dir, staged_bundle, symlinks=True, ignore=ignore)
+        os.mkdir(staged_bundle)
+        for name in sorted(MIRROR_COPY_FILES):
+            source = os.path.join(bundle_dir, name)
+            if not os.path.lexists(source):
+                continue
+            shutil.copy2(source, os.path.join(staged_bundle, name),
+                         follow_symlinks=False)
         _validate_bundle(
             staged_bundle, "copied", expected_fingerprint=fingerprint)
+        from .report import render_report
+
+        with open(os.path.join(staged_bundle, "report.md"), "w") as stream:
+            stream.write(render_report(load_bundle(staged_bundle)))
         if os.path.lexists(destination):
             raise MirrorError(
                 f"destination already exists and was left unchanged:"
@@ -126,8 +140,7 @@ def mirror_bundle(bundle_dir: str, mirror_dir: str) -> str:
             destination, "existing mirror",
             expected_fingerprint=fingerprint)
         return destination
-    _copy_bundle(
-        bundle_dir, destination, fingerprint, ignore_state=True)
+    _copy_bundle(bundle_dir, destination, fingerprint)
     return destination
 
 

--- a/src/nandatown/mirror.py
+++ b/src/nandatown/mirror.py
@@ -12,6 +12,10 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import stat
+import tempfile
+
+from .bundle import DIGEST_RE, verify_bundle
 
 
 class MirrorError(Exception):
@@ -19,41 +23,136 @@ class MirrorError(Exception):
 
 
 def _fingerprint_of(bundle_dir: str) -> str:
-    with open(os.path.join(bundle_dir, "manifest.json")) as f:
-        return json.load(f)["bundle_fingerprint"]
+    manifest_path = os.path.join(bundle_dir, "manifest.json")
+    try:
+        metadata = os.lstat(manifest_path)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise MirrorError("manifest.json is not a regular file")
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+        fingerprint = manifest["bundle_fingerprint"]
+    except MirrorError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError, KeyError,
+            TypeError) as exc:
+        raise MirrorError(f"cannot read bundle fingerprint: {exc}") from exc
+    if not isinstance(fingerprint, str) or not DIGEST_RE.fullmatch(fingerprint):
+        raise MirrorError("invalid bundle fingerprint in manifest")
+    return fingerprint
+
+
+def _tree_problem(bundle_dir: str, *, ignore_state: bool = False) -> str | None:
+    """Reject links and special files without following them."""
+    try:
+        root_metadata = os.lstat(bundle_dir)
+    except OSError as exc:
+        return f"bundle directory is unreadable: {exc}"
+    if not stat.S_ISDIR(root_metadata.st_mode):
+        return "bundle path is not a regular directory"
+
+    def inspect(directory: str, relative: str) -> str | None:
+        try:
+            with os.scandir(directory) as entries:
+                for entry in entries:
+                    if ignore_state and entry.name == "state":
+                        continue
+                    entry_relative = os.path.join(relative, entry.name)
+                    try:
+                        metadata = entry.stat(follow_symlinks=False)
+                    except OSError as exc:
+                        return f"{entry_relative} is unreadable: {exc}"
+                    if stat.S_ISDIR(metadata.st_mode):
+                        problem = inspect(entry.path, entry_relative)
+                        if problem:
+                            return problem
+                    elif not stat.S_ISREG(metadata.st_mode):
+                        return f"{entry_relative} is not a regular file"
+        except OSError as exc:
+            shown = relative or "."
+            return f"{shown} is unreadable: {exc}"
+        return None
+
+    return inspect(bundle_dir, "")
+
+
+def _validate_bundle(bundle_dir: str, label: str, *,
+                     expected_fingerprint: str | None = None,
+                     ignore_state: bool = False) -> str:
+    tree_problem = _tree_problem(bundle_dir, ignore_state=ignore_state)
+    if tree_problem:
+        raise MirrorError(f"{label} has an unsafe tree: {tree_problem}")
+    problems = verify_bundle(bundle_dir)
+    if problems:
+        raise MirrorError(f"{label} bundle fails verification: {problems}")
+    fingerprint = _fingerprint_of(bundle_dir)
+    if expected_fingerprint is not None \
+            and fingerprint != expected_fingerprint:
+        raise MirrorError(
+            f"{label} manifest disagrees with its content address")
+    return fingerprint
+
+
+def _copy_bundle(bundle_dir: str, destination: str, fingerprint: str,
+                 *, ignore_state: bool = False) -> None:
+    parent = os.path.dirname(destination)
+    os.makedirs(parent, exist_ok=True)
+    staging_root = tempfile.mkdtemp(prefix=".nandatown-copy-", dir=parent)
+    staged_bundle = os.path.join(staging_root, "bundle")
+    try:
+        ignore = shutil.ignore_patterns("state") if ignore_state else None
+        shutil.copytree(bundle_dir, staged_bundle, symlinks=True, ignore=ignore)
+        _validate_bundle(
+            staged_bundle, "copied", expected_fingerprint=fingerprint)
+        if os.path.lexists(destination):
+            raise MirrorError(
+                f"destination already exists and was left unchanged:"
+                f" {destination}")
+        os.rename(staged_bundle, destination)
+    except MirrorError:
+        raise
+    except OSError as exc:
+        raise MirrorError(f"could not copy verified bundle: {exc}") from exc
+    finally:
+        shutil.rmtree(staging_root, ignore_errors=True)
 
 
 def mirror_bundle(bundle_dir: str, mirror_dir: str) -> str:
-    fingerprint = _fingerprint_of(bundle_dir)
+    fingerprint = _validate_bundle(
+        bundle_dir, "source", ignore_state=True)
     slug = fingerprint.removeprefix("sha256:")
     destination = os.path.join(mirror_dir, slug)
-    if os.path.exists(destination):
+    if os.path.lexists(destination):
+        _validate_bundle(
+            destination, "existing mirror",
+            expected_fingerprint=fingerprint)
         return destination
-    os.makedirs(mirror_dir, exist_ok=True)
-    shutil.copytree(bundle_dir, destination,
-                    ignore=shutil.ignore_patterns("state"))
+    _copy_bundle(
+        bundle_dir, destination, fingerprint, ignore_state=True)
     return destination
 
 
 def recover_bundle(fingerprint: str, mirrors: list[str],
                    out_dir: str) -> str:
-    from .bundle import verify_bundle
-
+    if not isinstance(fingerprint, str) or not DIGEST_RE.fullmatch(fingerprint):
+        raise MirrorError(f"invalid bundle fingerprint: {fingerprint!r}")
     slug = fingerprint.removeprefix("sha256:")
+    destination = os.path.join(out_dir, f"recovered-{slug[:12]}")
+    if os.path.lexists(destination):
+        raise MirrorError(
+            f"destination already exists and was left unchanged: {destination}")
+
+    rejections: list[str] = []
     for mirror in mirrors:
         candidate = os.path.join(mirror, slug)
-        if not os.path.isdir(candidate):
+        if not os.path.lexists(candidate):
             continue
-        destination = os.path.join(out_dir, f"recovered-{slug[:12]}")
-        if os.path.exists(destination):
-            shutil.rmtree(destination)
-        shutil.copytree(candidate, destination)
-        if _fingerprint_of(destination) != fingerprint:
-            raise MirrorError(f"mirror {mirror} holds a bundle whose"
-                              " manifest disagrees with its address")
-        problems = verify_bundle(destination)
-        if problems:
-            raise MirrorError(f"recovered bundle fails verification:"
-                              f" {problems}")
-        return destination
-    raise MirrorError(f"no surviving mirror holds {fingerprint}")
+        try:
+            _validate_bundle(
+                candidate, f"mirror {mirror}",
+                expected_fingerprint=fingerprint)
+            _copy_bundle(candidate, destination, fingerprint)
+            return destination
+        except MirrorError as exc:
+            rejections.append(str(exc))
+    detail = f"; rejected: {'; '.join(rejections)}" if rejections else ""
+    raise MirrorError(f"no valid surviving mirror holds {fingerprint}{detail}")

--- a/src/nandatown/mirror.py
+++ b/src/nandatown/mirror.py
@@ -21,6 +21,7 @@ from .bundle import DIGEST_RE, RECORD_FILES, load_bundle, verify_bundle
 MIRROR_COPY_FILES = frozenset(
     [*RECORD_FILES, "manifest.json", "attestation.json", "receipt.json"])
 MIRROR_ALLOWED_FILES = MIRROR_COPY_FILES | {"report.md"}
+SOURCE_ONLY_MEMBERS = {"state", "town.html"}
 
 
 class MirrorError(Exception):
@@ -46,7 +47,7 @@ def _fingerprint_of(bundle_dir: str) -> str:
     return fingerprint
 
 
-def _tree_problem(bundle_dir: str, *, ignore_state: bool = False) -> str | None:
+def _tree_problem(bundle_dir: str, *, source_only: bool = False) -> str | None:
     """Reject links, special files, and unsupported top-level payloads."""
     try:
         root_metadata = os.lstat(bundle_dir)
@@ -58,7 +59,7 @@ def _tree_problem(bundle_dir: str, *, ignore_state: bool = False) -> str | None:
     try:
         with os.scandir(bundle_dir) as entries:
             for entry in entries:
-                if ignore_state and entry.name == "state":
+                if source_only and entry.name in SOURCE_ONLY_MEMBERS:
                     continue
                 if entry.name not in MIRROR_ALLOWED_FILES:
                     return f"{entry.name} is an unsupported bundle member"
@@ -75,8 +76,8 @@ def _tree_problem(bundle_dir: str, *, ignore_state: bool = False) -> str | None:
 
 def _validate_bundle(bundle_dir: str, label: str, *,
                      expected_fingerprint: str | None = None,
-                     ignore_state: bool = False) -> str:
-    tree_problem = _tree_problem(bundle_dir, ignore_state=ignore_state)
+                     source_only: bool = False) -> str:
+    tree_problem = _tree_problem(bundle_dir, source_only=source_only)
     if tree_problem:
         raise MirrorError(f"{label} has an unsafe tree: {tree_problem}")
     problems = verify_bundle(bundle_dir)
@@ -132,7 +133,7 @@ def _copy_bundle(bundle_dir: str, destination: str, fingerprint: str) -> None:
 
 def mirror_bundle(bundle_dir: str, mirror_dir: str) -> str:
     fingerprint = _validate_bundle(
-        bundle_dir, "source", ignore_state=True)
+        bundle_dir, "source", source_only=True)
     slug = fingerprint.removeprefix("sha256:")
     destination = os.path.join(mirror_dir, slug)
     if os.path.lexists(destination):

--- a/src/nandatown/path_profiles.py
+++ b/src/nandatown/path_profiles.py
@@ -15,7 +15,10 @@ from pydantic import BaseModel, ConfigDict
 
 from .records import fingerprint
 
+PATH_EVALUATOR = "path-evaluator@0.1"
+STRICT_PATH_EVALUATOR = "path-evaluator@0.2"
 QUOTE_INTENT_EVALUATOR = "quote-intent-evaluator@0.1"
+STRICT_QUOTE_INTENT_EVALUATOR = "quote-intent-evaluator@0.2"
 QUOTE_INTENT_FIELDS = ("sku", "color", "quantity", "merchant_id", "currency")
 
 
@@ -55,6 +58,24 @@ PATH_PROFILES: dict[str, PathProfile] = {
         limits={"timeout_seconds": 15.0, "max_response_bytes": 1_048_576},
         evaluator=QUOTE_INTENT_EVALUATOR,
     ),
+    "a2a-quote-intent@0.2": PathProfile(
+        profile_id="a2a-quote-intent",
+        version="0.2",
+        protocol="a2a",
+        capability="quote",
+        request={"sku": "widget", "quantity": 2, "unit_price_cents": 1995,
+                 "color": "blue", "merchant_id": "town-reference",
+                 "currency": "USD"},
+        expected={"max_total_cents": 3990, "terminal_fulfillments": 1,
+                  "quote": {"sku": "widget", "quantity": 2,
+                            "color": "blue",
+                            "merchant_id": "town-reference",
+                            "currency": "USD"}},
+        controlled_condition="duplicate_request",
+        limits={"timeout_seconds": 15.0,
+                "max_response_bytes": 1_048_576},
+        evaluator=STRICT_QUOTE_INTENT_EVALUATOR,
+    ),
     "a2a-capability-fulfillment@0.1": PathProfile(
         profile_id="a2a-capability-fulfillment",
         version="0.1",
@@ -65,7 +86,7 @@ PATH_PROFILES: dict[str, PathProfile] = {
         expected={"total_cents": 3990, "terminal_fulfillments": 1},
         controlled_condition="duplicate_request",
         limits={"timeout_seconds": 15.0},
-        evaluator="path-evaluator@0.1",
+        evaluator=PATH_EVALUATOR,
     ),
     "a2a-capability-fulfillment@0.2": PathProfile(
         profile_id="a2a-capability-fulfillment",
@@ -77,11 +98,24 @@ PATH_PROFILES: dict[str, PathProfile] = {
         expected={"total_cents": 3990, "terminal_fulfillments": 1},
         controlled_condition="duplicate_request",
         limits={"timeout_seconds": 15.0, "max_response_bytes": 1_048_576},
-        evaluator="path-evaluator@0.1",
+        evaluator=PATH_EVALUATOR,
+    ),
+    "a2a-capability-fulfillment@0.3": PathProfile(
+        profile_id="a2a-capability-fulfillment",
+        version="0.3",
+        protocol="a2a",
+        capability="quote",
+        request={"sku": "widget", "quantity": 2,
+                 "unit_price_cents": 1995},
+        expected={"total_cents": 3990, "terminal_fulfillments": 1},
+        controlled_condition="duplicate_request",
+        limits={"timeout_seconds": 15.0,
+                "max_response_bytes": 1_048_576},
+        evaluator=STRICT_PATH_EVALUATOR,
     ),
 }
 
-DEFAULT_PATH_PROFILE = "a2a-capability-fulfillment@0.2"
+DEFAULT_PATH_PROFILE = "a2a-capability-fulfillment@0.3"
 
 
 def get_path_profile(ref: str) -> PathProfile:

--- a/src/nandatown/path_runner.py
+++ b/src/nandatown/path_runner.py
@@ -53,6 +53,10 @@ STRICT_PATH_EVALUATORS = {
     STRICT_PATH_EVALUATOR,
     STRICT_QUOTE_INTENT_EVALUATOR,
 }
+LEGACY_PATH_EVALUATORS = {
+    PATH_EVALUATOR,
+    QUOTE_INTENT_EVALUATOR,
+}
 QUOTE_INTENT_EVALUATORS = {
     QUOTE_INTENT_EVALUATOR,
     STRICT_QUOTE_INTENT_EVALUATOR,
@@ -68,13 +72,15 @@ def path_evaluator_version(profile: PathProfile) -> str:
         return "path-quote-intent-0.1"
     if profile.evaluator == PATH_EVALUATOR:
         return PATH_EVALUATOR_VERSION
-    # Preserve the historical fallback for old price-only profiles and any
-    # already-issued profile that relied on it.
-    return PATH_EVALUATOR_VERSION
+    raise ValueError(f"unsupported path evaluator {profile.evaluator!r}")
 
 
 def _strict_path_semantics(profile: PathProfile) -> bool:
-    return profile.evaluator in STRICT_PATH_EVALUATORS
+    if profile.evaluator in STRICT_PATH_EVALUATORS:
+        return True
+    if profile.evaluator in LEGACY_PATH_EVALUATORS:
+        return False
+    raise ValueError(f"unsupported path evaluator {profile.evaluator!r}")
 
 
 def _quote_intent_semantics(profile: PathProfile) -> bool:
@@ -259,7 +265,12 @@ def run_path_test(subject_url: str | None, out_dir: str,
                                         http=client,
                                         max_response_bytes=response_budget,
                                         timeout_seconds=timeout)
-                    state = task.get("status", {}).get("state")
+                    status = task.get("status", {})
+                    if strict_semantics:
+                        state = (status.get("state")
+                                 if isinstance(status, dict) else None)
+                    else:
+                        state = status.get("state")
                     exchange_detail = {
                         "attempt": attempt,
                         "ok": True,
@@ -466,6 +477,12 @@ def evaluate_path(profile: PathProfile, run_id: str,
             note="Town's own driver malfunctioned: "
                  + driver_errors[0].detail.get("reason", "")
                  + "; this run is an error, not an agent failure"))
+    elif strict_semantics and len(first_exchange) > 1:
+        stages.append(StageResult(
+            name="protocol_invocation", status="failed",
+            evidence=[event.event_id for event in first_exchange],
+            note="expected exactly one protocol exchange for attempt 1,"
+                 f" observed {len(first_exchange)}"))
     elif first_exchange and first_exchange[0].detail.get("ok"):
         detail = first_exchange[0].detail
         if detail.get("kind") != "task" or not detail.get("state"):
@@ -497,10 +514,11 @@ def evaluate_path(profile: PathProfile, run_id: str,
 
     first_fulfillment = find("fulfillment_observed", attempt=1)
     first_bad = find("fulfillment_unparseable", attempt=1)
+    first_outcomes = first_fulfillment + first_bad
     expected_outputs = profile.expected.get("terminal_fulfillments", 1)
     if strict_semantics:
         successful_exchange = (
-            first_exchange
+            len(first_exchange) == 1
             and first_exchange[0].detail.get("ok")
             and first_exchange[0].detail.get("kind") == "task"
             and first_exchange[0].detail.get("state") == "completed"
@@ -522,6 +540,13 @@ def evaluate_path(profile: PathProfile, run_id: str,
                     evidence=evidence,
                     note="expected exactly one terminal text output,"
                          f" observed {output_count!r}"))
+            elif len(first_outcomes) != output_count:
+                stages.append(StageResult(
+                    name="semantic_result", status="failed",
+                    evidence=[event.event_id for event in first_outcomes],
+                    note=f"recorded {output_count} terminal text output but"
+                         f" observed {len(first_outcomes)} fulfillment"
+                         " evaluation events"))
             elif first_fulfillment:
                 stages.append(_semantic_fulfillment_stage(
                     profile, first_fulfillment[0]))
@@ -550,7 +575,16 @@ def evaluate_path(profile: PathProfile, run_id: str,
     second = find("fulfillment_observed", attempt=2)
     second_exchange = find("protocol_exchange", attempt=2)
     second_bad = find("fulfillment_unparseable", attempt=2)
-    if strict_semantics and first_fulfillment and second_exchange:
+    second_outcomes = second + second_bad
+    if strict_semantics and len(first_fulfillment) == 1 \
+            and len(second_exchange) > 1:
+        stages.append(StageResult(
+            name="duplicate_request", status="failed",
+            evidence=[event.event_id for event in second_exchange],
+            note="expected exactly one protocol exchange for attempt 2,"
+                 f" observed {len(second_exchange)}"))
+    elif strict_semantics and len(first_fulfillment) == 1 \
+            and len(second_exchange) == 1:
         detail = second_exchange[0].detail
         if not detail.get("ok"):
             stages.append(StageResult(
@@ -576,6 +610,13 @@ def evaluate_path(profile: PathProfile, run_id: str,
                 note="expected exactly one terminal text output from the"
                      " duplicate request, observed"
                      f" {detail.get('terminal_output_count')!r}"))
+        elif len(second_outcomes) != detail.get("terminal_output_count"):
+            stages.append(StageResult(
+                name="duplicate_request", status="failed",
+                evidence=[event.event_id for event in second_outcomes],
+                note="recorded one terminal text output from the duplicate"
+                     f" request but observed {len(second_outcomes)}"
+                     " fulfillment evaluation events"))
         elif second:
             same = (second[0].detail.get("content_digest")
                     == first_fulfillment[0].detail.get("content_digest"))

--- a/src/nandatown/path_runner.py
+++ b/src/nandatown/path_runner.py
@@ -33,8 +33,9 @@ from .a2a_transport import (
     validate_response_budget,
 )
 from .path_profiles import (
-    DEFAULT_PATH_PROFILE, QUOTE_INTENT_EVALUATOR, QUOTE_INTENT_FIELDS,
-    PathProfile, get_path_profile,
+    DEFAULT_PATH_PROFILE, PATH_EVALUATOR, QUOTE_INTENT_EVALUATOR,
+    QUOTE_INTENT_FIELDS, STRICT_PATH_EVALUATOR,
+    STRICT_QUOTE_INTENT_EVALUATOR, PathProfile, get_path_profile,
 )
 from .records import (
     EvidenceResult,
@@ -45,13 +46,39 @@ from .records import (
 )
 
 PATH_EVALUATOR_VERSION = "path-0.2"
+STRICT_PATH_EVALUATOR_VERSION = "path-0.3"
+STRICT_QUOTE_INTENT_EVALUATOR_VERSION = "path-quote-intent-0.2"
+
+STRICT_PATH_EVALUATORS = {
+    STRICT_PATH_EVALUATOR,
+    STRICT_QUOTE_INTENT_EVALUATOR,
+}
+QUOTE_INTENT_EVALUATORS = {
+    QUOTE_INTENT_EVALUATOR,
+    STRICT_QUOTE_INTENT_EVALUATOR,
+}
 
 
 def path_evaluator_version(profile: PathProfile) -> str:
-    # Existing price-only profiles retain their evaluator and replay semantics.
+    if profile.evaluator == STRICT_PATH_EVALUATOR:
+        return STRICT_PATH_EVALUATOR_VERSION
+    if profile.evaluator == STRICT_QUOTE_INTENT_EVALUATOR:
+        return STRICT_QUOTE_INTENT_EVALUATOR_VERSION
     if profile.evaluator == QUOTE_INTENT_EVALUATOR:
         return "path-quote-intent-0.1"
+    if profile.evaluator == PATH_EVALUATOR:
+        return PATH_EVALUATOR_VERSION
+    # Preserve the historical fallback for old price-only profiles and any
+    # already-issued profile that relied on it.
     return PATH_EVALUATOR_VERSION
+
+
+def _strict_path_semantics(profile: PathProfile) -> bool:
+    return profile.evaluator in STRICT_PATH_EVALUATORS
+
+
+def _quote_intent_semantics(profile: PathProfile) -> bool:
+    return profile.evaluator in QUOTE_INTENT_EVALUATORS
 
 
 def _quote_intent_errors(profile: PathProfile, detail: dict[str, Any]) -> list[str]:
@@ -73,6 +100,41 @@ def _quote_intent_errors(profile: PathProfile, detail: dict[str, Any]) -> list[s
         errors.append(f"total_cents: expected integer in [0, {maximum}],"
                       f" observed {total!r}")
     return errors
+
+
+def _semantic_fulfillment_stage(
+        profile: PathProfile, fulfillment: TownEvent) -> StageResult:
+    detail = fulfillment.detail
+    observed_total = detail.get("total_cents")
+    expected_request_id = fulfillment.subject
+    observed_request_id = detail.get("request_id")
+    request_ok = (isinstance(expected_request_id, str)
+                  and bool(expected_request_id)
+                  and isinstance(observed_request_id, str)
+                  and observed_request_id == expected_request_id)
+    quote_intent = _quote_intent_semantics(profile)
+    errors = _quote_intent_errors(profile, detail) if quote_intent else []
+    expected_total = profile.expected.get("total_cents")
+    result_ok = not errors if quote_intent else observed_total == expected_total
+    if result_ok and request_ok:
+        return StageResult(
+            name="semantic_result", status="passed",
+            evidence=[fulfillment.event_id],
+            note=(f"observed quote matches the item terms and budget;"
+                  f" total_cents {observed_total}; no purchase or delivery"
+                  " tested"
+                  if quote_intent else
+                  f"exactly one fulfillment, total {observed_total}"))
+    note = ("quote does not match the selected profile: " + "; ".join(errors)
+            if quote_intent else
+            f"protocol passed but the result is wrong:"
+            f" expected total {expected_total}, observed {observed_total}")
+    if not request_ok:
+        note += (f"; expected request_id {expected_request_id!r},"
+                 f" observed request_id {observed_request_id!r}")
+    return StageResult(
+        name="semantic_result", status="failed",
+        evidence=[fulfillment.event_id], note=note)
 
 
 STAGE_ORDER = ["resolution", "agent_card_retrieval",
@@ -141,9 +203,12 @@ def run_path_test(subject_url: str | None, out_dir: str,
                   agent_name: str | None = None,
                   http: httpx.Client | None = None
                   ) -> tuple[str, EvidenceResult]:
-    from .a2a_adapter import artifact_text, fetch_card, send_message
+    from .a2a_adapter import (
+        artifact_text, artifact_texts, fetch_card, send_message,
+    )
 
     profile = get_path_profile(profile_ref or DEFAULT_PATH_PROFILE)
+    strict_semantics = _strict_path_semantics(profile)
     run_id = "path-" + uuid.uuid4().hex[:12]
     nonce = uuid.uuid4().hex[:10]
     recorder = _Recorder(run_id)
@@ -195,37 +260,72 @@ def run_path_test(subject_url: str | None, out_dir: str,
                                         max_response_bytes=response_budget,
                                         timeout_seconds=timeout)
                     state = task.get("status", {}).get("state")
+                    exchange_detail = {
+                        "attempt": attempt,
+                        "ok": True,
+                        "task_id": task.get("id"),
+                        "kind": task.get("kind"),
+                        "state": state,
+                    }
+                    terminal_outputs = None
+                    if strict_semantics:
+                        terminal_outputs = artifact_texts(task)
+                        exchange_detail["terminal_output_count"] = len(
+                            terminal_outputs)
                     recorder.emit("town-requester", "protocol_exchange",
-                                  order_id,
-                                  {"attempt": attempt, "ok": True,
-                                   "task_id": task.get("id"),
-                                   "kind": task.get("kind"),
-                                   "state": state})
-                    text = artifact_text(task)
+                                  order_id, exchange_detail)
+                    if strict_semantics:
+                        if task.get("kind") != "task" or state != "completed":
+                            break
+                        expected_outputs = profile.expected.get(
+                            "terminal_fulfillments", 1)
+                        if len(terminal_outputs) != expected_outputs:
+                            recorder.emit(
+                                "town-requester", "fulfillment_unparseable",
+                                order_id,
+                                {"attempt": attempt,
+                                 "terminal_output_count": len(
+                                     terminal_outputs),
+                                 "reason":
+                                     "expected exactly one terminal text"
+                                     " output, observed"
+                                     f" {len(terminal_outputs)}"})
+                            break
+                        text = terminal_outputs[0]
+                    else:
+                        text = artifact_text(task)
                     try:
                         fulfillment = json.loads(text)
                         if not isinstance(fulfillment, dict):
                             recorder.emit("town-requester", "fulfillment_unparseable",
                                           order_id, {"attempt": attempt,
                                                      "reason": "quote is not a JSON object"})
+                            if strict_semantics:
+                                break
                             continue
                         detail = {
                             "attempt": attempt,
                             "total_cents": fulfillment.get("total_cents"),
                             "request_id": fulfillment.get("request_id"),
                             "content_digest": fingerprint(fulfillment)}
-                        if profile.evaluator == QUOTE_INTENT_EVALUATOR:
+                        if _quote_intent_semantics(profile):
                             detail["quote"] = {
                                 field: fulfillment[field] for field in QUOTE_INTENT_FIELDS
                                 if field in fulfillment}
                         recorder.emit(
                             "town-requester", "fulfillment_observed",
                             order_id, detail)
-                    except json.JSONDecodeError:
+                    except (json.JSONDecodeError, TypeError) as exc:
+                        if isinstance(exc, TypeError) and not strict_semantics:
+                            raise
+                        preview = (text[:200] if isinstance(text, str)
+                                   else repr(text)[:200])
                         recorder.emit("town-requester",
                                       "fulfillment_unparseable", order_id,
                                       {"attempt": attempt,
-                                       "text": text[:200]})
+                                       "text": preview})
+                        if strict_semantics:
+                            break
                 except (ValueError, httpx.HTTPError) as exc:
                     recorder.emit("town-requester", "protocol_exchange",
                                   order_id,
@@ -284,6 +384,8 @@ def evaluate_path(profile: PathProfile, run_id: str,
                   events: list[TownEvent]) -> EvidenceResult:
     """Stage results derived purely from the recorded observations, so
     any holder of the bundle can replay this judgment."""
+
+    strict_semantics = _strict_path_semantics(profile)
 
     def find(kind: str, **conds) -> list[TownEvent]:
         out = []
@@ -366,17 +468,23 @@ def evaluate_path(profile: PathProfile, run_id: str,
                  + "; this run is an error, not an agent failure"))
     elif first_exchange and first_exchange[0].detail.get("ok"):
         detail = first_exchange[0].detail
-        if detail.get("kind") == "task" and detail.get("state"):
+        if detail.get("kind") != "task" or not detail.get("state"):
+            stages.append(StageResult(
+                name="protocol_invocation", status="failed",
+                evidence=[first_exchange[0].event_id],
+                note="the response was not a well-formed task"))
+        elif strict_semantics and detail.get("state") != "completed":
+            stages.append(StageResult(
+                name="protocol_invocation", status="failed",
+                evidence=[first_exchange[0].event_id],
+                note="expected successful terminal task state 'completed',"
+                     f" observed {detail.get('state')!r}"))
+        else:
             stages.append(StageResult(
                 name="protocol_invocation", status="passed",
                 evidence=[first_exchange[0].event_id],
                 note=f"task {detail.get('task_id')} state"
                      f" {detail.get('state')}"))
-        else:
-            stages.append(StageResult(
-                name="protocol_invocation", status="failed",
-                evidence=[first_exchange[0].event_id],
-                note="the response was not a well-formed task"))
     elif first_exchange:
         stages.append(StageResult(
             name="protocol_invocation", status="failed",
@@ -387,45 +495,52 @@ def evaluate_path(profile: PathProfile, run_id: str,
                                   status="not_enough_evidence",
                                   note="invocation was never reached"))
 
-    expected_total = profile.expected.get("total_cents")
     first_fulfillment = find("fulfillment_observed", attempt=1)
-    if first_fulfillment:
-        detail = first_fulfillment[0].detail
-        observed_total = detail.get("total_cents")
-        expected_request_id = first_fulfillment[0].subject
-        observed_request_id = detail.get("request_id")
-        request_ok = (isinstance(expected_request_id, str)
-                      and bool(expected_request_id)
-                      and isinstance(observed_request_id, str)
-                      and observed_request_id == expected_request_id)
-        quote_intent = profile.evaluator == QUOTE_INTENT_EVALUATOR
-        errors = _quote_intent_errors(profile, detail) if quote_intent else []
-        result_ok = not errors if quote_intent else observed_total == expected_total
-        if result_ok and request_ok:
+    first_bad = find("fulfillment_unparseable", attempt=1)
+    expected_outputs = profile.expected.get("terminal_fulfillments", 1)
+    if strict_semantics:
+        successful_exchange = (
+            first_exchange
+            and first_exchange[0].detail.get("ok")
+            and first_exchange[0].detail.get("kind") == "task"
+            and first_exchange[0].detail.get("state") == "completed"
+        )
+        if not successful_exchange:
             stages.append(StageResult(
-                name="semantic_result", status="passed",
-                evidence=[first_fulfillment[0].event_id],
-                note=(f"observed quote matches the item terms and budget;"
-                      f" total_cents {observed_total}; no purchase or delivery tested"
-                      if quote_intent else
-                      f"exactly one fulfillment, total {observed_total}")))
+                name="semantic_result", status="not_enough_evidence",
+                note="no successful terminal task output was observed"))
         else:
-            note = ("quote does not match the selected profile: " + "; ".join(errors)
-                    if quote_intent else
-                    f"protocol passed but the result is wrong:"
-                    f" expected total {expected_total}, observed {observed_total}")
-            if not request_ok:
-                note += (f"; expected request_id {expected_request_id!r},"
-                         f" observed request_id {observed_request_id!r}")
-            stages.append(StageResult(
-                name="semantic_result", status="failed",
-                evidence=[first_fulfillment[0].event_id],
-                note=note))
-    elif find("fulfillment_unparseable", attempt=1):
-        bad = find("fulfillment_unparseable", attempt=1)[0]
+            output_count = first_exchange[0].detail.get(
+                "terminal_output_count")
+            if type(output_count) is not int \
+                    or output_count != expected_outputs:
+                evidence = [first_exchange[0].event_id]
+                if first_bad:
+                    evidence.append(first_bad[0].event_id)
+                stages.append(StageResult(
+                    name="semantic_result", status="failed",
+                    evidence=evidence,
+                    note="expected exactly one terminal text output,"
+                         f" observed {output_count!r}"))
+            elif first_fulfillment:
+                stages.append(_semantic_fulfillment_stage(
+                    profile, first_fulfillment[0]))
+            elif first_bad:
+                stages.append(StageResult(
+                    name="semantic_result", status="failed",
+                    evidence=[first_bad[0].event_id],
+                    note="the fulfillment artifact is not parseable"))
+            else:
+                stages.append(StageResult(
+                    name="semantic_result", status="not_enough_evidence",
+                    note="the terminal output was not evaluated"))
+    elif first_fulfillment:
+        stages.append(_semantic_fulfillment_stage(
+            profile, first_fulfillment[0]))
+    elif first_bad:
         stages.append(StageResult(
             name="semantic_result", status="failed",
-            evidence=[bad.event_id],
+            evidence=[first_bad[0].event_id],
             note="the fulfillment artifact is not parseable"))
     else:
         stages.append(StageResult(name="semantic_result",
@@ -433,7 +548,60 @@ def evaluate_path(profile: PathProfile, run_id: str,
                                   note="no fulfillment was observed"))
 
     second = find("fulfillment_observed", attempt=2)
-    if first_fulfillment and second:
+    second_exchange = find("protocol_exchange", attempt=2)
+    second_bad = find("fulfillment_unparseable", attempt=2)
+    if strict_semantics and first_fulfillment and second_exchange:
+        detail = second_exchange[0].detail
+        if not detail.get("ok"):
+            stages.append(StageResult(
+                name="duplicate_request", status="failed",
+                evidence=[second_exchange[0].event_id],
+                note="the duplicate request failed: "
+                     + detail.get("reason", "protocol invocation failed")))
+        elif detail.get("kind") != "task" or detail.get("state") != "completed":
+            stages.append(StageResult(
+                name="duplicate_request", status="failed",
+                evidence=[second_exchange[0].event_id],
+                note="expected duplicate request to return successful terminal"
+                     " task state 'completed', observed"
+                     f" {detail.get('state')!r}"))
+        elif type(detail.get("terminal_output_count")) is not int \
+                or detail.get("terminal_output_count") != expected_outputs:
+            evidence = [second_exchange[0].event_id]
+            if second_bad:
+                evidence.append(second_bad[0].event_id)
+            stages.append(StageResult(
+                name="duplicate_request", status="failed",
+                evidence=evidence,
+                note="expected exactly one terminal text output from the"
+                     " duplicate request, observed"
+                     f" {detail.get('terminal_output_count')!r}"))
+        elif second:
+            same = (second[0].detail.get("content_digest")
+                    == first_fulfillment[0].detail.get("content_digest"))
+            if same:
+                stages.append(StageResult(
+                    name="duplicate_request", status="passed",
+                    evidence=[second[0].event_id],
+                    note="the same logical order was delivered twice; no"
+                         " second distinct fulfillment appeared"))
+            else:
+                stages.append(StageResult(
+                    name="duplicate_request", status="failed",
+                    evidence=[first_fulfillment[0].event_id,
+                              second[0].event_id],
+                    note="idempotency defect: the duplicate produced a"
+                         " second distinct fulfillment"))
+        elif second_bad:
+            stages.append(StageResult(
+                name="duplicate_request", status="failed",
+                evidence=[second_bad[0].event_id],
+                note="the duplicate fulfillment artifact is not parseable"))
+        else:
+            stages.append(StageResult(
+                name="duplicate_request", status="not_enough_evidence",
+                note="the duplicate terminal output was not evaluated"))
+    elif not strict_semantics and first_fulfillment and second:
         same = (second[0].detail.get("content_digest")
                 == first_fulfillment[0].detail.get("content_digest"))
         if same:

--- a/src/nandatown/receipt.py
+++ b/src/nandatown/receipt.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import stat
 import time
 from typing import Any
 
@@ -30,6 +31,44 @@ DEFAULT_LIMITATIONS = [
     " safety",
     "a favorable result grants no permissions and endorses nothing",
 ]
+
+
+def _receipt_file_problem(path: str, *, missing_ok: bool = False) -> str | None:
+    try:
+        metadata = os.lstat(path)
+    except FileNotFoundError:
+        return None if missing_ok else "receipt missing"
+    except OSError as exc:
+        return f"receipt unreadable: {exc}"
+    if not stat.S_ISREG(metadata.st_mode):
+        return "receipt is not a regular file"
+    return None
+
+
+def _load_receipt_document(path: str) -> tuple[Any | None, str | None]:
+    problem = _receipt_file_problem(path)
+    if problem:
+        return None, problem
+    try:
+        with open(path) as f:
+            return json.load(f), None
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return None, f"receipt unreadable: {exc}"
+
+
+def _proof_window_problems(window: dict[str, Any], now: float) -> list[str]:
+    problems = []
+    for name in ("started", "evaluated"):
+        value = window.get(name)
+        if isinstance(value, bool) \
+                or not isinstance(value, (int, float)) \
+                or not math.isfinite(value):
+            problems.append(
+                f"the evidence window {name} timestamp must be finite")
+        elif value > now:
+            problems.append(
+                f"the evidence window {name} timestamp is in the future")
+    return problems
 
 
 def _bundle_receipt_fields(bundle: dict[str, Any]) -> dict[str, Any]:
@@ -77,6 +116,11 @@ def make_receipt(bundle_dir: str, keystore=None,
         default_keystore_dir,
     )
 
+    path = os.path.join(bundle_dir, "receipt.json")
+    path_problem = _receipt_file_problem(path, missing_ok=True)
+    if path_problem:
+        raise ValueError(f"refusing to write receipt: {path_problem}")
+
     bundle = load_bundle(bundle_dir)
     fields = _bundle_receipt_fields(bundle)
 
@@ -95,7 +139,6 @@ def make_receipt(bundle_dir: str, keystore=None,
     receipt = {"payload": payload,
                "signature": keystore.sign(signer, payload),
                "controller_public": identity["controller_public"]}
-    path = os.path.join(bundle_dir, "receipt.json")
     with open(path, "w") as f:
         json.dump(receipt, f, indent=2)
     return path
@@ -108,11 +151,9 @@ def verify_receipt(receipt_path: str,
     from .identity_portable import verify_signature
 
     problems: list[str] = []
-    try:
-        with open(receipt_path) as f:
-            receipt = json.load(f)
-    except (OSError, json.JSONDecodeError) as exc:
-        return [f"receipt unreadable: {exc}"]
+    receipt, read_problem = _load_receipt_document(receipt_path)
+    if read_problem:
+        return [read_problem]
     if not isinstance(receipt, dict):
         return ["receipt must be a JSON object"]
     payload = receipt.get("payload")
@@ -172,7 +213,7 @@ def render_proof(bundle_dir: str,
                  freshness_days: float = 30.0) -> tuple[bool, str]:
     """The TOWN-TESTED badge, rendered only when the evidence is
     conclusive, covered, fresh, and the bundle and receipt verify."""
-    from .bundle import verify_bundle
+    from .bundle import load_bundle, verify_bundle
 
     if isinstance(freshness_days, bool) \
             or not isinstance(freshness_days, (int, float)) \
@@ -186,16 +227,29 @@ def render_proof(bundle_dir: str,
         lines += [f"  {problem}" for problem in bundle_problems]
         return False, "\n".join(lines) + "\n"
 
+    bundle = load_bundle(bundle_dir)
+    window_problems = _proof_window_problems(
+        _bundle_receipt_fields(bundle)["window"], time.time())
+    if window_problems:
+        lines = ["No Town Proof. The evidence window is invalid:"]
+        lines += [f"  {problem}" for problem in window_problems]
+        return False, "\n".join(lines) + "\n"
+
     receipt_path = os.path.join(bundle_dir, "receipt.json")
-    if not os.path.exists(receipt_path):
+    if not os.path.lexists(receipt_path):
         make_receipt(bundle_dir)
     problems = verify_receipt(receipt_path, bundle_dir)
     if problems:
         lines = ["No Town Proof. Receipt verification failed:"]
         lines += [f"  {problem}" for problem in problems]
         return False, "\n".join(lines) + "\n"
-    with open(receipt_path) as f:
-        payload = json.load(f)["payload"]
+    receipt, read_problem = _load_receipt_document(receipt_path)
+    if read_problem:
+        return False, f"No Town Proof. {read_problem}.\n"
+    if not isinstance(receipt, dict) \
+            or not isinstance(receipt.get("payload"), dict):
+        return False, "No Town Proof. Receipt became malformed.\n"
+    payload = receipt["payload"]
 
     reasons: list[str] = list(problems)
     claim = payload["claim"]

--- a/src/nandatown/receipt.py
+++ b/src/nandatown/receipt.py
@@ -32,6 +32,122 @@ DEFAULT_LIMITATIONS = [
     "a favorable result grants no permissions and endorses nothing",
 ]
 
+RECEIPT_FIELDS = {"payload", "signature", "controller_public"}
+PAYLOAD_FIELDS = {
+    "claim", "observer", "window", "coverage", "limitations", "evidence",
+}
+CLAIM_FIELDS = {
+    "capability", "subject", "release_basis", "profile", "verdict",
+}
+WINDOW_FIELDS = {"started", "evaluated"}
+COVERAGE_FIELDS = {"tested", "not_tested"}
+EVIDENCE_FIELDS = {"bundle_fingerprint", "result_digest", "run_id"}
+RELEASE_BASIS_FIELDS = {"profile_fingerprint"}
+RELEASE_BASIS_OPTIONAL_FIELDS = {"card_digest"}
+RECEIPT_VERDICTS = {"passed", "failed", "incomplete", "error"}
+
+
+def _field_set_problems(value: dict[str, Any], label: str,
+                        required: set[str],
+                        optional: set[str] | None = None) -> list[str]:
+    optional = optional or set()
+    keys = set(value)
+    missing = sorted(required - keys)
+    unexpected = sorted(keys - required - optional)
+    problems = []
+    if missing:
+        problems.append(f"{label} is missing fields: {missing}")
+    if unexpected:
+        problems.append(f"{label} has unexpected fields: {unexpected}")
+    return problems
+
+
+def _nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _receipt_shape_problems(receipt: dict[str, Any],
+                            payload: dict[str, Any]) -> list[str]:
+    problems = _field_set_problems(receipt, "receipt", RECEIPT_FIELDS)
+    problems += _field_set_problems(payload, "receipt payload", PAYLOAD_FIELDS)
+
+    observer = payload.get("observer")
+    if not _nonempty_string(observer):
+        problems.append("receipt observer must be a non-empty string")
+
+    claim = payload.get("claim")
+    if not isinstance(claim, dict):
+        problems.append("receipt claim must be a JSON object")
+    else:
+        problems += _field_set_problems(
+            claim, "receipt claim", CLAIM_FIELDS)
+        for name in ("capability", "subject", "profile"):
+            if not _nonempty_string(claim.get(name)):
+                problems.append(
+                    f"receipt claim {name} must be a non-empty string")
+        if claim.get("verdict") not in RECEIPT_VERDICTS:
+            problems.append("receipt claim verdict is invalid")
+        release_basis = claim.get("release_basis")
+        if not isinstance(release_basis, dict):
+            problems.append("receipt claim release basis must be a JSON object")
+        else:
+            problems += _field_set_problems(
+                release_basis, "receipt claim release basis",
+                RELEASE_BASIS_FIELDS, RELEASE_BASIS_OPTIONAL_FIELDS)
+            for name in RELEASE_BASIS_FIELDS | RELEASE_BASIS_OPTIONAL_FIELDS:
+                if name in release_basis \
+                        and not _nonempty_string(release_basis[name]):
+                    problems.append(
+                        "receipt claim release basis"
+                        f" {name.replace('_', ' ')} must be a non-empty string")
+
+    window = payload.get("window")
+    if not isinstance(window, dict):
+        problems.append("receipt window must be a JSON object")
+    else:
+        problems += _field_set_problems(
+            window, "receipt window", WINDOW_FIELDS)
+        for name in WINDOW_FIELDS:
+            value = window.get(name)
+            if isinstance(value, bool) \
+                    or not isinstance(value, (int, float)) \
+                    or not math.isfinite(value):
+                problems.append(
+                    f"receipt window {name} must be a finite number")
+
+    coverage = payload.get("coverage")
+    if not isinstance(coverage, dict):
+        problems.append("receipt coverage must be a JSON object")
+    else:
+        problems += _field_set_problems(
+            coverage, "receipt coverage", COVERAGE_FIELDS)
+        for name in COVERAGE_FIELDS:
+            values = coverage.get(name)
+            if not isinstance(values, list) \
+                    or any(not _nonempty_string(value) for value in values):
+                problems.append(
+                    f"receipt coverage {name} must be a list of"
+                    " non-empty strings")
+
+    limitations = payload.get("limitations")
+    if not isinstance(limitations, list) or not limitations \
+            or any(not _nonempty_string(value) for value in limitations):
+        problems.append(
+            "receipt limitations must be a non-empty list of non-empty strings")
+
+    evidence = payload.get("evidence")
+    if not isinstance(evidence, dict):
+        problems.append("receipt evidence must be a JSON object")
+    else:
+        problems += _field_set_problems(
+            evidence, "receipt evidence", EVIDENCE_FIELDS)
+        for name in EVIDENCE_FIELDS:
+            if not _nonempty_string(evidence.get(name)):
+                problems.append(
+                    f"receipt evidence {name.replace('_', ' ')}"
+                    " must be a non-empty string")
+    return problems
+
 
 def _receipt_file_problem(path: str, *, missing_ok: bool = False) -> str | None:
     try:
@@ -79,8 +195,21 @@ def _bundle_receipt_fields(bundle: dict[str, Any]) -> dict[str, Any]:
     capability = getattr(profile, "capability", None) \
         or getattr(getattr(profile, "task", None), "kind", None) \
         or run.profile_name
-    subject = run.config.get("subject") \
-        or ", ".join(p["name"] for p in run.participants)
+    subject = run.config.get("subject")
+    if subject is not None and subject != "":
+        if not _nonempty_string(subject):
+            raise ValueError("bundle receipt subject must be a non-empty string")
+    else:
+        participant_names = []
+        for index, participant in enumerate(run.participants):
+            name = participant.get("name")
+            if not _nonempty_string(name):
+                raise ValueError(
+                    f"bundle participant {index} has no valid name")
+            participant_names.append(name)
+        if not participant_names:
+            raise ValueError("bundle has no participant name for receipt subject")
+        subject = ", ".join(participant_names)
     release_basis = {"profile_fingerprint": run.profile_fingerprint}
     if run.config.get("pinned_card_digest"):
         release_basis["card_digest"] = run.config["pinned_card_digest"]
@@ -159,6 +288,7 @@ def verify_receipt(receipt_path: str,
     payload = receipt.get("payload")
     if not isinstance(payload, dict):
         return ["receipt payload must be a JSON object"]
+    problems.extend(_receipt_shape_problems(receipt, payload))
     controller_public = receipt.get("controller_public")
     signature = receipt.get("signature")
     if not isinstance(controller_public, str) \
@@ -181,7 +311,12 @@ def verify_receipt(receipt_path: str,
                 ValueError) as exc:
             problems.append(f"bundle unreadable for receipt verification: {exc}")
             return problems
-        expected = _bundle_receipt_fields(bundle)
+        try:
+            expected = _bundle_receipt_fields(bundle)
+        except (KeyError, TypeError, ValueError) as exc:
+            problems.append(
+                f"bundle cannot produce receipt claims: {exc}")
+            return problems
         claim = payload.get("claim")
         if not isinstance(claim, dict):
             problems.append("receipt claim must be a JSON object")

--- a/src/nandatown/receipt.py
+++ b/src/nandatown/receipt.py
@@ -17,6 +17,7 @@ reputation score.
 from __future__ import annotations
 
 import json
+import math
 import os
 import time
 from typing import Any
@@ -31,6 +32,41 @@ DEFAULT_LIMITATIONS = [
 ]
 
 
+def _bundle_receipt_fields(bundle: dict[str, Any]) -> dict[str, Any]:
+    """Derive every receipt field that makes a claim about one bundle."""
+    run = bundle["run"]
+    result = bundle["result"]
+    profile = bundle["profile"]
+    capability = getattr(profile, "capability", None) \
+        or getattr(getattr(profile, "task", None), "kind", None) \
+        or run.profile_name
+    subject = run.config.get("subject") \
+        or ", ".join(p["name"] for p in run.participants)
+    release_basis = {"profile_fingerprint": run.profile_fingerprint}
+    if run.config.get("pinned_card_digest"):
+        release_basis["card_digest"] = run.config["pinned_card_digest"]
+    tested = [s.name for s in result.stages if s.status != "not_tested"]
+    not_tested = [s.name for s in result.stages
+                  if s.status == "not_tested"]
+    return {
+        "claim": {
+            "capability": capability,
+            "subject": subject,
+            "release_basis": release_basis,
+            "profile": run.profile_name,
+            "verdict": result.verdict,
+        },
+        "window": {"started": run.created_at,
+                   "evaluated": result.evaluated_at},
+        "coverage": {"tested": tested, "not_tested": not_tested},
+        "evidence": {
+            "bundle_fingerprint": bundle["manifest"]["bundle_fingerprint"],
+            "result_digest": fingerprint(result.model_dump()),
+            "run_id": run.run_id,
+        },
+    }
+
+
 def make_receipt(bundle_dir: str, keystore=None,
                  signer: str | None = None,
                  limitations: list[str] | None = None) -> str:
@@ -42,46 +78,19 @@ def make_receipt(bundle_dir: str, keystore=None,
     )
 
     bundle = load_bundle(bundle_dir)
-    run = bundle["run"]
-    result = bundle["result"]
-    profile = bundle["profile"]
-
-    capability = getattr(profile, "capability", None) \
-        or getattr(getattr(profile, "task", None), "kind", None) \
-        or run.profile_name
-    subject = run.config.get("subject") \
-        or ", ".join(p["name"] for p in run.participants)
-    release_basis = {"profile_fingerprint": run.profile_fingerprint}
-    if run.config.get("pinned_card_digest"):
-        release_basis["card_digest"] = run.config["pinned_card_digest"]
-
-    tested = [s.name for s in result.stages if s.status != "not_tested"]
-    not_tested = [s.name for s in result.stages
-                  if s.status == "not_tested"]
+    fields = _bundle_receipt_fields(bundle)
 
     keystore = keystore or Keystore(default_keystore_dir())
     signer = signer or OPERATOR_NAME
     identity = keystore.new_identity(signer)
 
     payload = {
-        "claim": {
-            "capability": capability,
-            "subject": subject,
-            "release_basis": release_basis,
-            "profile": run.profile_name,
-            "verdict": result.verdict,
-        },
+        "claim": fields["claim"],
         "observer": identity["agent_id"],
-        "window": {"started": run.created_at,
-                   "evaluated": result.evaluated_at},
-        "coverage": {"tested": tested, "not_tested": not_tested},
+        "window": fields["window"],
+        "coverage": fields["coverage"],
         "limitations": limitations or DEFAULT_LIMITATIONS,
-        "evidence": {
-            "bundle_fingerprint":
-                bundle["manifest"]["bundle_fingerprint"],
-            "result_digest": fingerprint(result.model_dump()),
-            "run_id": run.run_id,
-        },
+        "evidence": fields["evidence"],
     }
     receipt = {"payload": payload,
                "signature": keystore.sign(signer, payload),
@@ -104,27 +113,58 @@ def verify_receipt(receipt_path: str,
             receipt = json.load(f)
     except (OSError, json.JSONDecodeError) as exc:
         return [f"receipt unreadable: {exc}"]
-    payload = receipt.get("payload", {})
-    if not verify_signature(receipt.get("controller_public", ""),
-                            payload, receipt.get("signature", "")):
+    if not isinstance(receipt, dict):
+        return ["receipt must be a JSON object"]
+    payload = receipt.get("payload")
+    if not isinstance(payload, dict):
+        return ["receipt payload must be a JSON object"]
+    controller_public = receipt.get("controller_public")
+    signature = receipt.get("signature")
+    if not isinstance(controller_public, str) \
+            or not isinstance(signature, str):
+        problems.append("receipt signature and controller key must be strings")
+    elif not verify_signature(controller_public, payload, signature):
         problems.append("signature does not verify over the payload")
-    derived = ("did:town:"
-               + fingerprint(receipt.get("controller_public", ""))
-               .removeprefix("sha256:")[:24])
-    if derived != payload.get("observer"):
-        problems.append("observer id does not match the signing key")
+    if isinstance(controller_public, str):
+        derived = ("did:town:"
+                   + fingerprint(controller_public)
+                   .removeprefix("sha256:")[:24])
+        if derived != payload.get("observer"):
+            problems.append("observer id does not match the signing key")
     if bundle_dir:
         from .bundle import load_bundle
 
-        bundle = load_bundle(bundle_dir)
-        if payload.get("evidence", {}).get("bundle_fingerprint") \
-                != bundle["manifest"]["bundle_fingerprint"]:
-            problems.append("receipt names a different bundle"
-                            " fingerprint")
-        if payload.get("evidence", {}).get("result_digest") \
-                != fingerprint(bundle["result"].model_dump()):
-            problems.append("receipt result digest does not match the"
-                            " bundle's result")
+        try:
+            bundle = load_bundle(bundle_dir)
+        except (OSError, json.JSONDecodeError, KeyError, TypeError,
+                ValueError) as exc:
+            problems.append(f"bundle unreadable for receipt verification: {exc}")
+            return problems
+        expected = _bundle_receipt_fields(bundle)
+        claim = payload.get("claim")
+        if not isinstance(claim, dict):
+            problems.append("receipt claim must be a JSON object")
+        else:
+            for name, value in expected["claim"].items():
+                if claim.get(name) != value:
+                    problems.append(
+                        f"receipt claim {name.replace('_', ' ')} does not match bundle")
+        for name in ("coverage", "window"):
+            if payload.get(name) != expected[name]:
+                problems.append(f"receipt {name} does not match bundle")
+        evidence = payload.get("evidence")
+        if not isinstance(evidence, dict):
+            problems.append("receipt evidence must be a JSON object")
+        else:
+            labels = {
+                "bundle_fingerprint": "bundle fingerprint",
+                "result_digest": "result digest",
+                "run_id": "evidence run id",
+            }
+            for name, value in expected["evidence"].items():
+                if evidence.get(name) != value:
+                    problems.append(
+                        f"receipt {labels[name]} does not match bundle")
     return problems
 
 
@@ -133,6 +173,12 @@ def render_proof(bundle_dir: str,
     """The TOWN-TESTED badge, rendered only when the evidence is
     conclusive, covered, fresh, and the bundle and receipt verify."""
     from .bundle import verify_bundle
+
+    if isinstance(freshness_days, bool) \
+            or not isinstance(freshness_days, (int, float)) \
+            or not math.isfinite(freshness_days) or freshness_days < 0:
+        return (False, "No Town Proof. freshness days must be a finite"
+                " non-negative number.\n")
 
     bundle_problems = verify_bundle(bundle_dir)
     if bundle_problems:
@@ -144,6 +190,10 @@ def render_proof(bundle_dir: str,
     if not os.path.exists(receipt_path):
         make_receipt(bundle_dir)
     problems = verify_receipt(receipt_path, bundle_dir)
+    if problems:
+        lines = ["No Town Proof. Receipt verification failed:"]
+        lines += [f"  {problem}" for problem in problems]
+        return False, "\n".join(lines) + "\n"
     with open(receipt_path) as f:
         payload = json.load(f)["payload"]
 
@@ -159,6 +209,9 @@ def render_proof(bundle_dir: str,
                        " window")
     if not payload["coverage"]["tested"]:
         reasons.append("nothing was tested")
+    if payload["coverage"]["not_tested"]:
+        reasons.append("not tested: "
+                       + ", ".join(payload["coverage"]["not_tested"]))
 
     if reasons:
         lines = ["No Town Proof. The badge renders only from"

--- a/src/nandatown/report.py
+++ b/src/nandatown/report.py
@@ -31,7 +31,7 @@ STAGE_MEANING = {
                             " handled",
     "wakeup_loss_tolerated": "a lost wake-up hint did not lose inbox work",
     "ack_retry_survived": "a lost acknowledgement was retried and recorded",
-    "portable_identity": "not exercised in this run",
+    "portable_identity": "the participant joined with a verified portable identity grant",
     "discovery": "cards published and peers found through the index",
     "negotiation": "offers alternated to an agreed price inside bounds",
     "settlement": "money moved only through recorded escrow",
@@ -135,7 +135,8 @@ def render_report(bundle: dict[str, Any]) -> str:
     name_width = max(len(s.name) for s in result.stages)
     for s in result.stages:
         label = STATUS_LABEL[s.status]
-        meaning = STAGE_MEANING.get(s.name, "")
+        meaning = ("not exercised in this run" if s.status == "not_tested"
+                   else STAGE_MEANING.get(s.name, ""))
         evidence = f" [{', '.join(s.evidence)}]" if s.evidence else ""
         add(f"  {s.name.ljust(name_width)}  {label:<20} {meaning}{evidence}")
         if s.note:

--- a/tests/test_a2a_transport.py
+++ b/tests/test_a2a_transport.py
@@ -251,7 +251,7 @@ def test_real_cli_selects_shared_default_and_records_owned_policy(tmp_path):
     assert result.returncode == 0, result.stdout + result.stderr
     directory, = tmp_path.glob("path-*")
     bundle = load_bundle(str(directory))
-    assert bundle["run"].profile_name == "a2a-capability-fulfillment@0.2"
+    assert bundle["run"].profile_name == "a2a-capability-fulfillment@0.3"
     policy = bundle["run"].config["a2a_transport_policy"]
     assert policy["trust_env"] is False
     assert policy["transport_retries"] == 0

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -438,9 +438,14 @@ def test_historical_evaluator_mismatch_remains_explicit(tmp_path):
     result = json.loads(result_path.read_text())
     result["evaluator_version"] = "historical-evaluator"
     result_path.write_text(json.dumps(result))
+    run_path = bundle_path / "run.json"
+    run = json.loads(run_path.read_text())
+    run["releases"]["evaluator"] = "historical-evaluator"
+    run_path.write_text(json.dumps(run))
     manifest = json.loads((bundle_path / "manifest.json").read_text())
     manifest["evaluator_version"] = "historical-evaluator"
     refresh_file_hash(manifest, "result.json", result_path)
+    refresh_file_hash(manifest, "run.json", run_path)
     write_manifest(bundle_path, manifest)
 
     problems = verify_bundle(path)
@@ -449,6 +454,124 @@ def test_historical_evaluator_mismatch_remains_explicit(tmp_path):
         "evaluator version differs: bundle historical-evaluator, local 0.2.0;"
         " reproducibility not checked"
     ]
+
+
+def test_manifest_version_must_match_run_release(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    manifest_path = tmp_path / "bundle" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["nandatown_version"] = "forged-version"
+    manifest_path.write_text(json.dumps(manifest))
+
+    problems = verify_bundle(path)
+
+    assert "manifest nandatown version does not match run release" in problems
+
+
+def test_run_evaluator_release_must_match_result(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    bundle_path = tmp_path / "bundle"
+    run_path = bundle_path / "run.json"
+    run = json.loads(run_path.read_text())
+    run["releases"]["evaluator"] = "contradicts-result"
+    run_path.write_text(json.dumps(run))
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    refresh_file_hash(manifest, "run.json", run_path)
+    write_manifest(bundle_path, manifest)
+
+    problems = verify_bundle(path)
+
+    assert "run evaluator release does not match result" in problems
+
+
+@pytest.mark.parametrize(
+    ("record_name", "identifier", "problem"),
+    [("intents.jsonl", "intent_id", "duplicate intent ids"),
+     ("events.jsonl", "event_id", "duplicate event ids")],
+)
+def test_duplicate_record_id_is_rejected(
+        tmp_path, record_name, identifier, problem):
+    path, _ = make_bundle(tmp_path)
+    bundle_path = tmp_path / "bundle"
+    records_path = bundle_path / record_name
+    first = records_path.read_text().splitlines()[0]
+    assert json.loads(first)[identifier]
+    with open(records_path, "a") as stream:
+        stream.write(first + "\n")
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    refresh_file_hash(manifest, record_name, records_path)
+    write_manifest(bundle_path, manifest)
+
+    problems = verify_bundle(path)
+
+    assert any(problem in item for item in problems), problems
+
+
+def test_path_run_mode_must_match_manifest_mode(tmp_path):
+    url = "http://testserver"
+    with TestClient(build_a2a_app(url)) as client:
+        path, _ = run_path_test(url, str(tmp_path), http=client)
+    bundle_path = Path(path)
+    run_path = bundle_path / "run.json"
+    run = json.loads(run_path.read_text())
+    run["config"]["mode"] = "lab"
+    run_path.write_text(json.dumps(run))
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    refresh_file_hash(manifest, "run.json", run_path)
+    write_manifest(bundle_path, manifest)
+    (bundle_path / "attestation.json").unlink()
+
+    problems = verify_bundle(path)
+
+    assert "run mode does not match manifest mode" in problems
+
+
+def test_malformed_participant_fails_before_receipt_derivation(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    bundle_path = tmp_path / "bundle"
+    run_path = bundle_path / "run.json"
+    run = json.loads(run_path.read_text())
+    run["participants"] = [{}]
+    run_path.write_text(json.dumps(run))
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    refresh_file_hash(manifest, "run.json", run_path)
+    write_manifest(bundle_path, manifest)
+
+    problems = verify_bundle(path)
+
+    assert any("participant" in problem for problem in problems), problems
+    from nandatown.receipt import make_receipt
+    with pytest.raises(ValueError, match="participant"):
+        make_receipt(path)
+
+
+def test_historical_evaluator_mismatch_still_checks_attestation(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    bundle_path = tmp_path / "bundle"
+    keys = Keystore(str(tmp_path / "keys"))
+    attest_bundle(path, keystore=keys, signer="reviewer")
+    result_path = bundle_path / "result.json"
+    result = json.loads(result_path.read_text())
+    result["evaluator_version"] = "historical-evaluator"
+    result_path.write_text(json.dumps(result))
+    run_path = bundle_path / "run.json"
+    run = json.loads(run_path.read_text())
+    run["releases"]["evaluator"] = "historical-evaluator"
+    run_path.write_text(json.dumps(run))
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    manifest["evaluator_version"] = "historical-evaluator"
+    refresh_file_hash(manifest, "result.json", result_path)
+    refresh_file_hash(manifest, "run.json", run_path)
+    write_manifest(bundle_path, manifest)
+    attestation_path = bundle_path / "attestation.json"
+    attestation = json.loads(attestation_path.read_text())
+    attestation["signature"] = "00"
+    attestation_path.write_text(json.dumps(attestation))
+
+    problems = verify_bundle(path)
+
+    assert any("evaluator version differs" in problem for problem in problems)
+    assert "attestation signature does not verify" in problems
 
 
 def test_report_contains_scope_and_stages(tmp_path):

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -574,6 +574,28 @@ def test_historical_evaluator_mismatch_still_checks_attestation(tmp_path):
     assert "attestation signature does not verify" in problems
 
 
+def test_record_mismatch_still_checks_attestation(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    bundle_path = tmp_path / "bundle"
+    attest_bundle(path, keystore=Keystore(str(tmp_path / "keys")))
+    run_path = bundle_path / "run.json"
+    run = json.loads(run_path.read_text())
+    run["releases"]["evaluator"] = "contradicts-result"
+    run_path.write_text(json.dumps(run))
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    refresh_file_hash(manifest, "run.json", run_path)
+    write_manifest(bundle_path, manifest)
+    attestation_path = bundle_path / "attestation.json"
+    attestation = json.loads(attestation_path.read_text())
+    attestation["signature"] = "00"
+    attestation_path.write_text(json.dumps(attestation))
+
+    problems = verify_bundle(path)
+
+    assert "run evaluator release does not match result" in problems
+    assert "attestation signature does not verify" in problems
+
+
 def test_report_contains_scope_and_stages(tmp_path):
     path, _ = make_bundle(tmp_path)
     bundle = load_bundle(path)

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,8 +1,11 @@
 import hashlib
 import json
 import shutil
+from pathlib import Path
 
 import pytest
+from fastapi.testclient import TestClient
+from nandatown.a2a_adapter import build_a2a_app
 from nandatown.bundle import (
     attest_bundle,
     load_bundle,
@@ -10,6 +13,7 @@ from nandatown.bundle import (
     write_bundle,
 )
 from nandatown.identity_portable import Keystore
+from nandatown.path_runner import run_path_test
 from nandatown.report import render_report
 from nandatown.evaluator import evaluate
 from nandatown.records import RunRecord, fingerprint
@@ -259,6 +263,21 @@ def test_manifest_rejects_unknown_bundle_mode(tmp_path):
     assert any("unknown bundle mode" in problem for problem in problems), problems
 
 
+def test_manifest_rejects_unhashable_bundle_mode_without_raising(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    manifest_path = tmp_path / "bundle" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["mode"] = []
+    manifest_path.write_text(json.dumps(manifest))
+
+    try:
+        problems = verify_bundle(path)
+    except Exception as exc:  # pragma: no cover - public API must not raise
+        pytest.fail(f"malformed mode raised {type(exc).__name__}: {exc}")
+
+    assert any("unknown bundle mode" in problem for problem in problems), problems
+
+
 def test_bundle_rejects_symlinked_canonical_record(tmp_path):
     path, _ = make_bundle(tmp_path)
     bundle_path = tmp_path / "bundle"
@@ -354,6 +373,28 @@ def test_evaluator_replay_compares_complete_deterministic_result(tmp_path, chang
     expected = ("duplicate stage names" if change == "duplicate"
                 else "evaluator replay mismatch")
     assert any(expected in problem for problem in problems), problems
+
+
+def test_evaluator_replay_error_is_reported_not_raised(tmp_path):
+    url = "http://testserver"
+    with TestClient(build_a2a_app(url)) as client:
+        directory, _ = run_path_test(url, str(tmp_path), http=client)
+    bundle_path = Path(directory)
+    events_path = bundle_path / "events.jsonl"
+    events = [json.loads(line) for line in events_path.read_text().splitlines()]
+    card = next(event for event in events if event["kind"] == "card_retrieved")
+    card["detail"] = {}
+    events_path.write_text("".join(json.dumps(event) + "\n" for event in events))
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    refresh_file_hash(manifest, "events.jsonl", events_path)
+    write_manifest(bundle_path, manifest)
+
+    try:
+        problems = verify_bundle(directory)
+    except Exception as exc:  # pragma: no cover - verifier boundary
+        pytest.fail(f"evaluator replay raised {type(exc).__name__}: {exc}")
+
+    assert any("evaluator replay failed" in problem for problem in problems), problems
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,6 +1,8 @@
 import hashlib
 import json
+import shutil
 
+import pytest
 from nandatown.bundle import (
     attest_bundle,
     load_bundle,
@@ -22,7 +24,8 @@ def make_bundle(tmp_path):
     p = profile()
     events = clean_events()
     run = RunRecord(
-        run_id="run-1", profile_name=p.name, profile_fingerprint="sha256:x",
+        run_id="run-1", profile_name=p.name,
+        profile_fingerprint=fingerprint(p.model_dump()),
         created_at=1.0,
         participants=[{"name": "buyer", "role": "buyer"},
                       {"name": "seller", "role": "seller"}],
@@ -41,6 +44,11 @@ def make_bundle(tmp_path):
 def refresh_file_hash(manifest, name, path):
     manifest["files"][name] = "sha256:" + hashlib.sha256(
         path.read_bytes()).hexdigest()
+
+
+def write_manifest(bundle_path, manifest):
+    manifest["bundle_fingerprint"] = fingerprint(manifest["files"])
+    (bundle_path / "manifest.json").write_text(json.dumps(manifest))
 
 
 def test_clean_unsigned_bundle_remains_allowed(tmp_path):
@@ -162,12 +170,244 @@ def test_root_only_edit_is_detected(tmp_path):
     path, _ = make_bundle(tmp_path)
     manifest_file = tmp_path / "bundle" / "manifest.json"
     manifest = json.loads(manifest_file.read_text())
-    manifest["bundle_fingerprint"] = "sha256:attacker"
+    manifest["bundle_fingerprint"] = "sha256:" + "0" * 64
     manifest_file.write_text(json.dumps(manifest))
 
     problems = verify_bundle(path)
 
     assert any("bundle fingerprint mismatch" in p for p in problems)
+
+
+def test_manifest_must_name_all_five_canonical_records(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    bundle_path = tmp_path / "bundle"
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    del manifest["files"]["run.json"]
+    write_manifest(bundle_path, manifest)
+
+    problems = verify_bundle(path)
+
+    assert any("canonical records" in problem and "run.json" in problem
+               for problem in problems), problems
+
+
+def test_manifest_rejects_traversal_member_even_when_hash_matches(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    bundle_path = tmp_path / "bundle"
+    outside = tmp_path / "outside.json"
+    outside.write_text("outside")
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    manifest["files"]["../outside.json"] = (
+        "sha256:" + hashlib.sha256(outside.read_bytes()).hexdigest())
+    write_manifest(bundle_path, manifest)
+
+    problems = verify_bundle(path)
+
+    assert any("canonical records" in problem and "../outside.json" in problem
+               for problem in problems), problems
+
+
+@pytest.mark.parametrize("manifest_text", ["[]", "{not-json", '{"files": []}'],
+                         ids=["array", "invalid-json", "files-array"])
+def test_malformed_manifest_is_reported_not_raised(tmp_path, manifest_text):
+    path, _ = make_bundle(tmp_path)
+    (tmp_path / "bundle" / "manifest.json").write_text(manifest_text)
+
+    try:
+        problems = verify_bundle(path)
+    except Exception as exc:  # pragma: no cover - public API must not raise
+        pytest.fail(f"malformed manifest raised {type(exc).__name__}: {exc}")
+
+    assert problems
+    assert any("manifest.json" in problem for problem in problems)
+
+
+def test_manifest_rejects_malformed_file_digest(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    bundle_path = tmp_path / "bundle"
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    manifest["files"]["run.json"] = "sha256:not-a-digest"
+    write_manifest(bundle_path, manifest)
+
+    problems = verify_bundle(path)
+
+    assert any("run.json digest is malformed" in problem
+               for problem in problems), problems
+
+
+def test_manifest_rejects_malformed_bundle_fingerprint(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    manifest_path = tmp_path / "bundle" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["bundle_fingerprint"] = "sha256:not-a-digest"
+    manifest_path.write_text(json.dumps(manifest))
+
+    problems = verify_bundle(path)
+
+    assert "bundle fingerprint is malformed" in problems
+
+
+def test_manifest_rejects_unknown_bundle_mode(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    manifest_path = tmp_path / "bundle" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["mode"] = "mystery"
+    manifest_path.write_text(json.dumps(manifest))
+
+    problems = verify_bundle(path)
+
+    assert any("unknown bundle mode" in problem for problem in problems), problems
+
+
+def test_bundle_rejects_symlinked_canonical_record(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    bundle_path = tmp_path / "bundle"
+    run_path = bundle_path / "run.json"
+    outside = tmp_path / "run-copy.json"
+    shutil.copyfile(run_path, outside)
+    run_path.unlink()
+    run_path.symlink_to(outside)
+
+    problems = verify_bundle(path)
+
+    assert any("run.json is not a regular file" in problem
+               for problem in problems), problems
+
+
+def test_bundle_rejects_nonregular_canonical_record_without_reading_it(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    run_path = tmp_path / "bundle" / "run.json"
+    run_path.unlink()
+    run_path.mkdir()
+
+    try:
+        problems = verify_bundle(path)
+    except Exception as exc:  # pragma: no cover - must reject before open
+        pytest.fail(f"nonregular record raised {type(exc).__name__}: {exc}")
+
+    assert any("run.json is not a regular file" in problem
+               for problem in problems), problems
+
+
+@pytest.mark.parametrize(
+    ("record_name", "mutate", "message"),
+    [
+        ("run.json", lambda value: value.update(run_id="other-run"),
+         "run and result name different run ids"),
+        ("run.json", lambda value: value.update(profile_name="other-profile"),
+         "run profile name does not match profile"),
+        ("run.json", lambda value: value.update(
+            profile_fingerprint="sha256:" + "0" * 64),
+         "run profile fingerprint does not match profile"),
+        ("intents.jsonl", lambda value: value.update(run_id="other-run"),
+         "intent names a different run id"),
+        ("events.jsonl", lambda value: value.update(run_id="other-run"),
+         "event names a different run id"),
+        ("result.json", lambda value: value.update(run_id="other-run"),
+         "run and result name different run ids"),
+    ],
+)
+def test_bundle_binds_cross_record_metadata(
+        tmp_path, record_name, mutate, message):
+    path, _ = make_bundle(tmp_path)
+    bundle_path = tmp_path / "bundle"
+    record_path = bundle_path / record_name
+    if record_name.endswith(".jsonl"):
+        records = record_path.read_text().splitlines()
+        value = json.loads(records[0])
+        mutate(value)
+        records[0] = json.dumps(value)
+        record_path.write_text("\n".join(records) + "\n")
+    else:
+        value = json.loads(record_path.read_text())
+        mutate(value)
+        record_path.write_text(json.dumps(value))
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    refresh_file_hash(manifest, record_name, record_path)
+    write_manifest(bundle_path, manifest)
+
+    problems = verify_bundle(path)
+
+    assert message in problems, problems
+
+
+@pytest.mark.parametrize("change", ["note", "evidence", "duplicate"],
+                         ids=["stage-note", "stage-evidence", "duplicate-stage"])
+def test_evaluator_replay_compares_complete_deterministic_result(tmp_path, change):
+    path, _ = make_bundle(tmp_path)
+    bundle_path = tmp_path / "bundle"
+    result_path = bundle_path / "result.json"
+    result = json.loads(result_path.read_text())
+    if change == "note":
+        result["stages"][0]["note"] = "forged note"
+    elif change == "evidence":
+        result["stages"][0]["evidence"] = ["forged-event"]
+    else:
+        result["stages"].append(dict(result["stages"][0]))
+    result_path.write_text(json.dumps(result))
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    refresh_file_hash(manifest, "result.json", result_path)
+    write_manifest(bundle_path, manifest)
+
+    problems = verify_bundle(path)
+
+    expected = ("duplicate stage names" if change == "duplicate"
+                else "evaluator replay mismatch")
+    assert any(expected in problem for problem in problems), problems
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("run_id", "other-run"), ("verdict", "failed"),
+     ("evaluator_version", "other-evaluator")],
+)
+def test_validly_resigned_attestation_must_match_bundle(
+        tmp_path, field, value):
+    path, _ = make_bundle(tmp_path)
+    keys = Keystore(str(tmp_path / "keys"))
+    attest_bundle(path, keystore=keys, signer="reviewer")
+    attestation_path = tmp_path / "bundle" / "attestation.json"
+    attestation = json.loads(attestation_path.read_text())
+    attestation["payload"][field] = value
+    attestation["signature"] = keys.sign("reviewer", attestation["payload"])
+    attestation_path.write_text(json.dumps(attestation))
+
+    problems = verify_bundle(path)
+
+    assert any(f"attestation {field.replace('_', ' ')}" in problem
+               for problem in problems), problems
+
+
+def test_malformed_attestation_is_reported_not_raised(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    (tmp_path / "bundle" / "attestation.json").write_text("[]")
+
+    try:
+        problems = verify_bundle(path)
+    except Exception as exc:  # pragma: no cover - public API must not raise
+        pytest.fail(f"malformed attestation raised {type(exc).__name__}: {exc}")
+
+    assert any("attestation.json" in problem for problem in problems), problems
+
+
+def test_historical_evaluator_mismatch_remains_explicit(tmp_path):
+    path, _ = make_bundle(tmp_path)
+    bundle_path = tmp_path / "bundle"
+    result_path = bundle_path / "result.json"
+    result = json.loads(result_path.read_text())
+    result["evaluator_version"] = "historical-evaluator"
+    result_path.write_text(json.dumps(result))
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    manifest["evaluator_version"] = "historical-evaluator"
+    refresh_file_hash(manifest, "result.json", result_path)
+    write_manifest(bundle_path, manifest)
+
+    problems = verify_bundle(path)
+
+    assert problems == [
+        "evaluator version differs: bundle historical-evaluator, local 0.2.0;"
+        " reproducibility not checked"
+    ]
 
 
 def test_report_contains_scope_and_stages(tmp_path):

--- a/tests/test_cli_evidence.py
+++ b/tests/test_cli_evidence.py
@@ -1,0 +1,67 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from nandatown.a2a_adapter import build_a2a_app
+from nandatown.bundle import load_bundle
+from nandatown.cli import main
+from nandatown.path_runner import run_path_test
+from nandatown.report import render_report
+from nandatown.sim.runner import run_lab
+
+
+@pytest.fixture
+def path_client(monkeypatch):
+    with TestClient(build_a2a_app("http://testserver")) as client:
+        def run(url, out, **kwargs):
+            return run_path_test(url, out, http=client, **kwargs)
+        monkeypatch.setattr("nandatown.path_runner.run_path_test", run)
+        yield
+
+
+def test_path_cli_reports_untested_stages_in_denominator(tmp_path, capsys, path_client):
+    assert main(["test-agent", "--url", "http://testserver", "--out", str(tmp_path)]) == 0
+    text = capsys.readouterr().out
+    assert "5 of 6 path stages passed" in text
+    assert "1 not tested" in text
+
+
+def test_path_cli_rejects_ignored_track_profile(tmp_path, capsys, path_client):
+    assert main(["test-agent", "--url", "http://testserver",
+                 "--profile", "quote-clean", "--out", str(tmp_path)]) == 2
+    assert "--path-profile" in capsys.readouterr().out
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize("count", ["0", "-1"])
+def test_pulse_cli_rejects_nonpositive_count_without_creating_db(tmp_path, capsys, count):
+    database = tmp_path / "pulse.db"
+    assert main(["pulse", "--target", "demo=http://invalid.test", "--count", count,
+                 "--db", str(database)]) == 2
+    assert "count" in capsys.readouterr().out
+    assert not database.exists()
+
+
+@pytest.mark.parametrize("status", ["passed", "not_tested"])
+def test_report_identity_explanation_matches_observation(tmp_path, status):
+    directory, _ = run_lab("voting", str(tmp_path))
+    bundle = load_bundle(directory)
+    bundle["result"].stages = [bundle["result"].stages[0].model_copy(
+        update={"name": "portable_identity", "status": status, "note": ""})]
+
+    report = render_report(bundle)
+    line = next(line for line in report.splitlines() if "portable_identity" in line)
+
+    if status == "passed":
+        assert "not exercised" not in line
+        assert "verified" in line
+    else:
+        assert "not exercised" in line
+
+
+def test_report_untested_descriptor_does_not_claim_a_match(tmp_path, path_client):
+    with TestClient(build_a2a_app("http://testserver")) as client:
+        directory, _ = run_path_test("http://testserver", str(tmp_path), http=client)
+    report = render_report(load_bundle(directory))
+    line = next(line for line in report.splitlines() if "descriptor_consistency" in line)
+    assert "matches the pinned" not in line
+    assert "not exercised" in line

--- a/tests/test_compare_mirror.py
+++ b/tests/test_compare_mirror.py
@@ -217,3 +217,11 @@ def test_cli_compare_and_mirror(tmp_path, capsys):
     assert main(["recover", fingerprint, "--mirror",
                  str(tmp_path / "m"), "--out", out]) == 0
     assert "recovered and verified" in capsys.readouterr().out
+def test_mirror_cli_reports_invalid_source_without_traceback(tmp_path, capsys):
+    from nandatown.cli import main
+
+    source = tmp_path / "broken"
+    source.mkdir()
+    (source / "manifest.json").write_text("{")
+    assert main(["mirror", str(source), str(tmp_path / "mirror")]) == 1
+    assert "mirror failed:" in capsys.readouterr().out

--- a/tests/test_compare_mirror.py
+++ b/tests/test_compare_mirror.py
@@ -70,6 +70,136 @@ def test_tampered_mirror_is_rejected(tmp_path):
         recover_bundle(fingerprint, [mirror], str(tmp_path / "fresh"))
 
 
+@pytest.mark.parametrize(
+    "fingerprint",
+    ["sha256:../escape", "sha256:/absolute", "sha256:" + "a" * 63,
+     "a" * 64],
+    ids=["traversal", "absolute", "short", "missing-prefix"],
+)
+def test_recovery_rejects_invalid_fingerprint_addresses(tmp_path, fingerprint):
+    with pytest.raises(MirrorError, match="invalid bundle fingerprint"):
+        recover_bundle(fingerprint, [str(tmp_path / "mirror")],
+                       str(tmp_path / "fresh"))
+
+    assert not (tmp_path / "fresh").exists()
+
+
+def test_mirror_validates_source_before_copying(tmp_path):
+    bundle_dir, _ = run_lab("voting", str(tmp_path / "runs"))
+    manifest_path = os.path.join(bundle_dir, "manifest.json")
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+    manifest["bundle_fingerprint"] = "sha256:not-a-digest"
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f)
+
+    mirror = tmp_path / "mirror"
+    with pytest.raises(MirrorError, match="source bundle fails verification"):
+        mirror_bundle(bundle_dir, str(mirror))
+
+    assert not mirror.exists()
+
+
+def test_existing_corrupt_mirror_is_not_silently_accepted(tmp_path):
+    bundle_dir, _ = run_lab("voting", str(tmp_path / "runs"))
+    mirror = str(tmp_path / "mirror")
+    stored = mirror_bundle(bundle_dir, mirror)
+    with open(os.path.join(stored, "events.jsonl"), "a") as f:
+        f.write('{"forged": true}\n')
+
+    with pytest.raises(MirrorError, match="existing mirror"):
+        mirror_bundle(bundle_dir, mirror)
+
+
+def test_corrupt_first_mirror_does_not_hide_valid_later_mirror(tmp_path):
+    bundle_dir, _ = run_lab("voting", str(tmp_path / "runs"))
+    with open(os.path.join(bundle_dir, "manifest.json")) as f:
+        fingerprint = json.load(f)["bundle_fingerprint"]
+    mirror_a = str(tmp_path / "mirror-a")
+    mirror_b = str(tmp_path / "mirror-b")
+    stored_a = mirror_bundle(bundle_dir, mirror_a)
+    mirror_bundle(bundle_dir, mirror_b)
+    with open(os.path.join(stored_a, "events.jsonl"), "a") as f:
+        f.write('{"forged": true}\n')
+
+    restored = recover_bundle(fingerprint, [mirror_a, mirror_b],
+                              str(tmp_path / "fresh"))
+
+    assert os.path.exists(os.path.join(restored, "events.jsonl"))
+
+
+def test_recovery_rejects_unsafe_tree_before_copy_and_tries_next(tmp_path):
+    bundle_dir, _ = run_lab("voting", str(tmp_path / "runs"))
+    with open(os.path.join(bundle_dir, "manifest.json")) as f:
+        fingerprint = json.load(f)["bundle_fingerprint"]
+    mirror_a = str(tmp_path / "mirror-a")
+    mirror_b = str(tmp_path / "mirror-b")
+    stored_a = mirror_bundle(bundle_dir, mirror_a)
+    mirror_bundle(bundle_dir, mirror_b)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("must not be copied")
+    os.symlink(outside, os.path.join(stored_a, "unsafe-link"))
+
+    restored = recover_bundle(fingerprint, [mirror_a, mirror_b],
+                              str(tmp_path / "fresh"))
+
+    assert not os.path.lexists(os.path.join(restored, "unsafe-link"))
+
+
+def test_failed_recovery_does_not_leave_a_copied_destination(tmp_path):
+    bundle_dir, _ = run_lab("voting", str(tmp_path / "runs"))
+    with open(os.path.join(bundle_dir, "manifest.json")) as f:
+        fingerprint = json.load(f)["bundle_fingerprint"]
+    mirror = str(tmp_path / "mirror")
+    stored = mirror_bundle(bundle_dir, mirror)
+    with open(os.path.join(stored, "events.jsonl"), "a") as f:
+        f.write('{"forged": true}\n')
+    destination = (tmp_path / "fresh" /
+                   f"recovered-{fingerprint.removeprefix('sha256:')[:12]}")
+
+    with pytest.raises(MirrorError):
+        recover_bundle(fingerprint, [mirror], str(tmp_path / "fresh"))
+
+    assert not destination.exists()
+
+
+def test_recovery_preserves_preexisting_destination(tmp_path):
+    bundle_dir, _ = run_lab("voting", str(tmp_path / "runs"))
+    with open(os.path.join(bundle_dir, "manifest.json")) as f:
+        fingerprint = json.load(f)["bundle_fingerprint"]
+    mirror = str(tmp_path / "mirror")
+    mirror_bundle(bundle_dir, mirror)
+    destination = (tmp_path / "fresh" /
+                   f"recovered-{fingerprint.removeprefix('sha256:')[:12]}")
+    destination.mkdir(parents=True)
+    marker = destination / "user-data.txt"
+    marker.write_text("keep me")
+
+    with pytest.raises(MirrorError, match="already exists"):
+        recover_bundle(fingerprint, [mirror], str(tmp_path / "fresh"))
+
+    assert marker.read_text() == "keep me"
+
+
+def test_address_mismatch_does_not_hide_valid_later_mirror(tmp_path):
+    bundle_dir, _ = run_lab("voting", str(tmp_path / "runs-a"))
+    other_bundle, _ = run_lab("marketplace", str(tmp_path / "runs-b"))
+    with open(os.path.join(bundle_dir, "manifest.json")) as f:
+        fingerprint = json.load(f)["bundle_fingerprint"]
+    slug = fingerprint.removeprefix("sha256:")
+    bad_mirror = tmp_path / "bad-mirror"
+    bad_mirror.mkdir()
+    shutil.copytree(other_bundle, bad_mirror / slug)
+    good_mirror = str(tmp_path / "good-mirror")
+    mirror_bundle(bundle_dir, good_mirror)
+
+    restored = recover_bundle(
+        fingerprint, [str(bad_mirror), good_mirror], str(tmp_path / "fresh"))
+
+    with open(os.path.join(restored, "manifest.json")) as f:
+        assert json.load(f)["bundle_fingerprint"] == fingerprint
+
+
 def test_cli_compare_and_mirror(tmp_path, capsys):
     out = str(tmp_path)
     assert main(["compare", "voting", "--swap", "trust=reputation.v1",

--- a/tests/test_compare_mirror.py
+++ b/tests/test_compare_mirror.py
@@ -1,12 +1,14 @@
 import json
 import os
 import shutil
+from pathlib import Path
 
 import pytest
 
 from nandatown.cli import main
 from nandatown.compare import run_comparison
 from nandatown.mirror import MirrorError, mirror_bundle, recover_bundle
+from nandatown.receipt import make_receipt, verify_receipt
 from nandatown.sim.runner import run_lab
 
 
@@ -217,6 +219,8 @@ def test_cli_compare_and_mirror(tmp_path, capsys):
     assert main(["recover", fingerprint, "--mirror",
                  str(tmp_path / "m"), "--out", out]) == 0
     assert "recovered and verified" in capsys.readouterr().out
+
+
 def test_mirror_cli_reports_invalid_source_without_traceback(tmp_path, capsys):
     from nandatown.cli import main
 
@@ -225,3 +229,54 @@ def test_mirror_cli_reports_invalid_source_without_traceback(tmp_path, capsys):
     (source / "manifest.json").write_text("{")
     assert main(["mirror", str(source), str(tmp_path / "mirror")]) == 1
     assert "mirror failed:" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("extra", ["unsigned.txt", "state/secret.txt"])
+def test_recovery_rejects_unsigned_mirror_payload(tmp_path, extra):
+    bundle_dir, _ = run_lab("voting", str(tmp_path / "runs"))
+    manifest = json.loads(Path(bundle_dir, "manifest.json").read_text())
+    fingerprint = manifest["bundle_fingerprint"]
+    mirror = str(tmp_path / "mirror")
+    stored = Path(mirror_bundle(bundle_dir, mirror))
+    extra_path = stored / extra
+    extra_path.parent.mkdir(parents=True, exist_ok=True)
+    extra_path.write_text("must not be recovered")
+
+    with pytest.raises(MirrorError, match="unsupported bundle member"):
+        recover_bundle(fingerprint, [mirror], str(tmp_path / "fresh"))
+
+    assert not (tmp_path / "fresh").exists()
+
+
+def test_recovery_regenerates_unsigned_report(tmp_path):
+    bundle_dir, _ = run_lab("voting", str(tmp_path / "runs"))
+    manifest = json.loads(Path(bundle_dir, "manifest.json").read_text())
+    fingerprint = manifest["bundle_fingerprint"]
+    mirror = str(tmp_path / "mirror")
+    stored = Path(mirror_bundle(bundle_dir, mirror))
+    stored.joinpath("report.md").write_text("UNSIGNED MIRROR CLAIM")
+
+    restored = Path(recover_bundle(
+        fingerprint, [mirror], str(tmp_path / "fresh")))
+
+    report = restored.joinpath("report.md").read_text()
+    assert "UNSIGNED MIRROR CLAIM" not in report
+    assert "NANDA Town System Fitness Report" in report
+
+
+def test_recovery_rejects_invalid_receipt_and_preserves_valid_one(tmp_path):
+    bundle_dir, _ = run_lab("voting", str(tmp_path / "runs"))
+    receipt_path = make_receipt(bundle_dir)
+    manifest = json.loads(Path(bundle_dir, "manifest.json").read_text())
+    fingerprint = manifest["bundle_fingerprint"]
+    good_mirror = str(tmp_path / "good-mirror")
+    mirror_bundle(bundle_dir, good_mirror)
+    restored = Path(recover_bundle(
+        fingerprint, [good_mirror], str(tmp_path / "fresh")))
+    assert verify_receipt(str(restored / "receipt.json"), str(restored)) == []
+
+    bad_mirror = str(tmp_path / "bad-mirror")
+    stored = Path(mirror_bundle(bundle_dir, bad_mirror))
+    stored.joinpath("receipt.json").write_text("{}")
+    with pytest.raises(MirrorError, match="receipt"):
+        recover_bundle(fingerprint, [bad_mirror], str(tmp_path / "other"))

--- a/tests/test_compare_mirror.py
+++ b/tests/test_compare_mirror.py
@@ -231,7 +231,8 @@ def test_mirror_cli_reports_invalid_source_without_traceback(tmp_path, capsys):
     assert "mirror failed:" in capsys.readouterr().out
 
 
-@pytest.mark.parametrize("extra", ["unsigned.txt", "state/secret.txt"])
+@pytest.mark.parametrize(
+    "extra", ["unsigned.txt", "state/secret.txt", "town.html"])
 def test_recovery_rejects_unsigned_mirror_payload(tmp_path, extra):
     bundle_dir, _ = run_lab("voting", str(tmp_path / "runs"))
     manifest = json.loads(Path(bundle_dir, "manifest.json").read_text())
@@ -246,6 +247,30 @@ def test_recovery_rejects_unsigned_mirror_payload(tmp_path, extra):
         recover_bundle(fingerprint, [mirror], str(tmp_path / "fresh"))
 
     assert not (tmp_path / "fresh").exists()
+
+
+def test_visualized_source_mirrors_without_copying_generated_html(
+        tmp_path, capsys):
+    bundle_dir, _ = run_lab("voting", str(tmp_path / "runs"))
+    source = Path(bundle_dir)
+    source_report = source.joinpath("report.md").read_text()
+    assert main(["visualize", bundle_dir]) == 0
+    assert source.joinpath("town.html").is_file()
+    capsys.readouterr()
+    manifest = json.loads(source.joinpath("manifest.json").read_text())
+
+    mirror = str(tmp_path / "mirror")
+    stored = Path(mirror_bundle(bundle_dir, mirror))
+
+    assert not stored.joinpath("town.html").exists()
+    assert stored.joinpath("report.md").read_text() == source_report
+    stored.joinpath("report.md").write_text("UNSIGNED MIRROR CLAIM")
+
+    restored = Path(recover_bundle(
+        manifest["bundle_fingerprint"], [mirror], str(tmp_path / "fresh")))
+
+    assert not restored.joinpath("town.html").exists()
+    assert restored.joinpath("report.md").read_text() == source_report
 
 
 def test_recovery_regenerates_unsigned_report(tmp_path):

--- a/tests/test_lab_coverage.py
+++ b/tests/test_lab_coverage.py
@@ -185,14 +185,24 @@ def test_new_lab_bundles_replay_and_old_lab_versions_do_not(tmp_path, old_versio
     recorded["evaluator_version"] = old_version
     with open(result_path, "w") as handle:
         json.dump(recorded, handle)
+    run_path = os.path.join(bundle_dir, "run.json")
+    run = json.loads(open(run_path).read())
+    run["releases"]["evaluator"] = old_version
+    with open(run_path, "w") as handle:
+        json.dump(run, handle)
     manifest_path = os.path.join(bundle_dir, "manifest.json")
     manifest = json.loads(open(manifest_path).read())
+    manifest["evaluator_version"] = old_version
     manifest["files"]["result.json"] = "sha256:" + hashlib.sha256(
         open(result_path, "rb").read()
+    ).hexdigest()
+    manifest["files"]["run.json"] = "sha256:" + hashlib.sha256(
+        open(run_path, "rb").read()
     ).hexdigest()
     manifest["bundle_fingerprint"] = fingerprint(manifest["files"])
     with open(manifest_path, "w") as handle:
         json.dump(manifest, handle)
+    os.unlink(os.path.join(bundle_dir, "attestation.json"))
 
     assert verify_bundle(bundle_dir) == [
         f"evaluator version differs: bundle {old_version}, local "

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -280,7 +280,7 @@ def test_oversized_card_does_not_reach_path_invocation(tmp_path):
         "a2a_response_budget_exceeded: selected local byte budget exceeded for this run")
     assert stage(result, "semantic_result").status == "not_tested"
     bundle = load_bundle(bundle_dir)
-    assert bundle["run"].profile_name == "a2a-capability-fulfillment@0.2"
+    assert bundle["run"].profile_name == "a2a-capability-fulfillment@0.3"
     assert bundle["run"].config["a2a_transport_policy"] == {
         "policy_id": "a2a-bounded-json@0.1",
         "max_response_bytes": 1_048_576,

--- a/tests/test_path_strict.py
+++ b/tests/test_path_strict.py
@@ -1,6 +1,8 @@
 """Versioned regressions for exact terminal-output Path evaluation."""
 
+import hashlib
 import json
+from pathlib import Path
 
 import httpx
 import pytest
@@ -8,12 +10,14 @@ import pytest
 import nandatown.path_profiles as path_profiles
 from nandatown.a2a_adapter import build_agent_card
 from nandatown.bundle import load_bundle, verify_bundle
+from nandatown.records import fingerprint
 from nandatown.path_runner import path_evaluator_version, run_path_test
 
 
 SUBJECT = "http://testserver"
 STRICT_PRICE_PROFILE = "a2a-capability-fulfillment@0.3"
 STRICT_QUOTE_PROFILE = "a2a-quote-intent@0.2"
+MISSING = object()
 
 
 def _proposed_profile(ref, monkeypatch):
@@ -47,7 +51,8 @@ def _quote(order):
     }
 
 
-def shaped_client(*, state="completed", second_state=None, layout="single"):
+def shaped_client(*, state="completed", second_state=None, layout="single",
+                  raw_status=MISSING):
     attempts = 0
 
     def handle(request):
@@ -77,7 +82,7 @@ def shaped_client(*, state="completed", second_state=None, layout="single"):
         task = {
             "id": f"task-{attempts}",
             "kind": "task",
-            "status": {
+            "status": raw_status if raw_status is not MISSING else {
                 "state": second_state
                 if attempts == 2 and second_state is not None else state
             },
@@ -235,4 +240,80 @@ def test_explicit_legacy_profile_retains_first_output_and_state_semantics(
                  if event.kind == "protocol_exchange"]
     assert all("terminal_output_count" not in event.detail
                for event in exchanges)
+    assert verify_bundle(directory) == []
+
+
+def test_unknown_path_evaluator_is_not_replayed_as_legacy(
+        tmp_path):
+    directory, _ = _run(
+        tmp_path, "a2a-capability-fulfillment@0.2")
+    bundle_path = Path(directory)
+    profile_path = bundle_path / "profile.json"
+    profile = json.loads(profile_path.read_text())
+    profile["evaluator"] = "future-path-evaluator@9.9"
+    profile_path.write_text(json.dumps(profile))
+    run_path = bundle_path / "run.json"
+    run = json.loads(run_path.read_text())
+    run["profile_fingerprint"] = fingerprint(profile)
+    run_path.write_text(json.dumps(run))
+    manifest_path = bundle_path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    for name, path in (("profile.json", profile_path),
+                       ("run.json", run_path)):
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        manifest["files"][name] = "sha256:" + digest
+    manifest["bundle_fingerprint"] = fingerprint(manifest["files"])
+    manifest_path.write_text(json.dumps(manifest))
+    (bundle_path / "attestation.json").unlink()
+
+    try:
+        problems = verify_bundle(directory)
+    except Exception as exc:  # pragma: no cover - verifier boundary
+        pytest.fail(f"unknown evaluator raised {type(exc).__name__}: {exc}")
+
+    assert any("unsupported path evaluator" in problem
+               for problem in problems), problems
+
+
+def test_strict_replay_rejects_extra_observed_fulfillment(tmp_path):
+    directory, result = _run(tmp_path, STRICT_PRICE_PROFILE)
+    assert result.verdict == "passed"
+    bundle_path = Path(directory)
+    events_path = bundle_path / "events.jsonl"
+    events = [json.loads(line) for line in events_path.read_text().splitlines()]
+    original = next(
+        event for event in events
+        if event["kind"] == "fulfillment_observed"
+        and event["detail"]["attempt"] == 1)
+    hidden = json.loads(json.dumps(original))
+    hidden["event_id"] = "ev-hidden-conflicting-fulfillment"
+    hidden["detail"]["total_cents"] = 1
+    hidden["detail"]["content_digest"] = "sha256:" + "0" * 64
+    events.append(hidden)
+    events_path.write_text(
+        "".join(json.dumps(event) + "\n" for event in events))
+    manifest_path = bundle_path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["files"]["events.jsonl"] = (
+        "sha256:" + hashlib.sha256(events_path.read_bytes()).hexdigest())
+    manifest["bundle_fingerprint"] = fingerprint(manifest["files"])
+    manifest_path.write_text(json.dumps(manifest))
+    (bundle_path / "attestation.json").unlink()
+
+    problems = verify_bundle(directory)
+
+    assert any("evaluator replay mismatch" in problem
+               for problem in problems), problems
+
+
+def test_strict_malformed_status_is_subject_failure_not_town_error(tmp_path):
+    directory, result = _run(
+        tmp_path, STRICT_PRICE_PROFILE, raw_status=[])
+
+    invocation = _stage(result, "protocol_invocation")
+    assert invocation.status == "failed"
+    assert result.verdict == "failed"
+    bundle = load_bundle(directory)
+    assert not any(event.kind == "town_driver_error"
+                   for event in bundle["events"])
     assert verify_bundle(directory) == []

--- a/tests/test_path_strict.py
+++ b/tests/test_path_strict.py
@@ -1,0 +1,238 @@
+"""Versioned regressions for exact terminal-output Path evaluation."""
+
+import json
+
+import httpx
+import pytest
+
+import nandatown.path_profiles as path_profiles
+from nandatown.a2a_adapter import build_agent_card
+from nandatown.bundle import load_bundle, verify_bundle
+from nandatown.path_runner import path_evaluator_version, run_path_test
+
+
+SUBJECT = "http://testserver"
+STRICT_PRICE_PROFILE = "a2a-capability-fulfillment@0.3"
+STRICT_QUOTE_PROFILE = "a2a-quote-intent@0.2"
+
+
+def _proposed_profile(ref, monkeypatch):
+    """Let the RED tests exercise old dispatch before the catalog exists."""
+    if ref in path_profiles.PATH_PROFILES:
+        return path_profiles.get_path_profile(ref)
+    if ref == STRICT_PRICE_PROFILE:
+        base_ref = "a2a-capability-fulfillment@0.2"
+        changes = {"version": "0.3", "evaluator": "path-evaluator@0.2"}
+    else:
+        base_ref = "a2a-quote-intent@0.1"
+        changes = {
+            "version": "0.2",
+            "evaluator": "quote-intent-evaluator@0.2",
+        }
+    profile = path_profiles.get_path_profile(base_ref).model_copy(
+        update=changes)
+    monkeypatch.setitem(path_profiles.PATH_PROFILES, profile.ref, profile)
+    return profile
+
+
+def _quote(order):
+    return {
+        "request_id": order["request_id"],
+        "total_cents": 3990,
+        "sku": "widget",
+        "quantity": 2,
+        "color": "blue",
+        "merchant_id": "town-reference",
+        "currency": "USD",
+    }
+
+
+def shaped_client(*, state="completed", second_state=None, layout="single"):
+    attempts = 0
+
+    def handle(request):
+        nonlocal attempts
+        if request.method == "GET":
+            return httpx.Response(200, json=build_agent_card(SUBJECT))
+        attempts += 1
+        envelope = json.loads(request.content)
+        order = json.loads(
+            envelope["params"]["message"]["parts"][0]["text"])
+        first = {"kind": "text", "text": json.dumps(_quote(order))}
+        extra = {"kind": "text", "text": json.dumps({"hidden": True})}
+        selected_layout = (
+            "multiple_artifacts"
+            if layout == "second_attempt_multiple" and attempts == 2
+            else "single" if layout == "second_attempt_multiple" else layout
+        )
+        if selected_layout == "multiple_artifacts":
+            artifacts = [
+                {"artifactId": "quote", "parts": [first]},
+                {"artifactId": "hidden", "parts": [extra]},
+            ]
+        elif selected_layout == "multiple_parts":
+            artifacts = [{"artifactId": "quote", "parts": [first, extra]}]
+        else:
+            artifacts = [{"artifactId": "quote", "parts": [first]}]
+        task = {
+            "id": f"task-{attempts}",
+            "kind": "task",
+            "status": {
+                "state": second_state
+                if attempts == 2 and second_state is not None else state
+            },
+            "artifacts": artifacts,
+        }
+        return httpx.Response(200, json={
+            "jsonrpc": "2.0", "id": envelope["id"], "result": task,
+        })
+
+    return httpx.Client(
+        base_url=SUBJECT, transport=httpx.MockTransport(handle))
+
+
+def _run(tmp_path, profile_ref, **shape):
+    with shaped_client(**shape) as http:
+        return run_path_test(
+            SUBJECT, str(tmp_path), profile_ref=profile_ref, http=http)
+
+
+def _stage(result, name):
+    return next(stage for stage in result.stages if stage.name == name)
+
+
+def test_new_profiles_are_explicit_without_relabeling_legacy_evidence():
+    legacy = {
+        "a2a-capability-fulfillment@0.1": (
+            "sha256:80d238c2de68dbe3de577ad88ae5eb742daeaf2628dc7802be2b11e68b8d4b83",
+            "path-0.2",
+        ),
+        "a2a-capability-fulfillment@0.2": (
+            "sha256:92b5a2337f362a0eb6d6baf2810d42e58283a6d352921a4bf875764b74aeca3b",
+            "path-0.2",
+        ),
+        "a2a-quote-intent@0.1": (
+            "sha256:7d9ecb75a3c2d6b1f5abff6a28d218d2532fea3a491b4fd9f5ef7ae6b8342997",
+            "path-quote-intent-0.1",
+        ),
+    }
+    for ref, (profile_fingerprint, evaluator_version) in legacy.items():
+        profile = path_profiles.get_path_profile(ref)
+        assert profile.fingerprint() == profile_fingerprint
+        assert path_evaluator_version(profile) == evaluator_version
+
+    strict_price = path_profiles.get_path_profile(STRICT_PRICE_PROFILE)
+    strict_quote = path_profiles.get_path_profile(STRICT_QUOTE_PROFILE)
+    assert strict_price.evaluator == "path-evaluator@0.2"
+    assert strict_quote.evaluator == "quote-intent-evaluator@0.2"
+    assert path_evaluator_version(strict_price) == "path-0.3"
+    assert path_evaluator_version(strict_quote) == "path-quote-intent-0.2"
+    assert path_profiles.DEFAULT_PATH_PROFILE == STRICT_PRICE_PROFILE
+
+
+@pytest.mark.parametrize("state", ["failed", "working", "input-required"])
+def test_strict_profile_requires_successful_terminal_state(
+        tmp_path, monkeypatch, state):
+    profile = _proposed_profile(STRICT_PRICE_PROFILE, monkeypatch)
+
+    directory, result = _run(tmp_path, profile.ref, state=state)
+
+    invocation = _stage(result, "protocol_invocation")
+    assert invocation.status == "failed"
+    assert "completed" in invocation.note
+    assert state in invocation.note
+    assert _stage(result, "semantic_result").status == "not_tested"
+    assert result.verdict == "failed"
+    bundle = load_bundle(directory)
+    assert len([event for event in bundle["events"]
+                if event.kind == "protocol_exchange"]) == 1
+    assert not any(event.kind == "fulfillment_observed"
+                   for event in bundle["events"])
+    assert verify_bundle(directory) == []
+
+
+@pytest.mark.parametrize("profile_ref", [
+    STRICT_PRICE_PROFILE,
+    STRICT_QUOTE_PROFILE,
+])
+@pytest.mark.parametrize("layout", ["multiple_artifacts", "multiple_parts"])
+def test_strict_profile_counts_every_terminal_text_output(
+        tmp_path, monkeypatch, profile_ref, layout):
+    profile = _proposed_profile(profile_ref, monkeypatch)
+
+    directory, result = _run(tmp_path, profile.ref, layout=layout)
+
+    assert _stage(result, "protocol_invocation").status == "passed"
+    semantic = _stage(result, "semantic_result")
+    assert semantic.status == "failed"
+    assert "exactly one terminal text output" in semantic.note
+    assert "observed 2" in semantic.note
+    assert result.verdict == "failed"
+    bundle = load_bundle(directory)
+    exchanges = [event for event in bundle["events"]
+                 if event.kind == "protocol_exchange"]
+    assert len(exchanges) == 1
+    first_exchange = exchanges[0]
+    assert first_exchange.detail["terminal_output_count"] == 2
+    assert verify_bundle(directory) == []
+
+
+def test_strict_profile_rejects_extra_output_on_duplicate_attempt(
+        tmp_path, monkeypatch):
+    profile = _proposed_profile(STRICT_PRICE_PROFILE, monkeypatch)
+
+    directory, result = _run(
+        tmp_path, profile.ref, layout="second_attempt_multiple")
+
+    assert _stage(result, "semantic_result").status == "passed"
+    duplicate = _stage(result, "duplicate_request")
+    assert duplicate.status == "failed"
+    assert "exactly one terminal text output" in duplicate.note
+    assert "observed 2" in duplicate.note
+    assert result.verdict == "failed"
+    assert verify_bundle(directory) == []
+
+
+def test_strict_profile_requires_duplicate_attempt_to_complete(
+        tmp_path, monkeypatch):
+    profile = _proposed_profile(STRICT_PRICE_PROFILE, monkeypatch)
+
+    directory, result = _run(
+        tmp_path, profile.ref, second_state="working")
+
+    assert _stage(result, "semantic_result").status == "passed"
+    duplicate = _stage(result, "duplicate_request")
+    assert duplicate.status == "failed"
+    assert "completed" in duplicate.note
+    assert "working" in duplicate.note
+    assert result.verdict == "failed"
+    assert verify_bundle(directory) == []
+
+
+def test_strict_quote_profile_passes_and_replays(tmp_path, monkeypatch):
+    profile = _proposed_profile(STRICT_QUOTE_PROFILE, monkeypatch)
+
+    directory, result = _run(tmp_path, profile.ref)
+
+    assert result.verdict == "passed"
+    assert result.evaluator_version == "path-quote-intent-0.2"
+    assert verify_bundle(directory) == []
+
+
+def test_explicit_legacy_profile_retains_first_output_and_state_semantics(
+        tmp_path):
+    directory, result = _run(
+        tmp_path,
+        "a2a-capability-fulfillment@0.2",
+        state="failed",
+        layout="multiple_artifacts",
+    )
+
+    assert result.verdict == "passed"
+    assert result.evaluator_version == "path-0.2"
+    bundle = load_bundle(directory)
+    exchanges = [event for event in bundle["events"]
+                 if event.kind == "protocol_exchange"]
+    assert all("terminal_output_count" not in event.detail
+               for event in exchanges)
+    assert verify_bundle(directory) == []

--- a/tests/test_proof_integrity.py
+++ b/tests/test_proof_integrity.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from nandatown.a2a_adapter import build_a2a_app, build_agent_card
 from nandatown.bundle import attest_bundle, verify_bundle
 from nandatown.cli import main
+from nandatown.identity_portable import Keystore
 from nandatown.path_runner import run_path_test
 from nandatown.receipt import make_receipt, render_proof, verify_receipt
 from nandatown.records import fingerprint
@@ -115,3 +116,84 @@ def test_partial_receipt_remains_independently_verifiable(tmp_path):
 
     assert verify_receipt(path) == []
     assert verify_receipt(path, directory) == []
+
+    ok, text = render_proof(directory)
+
+    assert not ok
+    assert "descriptor_consistency" in text
+    assert "not tested" in text
+
+
+def _resign_changed_receipt(directory, keys, path, value):
+    receipt_path = directory / "receipt.json"
+    receipt = json.loads(receipt_path.read_text())
+    target = receipt["payload"]
+    for part in path[:-1]:
+        target = target[part]
+    target[path[-1]] = value
+    receipt["signature"] = keys.sign("reviewer", receipt["payload"])
+    receipt_path.write_text(json.dumps(receipt))
+    return receipt_path
+
+
+@pytest.mark.parametrize(
+    ("field", "path", "value"),
+    [
+        ("claim verdict", ("claim", "verdict"), "failed"),
+        ("claim subject", ("claim", "subject"), "other-agent"),
+        ("claim capability", ("claim", "capability"), "other-capability"),
+        ("claim profile", ("claim", "profile"), "other-profile"),
+        ("claim release basis", ("claim", "release_basis"),
+         {"profile_fingerprint": "sha256:other"}),
+        ("coverage", ("coverage",), {"tested": ["invented"],
+                                      "not_tested": []}),
+        ("evidence run id", ("evidence", "run_id"), "other-run"),
+        ("window", ("window",), {"started": 1.0, "evaluated": 2.0}),
+    ],
+)
+def test_bundle_aware_verification_rejects_validly_resigned_false_claims(
+        tmp_path, field, path, value):
+    directory = complete_bundle(tmp_path)
+    keys = Keystore(str(tmp_path / "keys"))
+    make_receipt(str(directory), keystore=keys, signer="reviewer")
+    receipt_path = _resign_changed_receipt(directory, keys, path, value)
+
+    assert verify_receipt(str(receipt_path)) == []
+    problems = verify_receipt(str(receipt_path), str(directory))
+
+    assert any(field in problem for problem in problems), problems
+
+
+def test_validly_resigned_pass_claim_cannot_badge_failed_bundle(tmp_path):
+    url = "http://testserver"
+    with TestClient(build_a2a_app(url, defect="wrong_total")) as client:
+        directory_text, result = run_path_test(
+            url, str(tmp_path), http=client,
+            pin_card_digest=fingerprint(build_agent_card(url)))
+    assert result.verdict == "failed"
+    directory = Path(directory_text)
+    keys = Keystore(str(tmp_path / "keys"))
+    make_receipt(str(directory), keystore=keys, signer="reviewer")
+    receipt_path = _resign_changed_receipt(
+        directory, keys, ("claim", "verdict"), "passed")
+    assert verify_receipt(str(receipt_path)) == []
+
+    ok, text = render_proof(str(directory))
+
+    assert not ok
+    assert "claim verdict" in text
+    assert "TOWN-TESTED" not in text
+
+
+def test_malformed_existing_receipt_refuses_proof_without_crashing(tmp_path):
+    directory = complete_bundle(tmp_path)
+    (directory / "receipt.json").write_text("{}")
+
+    try:
+        ok, text = render_proof(str(directory))
+    except Exception as exc:  # pragma: no cover - the assertion is the contract
+        pytest.fail(f"malformed receipt raised {type(exc).__name__}: {exc}")
+
+    assert not ok
+    assert "receipt" in text
+    assert "TOWN-TESTED" not in text

--- a/tests/test_proof_integrity.py
+++ b/tests/test_proof_integrity.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -196,4 +197,60 @@ def test_malformed_existing_receipt_refuses_proof_without_crashing(tmp_path):
 
     assert not ok
     assert "receipt" in text
+    assert "TOWN-TESTED" not in text
+
+
+def test_make_receipt_does_not_write_through_dangling_symlink(tmp_path):
+    directory = complete_bundle(tmp_path)
+    outside = tmp_path / "outside-receipt.json"
+    (directory / "receipt.json").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="regular file"):
+        make_receipt(str(directory))
+
+    assert not outside.exists()
+
+
+def test_proof_rejects_dangling_receipt_symlink_without_creating_target(
+        tmp_path):
+    directory = complete_bundle(tmp_path)
+    outside = tmp_path / "outside-receipt.json"
+    (directory / "receipt.json").symlink_to(outside)
+
+    ok, text = render_proof(str(directory))
+
+    assert not ok
+    assert "not a regular file" in text
+    assert not outside.exists()
+
+
+@pytest.mark.parametrize(
+    ("evaluated_at", "reason"),
+    [(float("nan"), "finite"), (float("inf"), "finite"),
+     (float("-inf"), "finite"), (time.time() + 86400, "future")],
+    ids=["nan", "positive-infinity", "negative-infinity", "future"],
+)
+def test_proof_rejects_invalid_evidence_timestamp(
+        tmp_path, evaluated_at, reason):
+    directory = complete_bundle(tmp_path)
+    result_path = directory / "result.json"
+    result = json.loads(result_path.read_text())
+    result["evaluated_at"] = evaluated_at
+    result_path.write_text(json.dumps(result))
+    manifest_path = directory / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["files"]["result.json"] = (
+        "sha256:" + hashlib.sha256(result_path.read_bytes()).hexdigest())
+    manifest["bundle_fingerprint"] = fingerprint(manifest["files"])
+    manifest_path.write_text(json.dumps(manifest))
+    attest_bundle(str(directory))
+    assert verify_bundle(str(directory)) == []
+
+    try:
+        ok, text = render_proof(str(directory))
+    except Exception as exc:  # pragma: no cover - public proof boundary
+        pytest.fail(f"invalid evidence timestamp raised {type(exc).__name__}: {exc}")
+
+    assert not ok
+    assert reason in text.lower()
     assert "TOWN-TESTED" not in text

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,12 +1,14 @@
 import json
 import os
 
+import pytest
 from fastapi.testclient import TestClient
 
-from nandatown.a2a_adapter import build_a2a_app
+from nandatown.a2a_adapter import build_a2a_app, build_agent_card
 from nandatown.cli import main
 from nandatown.path_runner import run_path_test
 from nandatown.receipt import make_receipt, render_proof, verify_receipt
+from nandatown.records import fingerprint
 
 
 def passed_bundle(tmp_path):
@@ -14,6 +16,17 @@ def passed_bundle(tmp_path):
         "http://testserver", str(tmp_path),
         http=TestClient(build_a2a_app("http://testserver")))
     assert result.verdict == "passed"
+    return bundle_dir
+
+
+def complete_passed_bundle(tmp_path):
+    url = "http://testserver"
+    bundle_dir, result = run_path_test(
+        url, str(tmp_path),
+        pin_card_digest=fingerprint(build_agent_card(url)),
+        http=TestClient(build_a2a_app(url)))
+    assert result.verdict == "passed"
+    assert all(stage.status == "passed" for stage in result.stages)
     return bundle_dir
 
 
@@ -59,7 +72,7 @@ def test_tampered_receipt_is_caught(tmp_path):
 
 
 def test_proof_renders_only_from_passing_fresh_evidence(tmp_path):
-    bundle_dir = passed_bundle(tmp_path)
+    bundle_dir = complete_passed_bundle(tmp_path)
     ok, text = render_proof(bundle_dir)
     assert ok, text
     assert "TOWN-TESTED" in text
@@ -74,7 +87,7 @@ def test_proof_renders_only_from_passing_fresh_evidence(tmp_path):
 
 
 def test_stale_evidence_refuses_a_badge(tmp_path):
-    bundle_dir = passed_bundle(tmp_path)
+    bundle_dir = complete_passed_bundle(tmp_path)
     path = make_receipt(bundle_dir)
     ok, text = render_proof(bundle_dir, freshness_days=0.0)
     assert not ok
@@ -83,7 +96,7 @@ def test_stale_evidence_refuses_a_badge(tmp_path):
 
 
 def test_cli_receipt_verify_proof(tmp_path, capsys):
-    bundle_dir = passed_bundle(tmp_path)
+    bundle_dir = complete_passed_bundle(tmp_path)
     assert main(["receipt", bundle_dir]) == 0
     assert main(["verify-receipt", f"{bundle_dir}/receipt.json",
                  "--bundle", bundle_dir]) == 0
@@ -91,3 +104,32 @@ def test_cli_receipt_verify_proof(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "TOWN-TESTED" in out
     assert "commitment is not truth" in out
+
+
+@pytest.mark.parametrize("freshness_days", [float("nan"), float("inf"), -1.0],
+                         ids=["nan", "infinite", "negative"])
+def test_proof_rejects_invalid_freshness_domain(tmp_path, freshness_days):
+    bundle_dir = complete_passed_bundle(tmp_path)
+
+    ok, text = render_proof(bundle_dir, freshness_days=freshness_days)
+
+    assert not ok
+    assert "freshness days must be a finite non-negative number" in text
+
+
+@pytest.mark.parametrize("document", [[], {"payload": []},
+                                         {"payload": {},
+                                          "controller_public": [],
+                                          "signature": []}],
+                         ids=["list", "payload-list", "non-string-signature"])
+def test_malformed_receipt_is_reported_not_raised(tmp_path, document):
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.write_text(json.dumps(document))
+
+    try:
+        problems = verify_receipt(str(receipt_path))
+    except Exception as exc:  # pragma: no cover - the assertion is the contract
+        pytest.fail(f"malformed receipt raised {type(exc).__name__}: {exc}")
+
+    assert problems
+    assert any("receipt" in problem for problem in problems)

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from nandatown.a2a_adapter import build_a2a_app, build_agent_card
 from nandatown.cli import main
+from nandatown.identity_portable import Keystore
 from nandatown.path_runner import run_path_test
 from nandatown.receipt import make_receipt, render_proof, verify_receipt
 from nandatown.records import fingerprint
@@ -159,3 +160,60 @@ def test_fifo_receipt_is_rejected_before_open(tmp_path, monkeypatch):
     problems = verify_receipt(str(receipt_path))
 
     assert any("not a regular file" in problem for problem in problems), problems
+
+
+def test_detached_verification_rejects_signed_sparse_payload(tmp_path):
+    keys = Keystore(str(tmp_path / "keys"))
+    identity = keys.new_identity("reviewer")
+    payload = {"observer": identity["agent_id"]}
+    receipt = {
+        "payload": payload,
+        "signature": keys.sign("reviewer", payload),
+        "controller_public": identity["controller_public"],
+    }
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.write_text(json.dumps(receipt))
+
+    problems = verify_receipt(str(receipt_path))
+
+    assert any("payload" in problem and "missing" in problem
+               for problem in problems), problems
+
+
+@pytest.mark.parametrize(
+    ("change", "expected"),
+    [
+        ("claim-extra", "claim has unexpected fields"),
+        ("evidence-extra", "evidence has unexpected fields"),
+        ("payload-extra", "payload has unexpected fields"),
+        ("receipt-extra", "receipt has unexpected fields"),
+        ("missing-limitations", "payload is missing fields"),
+    ],
+)
+def test_signed_receipt_rejects_unrecognized_or_missing_claim_shape(
+        tmp_path, change, expected):
+    bundle_dir = complete_passed_bundle(tmp_path)
+    keys = Keystore(str(tmp_path / "keys"))
+    receipt_path = make_receipt(
+        bundle_dir, keystore=keys, signer="reviewer")
+    with open(receipt_path) as stream:
+        receipt = json.load(stream)
+    if change == "claim-extra":
+        receipt["payload"]["claim"]["universally_safe"] = True
+    elif change == "evidence-extra":
+        receipt["payload"]["evidence"]["independently_observed"] = True
+    elif change == "payload-extra":
+        receipt["payload"]["endorsement"] = True
+    elif change == "receipt-extra":
+        receipt["endorsement"] = True
+    else:
+        receipt["payload"].pop("limitations")
+    receipt["signature"] = keys.sign("reviewer", receipt["payload"])
+    with open(receipt_path, "w") as stream:
+        json.dump(receipt, stream)
+
+    detached = verify_receipt(receipt_path)
+    bundle_aware = verify_receipt(receipt_path, bundle_dir)
+
+    assert any(expected in problem for problem in detached), detached
+    assert any(expected in problem for problem in bundle_aware), bundle_aware

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -133,3 +133,29 @@ def test_malformed_receipt_is_reported_not_raised(tmp_path, document):
 
     assert problems
     assert any("receipt" in problem for problem in problems)
+
+
+def test_symlinked_receipt_is_rejected_before_read(tmp_path):
+    target = tmp_path / "target.json"
+    target.write_text("{}")
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.symlink_to(target)
+
+    problems = verify_receipt(str(receipt_path))
+
+    assert any("not a regular file" in problem for problem in problems), problems
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO unavailable")
+def test_fifo_receipt_is_rejected_before_open(tmp_path, monkeypatch):
+    receipt_path = tmp_path / "receipt.json"
+    os.mkfifo(receipt_path)
+
+    def forbidden_open(*_args, **_kwargs):
+        pytest.fail("verify_receipt attempted to open a FIFO")
+
+    monkeypatch.setattr("builtins.open", forbidden_open)
+
+    problems = verify_receipt(str(receipt_path))
+
+    assert any("not a regular file" in problem for problem in problems), problems


### PR DESCRIPTION
## Why

A valid signature alone was too easily confused with agreement between a receipt's claims and its bundle. Incomplete/malformed bundle manifests and replay ambiguities could also undermine downstream verification. Path accepted weaker terminal-output semantics without an explicit new contract.

## Changes

- Verify the exact canonical record set, regular files/digests, record/profile/result identities, deterministic replay and optional attestation claims; malformed inputs return clear problems.
- Bind bundle-aware receipt verification to actual claim, coverage, release basis, window and evidence fields; bound unsafe receipt files and invalid timestamps.
- Preserve the existing semantic boundary: partial receipts remain valid signed evidence; only fully covered, fresh, passed, verified evidence is badge-eligible. Detached signature verification establishes key commitment, not observation truth.
- Add explicit strict profiles: capability fulfillment `@0.3` and quote intent `@0.2`. Require completed tasks, exact output cardinality, matching request IDs and deterministic duplicate semantics. Historical profiles retain their fingerprints/meaning; unknown evaluators fail closed.
- Constrain mirror payloads, verify candidates, preserve existing destinations, try surviving mirrors and regenerate reports. Source-only private state/generated viewer files are not copied.
- Make CLI coverage denominators and failure diagnostics agree with the evidence contract.

## Review and compatibility

This is the largest remediation PR because receipt claims, bundle verification, replay and recovery form one dependency boundary. Commits are separated for review. It does not add a required-stage system, accepted-observer policy, global agent certification, native harness auto-detection or full A2A conformance. The one-text-part rule belongs to the named synthetic profile.

## Verification

Fresh standalone base: `53178b9c780d7a7dd6ce723131c4250de03908dd`.
- `python -m pytest -q` on Python 3.12 — 759 passed, 8 existing warnings.
- `git diff --check` — clean.
- TDD regressions and independent adversarial reviews cover re-signed false claims, missing/duplicate/malformed records, unsafe files, ambiguous replay, bad mirror candidates and strict/legacy compatibility.
- Final combined code separately passed 817 tests on Python 3.12 and a clean Python 3.11 wheel.
- Real localhost HTTP strict-Path controls: pinned complete result → 6/6 + badge; unpinned result → valid signed partial receipt, no badge naming descriptor_consistency; wrong-total and duplicate-fulfillment cases fail their intended stages. All four verified and survived viewer → mirror → recovery with unchanged eligibility.

These local controls test Town's own reference endpoint, not independent ecosystem adoption. Prefer this core PR before the verified-viewers and current-manual PRs.
