### PR TITLE
fix(viewers): safely render evidence and rank only verified bundles

### DIFF
--- a/src/nandatown/board.py
+++ b/src/nandatown/board.py
@@ -30,13 +30,20 @@ def scan_bundles(directory: str) -> list[dict[str, Any]]:
         manifest_path = os.path.join(bundle_dir, "manifest.json")
         if not os.path.lexists(manifest_path):
             continue
-        problems = verify_bundle(bundle_dir)
+        try:
+            problems = verify_bundle(bundle_dir)
+            bundle = None if problems else load_bundle(bundle_dir)
+        except Exception as exc:
+            # A board entry is untrusted input. Older verifier versions may
+            # raise while parsing it; one bad entry must not hide good runs.
+            problems = [f"bundle unreadable: {type(exc).__name__}"]
+            bundle = None
         if problems:
             rows.append({"run_id": entry, "directory": entry, "verified": False,
                          "problems": problems, "profile": "unverified",
                          "mode": "unknown", "verdict": "unverified", "at": 0.0})
             continue
-        bundle = load_bundle(bundle_dir)
+        assert bundle is not None
         address = bundle["manifest"]["bundle_fingerprint"]
         if address in seen_fingerprints:
             continue

--- a/src/nandatown/board.py
+++ b/src/nandatown/board.py
@@ -26,7 +26,8 @@ def scan_bundles(directory: str) -> list[dict[str, Any]]:
         problems = verify_bundle(bundle_dir)
         if problems:
             rows.append({"run_id": entry, "verified": False,
-                         "problems": problems})
+                         "problems": problems, "profile": "unverified",
+                         "mode": "unknown", "verdict": "unverified", "at": 0.0})
             continue
         bundle = load_bundle(bundle_dir)
         run, result = bundle["run"], bundle["result"]

--- a/src/nandatown/board.py
+++ b/src/nandatown/board.py
@@ -14,8 +14,15 @@ from typing import Any
 from .bundle import load_bundle, verify_bundle
 
 
+def display_text(value: Any) -> str:
+    """Keep paths and evidence labels on one inert terminal line."""
+    return "".join(char if char.isprintable() else repr(char)[1:-1]
+                   for char in str(value))
+
+
 def scan_bundles(directory: str) -> list[dict[str, Any]]:
     rows = []
+    seen_fingerprints = set()
     if not os.path.isdir(directory):
         return rows
     for entry in sorted(os.listdir(directory)):
@@ -25,14 +32,19 @@ def scan_bundles(directory: str) -> list[dict[str, Any]]:
             continue
         problems = verify_bundle(bundle_dir)
         if problems:
-            rows.append({"run_id": entry, "verified": False,
+            rows.append({"run_id": entry, "directory": entry, "verified": False,
                          "problems": problems, "profile": "unverified",
                          "mode": "unknown", "verdict": "unverified", "at": 0.0})
             continue
         bundle = load_bundle(bundle_dir)
+        address = bundle["manifest"]["bundle_fingerprint"]
+        if address in seen_fingerprints:
+            continue
+        seen_fingerprints.add(address)
         run, result = bundle["run"], bundle["result"]
         rows.append({
             "run_id": run.run_id,
+            "directory": entry,
             "profile": run.profile_name,
             "mode": bundle["mode"],
             "verdict": result.verdict,
@@ -46,7 +58,7 @@ def scan_bundles(directory: str) -> list[dict[str, Any]]:
 def render_board(directory: str) -> str:
     rows = scan_bundles(directory)
     if not rows:
-        return (f"no evidence bundles under {directory}; run one with:"
+        return (f"no evidence bundles under {display_text(directory)}; run one with:"
                 " nandatown run\n")
     groups: dict[str, dict[str, Any]] = {}
     for row in rows:
@@ -61,15 +73,15 @@ def render_board(directory: str) -> str:
         if row["at"] >= g["last_at"]:
             g["last_at"] = row["at"]
             g["last_verdict"] = row["verdict"]
-    width = max((len(name) for name in groups), default=0)
-    lines = [f"Town board over {directory} ({len(rows)} bundles)",
+    width = max((len(display_text(name)) for name in groups), default=0)
+    lines = [f"Town board over {display_text(directory)} ({len(rows)} bundles)",
              "=" * 40]
     ranked = sorted(groups.items(),
                     key=lambda kv: (-kv[1]["passed"] / kv[1]["runs"],
                                     kv[0]))
     for name, g in ranked:
         rate = 100.0 * g["passed"] / g["runs"]
-        lines.append(f"{name.ljust(width)}  {g['mode']:<5}"
+        lines.append(f"{display_text(name).ljust(width)}  {g['mode']:<5}"
                      f" {g['passed']}/{g['runs']} passed"
                      f" ({rate:5.1f}%), last {g['last_verdict']}")
     lines.append("")
@@ -77,9 +89,11 @@ def render_board(directory: str) -> str:
     if unverified:
         lines.append("Unverified bundles (excluded from rankings):")
         for row in unverified:
-            lines.append(f"  {row['run_id']}: {'; '.join(row['problems'])}")
+            lines.append(f"  {display_text(row['run_id'])}: "
+                         f"{display_text('; '.join(row['problems']))}")
         lines.append("")
     lines.append("Rankings include only bundles verified with the local evaluator."
+                 " Identical bundle copies count once."
                  " Verification checks recorded evidence, not independent truth."
                  " The board is a view, not a record.")
     return "\n".join(lines) + "\n"

--- a/src/nandatown/board.py
+++ b/src/nandatown/board.py
@@ -48,7 +48,9 @@ def scan_bundles(directory: str) -> list[dict[str, Any]]:
             "profile": run.profile_name,
             "mode": bundle["mode"],
             "verdict": result.verdict,
-            "at": run.created_at,
+            # Lab starts at logical time zero. The result's hash-committed
+            # evaluation time gives every mode the same wall-clock chronology.
+            "at": result.evaluated_at,
             "verified": True,
             "problems": [],
         })

--- a/src/nandatown/board.py
+++ b/src/nandatown/board.py
@@ -1,4 +1,4 @@
-"""The local leaderboard: what has been proven on this machine.
+"""The local leaderboard over verified recorded evidence.
 
 Scans a runs directory for evidence bundles and shows, per profile or
 scenario, how many runs exist and how many passed. Rankings derive from
@@ -8,9 +8,10 @@ record.
 
 from __future__ import annotations
 
-import json
 import os
 from typing import Any
+
+from .bundle import load_bundle, verify_bundle
 
 
 def scan_bundles(directory: str) -> list[dict[str, Any]]:
@@ -20,24 +21,23 @@ def scan_bundles(directory: str) -> list[dict[str, Any]]:
     for entry in sorted(os.listdir(directory)):
         bundle_dir = os.path.join(directory, entry)
         manifest_path = os.path.join(bundle_dir, "manifest.json")
-        run_path = os.path.join(bundle_dir, "run.json")
-        result_path = os.path.join(bundle_dir, "result.json")
-        if not (os.path.exists(manifest_path)
-                and os.path.exists(run_path)
-                and os.path.exists(result_path)):
+        if not os.path.lexists(manifest_path):
             continue
-        with open(manifest_path) as f:
-            manifest = json.load(f)
-        with open(run_path) as f:
-            run = json.load(f)
-        with open(result_path) as f:
-            result = json.load(f)
+        problems = verify_bundle(bundle_dir)
+        if problems:
+            rows.append({"run_id": entry, "verified": False,
+                         "problems": problems})
+            continue
+        bundle = load_bundle(bundle_dir)
+        run, result = bundle["run"], bundle["result"]
         rows.append({
-            "run_id": run["run_id"],
-            "profile": run["profile_name"],
-            "mode": manifest.get("mode", "track"),
-            "verdict": result["verdict"],
-            "at": manifest.get("created_at", 0.0),
+            "run_id": run.run_id,
+            "profile": run.profile_name,
+            "mode": bundle["mode"],
+            "verdict": result.verdict,
+            "at": run.created_at,
+            "verified": True,
+            "problems": [],
         })
     return rows
 
@@ -49,6 +49,8 @@ def render_board(directory: str) -> str:
                 " nandatown run\n")
     groups: dict[str, dict[str, Any]] = {}
     for row in rows:
+        if not row["verified"]:
+            continue
         g = groups.setdefault(row["profile"],
                               {"mode": row["mode"], "runs": 0,
                                "passed": 0, "last_verdict": "",
@@ -58,7 +60,7 @@ def render_board(directory: str) -> str:
         if row["at"] >= g["last_at"]:
             g["last_at"] = row["at"]
             g["last_verdict"] = row["verdict"]
-    width = max(len(name) for name in groups)
+    width = max((len(name) for name in groups), default=0)
     lines = [f"Town board over {directory} ({len(rows)} bundles)",
              "=" * 40]
     ranked = sorted(groups.items(),
@@ -70,7 +72,13 @@ def render_board(directory: str) -> str:
                      f" {g['passed']}/{g['runs']} passed"
                      f" ({rate:5.1f}%), last {g['last_verdict']}")
     lines.append("")
-    lines.append("Every line is backed by a verifiable bundle:"
-                 " nandatown verify <dir>. The board is a view, not a"
-                 " record.")
+    unverified = [row for row in rows if not row["verified"]]
+    if unverified:
+        lines.append("Unverified bundles (excluded from rankings):")
+        for row in unverified:
+            lines.append(f"  {row['run_id']}: {'; '.join(row['problems'])}")
+        lines.append("")
+    lines.append("Rankings include only bundles verified with the local evaluator."
+                 " Verification checks recorded evidence, not independent truth."
+                 " The board is a view, not a record.")
     return "\n".join(lines) + "\n"

--- a/src/nandatown/tui.py
+++ b/src/nandatown/tui.py
@@ -246,13 +246,15 @@ class TownApp(App):
             f" Evidence here: {len(rows)} bundles, {passed} passed.")
 
     def _refresh_bundles(self) -> None:
-        from .board import scan_bundles
+        from .board import display_text, scan_bundles
+        from rich.text import Text
 
         table = self.query_one("#bundle-table", DataTable)
         table.clear()
         for row in reversed(scan_bundles(self.out_dir)):
-            table.add_row(row["run_id"], row["profile"], row["mode"],
-                          row["verdict"], key=row["run_id"])
+            table.add_row(*(Text(display_text(row[field])) for field in
+                            ("run_id", "profile", "mode", "verdict")),
+                          key=row["directory"])
 
     def _refresh_protocols(self) -> None:
         from .protocols import protocol_entries
@@ -473,8 +475,8 @@ class TownApp(App):
         table = self.query_one("#bundle-table", DataTable)
         if table.row_count == 0:
             return None
-        row = table.get_row_at(table.cursor_row)
-        return os.path.join(self.out_dir, str(row[0]))
+        key = table.coordinate_to_cell_key(table.cursor_coordinate).row_key
+        return os.path.join(self.out_dir, key.value)
 
     @on(Button.Pressed, "#ev-refresh")
     def _on_ev_refresh(self) -> None:

--- a/src/nandatown/visualizer.py
+++ b/src/nandatown/visualizer.py
@@ -8,6 +8,7 @@ view. No network, no external assets: the whole run travels in the file.
 from __future__ import annotations
 
 import json
+from html import escape
 from typing import Any
 
 TEMPLATE = """<!DOCTYPE html>
@@ -54,6 +55,7 @@ TEMPLATE = """<!DOCTYPE html>
   .failed { color: var(--bad); }
   .not_enough_evidence { color: var(--warn); }
   .not_tested { color: var(--dim); }
+  .error { color: var(--bad); }
   .verdict { font-size: 15px; font-weight: bold; margin: 6px 0; }
   .scope { color: var(--dim); font-size: 11px; margin-top: 10px; }
 </style>
@@ -94,15 +96,21 @@ v.textContent = 'Verdict: ' + data.result.verdict.toUpperCase();
 v.className = 'verdict ' +
   (data.result.verdict === 'passed' ? 'passed' : 'failed');
 const stages = document.getElementById('stages');
+const statuses = new Set(['passed', 'failed', 'not_enough_evidence',
+                          'not_tested', 'error']);
 for (const s of data.result.stages) {
   const tr = document.createElement('tr');
-  tr.innerHTML = '<td>' + s.name + '</td><td class="' + s.status + '">' +
-    s.status.replaceAll('_', ' ') + '</td>';
+  const name = document.createElement('td');
+  name.textContent = s.name;
+  const status = document.createElement('td');
+  status.textContent = s.status.replaceAll('_', ' ');
+  if (statuses.has(s.status)) status.className = s.status;
+  tr.append(name, status);
   stages.appendChild(tr);
 }
 const svg = document.getElementById('map');
 const cx = 320, cy = 200, R = 150;
-const pos = {};
+const pos = Object.create(null);
 agents.forEach((a, i) => {
   const ang = (2 * Math.PI * i) / agents.length - Math.PI / 2;
   pos[a.name] = [cx + R * Math.cos(ang), cy + R * Math.sin(ang)];
@@ -126,15 +134,22 @@ for (const a of agents) {
 const log = document.getElementById('log');
 events.forEach((e, i) => {
   const d = document.createElement('div');
-  d.innerHTML = 't=' + e.at.toFixed(2) + ' <span class="o">[' +
-    e.observer + ']</span> <span class="k">' + e.kind + '</span> ' +
-    e.subject + ' ' +
-    (Object.keys(e.detail).length ? JSON.stringify(e.detail) : '');
+  const observer = document.createElement('span');
+  observer.className = 'o';
+  observer.textContent = '[' + e.observer + ']';
+  const kind = document.createElement('span');
+  kind.className = 'k';
+  kind.textContent = e.kind;
+  d.append('t=' + e.at.toFixed(2) + ' ', observer, ' ', kind, ' ',
+           e.subject, ' ',
+           Object.keys(e.detail).length ? JSON.stringify(e.detail) : '');
   d.id = 'ev' + i;
   log.appendChild(d);
 });
 const scrub = document.getElementById('scrub');
-scrub.max = events.length - 1;
+scrub.max = Math.max(0, events.length - 1);
+scrub.disabled = events.length === 0;
+document.getElementById('play').disabled = events.length === 0;
 let playing = null;
 function pulse(from, to, dropped) {
   if (!pos[from] || !pos[to]) return;
@@ -181,7 +196,7 @@ document.getElementById('play').addEventListener('click', function () {
     show(+scrub.value, true);
   }, 350);
 });
-show(0, false);
+if (events.length) show(0, false);
 </script>
 </body>
 </html>
@@ -196,6 +211,9 @@ def render_visualizer(bundle: dict[str, Any]) -> str:
         meta = (f"Lab scenario {profile.name}, seed"
                 f" {run.config.get('seed')}, deterministic replay of"
                 f" {len(bundle['events'])} events")
+    elif bundle.get("mode") == "path":
+        meta = (f"Path profile {profile.ref}, capability {profile.capability},"
+                f" {len(bundle['events'])} events")
     else:
         meta = (f"Track profile {profile.name}, fault {profile.fault},"
                 f" {len(bundle['events'])} events")
@@ -207,9 +225,10 @@ def render_visualizer(bundle: dict[str, Any]) -> str:
         "events": [e.model_dump() for e in bundle["events"]],
         "result": result.model_dump(),
     }
-    payload = json.dumps(data).replace("</", "<\\/")
+    payload = (json.dumps(data).replace("<", "\\u003c")
+               .replace(">", "\\u003e").replace("&", "\\u0026"))
     return (TEMPLATE
-            .replace("__RUN_ID__", run.run_id)
+            .replace("__RUN_ID__", escape(run.run_id))
             .replace("__DATA__", payload))
 
 

--- a/tests/test_scaffold_board.py
+++ b/tests/test_scaffold_board.py
@@ -146,7 +146,41 @@ def test_unverified_bundle_remains_visible_in_terminal_browser(tmp_path):
         async with app.run_test():
             table = app.query_one("#bundle-table", DataTable)
             assert table.row_count == 1
-            assert "unverified" in table.get_row("broken")
+            assert "unverified" in [str(cell) for cell in table.get_row("broken")]
             assert "0 passed" in str(app.query_one("#town-status", Static).render())
 
     asyncio.run(browse())
+
+
+def test_duplicate_bundle_copies_count_once_and_open_the_actual_directory(tmp_path):
+    import asyncio
+    import shutil
+    from textual.widgets import DataTable
+    from nandatown.tui import TownApp
+
+    directory, _ = run_lab("voting", str(tmp_path))
+    copied = tmp_path / "a-copy-with-a-different-name"
+    shutil.copytree(directory, copied)
+    rows = scan_bundles(str(tmp_path))
+    assert len(rows) == 1
+    assert "1/1 passed" in render_board(str(tmp_path))
+
+    async def browse():
+        app = TownApp(out_dir=str(tmp_path))
+        async with app.run_test():
+            table = app.query_one("#bundle-table", DataTable)
+            assert table.row_count == 1
+            table.move_cursor(row=0)
+            assert Path(app._selected_bundle()) == copied
+
+    asyncio.run(browse())
+
+
+def test_board_escapes_control_characters_in_unverified_paths(tmp_path):
+    bad = tmp_path / "bad\nINJECTED\x1b[2J"
+    bad.mkdir()
+    (bad / "manifest.json").write_text("{")
+    rendered = render_board(str(tmp_path))
+    assert "\x1b" not in rendered
+    assert "bad\nINJECTED" not in rendered
+    assert "bad\\nINJECTED\\x1b[2J" in rendered

--- a/tests/test_scaffold_board.py
+++ b/tests/test_scaffold_board.py
@@ -130,3 +130,23 @@ def test_board_retains_evaluator_mismatch_as_unverified(tmp_path):
 
     assert "evaluator version differs" in board
     assert "1/1 passed" not in board
+
+
+def test_unverified_bundle_remains_visible_in_terminal_browser(tmp_path):
+    import asyncio
+    from textual.widgets import DataTable, Static
+    from nandatown.tui import TownApp
+
+    bad = tmp_path / "broken"
+    bad.mkdir()
+    (bad / "manifest.json").write_text("{")
+
+    async def browse():
+        app = TownApp(out_dir=str(tmp_path))
+        async with app.run_test():
+            table = app.query_one("#bundle-table", DataTable)
+            assert table.row_count == 1
+            assert "unverified" in table.get_row("broken")
+            assert "0 passed" in str(app.query_one("#town-status", Static).render())
+
+    asyncio.run(browse())

--- a/tests/test_scaffold_board.py
+++ b/tests/test_scaffold_board.py
@@ -72,6 +72,18 @@ def test_board_groups_and_ranks(tmp_path):
     assert voting_line < weak_line
 
 
+def test_lab_board_uses_committed_evaluation_time(tmp_path):
+    directory, result = run_lab("voting", str(tmp_path))
+    run = json.loads(Path(directory, "run.json").read_text())
+    assert run["created_at"] == 0.0
+
+    row = scan_bundles(str(tmp_path))[0]
+
+    assert row["verified"] is True
+    assert row["at"] == result.evaluated_at
+    assert row["at"] > 0.0
+
+
 def test_cli_new_and_board(tmp_path, capsys):
     assert main(["new", "scenario", "demo", "--dir", str(tmp_path)]) == 0
     assert main(["board", str(tmp_path)]) == 0

--- a/tests/test_scaffold_board.py
+++ b/tests/test_scaffold_board.py
@@ -1,4 +1,6 @@
 import pytest
+import json
+from pathlib import Path
 
 from nandatown.board import render_board, scan_bundles
 from nandatown.cli import main
@@ -75,3 +77,56 @@ def test_cli_new_and_board(tmp_path, capsys):
     assert main(["board", str(tmp_path)]) == 0
     out = capsys.readouterr().out
     assert "no evidence bundles" in out
+
+
+def test_board_excludes_tampered_results_from_rankings(tmp_path):
+    directory, _ = run_lab("capability_spoofing_weak_auth", str(tmp_path))
+    result_path = Path(directory) / "result.json"
+    result = json.loads(result_path.read_text())
+    result["verdict"] = "passed"
+    result_path.write_text(json.dumps(result))
+    run_lab("voting", str(tmp_path))
+
+    rows = scan_bundles(str(tmp_path))
+    bad = next(row for row in rows if row["run_id"] == Path(directory).name)
+    assert bad["verified"] is False
+    assert any("hash mismatch" in problem for problem in bad["problems"])
+    board = render_board(str(tmp_path))
+    assert board.count("1/1 passed") == 1
+    assert "excluded from rankings" in board
+    assert "hash mismatch" in board
+
+
+def test_board_reports_malformed_bundles_without_losing_good_runs(tmp_path):
+    bad = tmp_path / "broken"
+    bad.mkdir()
+    (bad / "manifest.json").write_text("{")
+    (bad / "run.json").write_text("{")
+    (bad / "result.json").write_text("{")
+    run_lab("voting", str(tmp_path))
+
+    board = render_board(str(tmp_path))
+
+    assert "1/1 passed" in board
+    assert "broken" in board
+    assert "unreadable" in board
+
+
+def test_board_retains_evaluator_mismatch_as_unverified(tmp_path):
+    directory, _ = run_lab("voting", str(tmp_path))
+    result_path = Path(directory) / "result.json"
+    result = json.loads(result_path.read_text())
+    result["evaluator_version"] = "historical-version"
+    result_path.write_text(json.dumps(result))
+    import hashlib
+    from nandatown.records import fingerprint
+    manifest_path = Path(directory) / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["files"]["result.json"] = "sha256:" + hashlib.sha256(result_path.read_bytes()).hexdigest()
+    manifest["bundle_fingerprint"] = fingerprint(manifest["files"])
+    manifest_path.write_text(json.dumps(manifest))
+
+    board = render_board(str(tmp_path))
+
+    assert "evaluator version differs" in board
+    assert "1/1 passed" not in board

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -64,6 +64,6 @@ def test_path_bundle_visualizes_with_its_actual_profile(tmp_path):
     data = json.loads(page.data)
 
     assert result.verdict == "passed"
-    assert f"Path profile {bundle['profile'].name}" in data["meta"]
+    assert f"Path profile {bundle['profile'].ref}" in data["meta"]
     assert "quote" in data["meta"]
     assert data["result"]["verdict"] == "passed"

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,0 +1,68 @@
+import json
+from html.parser import HTMLParser
+
+from fastapi.testclient import TestClient
+
+from nandatown.a2a_adapter import build_a2a_app
+from nandatown.bundle import load_bundle
+from nandatown.path_runner import run_path_test
+from nandatown.sim.runner import run_lab
+from nandatown.visualizer import render_visualizer
+
+
+class Page(HTMLParser):
+    def __init__(self, source):
+        super().__init__()
+        self.tags = []
+        self.current = None
+        self.title = ""
+        self.data = ""
+        self.feed(source)
+
+    def handle_starttag(self, tag, attrs):
+        self.tags.append((tag, dict(attrs)))
+        if tag == "title" or (tag == "script" and dict(attrs).get("id") == "data"):
+            self.current = tag
+
+    def handle_endtag(self, tag):
+        if tag == self.current:
+            self.current = None
+
+    def handle_data(self, data):
+        if self.current == "title":
+            self.title += data
+        elif self.current == "script":
+            self.data += data
+
+
+def test_hostile_bundle_text_cannot_escape_page_data(tmp_path):
+    directory, _ = run_lab("marketplace", str(tmp_path))
+    bundle = load_bundle(directory)
+    attack = '</title><script>window.attacked=true</script><img src=x onerror="alert(1)">'
+    bundle["run"] = bundle["run"].model_copy(update={"run_id": attack})
+    bundle["events"][0] = bundle["events"][0].model_copy(
+        update={"subject": attack, "detail": {"text": "</script>&<>"}})
+
+    page = Page(render_visualizer(bundle))
+
+    assert page.title == "NANDA Town run " + attack
+    assert not any(tag == "img" for tag, _ in page.tags)
+    assert len([tag for tag, _ in page.tags if tag == "script"]) == 2
+    data = json.loads(page.data)
+    assert data["title"] == attack
+    assert data["events"][0]["subject"] == attack
+    assert data["events"][0]["detail"]["text"] == "</script>&<>"
+
+
+def test_path_bundle_visualizes_with_its_actual_profile(tmp_path):
+    with TestClient(build_a2a_app("http://testserver")) as client:
+        directory, result = run_path_test(
+            "http://testserver", str(tmp_path), http=client)
+
+    page = Page(render_visualizer(load_bundle(directory)))
+    data = json.loads(page.data)
+
+    assert result.verdict == "passed"
+    assert "Path profile a2a-capability-fulfillment@0.2" in data["meta"]
+    assert "quote" in data["meta"]
+    assert data["result"]["verdict"] == "passed"

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -59,10 +59,11 @@ def test_path_bundle_visualizes_with_its_actual_profile(tmp_path):
         directory, result = run_path_test(
             "http://testserver", str(tmp_path), http=client)
 
-    page = Page(render_visualizer(load_bundle(directory)))
+    bundle = load_bundle(directory)
+    page = Page(render_visualizer(bundle))
     data = json.loads(page.data)
 
     assert result.verdict == "passed"
-    assert "Path profile a2a-capability-fulfillment@0.2" in data["meta"]
+    assert f"Path profile {bundle['profile'].name}" in data["meta"]
     assert "quote" in data["meta"]
     assert data["result"]["verdict"] == "passed"


### PR DESCRIPTION
## Summary

- Render participant-controlled viewer values as inert text, escape the HTML title/script-data boundary, constrain styles, and support the actual Path profile and empty timelines.
- Verify before ranking on the local board; keep bad evidence visible as unverified instead of silently hiding it or granting a result.
- Deduplicate identical bundles, use actual directory keys for recovered/renamed bundles, escape terminal control characters, and use committed evaluation time rather than Lab logical zero for chronology.
- Contain malformed verifier/loader errors at the board boundary so one bad bundle cannot hide good runs even before the companion hardened-verifier PR lands.

## Verification

Fresh standalone base: `53178b9c780d7a7dd6ce723131c4250de03908dd`.
- `python -m pytest -q` on Python 3.12 — 664 passed, 8 existing warnings.
- `git diff --check` — clean.
- Browser-DOM hostile-input regression failed against the original renderer and passed after safe text rendering.
- Current Path rendering, board ranking/deduplication, recovered directory selection, terminal control characters and chronology have behavioral tests.
- Independent review cleared the viewer/board changes. Standalone tests exposed a malformed-manifest exception from the older verifier; the added containment fixed all three failures.

The branch passes independently. Merge #261 first for its stronger underlying verification contract; no stack or rebase is required. A local verified ranking is not an independent observer endorsement. The final current-manual PR is #263.
